### PR TITLE
Install 'nodejs-legacy' with distribution NodeJS

### DIFF
--- a/ansible/roles/debops.nodejs/defaults/main.yml
+++ b/ansible/roles/debops.nodejs/defaults/main.yml
@@ -74,7 +74,7 @@ nodejs__base_packages: [ 'nodejs' ]
 #
 # List of APT packages which are only needed when NodeJS is installed from
 # current OS release repositories.
-nodejs__distribution_packages: '{{ (["npm"]
+nodejs__distribution_packages: '{{ ([ "npm", "nodejs-legacy" ]
                                     if not nodejs__upstream|bool
                                     else []) }}'
 


### PR DESCRIPTION
The '/usr/bin/node' symlink provided by the 'nodejs-legacy' package is
still required by some applications.

Fixes #33