### PR TITLE
Jessie debian-installer compatible GnuPG configuration

### DIFF
--- a/ansible/roles/debops.reprepro/defaults/main.yml
+++ b/ansible/roles/debops.reprepro/defaults/main.yml
@@ -97,6 +97,12 @@ reprepro_gpg_name: '{{ reprepro_domain.split(".")[0] | capitalize + " Automatic 
 reprepro_gpg_email: '{{ reprepro_distribution | lower + "-packages@" + reprepro_domain }}'
 reprepro_gpg_expire_days: '{{ (365 * 5) }}'
 
+# The debian-installer version in jessie (and before) does not support GPG keys signatures
+# using SHA512 or SHA384 digests. This variable configures GnuPG to not use these algorithms
+# This is ONLY relevant if you want to install using your repository. The GnuPG and APT in
+# an installed system support SHA512 and SHA384.
+reprepro_installer_jessie_compatibility: False
+
 # Name of the snapshot file which contains reprepro GnuPG key
 reprepro_gpg_snapshot_name: 'gnupg.tar'
 

--- a/ansible/roles/debops.reprepro/templates/var/lib/reprepro/gnupg/gpg.conf.j2
+++ b/ansible/roles/debops.reprepro/templates/var/lib/reprepro/gnupg/gpg.conf.j2
@@ -1,3 +1,8 @@
+{% if reprepro_installer_jessie_compatibility %}
+{% set digest_preference = 'SHA256 SHA224' %}
+{% else %}
+{% set digest_preference = 'SHA512 SHA384 SHA256 SHA224' %}
+{% endif %}
 # This file is managed remotely, all changes will be lost
 
 # GPG Configuration Options
@@ -17,11 +22,11 @@ armor
 fixed-list-mode
 
 # OpenPGP Options
-personal-digest-preferences SHA512 SHA384 SHA256 SHA224
+personal-digest-preferences {{ digest_preference }}
 
 # GPG Esoteric Options
-default-preference-list SHA512 SHA384 SHA256 SHA224 AES256 AES192 AES CAST5 BZIP2 ZLIB ZIP Uncompressed
-cert-digest-algo SHA512
+default-preference-list {{ digest_preference }} AES256 AES192 AES CAST5 BZIP2 ZLIB ZIP Uncompressed
+cert-digest-algo {{ 'SHA256' if  reprepro_installer_jessie_compatibility else 'SHA512' }}
 no-comments
 no-emit-version
 


### PR DESCRIPTION
The stripped down version of gpgv used in the jessie installer does not
support SHA512 and SHA384 as digest algorithms. Neither for singing
release files nor key certifications (ie. self signatures).

This adds a new variable reprepro_installer_jessie_compatibility to
disable the unsupported algorithms. This defaults to False. If you
change this variables to True, you have to regenerate your archive
signing key. Otherwise your key won't work as it contains unsupported
self-signatures.