### PR TITLE
Ensure that '/etc/ansible/fact.d/' is a directory

### DIFF
--- a/ansible/roles/debops.apt_listchanges/tasks/main.yml
+++ b/ansible/roles/debops.apt_listchanges/tasks/main.yml
@@ -21,6 +21,7 @@
 - name: Make sure that Ansible fact directory exists
   file:
     path: '/etc/ansible/facts.d'
+    state: 'directory'
     owner: 'root'
     group: 'root'
     mode: '0755'


### PR DESCRIPTION
Fixes an issue with the 'debops.apt_listchanges' role when executed as
standalone.