### PR TITLE
debops.dovecot fix inventory group, add role tags section to docs

### DIFF
--- a/ansible/roles/debops.dovecot/docs/getting-started.rst
+++ b/ansible/roles/debops.dovecot/docs/getting-started.rst
@@ -16,10 +16,10 @@ login via IMAP and access its mails stored as an mbox file in ``/var/mail/<usern
 Example inventory
 -----------------
 
-You can install Dovecot on a host by adding it to the ``[debops_dovecot]`` group
+You can install Dovecot on a host by adding it to the ``[debops_service_dovecot]`` group
 in your Ansible inventory::
 
-    [debops_dovecot]
+    [debops_service_dovecot]
     hostname
 
 Example playbook
@@ -30,12 +30,25 @@ Here's an example playbook which uses ``debops.dovecot`` role to install Dovecot
     ---
 
     - name: Setup Dovecot IMAP Server
-      hosts: debops_dovecot
+      hosts: debops_service_dovecot
 
       roles:
         - role: debops.dovecot
           tags: dovecot
 
+Ansible tags
+------------
+
+You can use Ansible ``--tags`` or ``--skip-tags`` parameters to limit what
+tasks are performed during Ansible run. This can be used after a host was first
+configured to speed up playbook execution, when you are sure that most of the
+configuration is already in the desired state.
+
+Available role tags:
+
+``role::dovecot``
+  Main role tag, should be used in the playbook to execute all of the role
+  tasks as well as role dependencies.
 
 .. _ansible-pki: https://github.com/debops/ansible-pki
 .. _ansible-ferm: https://github.com/debops/ansible-ferm


### PR DESCRIPTION
As requested the [same PR](https://github.com/debops/ansible-dovecot/pull/37) posted to debops/dovecot done for debops/debops.