### PR TITLE
debops-contrib.etckeeper: Fix custom Git ignore list entries not applied

### DIFF
--- a/ansible/roles/debops-contrib.etckeeper/tasks/main.yml
+++ b/ansible/roles/debops-contrib.etckeeper/tasks/main.yml
@@ -104,6 +104,7 @@
     mode: '{{ etckeeper__repository_permissions|d("0700") }}'
     owner: 'root'
     group: '{{ etckeeper__repository_group|d("root") }}'
+  when: (etckeeper__vcs == 'git')
 
 ## Set VCS user, email used for auto committing changes [[[
 - name: Set user, email for the git repository


### PR DESCRIPTION
This role adds custom entries to /etc/.gitignore after invoking
'etckeeper init'.

However, at that moment all files are already added to Git index, so we
need to remove them again before calling 'etckeeper commit'. Otherwise
custom ignore list has no effect.

See /etc/etckeeper/init.d/70vcs-add