### PR TITLE
Add an improved script to check PEP8 compliance

### DIFF
--- a/lib/tests/check-pep8
+++ b/lib/tests/check-pep8
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Find all Python scripts and check their PEP8 compliance using pycodestyle
+
+# Copyright (C) 2017 Maciej Delmanowski <drybjed@gmail.com>
+# Copyright (C) 2017 DebOps https://debops.org/
+
+
+set -o nounset -o pipefail -o errexit
+
+declare -a file_list
+
+if ! type pycodestyle > /dev/null 2>&1 ; then
+    printf "%s\n" "Error: pycodestyle not found"
+    exit 1
+fi
+
+printf "%s " "Searching for Python scripts"
+
+counter=0
+
+while read in ; do
+    if file -i "${in}" | grep -q x-python ; then
+        file_list+=("${in}")
+        counter=$(( counter + 1 ))
+        counter_state=$(( counter % 5 ))
+        if [ ${counter_state} -eq 0 ] ; then
+            printf "%s" "."
+        fi
+    fi
+done < <(find . -type f)
+
+printf " %s\n" "found ${#file_list[@]} Python scripts"
+
+pycodestyle --count --show-source --statistics "${file_list[@]}"


### PR DESCRIPTION
The 'pycodestyle' command alone finds only '*.py' files. The new script
is a wrapper which finds all Python scripts in the repository, including
Ansible fact scripts, and checks their PEP8 compliance.

The script is not enabled on Travis or in the Makefile yet, because
there are 690 PEP8 errors still to fix in the repository.