### PR TITLE
s/always_run: True/check_mode: False/g in all tasks files

### DIFF
--- a/ansible/roles/debops-contrib.apparmor/tasks/main.yml
+++ b/ansible/roles/debops-contrib.apparmor/tasks/main.yml
@@ -57,7 +57,7 @@
       (apparmor__enabled|d() | bool) and
       (ansible_cmdline.apparmor|d(0)|string == "1") and
       (ansible_cmdline.security|d("none") == "apparmor") }}'
-  always_run: True
+  check_mode: False
 
 - name: Flush the handlers in case the next tasks fails
   meta: flush_handlers

--- a/ansible/roles/debops-contrib.firejail/tasks/main.yml
+++ b/ansible/roles/debops-contrib.firejail/tasks/main.yml
@@ -19,7 +19,7 @@
 - name: Get program file path of firejail
   command: which -a firejail
   register: firejail__register_program_file_path
-  always_run: True
+  check_mode: False
   changed_when: False
   failed_when: firejail__register_program_file_path.rc not in [ 0, 1 ]
   when: (firejail__program_file_path == "auto")
@@ -55,7 +55,7 @@
 # Gather list of installed programs [[[
 - name: Check if programs which should be sandboxed are installed
   command: which -a {{ item | quote }}
-  always_run: True
+  check_mode: False
   changed_when: False
   failed_when: firejail__register_cmd_which_programs.rc not in [ 0, 1 ]
   register: firejail__register_cmd_which_programs

--- a/ansible/roles/debops-contrib.snapshot_snapper/tasks/main.yml
+++ b/ansible/roles/debops-contrib.snapshot_snapper/tasks/main.yml
@@ -49,7 +49,7 @@
   command: grep PRUNENAMES=.*{{ snapshot_snapper__directory }}.* /etc/updatedb.conf
   failed_when: False
   changed_when: False
-  always_run: True
+  check_mode: False
   when: snapshot_snapper__directory != "" and "mlocate" in snapshot_snapper__combined_packages
   register: snapshot_snapper__register_updatedb_configured
 


### PR DESCRIPTION
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead.. This feature will be removed in version 2.4. Deprecation

git ls-files -z "$(git rev-parse --show-toplevel)" | xargs --null -I '{}' find '{}' -type f -print0 | xargs --null sed --in-place --regexp-extended 's/always_run: True/check_mode: False/g;'

Closes: https://github.com/debops-contrib/ansible-apparmor/pull/3
cc: @computerlyrik