### PR TITLE
Add option to disable Mailman site notification

### DIFF
--- a/ansible/roles/debops.mailman/defaults/main.yml
+++ b/ansible/roles/debops.mailman/defaults/main.yml
@@ -86,6 +86,13 @@ mailman__site_postmaster: 'postmaster@{{ mailman__domain }}'
 #
 # Default site mailing list, usually ``mailman``.
 mailman__site_list: 'mailman'
+
+                                                                   # ]]]
+# .. envvar:: mailman__site_list_notify [[[
+#
+# Enable or disable sending a notification e-mail about creation of the site
+# mailing list.
+mailman__site_list_notify: True
                                                                    # ]]]
                                                                    # ]]]
 # Mail messages and SMTP configuration [[[

--- a/ansible/roles/debops.mailman/tasks/main.yml
+++ b/ansible/roles/debops.mailman/tasks/main.yml
@@ -84,7 +84,7 @@
   when: mailman__register_postfix_transport.changed|bool
 
 - name: Create Mailman site list
-  shell: echo | newlist --language={{ mailman__site_language }} {{ mailman__site_list }} {{ mailman__site_admin }}
+  shell: echo | newlist {{ '' if (mailman__site_list_notify|bool) else '--quiet' }} --language={{ mailman__site_language }} {{ mailman__site_list }} {{ mailman__site_admin }}
          {{ lookup('password', secret + '/credentials/' + ansible_fqdn + '/mailman/list/' + mailman__site_domain + '/' + mailman__site_list + '/admin/password chars=ascii,numbers,digits,hexdigits length=' + mailman__site_password_length) }}
   args:
     creates: '/var/lib/mailman/lists/{{ mailman__site_list }}/config.pck'


### PR DESCRIPTION
By default the 'debops.mailman' role sends an e-mail notification to the
administrator on initial install. The new variable allows to disable
this functionality for testing purposes.