### PR TITLE
Php installed from sury uses the same path as php7*

### DIFF
--- a/ansible/roles/debops.php/env/tasks/main.yml
+++ b/ansible/roles/debops.php/env/tasks/main.yml
@@ -67,19 +67,6 @@
 
 - name: Set PHP base paths
   set_fact:
-    php__version: '{{ ansible_local.php.version
-                      if (ansible_local|d() and ansible_local.php|d() and
-                          ansible_local.php.version|d())
-                      else php__register_version.stdout }}'
-    php__long_version: '{{ ansible_local.php.long_version
-                           if (ansible_local|d() and ansible_local.php|d() and
-                               ansible_local.php.long_version|d() and
-                               ansible_local.php.long_version|d() != "(none)")
-                           else php__register_long_version.stdout }}'
-  tags: [ 'role::php:pools', 'role::php:config' ]
-
-- name: Set PHP base paths
-  set_fact:
     php__etc_base: '{{ ("/etc/php/" + php__version)
                        if (php__version | version_compare("7.0", ">=") or php__sury|bool)
                        else "/etc/php5" }}'


### PR DESCRIPTION
I installed php5.6 on ubuntu 16 with the following configuration
```
php__version_preference: [ 'php5.6' ]
php__sury: True
```
The php configuration was installed in /etc/php/5.6
The calculated paths where expecting to be in /etc/php5 