### PR TITLE
Add note to Ansigenome template that separate repos are not upstream

### DIFF
--- a/lib/debops-tools/misc/ansigenome/templates/DebOps-README.md.j2
+++ b/lib/debops-tools/misc/ansigenome/templates/DebOps-README.md.j2
@@ -28,6 +28,11 @@ ansible-galaxy install {{ role.galaxy_name }}
 More information about `{{ role.galaxy_name }}` can be found in the
 [official {{ role.galaxy_name }} documentation](https://docs.debops.org/en/latest/ansible/roles/{{ role.slug }}/docs/).
 
+## Contributing
+
+Please note that this repository is not the upstream repository where changes should be contributed to.
+Head over to https://github.com/debops/debops where you can find the contents of this repo and where changes are welcome.
+
 {% endblock %}
 {% block standalone %}
 


### PR DESCRIPTION
I fear that people might miss the recent merge into the monorepo and create PRs against the old repos which will cause unnecessary work.

Not sure if that will help but it is a start. I would propose to also add a temporary CONTRIBUTING.rst file into the root of each separate repo.