### PR TITLE
Fix rsyslog network modules without requiring TLS

### DIFF
--- a/ansible/roles/debops.rsyslog/defaults/main.yml
+++ b/ansible/roles/debops.rsyslog/defaults/main.yml
@@ -478,16 +478,10 @@ rsyslog__conf_network_modules:
       - comment: 'Enable UDP support'
         options: |-
           module(load="imudp")
-        state: '{{ "present"
-                  if (rsyslog__send_over_tls_only)
-                  else "absent" }}'
 
       - comment: 'Enable TCP support'
         options: |-
           module(load="imptcp")
-        state: '{{ "present"
-                  if (rsyslog__send_over_tls_only)
-                  else "absent" }}'
 
       - comment: 'Enable GnuTLS TCP support'
         options: |-


### PR DESCRIPTION
The UDP and TCP modules are also useful if you don't require everything
to use TLS.