### PR TITLE
debops-contrib.etckeeper: Fix name of ignore list variable used in docs

### DIFF
--- a/ansible/roles/debops-contrib.etckeeper/docs/getting-started.rst
+++ b/ansible/roles/debops-contrib.etckeeper/docs/getting-started.rst
@@ -17,8 +17,8 @@ Example inventory
 
 .. code-block:: YAML
 
-   ## If you don’t what to track hashed passwords.
-   etckeeper__gitignore_group:
+   ## If you don’t want to track hashed passwords.
+   etckeeper__ignore_host_group_list:
      - 'shadow'
      - 'shadow-'
 


### PR DESCRIPTION
Replace `etckeeper__gitignore_group` which was renamed to
`etckeeper__ignore_host_group_list`.