### PR TITLE
Add the 'CODEOWNERS' file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,72 @@
+# This is a GitHub CODEOWNERS file, which uses a syntax similar to the
+# '.gitignore' file to define the reviewers of certain files or directories in
+# the repository. Order of the entries is important, the last matching entry
+# wins. You can read more about how this file works at
+# https://help.github.com/articles/about-codeowners/
+
+# Each person or team that's included as reviewers requires write access to the
+# repository. If you want to be included as a reviewer for the roles,
+# playbooks, or other code included in the DebOps monorepo, create an issue in
+# the https://github.com/debops/debops/ repository. Additional teams will be
+# created as needed.
+
+# Global, default reviewers for everything in the repository
+*                                                   @ddebops/core-team
+
+
+/ansible/roles/debops.apache/                       @drybjed @ypid
+/ansible/playbooks/service/apache.yml               @drybjed @ypid
+
+/ansible/roles/debops.apt_cacher_ng/                @drybjed @ypid
+/ansible/playbooks/service/apt_cacher_ng.yml        @drybjed @ypid
+
+/ansible/roles/debops.cryptsetup/                   @drybjed @ypid
+/ansible/playbooks/service/cryptsetup*.yml          @drybjed @ypid
+
+/ansible/roles/debops.debops_api/                   @drybjed @ypid
+/ansible/playbooks/service/debops_api.yml           @drybjed @ypid
+
+/ansible/roles/debops.dovecot/                      @debops/mail-team
+/ansible/playbooks/service/dovecot.yml              @debops/mail-team
+
+/ansible/roles/debops.gitlab*/                      @debops/gitlab-team
+/ansible/playbooks/service/gitlab*.yml              @debops/gitlab-team
+
+/ansible/roles/debops.grub/                         @debops/system-team
+/ansible/playbooks/service/grub.yml                 @debops/system-team
+
+/ansible/roles/debops.mailman/                      @debops/mail-team
+/ansible/playbooks/service/mailman.yml              @debops/mail-team
+
+/ansible/roles/debops.nullmailer/                   @debops/mail-team
+/ansible/playbooks/service/nullmailer.yml           @debops/mail-team
+
+/ansible/roles/debops.opendkim/                     @debops/mail-team
+/ansible/playbooks/service/opendkim.yml             @debops/mail-team
+
+/ansible/roles/debops.owncloud/                     @debops/cloud-team
+/ansible/playbooks/service/owncloud*.yml            @debops/cloud-team
+
+/ansible/roles/debops.persistent_paths/             @drybjed @ypid
+/ansible/playbooks/service/persisten_paths.yml      @drybjed @ypid
+
+/ansible/roles/debops.postconf/                     @debops/mail-team
+/ansible/playbooks/service/postconf.yml             @debops/mail-team
+
+/ansible/roles/debops.postfix/                      @debops/mail-team
+/ansible/playbooks/service/postfix.yml              @debops/mail-team
+
+/ansible/roles/debops.postscreen/                   @debops/mail-team
+/ansible/playbooks/service/postscreen.yml           @debops/mail-team
+
+/ansible/roles/debops.postwhite/                    @debops/mail-team
+/ansible/playbooks/service/postwhite.yml            @debops/mail-team
+
+/ansible/roles/debops.saslauthd/                    @debops/mail-team
+/ansible/playbooks/service/saslauthd.yml            @debops/mail-team
+
+/ansible/roles/debops.unbound/                      @debops/mail-team
+/ansible/playbooks/service/unbound.yml              @debops/mail-team
+
+/ansible/roles/debops.sysctl/                       @drybjed @ypid
+/ansible/playbooks/service/sysctl.yml               @drybjed @ypid


### PR DESCRIPTION
This file defines the "owners" of particular DebOps roles, which will be
automatically added as reviewers to any pull requests involving their
roles.