### PR TITLE
Fix missing plugin paths in generated ansible.cfg

### DIFF
--- a/lib/debops-tools/bin/debops
+++ b/lib/debops-tools/bin/debops
@@ -70,7 +70,15 @@ def gen_ansible_cfg(filename, config, project_root, playbooks_path,
         if type in defaults:
             # prepend value from .debops.cfg
             yield defaults[type]
+        yield os.path.join(project_root, "ansible", "playbooks", type)
+        yield os.path.join(project_root, "ansible", "plugins", type)
         yield os.path.join(project_root, "ansible", type)
+        yield os.path.join(project_root, "debops", "ansible", "playbooks", "playbooks", type)
+        yield os.path.join(project_root, "debops", "ansible", "playbooks", type)
+        yield os.path.join(project_root, "debops", "ansible", "plugins", type)
+        yield os.path.join(project_root, "debops", "ansible", type)
+        yield os.path.join(monorepo_path, "ansible", "playbooks", "playbooks", type)
+        yield os.path.join(monorepo_path, "ansible", "playbooks", type)
         yield os.path.join(monorepo_path, "ansible", "plugins", type)
         yield os.path.join(monorepo_path, "ansible", type)
         yield os.path.join(playbooks_path, type)
@@ -88,6 +96,7 @@ def gen_ansible_cfg(filename, config, project_root, playbooks_path,
         defaults.get('roles_path'), # value from .debops.cfg or None
         os.path.join(project_root, "roles"),
         os.path.join(project_root, "ansible", "roles"),
+        os.path.join(project_root, "debops", "ansible", "roles"),
         os.path.join(monorepo_path, "ansible", "roles"),
         os.path.join(playbooks_path, "..", "roles"),
         os.path.join(playbooks_path, "roles"),
@@ -126,6 +135,8 @@ def main(cmd_args):
         tries = [
             (project_root, "playbooks", playbook),
             (project_root, "ansible", "playbooks", playbook),
+            (project_root, "debops", "ansible", "playbooks", playbook),
+            (project_root, "debops", "ansible", "playbooks", "playbooks", playbook),
             (monorepo_path, "ansible", "playbooks", playbook),
             (monorepo_path, "ansible", "playbooks", "playbooks", playbook),
             (playbooks_path, playbook),

--- a/lib/debops-tools/setup.py
+++ b/lib/debops-tools/setup.py
@@ -11,7 +11,7 @@ README = open('README.rst').read()
 
 setup(
     name="debops",
-    version="0.6.0",
+    version="0.6.1",
     install_requires=['netaddr', 'argparse', 'passlib', 'ansible'],
 
     scripts=['bin/debops',
@@ -35,7 +35,7 @@ setup(
     keywords="ansible",
     url="https://debops.org/",
     download_url="https://github.com/debops/debops-tools"
-                 "/archive/v0.6.0.tar.gz",
+                 "/archive/v0.6.1.tar.gz",
     classifiers=[
                  'Development Status :: 4 - Beta',
                  'Environment :: Console',


### PR DESCRIPTION
The 'debops' script will now include paths to Ansible plugins located in
the playbook directories, in addition to a set of separate directories.
This is done to preserve backwards compatibility with existing set of
DebOps playbooks.

The script will now look for Ansible roles, playbooks and plugins in the
'debops/' subdirectory of a project directory. This allows installation
of the DebOps monorepo inside of the project directory to keep it
separate from the main monorepo in '~/.local/share/debops/', either
directly or via a symlink, allowing for a completely self-contained
development environment.

The 'debops-tools' version is increased to allow clean upgrade on
installs done via PyPI.