### PR TITLE
Adding bootstrap__etc_hosts to make it possible to disable hostname addition to /etc/hosts

### DIFF
--- a/ansible/roles/debops.bootstrap/defaults/main.yml
+++ b/ansible/roles/debops.bootstrap/defaults/main.yml
@@ -36,6 +36,14 @@ bootstrap__domain: '{{ inventory_hostname.split(".")[1:] | join(".") }}'
 bootstrap__hostname: '{{ inventory_hostname_short | d(inventory_hostname.split(".")[0]) }}'
 
                                                                    # ]]]
+# .. envvar:: bootstrap__etc_hosts [[[
+#
+# Add the hostname to /etc/hosts and make it point to 127.0.1.1
+# This is usually what you want except if you manage yourself the
+# hostname entry and want it to point to some other IP.
+bootstrap__etc_hosts: True
+
+                                                                   # ]]]
 # .. envvar:: bootstrap__hostname_v6_loopback [[[
 #
 # Set custom DNS hostname on a given host also for IPv6.

--- a/ansible/roles/debops.bootstrap/tasks/main.yml
+++ b/ansible/roles/debops.bootstrap/tasks/main.yml
@@ -104,7 +104,7 @@
               if bootstrap__domain|d()
               else '') }}"
   tags: [ 'role::bootstrap:hostname' ]
-  when: (bootstrap__hostname_domain_config_enabled|bool and ((item.type == 'inet6' and bootstrap__hostname_v6_loopback|d()) or item.type == 'inet4'))
+  when: (bootstrap__hostname_domain_config_enabled|bool and bootstrap__etc_hosts|bool and ((item.type == 'inet6' and bootstrap__hostname_v6_loopback|d()) or item.type == 'inet4'))
   with_items:
     - ip_address: '{{ bootstrap__ipv4 | default("127.0.1.1") }}'
       insertafter: '{{ "^127.0.0.1" | replace(".", "\.") }}'


### PR DESCRIPTION
Closes debops/ansible-bootstrap#52