### PR TITLE
Change 'undefined' condition to 'not defined'

### DIFF
--- a/ansible/roles/debops.hashicorp/README.md
+++ b/ansible/roles/debops.hashicorp/README.md
@@ -19,7 +19,7 @@ After that, other Ansible roles can be used to configure them as needed.
 
 ### Installation
 
-This role requires at least Ansible `v2.0.0`. To install it, run:
+This role requires at least Ansible `v2.4.0`. To install it, run:
 
 ```Shell
 ansible-galaxy install debops.hashicorp

--- a/ansible/roles/debops.hashicorp/meta/main.yml
+++ b/ansible/roles/debops.hashicorp/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   description: 'Securely install HashiCorp applications'
   company: 'DebOps'
   license: 'GPL-3.0'
-  min_ansible_version: '2.0.0'
+  min_ansible_version: '2.4.0'
   platforms:
   - name: Ubuntu
     versions:

--- a/ansible/roles/debops.hashicorp/tasks/main.yml
+++ b/ansible/roles/debops.hashicorp/tasks/main.yml
@@ -116,10 +116,10 @@
       with_nested:
         - '{{ (hashicorp__applications + hashicorp__dependent_applications) | unique }}'
         - [ '{{ hashicorp__tar_suffix }}', '{{ hashicorp__hash_suffix }}', '{{ hashicorp__sig_suffix }}' ]
-      when: (ansible_local is undefined or (ansible_local|d() and (ansible_local.hashicorp is undefined or
+      when: (ansible_local.hashicorp is not defined or
              (ansible_local.hashicorp|d() and ansible_local.hashicorp.applications|d() and
-              (ansible_local.hashicorp.applications[item.0] is undefined or
-               (ansible_local.hashicorp.applications[item.0] != hashicorp__combined_version_map[item.0]))))))
+              (ansible_local.hashicorp.applications[item.0] is not defined or
+               (ansible_local.hashicorp.applications[item.0] != hashicorp__combined_version_map[item.0]))))
       tags: [ 'role::hashicorp:download', 'role::hashicorp:verify' ]
 
     - name: Download Consul Web UI
@@ -133,11 +133,11 @@
         - [ '{{ hashicorp__consul_webui_suffix }}' ]
       when: (hashicorp__consul_webui|bool and
              ('consul' in (hashicorp__applications + hashicorp__dependent_applications) | unique) and
-              (ansible_local is undefined or (ansible_local|d() and ansible_local.hashicorp is undefined or
+              (ansible_local.hashicorp is not defined or
                (ansible_local.hashicorp|d() and ansible_local.hashicorp.applications|d() and
-                (ansible_local.hashicorp.applications['consul'] is undefined or
+                (ansible_local.hashicorp.applications['consul'] is not defined or
                  (ansible_local.hashicorp.applications['consul'] != hashicorp__combined_version_map['consul'])) or
-                not ansible_local.hashicorp.consul_webui | bool))))
+                not ansible_local.hashicorp.consul_webui | bool)))
       tags: [ 'role::hashicorp:download', 'role::hashicorp:verify' ]
 
 
@@ -211,9 +211,9 @@
     - '{{ (hashicorp__applications + hashicorp__dependent_applications) | unique }}'
     - '{{ hashicorp__register_unpack.results }}'
   when: (item.1|changed or (ansible_local|d() and
-         (ansible_local.hashicorp is undefined or
+         (ansible_local.hashicorp is not defined or
           (ansible_local.hashicorp|d() and ansible_local.hashicorp.applications|d() and
-           (ansible_local.hashicorp.applications[item.0] is undefined or
+           (ansible_local.hashicorp.applications[item.0] is not defined or
             (ansible_local.hashicorp.applications[item.0] != hashicorp__combined_version_map[item.0]))))))
   tags: [ 'role::hashicorp:install' ]
 


### PR DESCRIPTION
The 'debops.hashicorp' role didn't install the Hashicorp software as
expected during testing on Ansible 2.4. This seems to be related to the
issue with 'undefined' not being correctly interpreted by Ansible.

See https://github.com/ansible/ansible/issues/23675 for more details.