### PR TITLE
Changed nmbd handler state to support sysvinit on Jessie

### DIFF
--- a/ansible/roles/debops.samba/handlers/main.yml
+++ b/ansible/roles/debops.samba/handlers/main.yml
@@ -7,7 +7,7 @@
 - name: Reload nmbd
   service:
     name: 'nmbd'
-    state: 'reloaded'
+    state: 'restarted'
 
 - name: Reload smbd
   service:


### PR DESCRIPTION
When I ran this latest updated against a Debian Jessie box that is using the sysVinit system I got an error that the reloaded state wasn't supported. Since the restarted state should work on all systems I changed it to that.