### PR TITLE
Add test environment based on GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,1214 @@
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+
+# Test DebOps roles and playbooks using Gitlab CI, Vagrant and Jane
+#
+# Copyright (C) 2017 Maciej Delmanowski <drybjed@gmail.com>
+# Copyright (C) 2017 DebOps https://debops.org/
+
+
+# This file is part of DebOps.
+#
+# DebOps is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# DebOps is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with DebOps. If not, see https://www.gnu.org/licenses/.
+
+---
+
+variables:
+  TEST_PLAYBOOKS: '/vagrant/lib/tests/playbooks'
+  DEBOPS_PLAYBOOKS:  '/vagrant/ansible/playbooks'
+  VAGRANT_DOTFILE_PATH: '/var/tmp/vagrant-dotfile-${CI_JOB_ID}'
+  GIT_STRATEGY: 'clone'
+  TERM: 'xterm'
+
+stages:
+
+  - 'DebOps roles (no deps)'
+  - 'DebOps roles (1st deps)'
+  - 'DebOps roles (2nd deps)'
+  - 'DebOps roles (3rd deps)'
+  - 'DebOps roles (4th deps)'
+  - 'DebOps roles (5th deps)'
+  - 'DebOps roles (6th deps)'
+
+
+# === Role testing templates === [[[1
+
+.tpl_test_role_base: &test_role_base
+  tags: [ 'shell', 'vagrant' ]
+  before_script:
+    - './lib/tests/jane gitlab before_script'
+  script:
+    - './lib/tests/jane gitlab script'
+  after_script:
+    - './lib/tests/jane gitlab after_script'
+  # This requires newer GitLab version
+  #retry: 1
+
+
+.tpl_test_role_no_deps: &test_role_no_deps
+  <<: *test_role_base
+  stage: 'DebOps roles (no deps)'
+
+.tpl_test_role_1st_deps: &test_role_1st_deps
+  <<: *test_role_base
+  stage: 'DebOps roles (1st deps)'
+
+.tpl_test_role_2nd_deps: &test_role_2nd_deps
+  <<: *test_role_base
+  stage: 'DebOps roles (2nd deps)'
+
+.tpl_test_role_3rd_deps: &test_role_3rd_deps
+  <<: *test_role_base
+  stage: 'DebOps roles (3rd deps)'
+
+.tpl_test_role_4th_deps: &test_role_4th_deps
+  <<: *test_role_base
+  stage: 'DebOps roles (4th deps)'
+
+.tpl_test_role_5th_deps: &test_role_5th_deps
+  <<: *test_role_base
+  stage: 'DebOps roles (5th deps)'
+
+.tpl_test_role_6th_deps: &test_role_6th_deps
+  <<: *test_role_base
+  stage: 'DebOps roles (6th deps)'
+
+
+# === Ansible roles === [[[1
+
+# --- apache --- [[[2
+
+'apache role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/apache.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_apache'
+    JANE_DIFF_PATTERN: '.*/debops.apache/.*'
+    JANE_LOG_PATTERN: '\[debops\.apache\]'
+
+
+# --- apt --- [[[2
+
+'apt role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/apt.yml'
+    JANE_DIFF_PATTERN: '.*/debops.apt/.*'
+    JANE_LOG_PATTERN: '\[debops\.apt\]'
+
+'apt_cacher_ng role':
+  <<: *test_role_2nd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/apt_cacher_ng.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_apt_cacher_ng'
+    JANE_DIFF_PATTERN: '.*/debops.apt_cacher_ng/.*'
+    JANE_LOG_PATTERN: '\[debops\.apt_cacher_ng\]'
+
+'apt_listchanges role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/apt_listchanges.yml'
+    JANE_DIFF_PATTERN: '.*/debops.apt_listchanges/.*'
+    JANE_LOG_PATTERN: '\[debops\.apt_listchanges\]'
+
+'apt_install role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/apt_install.yml'
+    JANE_DIFF_PATTERN: '.*/debops.apt_install/.*'
+    JANE_LOG_PATTERN: '\[debops\.apt_install\]'
+
+'apt_preferences role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/apt_preferences.yml'
+    JANE_DIFF_PATTERN: '.*/debops.apt_preferences/.*'
+    JANE_LOG_PATTERN: '\[debops\.apt_preferences\]'
+
+'apt_proxy role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/apt_proxy.yml'
+    JANE_DIFF_PATTERN: '.*/debops.apt_proxy/.*'
+    JANE_LOG_PATTERN: '\[debops\.apt_proxy\]'
+
+
+# --- atd --- [[[2
+
+'atd role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/atd.yml'
+    JANE_DIFF_PATTERN: '.*/debops.atd/.*'
+    JANE_LOG_PATTERN: '\[debops\.atd\]'
+
+
+# --- auth --- [[[2
+
+'auth role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/auth.yml'
+    JANE_DIFF_PATTERN: '.*/debops.auth/.*'
+    JANE_LOG_PATTERN: '\[debops\.auth\]'
+
+'authorized_keys role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/authorized_keys.yml'
+    JANE_DIFF_PATTERN: '.*/debops.authorized_keys/.*'
+    JANE_LOG_PATTERN: '\[debops\.authorized_keys\]'
+
+
+# --- avahi --- [[[2
+
+'avahi role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/avahi.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_avahi'
+    JANE_DIFF_PATTERN: '.*/debops.avahi/.*'
+    JANE_LOG_PATTERN: '\[debops\.avahi\]'
+
+
+# --- b --- [[[2
+
+'bootstrap role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/bootstrap.yml'
+    JANE_INVENTORY_HOSTVARS: 'ansible_become=true bootstrap__raw=false'
+    JANE_DIFF_PATTERN: '.*/debops.bootstrap/.*'
+    JANE_LOG_PATTERN: '\[debops\.bootstrap\]'
+
+# At the moment BoxBackup role is broken, needs to be updated.
+#'boxbackup role':
+#  <<: *test_role_1st_deps
+#  variables:
+#    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/boxbackup.yml'
+#    JANE_INVENTORY_GROUPS: 'debops_service_boxbackup'
+#    JANE_DIFF_PATTERN: '.*/debops.boxbackup/.*'
+#    JANE_LOG_PATTERN: '\[debops\.boxbackup\]'
+
+
+# --- c --- [[[2
+
+'common playbook':
+  <<: *test_role_2nd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/common.yml'
+    JANE_DIFF_PATTERN: '.*/playbooks\/common\.yml/.*'
+    JANE_LOG_PATTERN: '\[common playbook\]'
+  tags: [ 'shell', 'vagrant-vm' ]
+
+'console role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/console.yml'
+    JANE_DIFF_PATTERN: '.*/debops.console/.*'
+    JANE_LOG_PATTERN: '\[debops\.console\]'
+
+'core role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/core.yml'
+    JANE_DIFF_PATTERN: '.*/debops.core/.*'
+    JANE_LOG_PATTERN: '\[debops\.core\]'
+
+'cran role':
+  <<: *test_role_2nd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/cran.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_cran'
+    JANE_DIFF_PATTERN: '.*/debops.cran/.*'
+    JANE_LOG_PATTERN: '\[debops\.cran\]'
+
+'cron role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/cron.yml'
+    JANE_DIFF_PATTERN: '.*/debops.cron/.*'
+    JANE_LOG_PATTERN: '\[debops\.cron\]'
+
+'cryptsetup role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/cryptsetup.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_cryptsetup'
+    JANE_DIFF_PATTERN: '.*/debops.cryptsetup/.*'
+    JANE_LOG_PATTERN: '\[debops\.cryptsetup\]'
+  tags: [ 'shell', 'vagrant-vm' ]
+
+'cryptsetup/persistent_paths role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/cryptsetup-persistent_paths.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_cryptsetup_persistent_paths'
+    JANE_DIFF_PATTERN: '.*/debops.cryptsetup/.*'
+    JANE_LOG_PATTERN: '\[debops\.cryptsetup\]'
+  tags: [ 'shell', 'vagrant-vm' ]
+
+
+# --- d --- [[[2
+
+'debops role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/debops.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_debops'
+    JANE_DIFF_PATTERN: '.*/debops.debops/.*'
+    JANE_LOG_PATTERN: '\[debops\.debops\]'
+
+# The 'debops_api' role is currently broken, needs to be updated.
+#'debops_api role':
+#  <<: *test_role_2nd_deps
+#  variables:
+#    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/debops_api.yml'
+#    JANE_INVENTORY_GROUPS: 'debops_service_debops_api'
+#    JANE_DIFF_PATTERN: '.*/debops.debops_api/.*'
+#    JANE_LOG_PATTERN: '\[debops\.debops_api\]'
+
+'debops_fact role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/debops_fact.yml'
+    JANE_DIFF_PATTERN: '.*/debops.debops_fact/.*'
+    JANE_LOG_PATTERN: '\[debops\.debops_fact\]'
+
+'dhcpd role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/dhcpd.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_dhcpd'
+    JANE_DIFF_PATTERN: '.*/debops.dhcpd/.*'
+    JANE_LOG_PATTERN: '\[debops\.dhcpd\]'
+
+'dhparam role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/dhparam.yml'
+    JANE_DIFF_PATTERN: '.*/debops.dhparam/.*'
+    JANE_LOG_PATTERN: '\[debops\.dhparam\]'
+
+'dnsmasq role':
+  <<: *test_role_2nd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/ifupdown.yml ${DEBOPS_PLAYBOOKS}/service/dnsmasq.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_ifupdown,debops_service_dnsmasq'
+    JANE_INVENTORY_HOSTVARS: '/vagrant/lib/tests/inventory/dnsmasq.json'
+    JANE_DIFF_PATTERN: '.*/debops.dnsmasq/.*'
+    JANE_LOG_PATTERN: '\[debops\.dnsmasq\]'
+  tags: [ 'shell', 'vagrant-vm' ]
+
+'dnsmasq/persistent_paths role':
+  <<: *test_role_2nd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/ifupdown.yml ${DEBOPS_PLAYBOOKS}/service/dnsmasq-persistent_paths.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_ifupdown,debops_service_dnsmasq_persistent_paths'
+    JANE_INVENTORY_HOSTVARS: '/vagrant/lib/tests/inventory/dnsmasq.json'
+    JANE_DIFF_PATTERN: '.*/debops.dnsmasq/.*'
+    JANE_LOG_PATTERN: '\[debops\.dnsmasq\]'
+  tags: [ 'shell', 'vagrant-vm' ]
+
+'docker role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/docker.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_docker'
+    JANE_DIFF_PATTERN: '.*/debops.docker/.*'
+    JANE_LOG_PATTERN: '\[debops\.docker\]'
+  tags: [ 'shell', 'vagrant-vm' ]
+
+'docker_gen role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/docker_gen.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_docker_gen'
+    JANE_DIFF_PATTERN: '.*/debops.docker_gen/.*'
+    JANE_LOG_PATTERN: '\[debops\.docker_gen\]'
+
+'dokuwiki role':
+  <<: *test_role_2nd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/dokuwiki.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_dokuwiki'
+    JANE_DIFF_PATTERN: '.*/debops.dokuwiki/.*'
+    JANE_LOG_PATTERN: '\[debops\.dokuwiki\]'
+
+'dovecot role':
+  <<: *test_role_3rd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/dovecot.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_dovecot'
+    JANE_INVENTORY_HOSTVARS: 'dovecot_pki=false'
+    JANE_DIFF_PATTERN: '.*/debops.dovecot/.*'
+    JANE_LOG_PATTERN: '\[debops\.dovecot\]'
+
+
+# --- e --- [[[2
+
+'elastic_co role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/elastic_co.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_elastic_co'
+    JANE_DIFF_PATTERN: '.*/debops.elastic_co/.*'
+    JANE_LOG_PATTERN: '\[debops\.elastic_co\]'
+
+'elasticsearch role':
+  <<: *test_role_2nd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/elasticsearch.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_elasticsearch'
+    JANE_DIFF_PATTERN: '.*/debops.elasticsearch/.*'
+    JANE_LOG_PATTERN: '\[debops\.elasticsearch\]'
+
+'environment role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/environment.yml'
+    JANE_DIFF_PATTERN: '.*/debops.environment/.*'
+    JANE_LOG_PATTERN: '\[debops\.environment\]'
+
+'etc_aliases role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/etc_aliases.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_etc_aliases'
+    JANE_DIFF_PATTERN: '.*/debops.etc_aliases/.*'
+    JANE_LOG_PATTERN: '\[debops\.etc_aliases\]'
+
+'etc_services role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/etc_services.yml'
+    JANE_DIFF_PATTERN: '.*/debops.etc_services/.*'
+    JANE_LOG_PATTERN: '\[debops\.etc_services\]'
+
+'etherpad role':
+  <<: *test_role_2nd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/etherpad.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_etherpad'
+    JANE_DIFF_PATTERN: '.*/debops.etherpad/.*'
+    JANE_LOG_PATTERN: '\[debops\.etherpad\]'
+
+'etherpad/mariadb role':
+  <<: *test_role_2nd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/mariadb_server.yml ${DEBOPS_PLAYBOOKS}/service/etherpad.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_mariadb_server,debops_service_etherpad'
+    JANE_DIFF_PATTERN: '.*/debops.etherpad/.*'
+    JANE_LOG_PATTERN: '\[debops\.etherpad\]'
+
+
+# --- f --- [[[2
+
+'fail2ban role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/fail2ban.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_fail2ban'
+    JANE_DIFF_PATTERN: '.*/debops.fail2ban/.*'
+    JANE_LOG_PATTERN: '\[debops\.fail2ban\]'
+
+'fcgiwrap role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/fcgiwrap.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_fcgiwrap'
+    JANE_DIFF_PATTERN: '.*/debops.fcgiwrap/.*'
+    JANE_LOG_PATTERN: '\[debops\.fcgiwrap\]'
+
+'ferm role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/ferm.yml'
+    JANE_DIFF_PATTERN: '.*/debops.ferm/.*'
+    JANE_LOG_PATTERN: '\[debops\.ferm\]'
+
+
+# --- g --- [[[2
+
+'gitlab role':
+  <<: *test_role_3rd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/auth.yml ${DEBOPS_PLAYBOOKS}/service/postgresql_server.yml ${DEBOPS_PLAYBOOKS}/service/gitlab.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_auth,debops_service_postgresql_server,debops_service_gitlab'
+    JANE_INVENTORY_HOSTVARS: 'redis__overcommit_memory_enable=false postgresql__delegate_to=localhost gitlab_support_filesystem_acl=false'
+    JANE_DIFF_PATTERN: '.*/debops.gitlab/.*'
+    JANE_LOG_PATTERN: '\[debops\.gitlab\]'
+    VAGRANT_MASTER_MEMORY: '2048'
+  tags: [ 'shell', 'vagrant-vm', 'mem-4GB' ]
+
+'gitlab_runner role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/gitlab_runner.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_gitlab_runner'
+    JANE_DIFF_PATTERN: '.*/debops.gitlab_runner/.*'
+    JANE_LOG_PATTERN: '\[debops\.gitlab_runner\]'
+
+'gitlab_runner/docker role':
+  <<: *test_role_2nd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/docker.yml ${DEBOPS_PLAYBOOKS}/service/gitlab_runner.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_docker,debops_service_gitlab_runner'
+    JANE_DIFF_PATTERN: '.*/debops.gitlab_runner/.*'
+    JANE_LOG_PATTERN: '\[debops\.gitlab_runner\]'
+  tags: [ 'shell', 'vagrant-vm' ]
+
+'gitlab_runner/libvirt role':
+  <<: *test_role_2nd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/libvirtd.yml ${DEBOPS_PLAYBOOKS}/service/gitlab_runner.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_libvirtd,debops_service_gitlab_runner'
+    JANE_DIFF_PATTERN: '.*/debops.gitlab_runner/.*'
+    JANE_LOG_PATTERN: '\[debops\.gitlab_runner\]'
+  tags: [ 'shell', 'vagrant-vm' ]
+
+'gitlab_runner/lxc role':
+  <<: *test_role_2nd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/lxc.yml ${DEBOPS_PLAYBOOKS}/service/gitlab_runner.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_lxc,debops_service_gitlab_runner'
+    JANE_DIFF_PATTERN: '.*/debops.gitlab_runner/.*'
+    JANE_LOG_PATTERN: '\[debops\.gitlab_runner\]'
+  tags: [ 'shell', 'vagrant-vm' ]
+
+'gitusers role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/gitusers.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_gitusers'
+    JANE_DIFF_PATTERN: '.*/debops.gitusers/.*'
+    JANE_LOG_PATTERN: '\[debops\.gitusers\]'
+
+'golang role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/golang.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_golang'
+    JANE_DIFF_PATTERN: '.*/debops.golang/.*'
+    JANE_LOG_PATTERN: '\[debops\.golang\]'
+
+'grub role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/grub.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_grub'
+    JANE_DIFF_PATTERN: '.*/debops.grub/.*'
+    JANE_LOG_PATTERN: '\[debops\.grub\]'
+  tags: [ 'shell', 'vagrant-vm' ]
+
+'gunicorn role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/gunicorn.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_gunicorn'
+    JANE_DIFF_PATTERN: '.*/debops.gunicorn/.*'
+    JANE_LOG_PATTERN: '\[debops\.gunicorn\]'
+
+
+# --- h --- [[[2
+
+'hashicorp role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/hashicorp.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_hashicorp'
+    JANE_INVENTORY_HOSTVARS: 'hashicorp__applications=[\"consul\",\"consul-template\"]'
+    JANE_DIFF_PATTERN: '.*/debops.hashicorp/.*'
+    JANE_LOG_PATTERN: '\[debops\.hashicorp\]'
+
+'hwraid role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/hwraid.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_hwraid'
+    JANE_DIFF_PATTERN: '.*/debops.hwraid/.*'
+    JANE_LOG_PATTERN: '\[debops\.hwraid\]'
+
+
+# --- i --- [[[2
+
+'ifupdown role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/ifupdown.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_ifupdown'
+    JANE_DIFF_PATTERN: '.*/debops.ifupdown/.*'
+    JANE_LOG_PATTERN: '\[debops\.ifupdown\]'
+  tags: [ 'shell', 'vagrant-vm' ]
+
+'ipxe role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/ipxe.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_ipxe'
+    JANE_DIFF_PATTERN: '.*/debops.ipxe/.*'
+    JANE_LOG_PATTERN: '\[debops\.ipxe\]'
+
+'iscsi role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/iscsi.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_iscsi'
+    JANE_DIFF_PATTERN: '.*/debops.iscsi/.*'
+    JANE_LOG_PATTERN: '\[debops\.iscsi\]'
+  tags: [ 'shell', 'vagrant-vm' ]
+
+
+# --- j --- [[[2
+
+'java role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/java.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_java'
+    JANE_DIFF_PATTERN: '.*/debops.java/.*'
+    JANE_LOG_PATTERN: '\[debops\.java\]'
+
+
+# --- k --- [[[2
+
+'kibana role':
+  <<: *test_role_2nd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/kibana.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_kibana'
+    JANE_DIFF_PATTERN: '.*/debops.kibana/.*'
+    JANE_LOG_PATTERN: '\[debops\.kibana\]'
+
+
+# --- l --- [[[2
+
+'librenms role':
+  <<: *test_role_3rd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/apt.yml ${DEBOPS_PLAYBOOKS}/service/mariadb_server.yml ${DEBOPS_PLAYBOOKS}/service/librenms.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_apt,debops_service_mariadb_server,debops_service_librenms'
+    JANE_INVENTORY_HOSTVARS: 'apt__nonfree=true librenms__devices=[]'
+    JANE_DIFF_PATTERN: '.*/debops.librenms/.*'
+    JANE_LOG_PATTERN: '\[debops\.librenms\]'
+
+'libvirt role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/libvirt.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_libvirt'
+    JANE_DIFF_PATTERN: '.*/debops.libvirt/.*'
+    JANE_LOG_PATTERN: '\[debops\.libvirt\]'
+  tags: [ 'shell', 'vagrant-vm' ]
+
+'libvirtd role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/libvirtd.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_libvirtd'
+    JANE_DIFF_PATTERN: '.*/debops.libvirtd/.*'
+    JANE_LOG_PATTERN: '\[debops\.libvirtd\]'
+  tags: [ 'shell', 'vagrant-vm' ]
+
+'libvirtd_qemu role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/libvirtd_qemu.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_libvirtd_qemu'
+    JANE_DIFF_PATTERN: '.*/debops.libvirtd_qemu/.*'
+    JANE_LOG_PATTERN: '\[debops\.libvirtd_qemu\]'
+  tags: [ 'shell', 'vagrant-vm' ]
+
+'locales role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/locales.yml'
+    JANE_DIFF_PATTERN: '.*/debops.locales/.*'
+    JANE_LOG_PATTERN: '\[debops\.locales\]'
+
+'logrotate role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/logrotate.yml'
+    JANE_DIFF_PATTERN: '.*/debops.logrotate/.*'
+    JANE_LOG_PATTERN: '\[debops\.logrotate\]'
+
+'lvm role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/lvm.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_lvm'
+    JANE_DIFF_PATTERN: '.*/debops.lvm/.*'
+    JANE_LOG_PATTERN: '\[debops\.lvm\]'
+  tags: [ 'shell', 'vagrant-vm' ]
+
+'lxc role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/lxc.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_lxc'
+    JANE_DIFF_PATTERN: '.*/debops.lxc/.*'
+    JANE_LOG_PATTERN: '\[debops\.lxc\]'
+  tags: [ 'shell', 'vagrant-vm' ]
+
+
+# --- m --- [[[2
+
+'mailman role':
+  <<: *test_role_3rd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/mailman.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_mailman'
+    JANE_INVENTORY_HOSTVARS: 'mailman__site_list_notify=false'
+    JANE_DIFF_PATTERN: '.*/debops.mailman/.*'
+    JANE_LOG_PATTERN: '\[debops\.mailman\]'
+
+'mariadb role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/mariadb.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_mariadb'
+    JANE_DIFF_PATTERN: '.*/debops.mariadb/.*'
+    JANE_LOG_PATTERN: '\[debops\.mariadb\]'
+
+'mariadb_server role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/mariadb_server.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_mariadb_server'
+    JANE_DIFF_PATTERN: '.*/debops.mariadb_server/.*'
+    JANE_LOG_PATTERN: '\[debops\.mariadb_server\]'
+
+'mariadb_server/client role':
+  <<: *test_role_2nd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/mariadb_server.yml ${DEBOPS_PLAYBOOKS}/service/mariadb.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_mariadb_server,debops_service_mariadb'
+    JANE_INVENTORY_HOSTVARS: '/vagrant/lib/tests/inventory/mariadb_server-client.json'
+    JANE_DIFF_PATTERN: '.*/debops.mariadb/.*'
+    JANE_LOG_PATTERN: '\[debops\.mariadb\]'
+
+'memcached role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/memcached.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_memcached'
+    JANE_DIFF_PATTERN: '.*/debops.memcached/.*'
+    JANE_LOG_PATTERN: '\[debops\.memcached\]'
+
+'monit role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/monit.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_monit'
+    JANE_DIFF_PATTERN: '.*/debops.monit/.*'
+    JANE_LOG_PATTERN: '\[debops\.monit\]'
+
+'mosquitto role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/mosquitto-plain.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_mosquitto'
+    JANE_DIFF_PATTERN: '.*/debops.mosquitto/.*'
+    JANE_LOG_PATTERN: '\[debops\.mosquitto\]'
+
+'mosquitto/nginx role':
+  <<: *test_role_2nd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/mosquitto-nginx.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_mosquitto_nginx'
+    JANE_DIFF_PATTERN: '.*/debops.mosquitto/.*'
+    JANE_LOG_PATTERN: '\[debops\.mosquitto\]'
+
+
+# --- n --- [[[2
+
+'netbox role':
+  <<: *test_role_3rd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/postgresql_server.yml ${DEBOPS_PLAYBOOKS}/service/netbox.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_postgresql_server,debops_service_netbox'
+    JANE_INVENTORY_HOSTVARS: 'postgresql__delegate_to=localhost'
+    JANE_DIFF_PATTERN: '.*/debops.netbox/.*'
+    JANE_LOG_PATTERN: '\[debops\.netbox\]'
+
+'nfs role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/nfs.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_nfs'
+    JANE_DIFF_PATTERN: '.*/debops.nfs/.*'
+    JANE_LOG_PATTERN: '\[debops\.nfs\]'
+
+'nfs_server role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/nfs_server.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_nfs_server'
+    JANE_DIFF_PATTERN: '.*/debops.nfs_server/.*'
+    JANE_LOG_PATTERN: '\[debops\.nfs_server\]'
+
+'nginx role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/nginx.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_nginx'
+    JANE_DIFF_PATTERN: '.*/debops.nginx/.*'
+    JANE_LOG_PATTERN: '\[debops\.nginx\]'
+
+'nginx/passenger role':
+  <<: *test_role_2nd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/nginx.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_nginx'
+    JANE_INVENTORY_HOSTVARS: 'nginx_flavor=passenger'
+    JANE_DIFF_PATTERN: '.*/debops.nginx/.*'
+    JANE_LOG_PATTERN: '\[debops\.nginx\]'
+
+'nodejs role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/nodejs.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_nodejs'
+    JANE_DIFF_PATTERN: '.*/debops.nodejs/.*'
+    JANE_LOG_PATTERN: '\[debops\.nodejs\]'
+
+'nsswitch role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/nsswitch.yml'
+    JANE_DIFF_PATTERN: '.*/debops.nsswitch/.*'
+    JANE_LOG_PATTERN: '\[debops\.nsswitch\]'
+
+'ntp role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/ntp.yml'
+    JANE_DIFF_PATTERN: '.*/debops.ntp/.*'
+    JANE_LOG_PATTERN: '\[debops\.ntp\]'
+
+'nullmailer role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/nullmailer.yml'
+    JANE_DIFF_PATTERN: '.*/debops.nullmailer/.*'
+    JANE_LOG_PATTERN: '\[debops\.nullmailer\]'
+
+
+# --- o --- [[[2
+
+'opendkim role':
+  <<: *test_role_3rd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/opendkim.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_opendkim'
+    JANE_DIFF_PATTERN: '.*/debops.opendkim/.*'
+    JANE_LOG_PATTERN: '\[debops\.opendkim\]'
+
+# The 'debops.openvz' role is currently not considered for Debian Stretch and
+# beyond.
+
+'owncloud/apache role':
+  <<: *test_role_3rd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/mariadb_server.yml ${DEBOPS_PLAYBOOKS}/service/owncloud-apache.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_mariadb_server,debops_service_owncloud_apache'
+    JANE_DIFF_PATTERN: '.*/debops.owncloud/.*'
+    JANE_LOG_PATTERN: '\[debops\.owncloud\]'
+
+'owncloud/nginx role':
+  <<: *test_role_3rd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/mariadb_server.yml ${DEBOPS_PLAYBOOKS}/service/owncloud-nginx.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_mariadb_server,debops_service_owncloud'
+    JANE_DIFF_PATTERN: '.*/debops.owncloud/.*'
+    JANE_LOG_PATTERN: '\[debops\.owncloud\]'
+
+
+# --- p --- [[[2
+
+'persistent_paths role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/persistent_paths.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_persistent_paths'
+    JANE_DIFF_PATTERN: '.*/debops.persistent_paths/.*'
+    JANE_LOG_PATTERN: '\[debops\.persistent_paths\]'
+
+'php role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/php.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_php'
+    JANE_DIFF_PATTERN: '.*/debops.php/.*'
+    JANE_LOG_PATTERN: '\[debops\.php\]'
+
+'phpipam role':
+  <<: *test_role_2nd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/mariadb_server.yml ${DEBOPS_PLAYBOOKS}/service/phpipam.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_mariadb_server,debops_service_phpipam'
+    JANE_DIFF_PATTERN: '.*/debops.phpipam/.*'
+    JANE_LOG_PATTERN: '\[debops\.phpipam\]'
+
+'phpmyadmin role':
+  <<: *test_role_2nd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/mariadb_server.yml ${DEBOPS_PLAYBOOKS}/service/phpmyadmin.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_mariadb_server,debops_service_phpmyadmin'
+    JANE_DIFF_PATTERN: '.*/debops.phpmyadmin/.*'
+    JANE_LOG_PATTERN: '\[debops\.phpmyadmin\]'
+
+'pki role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/pki.yml'
+    JANE_DIFF_PATTERN: '.*/debops.pki/.*'
+    JANE_LOG_PATTERN: '\[debops\.pki\]'
+
+'postconf role':
+  <<: *test_role_3rd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/postconf.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_postconf'
+    JANE_DIFF_PATTERN: '.*/debops.postconf/.*'
+    JANE_LOG_PATTERN: '\[debops\.postconf\]'
+
+'postfix role':
+  <<: *test_role_2nd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/postfix.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_postfix'
+    JANE_DIFF_PATTERN: '.*/debops.postfix/.*'
+    JANE_LOG_PATTERN: '\[debops\.postfix\]'
+
+'postgresql role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/postgresql.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_postgresql'
+    JANE_DIFF_PATTERN: '.*/debops.postgresql/.*'
+    JANE_LOG_PATTERN: '\[debops\.postgresql\]'
+
+'postgresql_server role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/postgresql_server.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_postgresql_server'
+    JANE_DIFF_PATTERN: '.*/debops.postgresql_server/.*'
+    JANE_LOG_PATTERN: '\[debops\.postgresql_server\]'
+
+'postgresql_server/client role':
+  <<: *test_role_2nd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/postgresql_server.yml ${DEBOPS_PLAYBOOKS}/service/postgresql.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_postgresql_server,debops_service_postgresql'
+    JANE_INVENTORY_HOSTVARS: '/vagrant/lib/tests/inventory/postgresql_server-client.json'
+    JANE_DIFF_PATTERN: '.*/debops.postgresql/.*'
+    JANE_LOG_PATTERN: '\[debops\.postgresql\]'
+
+'postscreen role':
+  <<: *test_role_3rd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/postscreen.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_postscreen'
+    JANE_DIFF_PATTERN: '.*/debops.postscreen/.*'
+    JANE_LOG_PATTERN: '\[debops\.postscreen\]'
+
+'postwhite role':
+  <<: *test_role_3rd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/postwhite.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_postwhite'
+    JANE_DIFF_PATTERN: '.*/debops.postwhite/.*'
+    JANE_LOG_PATTERN: '\[debops\.postscreen\]'
+
+'preseed role':
+  <<: *test_role_2nd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/preseed.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_preseed'
+    JANE_DIFF_PATTERN: '.*/debops.preseed/.*'
+    JANE_LOG_PATTERN: '\[debops\.preseed\]'
+
+
+# --- r --- [[[2
+
+'rabbitmq_management role':
+  <<: *test_role_2nd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/rabbitmq_management.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_rabbitmq_management'
+    JANE_DIFF_PATTERN: '.*/debops.rabbitmq_management/.*'
+    JANE_LOG_PATTERN: '\[debops\.rabbitmq_management\]'
+
+'rabbitmq_server role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/rabbitmq_server.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_rabbitmq_server'
+    JANE_DIFF_PATTERN: '.*/debops.rabbitmq_server/.*'
+    JANE_LOG_PATTERN: '\[debops\.rabbitmq_server\]'
+
+'radvd role':
+  <<: *test_role_2nd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/ifupdown.yml ${DEBOPS_PLAYBOOKS}/service/radvd.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_ifupdown,debops_service_radvd'
+    JANE_INVENTORY_HOSTVARS: '/vagrant/lib/tests/inventory/radvd.json'
+    JANE_DIFF_PATTERN: '.*/debops.radvd/.*'
+    JANE_LOG_PATTERN: '\[debops\.radvd\]'
+  tags: [ 'shell', 'vagrant-vm' ]
+
+'redis role':
+  <<: *test_role_2nd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/redis.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_redis'
+    JANE_INVENTORY_HOSTVARS: 'redis__overcommit_memory_enable=false'
+    JANE_DIFF_PATTERN: '.*/debops.redis/.*'
+    JANE_LOG_PATTERN: '\[debops\.redis\]'
+
+'reprepro role':
+  <<: *test_role_2nd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/reprepro.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_reprepro'
+    JANE_INVENTORY_HOSTVARS: 'reprepro_gpg_key_length=\"512\"'
+    JANE_DIFF_PATTERN: '.*/debops.reprepro/.*'
+    JANE_LOG_PATTERN: '\[debops\.reprepro\]'
+
+'resources role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/resources.yml'
+    JANE_DIFF_PATTERN: '.*/debops.resources/.*'
+    JANE_LOG_PATTERN: '\[debops\.resources\]'
+
+'root_account role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/root_account.yml'
+    JANE_DIFF_PATTERN: '.*/debops.root_account/.*'
+    JANE_LOG_PATTERN: '\[debops\.root_account\]'
+
+'rsnapshot role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/rsnapshot.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_rsnapshot'
+    JANE_DIFF_PATTERN: '.*/debops.rsnapshot/.*'
+    JANE_LOG_PATTERN: '\[debops\.rsnapshot\]'
+
+'rstudio_server role':
+  <<: *test_role_3rd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/rstudio_server.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_rstudio_server'
+    JANE_DIFF_PATTERN: '.*/debops.rstudio_server/.*'
+    JANE_LOG_PATTERN: '\[debops\.rstudio_server\]'
+
+'rsyslog role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/rsyslog.yml'
+    JANE_DIFF_PATTERN: '.*/debops.rsyslog/.*'
+    JANE_LOG_PATTERN: '\[debops\.rsyslog\]'
+
+'ruby role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/ruby.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_ruby'
+    JANE_DIFF_PATTERN: '.*/debops.ruby/.*'
+    JANE_LOG_PATTERN: '\[debops\.ruby\]'
+
+
+# --- s --- [[[2
+
+'salt role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/salt.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_salt'
+    JANE_DIFF_PATTERN: '.*/debops.salt/.*'
+    JANE_LOG_PATTERN: '\[debops\.salt\]'
+
+'samba role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/samba.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_samba'
+    JANE_INVENTORY_HOSTVARS: 'samba__kernel_modules_load=false'
+    JANE_DIFF_PATTERN: '.*/debops.samba/.*'
+    JANE_LOG_PATTERN: '\[debops\.samba\]'
+
+'saslauthd role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/saslauthd.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_saslauthd'
+    JANE_DIFF_PATTERN: '.*/debops.saslauthd/.*'
+    JANE_LOG_PATTERN: '\[debops\.saslauthd\]'
+
+'secret role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/apt_proxy.yml'
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/secret.yml'
+    JANE_DIFF_PATTERN: '.*/debops.secret/.*'
+    JANE_LOG_PATTERN: '\[debops\.secret\]'
+
+'sftpusers role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/sftpusers.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_sftpusers'
+    JANE_DIFF_PATTERN: '.*/debops.sftpusers/.*'
+    JANE_LOG_PATTERN: '\[debops\.sftpusers\]'
+
+'sks role':
+  <<: *test_role_2nd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/sks.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_sks'
+    JANE_DIFF_PATTERN: '.*/debops.sks/.*'
+    JANE_LOG_PATTERN: '\[debops\.sks\]'
+
+'slapd role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/slapd.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_slapd'
+    JANE_INVENTORY_HOSTVARS: 'slapd_pki=false'
+    JANE_DIFF_PATTERN: '.*/debops.slapd/.*'
+    JANE_LOG_PATTERN: '\[debops\.slapd\]'
+
+'smstools role':
+  <<: *test_role_3rd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/smstools.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_smstools'
+    JANE_DIFF_PATTERN: '.*/debops.smstools/.*'
+    JANE_LOG_PATTERN: '\[debops\.smstools\]'
+
+'snmpd role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/snmpd.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_snmpd'
+    JANE_DIFF_PATTERN: '.*/debops.snmpd/.*'
+    JANE_LOG_PATTERN: '\[debops\.snmpd\]'
+
+'sshd role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/sshd.yml'
+    JANE_INVENTORY_HOSTVARS: 'sshd__allow_groups=[\"root\",\"admins\",\"vagrant\"]'
+    JANE_DIFF_PATTERN: '.*/debops.sshd/.*'
+    JANE_LOG_PATTERN: '\[debops\.sshd\]'
+
+'stunnel role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/stunnel.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_stunnel'
+    JANE_DIFF_PATTERN: '.*/debops.stunnel/.*'
+    JANE_LOG_PATTERN: '\[debops\.stunnel\]'
+
+'swapfile role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/swapfile.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_swapfile'
+    JANE_DIFF_PATTERN: '.*/debops.swapfile/.*'
+    JANE_LOG_PATTERN: '\[debops\.swapfile\]'
+  tags: [ 'shell', 'vagrant-vm' ]
+
+'sysctl role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/sysctl.yml'
+    JANE_DIFF_PATTERN: '.*/debops.sysctl/.*'
+    JANE_LOG_PATTERN: '\[debops\.sysctl\]'
+  tags: [ 'shell', 'vagrant-vm' ]
+
+'sysfs role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/sysfs.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_sysfs'
+    JANE_INVENTORY_HOSTVARS: '/vagrant/lib/tests/inventory/sysfs.json'
+    JANE_DIFF_PATTERN: '.*/debops.sysfs/.*'
+    JANE_LOG_PATTERN: '\[debops\.sysfs\]'
+  tags: [ 'shell', 'vagrant-vm' ]
+
+
+# --- t --- [[[2
+
+'tcpwrappers role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/tcpwrappers.yml'
+    JANE_DIFF_PATTERN: '.*/debops.tcpwrappers/.*'
+    JANE_LOG_PATTERN: '\[debops\.tcpwrappers\]'
+
+'tftpd role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/tftpd.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_tftpd'
+    JANE_DIFF_PATTERN: '.*/debops.tftpd/.*'
+    JANE_LOG_PATTERN: '\[debops\.tftpd\]'
+
+'tgt role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/tgt.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_tgt'
+    JANE_DIFF_PATTERN: '.*/debops.tgt/.*'
+    JANE_LOG_PATTERN: '\[debops\.tgt\]'
+
+'tinc/gateway role':
+  <<: *test_role_3rd_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/ifupdown.yml ${DEBOPS_PLAYBOOKS}/service/tinc.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_ifupdown,debops_service_tinc'
+    JANE_INVENTORY_HOSTVARS: '/vagrant/lib/tests/inventory/tinc-gateway.json'
+    JANE_DIFF_PATTERN: '.*/debops.tinc/.*'
+    JANE_LOG_PATTERN: '\[debops\.tinc\]'
+  tags: [ 'shell', 'vagrant-vm' ]
+
+
+# --- u --- [[[2
+
+'unattended_upgrades role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/unattended_upgrades.yml'
+    JANE_DIFF_PATTERN: '.*/debops.unattended_upgrades/.*'
+    JANE_LOG_PATTERN: '\[debops\.unattended_upgrades\]'
+
+'unbound role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/unbound.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_unbound'
+    JANE_DIFF_PATTERN: '.*/debops.unbound/.*'
+    JANE_LOG_PATTERN: '\[debops\.unbound\]'
+
+'users role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/users.yml'
+    JANE_DIFF_PATTERN: '.*/debops.users/.*'
+    JANE_LOG_PATTERN: '\[debops\.users\]'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,6 +49,10 @@ Added
 - [debops.libvirtd] The role can now detect if nested KVM is enabled in
   a particular virtual machine and install KVM support.
 
+- DebOps roles and playbooks can now be tested using local or remote
+  `GitLab CI <https://about.gitlab.com/>`_ instance, with Vagrant, KVM and LXC
+  technologies and some custom scripts.
+
 Changed
 ~~~~~~~
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,61 +26,362 @@
 #         parameters (3072, 2048) instead of a smaller one (1024). Initial DH
 #         parameter generation may take a long time.
 #
-#     APT_CACHE=""             (http://apt.example.org:3142)
+#     APT_HTTP_PROXY=""           (http://apt.example.org:3142)
 #         Set a custom APT cache URL inside the Vagrant box.
 
 
-$set_environment_variables = <<SCRIPT
-tee "/etc/profile.d/vagrant_vars.sh" > "/dev/null" <<EOF
-export VAGRANT_ENVIRONMENT="true"
-EOF
-SCRIPT
+$provision_box = <<SCRIPT
+set -o nounset -o pipefail -o errexit
 
-$set_apt_cache = <<SCRIPT
-if [ -n "#{ENV['APT_CACHE']}" ] ; then
-    printf "%s\n" "Configuring APT cache at '#{ENV['APT_CACHE']}'..."
-    cat <<EOF | sudo tee /etc/apt/apt.conf.d/00aptproxy
-Acquire::http::Proxy "#{ENV['APT_CACHE']}";
+export JANE_VAGRANT_INCEPTION="true"
+readonly PROVISION_CI="#{ENV['CI']}"
+readonly PROVISION_GITLAB_CI="#{ENV['GITLAB_CI']}"
+readonly PROVISION_VAGRANT_HOSTNAME="#{ENV['VAGRANT_HOSTNAME']}"
+readonly PROVISION_APT_HTTP_PROXY="#{ENV['APT_HTTP_PROXY']}"
+readonly PROVISION_APT_HTTPS_PROXY="#{ENV['APT_HTTPS_PROXY']}"
+readonly PROVISION_ANSIBLE_FROM="#{ENV['ANSIBLE_FROM'] || 'debian'}"
+
+# Install the Jane script
+if ! type jane > /dev/null 2>&1 ; then
+    export JANE_BOX_INIT="true"
+    if [ -e "/vagrant/lib/tests/jane" ] ; then
+        cp /vagrant/lib/tests/jane /usr/local/bin/jane && chmod +x /usr/local/bin/jane
+        jane notify info "Jane installed"
+    else
+        tee "/usr/local/bin/jane" > "/dev/null" <<EOF
+#!/bin/sh
+
+# Fake stub Jane script
+printf "%s\\n" "JANE: \\${\*}"
+EOF
+    chmod +x /usr/local/bin/jane
+    fi
+else
+    if [ -e "/vagrant/lib/tests/jane" ] ; then
+        if ! cmp "/vagrant/lib/tests/jane" "/usr/local/bin/jane" ; then
+            cp /vagrant/lib/tests/jane /usr/local/bin/jane && chmod +x /usr/local/bin/jane
+            jane notify info "Jane updated"
+        else
+            jane notify ok "Jane up to date"
+        fi
+    else
+        jane notify ok "Jane found at '$(which jane)'"
+    fi
+fi
+
+# Disable automated APT operations as soon as possible.  This is only valid for
+# testing environments and helps avoid errors due to locked APT/dpkg.
+# https://unix.stackexchange.com/questions/315502/
+if [ -n "${PROVISION_CI}" ] ; then
+
+   jane notify info "Stopping apt-daily.service..."
+   systemctl stop apt-daily.service || true
+   systemctl kill --kill-who=all apt-daily.service || true
+   systemctl stop apt-daily.timer || true
+
+   next_wait_time=0
+   until systemctl list-units --all apt-daily.service | fgrep -q dead || [ $next_wait_time -eq 2 ] ; do
+       jane notify info "Waiting for apt-daily.service to go down..."
+       sleep $(( next_wait_time++ ))
+   done
+
+   jane notify info "Stopping apt-daily-upgrade.service..."
+   systemctl stop apt-daily-upgrade.service || true
+   systemctl kill --kill-who=all apt-daily-upgrade.service || true
+   systemctl stop apt-daily-upgrade.timer || true
+
+   next_wait_time=1
+   until systemctl list-units --all apt-daily-upgrade.service | fgrep -q dead || [ $next_wait_time -eq 4 ] ; do
+       jane notify info "Waiting for apt-daily-upgrade.service to go down..."
+       sleep $(( next_wait_time++ ))
+   done
+
+   rm -rf /var/lib/systemd/timers/*.timer
+fi
+
+# Configure APT proxy
+if [ -n "${PROVISION_APT_HTTP_PROXY}" ] ; then
+    tee "/etc/apt/apt.conf.d/00aptproxy" > "/dev/null" <<EOF
+Acquire::http::Proxy "${PROVISION_APT_HTTP_PROXY}";
+Acquire::https::Proxy "false";
+EOF
+    if [ -n "${PROVISION_APT_HTTPS_PROXY}" ] ; then
+        tee -a "/etc/apt/apt.conf.d/00aptproxy" > "/dev/null" <<EOF
+Acquire::https::Proxy "${PROVISION_APT_HTTPS_PROXY}";
+EOF
+    else
+        tee -a "/etc/apt/apt.conf.d/00aptproxy" > "/dev/null" <<EOF
+Acquire::https::Proxy "DIRECT";
+EOF
+    fi
+fi
+
+# Configure GitLab CI environment
+if [ -n "${PROVISION_GITLAB_CI}" ] && [ "${PROVISION_GITLAB_CI}" == "true" ] ; then
+    tee "/etc/profile.d/vagrant_vars.sh" > "/dev/null" <<EOF
+export JANE_INCEPTION="true"
+export CI="#{ENV['CI']}"
+export GITLAB_CI="#{ENV['GITLAB_CI']}"
+export CI_JOB_ID="#{ENV['CI_JOB_ID']}"
+export CI_JOB_NAME="#{ENV['CI_JOB_NAME']}"
+export CI_JOB_STAGE="#{ENV['CI_JOB_STAGE']}"
+export JANE_TEST_PLAY="#{ENV['JANE_TEST_PLAY']}"
+export JANE_FORCE_TESTS="#{ENV['JANE_FORCE_TESTS']}"
+export JANE_INVENTORY_GROUPS="#{ENV['JANE_INVENTORY_GROUPS']}"
+export JANE_INVENTORY_HOSTVARS="#{ENV['JANE_INVENTORY_HOSTVARS']}"
+export JANE_KEEP_BOX="#{ENV['JANE_KEEP_BOX']}"
+export VAGRANT_BOX="#{ENV['VAGRANT_BOX']}"
+export VAGRANT_DOTFILE_PATH="#{ENV['VAGRANT_DOTFILE_PATH']}"
+export TERM="#{ENV['TERM']}"
 EOF
 fi
-SCRIPT
 
-$set_hostname = <<SCRIPT
-if [ -n "#{ENV['VAGRANT_HOSTNAME']}" ] ; then
-    export REAL_HOSTNAME="#{ENV['VAGRANT_HOSTNAME']}"
+provision_apt_http_proxy=""
+provision_apt_https_proxy=""
+eval $(apt-config shell provision_apt_http_proxy Acquire::http::Proxy)
+eval $(apt-config shell provision_apt_https_proxy Acquire::https::Proxy)
+
+if [ -n "${provision_apt_http_proxy}" ] ; then
+    jane notify config "APT HTTP proxy is enabled: '${provision_apt_http_proxy}'"
+fi
+
+if [ -n "${provision_apt_https_proxy}" ] ; then
+    if [ "${provision_apt_https_proxy}" == "DIRECT" ] ; then
+        jane notify config "APT HTTPS proxy is disabled"
+    else
+        jane notify config "APT HTTPS proxy is enabled: '${provision_apt_https_proxy}'"
+    fi
+fi
+
+# Configure hostname and domain
+REAL_HOSTNAME=""
+if [ -n "${PROVISION_VAGRANT_HOSTNAME}" ] ; then
+    export REAL_HOSTNAME="${PROVISION_VAGRANT_HOSTNAME}"
+elif [ -n "${PROVISION_GITLAB_CI}" ] && [ "${PROVISION_GITLAB_CI}" == "true" ] ; then
+    export REAL_HOSTNAME="ci-$(cat /proc/sys/kernel/random/uuid)"
 fi
 
 if [ -n "${REAL_HOSTNAME}" ] ; then
-    printf "%s\n" "Changing the hostname to '${REAL_HOSTNAME}'..."
+    current_fqdn="$(dnsdomainname -A)"
+    jane notify info "Changing box hostname to '${REAL_HOSTNAME}'..."
     if [ -d /run/systemd/system ] ; then
-        hostnamectl set-hostname ${REAL_HOSTNAME}
-        systemctl restart networking.service
+        hostnamectl set-hostname "${REAL_HOSTNAME}"
+        if [ "$(systemctl is-active systemd-networkd.service)" == "active" ] ; then
+            jane notify info "Requesting restart of 'systemd-networkd.service'"
+            systemctl restart systemd-networkd.service
+        else
+            jane notify info "Requesting restart of 'networking.service'..."
+            systemctl restart networking.service
+        fi
     else
-        hostname ${REAL_HOSTNAME}
-        echo "${REAL_HOSTNAME}" > /etc/hostname
+        hostname "${REAL_HOSTNAME}"
+        printf "%s\n" "${REAL_HOSTNAME}" > /etc/hostname
+        jane notify info "Requesting restart of 'networking' service..."
         /etc/init.d/networking restart
     fi
+    jane notify info "Waiting for network configuration to settle..."
+    loop_timeout=5
+    sleep 2
+    until [ "$(dnsdomainname -A)" != "${current_fqdn}" ] || [ ${loop_timeout} -eq 7 ] ; do
+        jane notify info "Waiting for new FQDNs..."
+        sleep $(( loop_timeout++ ))
+    done
+    if [ -z "$(dnsdomainname)" ] ; then
+        jane notify warning "DNS domain configuration failed, enforcing in /etc/hosts...."
+        known_fqdns=( $(dnsdomainname -A) )
+        for item in "${!known_fqdns[@]}" ; do
+            case "${known_fqdns[${item}]}" in
+                *.*)
+                    jane notify info "Adding FQDN: '${known_fqdns[${item}]}'..."
+                    ip_index="$(( ${item} + 1 ))"
+                    printf "%s\n" "127.0.1.${ip_index} ${known_fqdns[${item}]} $(hostname)" >> /etc/hosts
+                    ;;
+            esac
+        done
+    fi
+    if [ "${REAL_HOSTNAME}" == "$(hostname)" ] ; then
+        jane notify ok "Hostname changed successfully"
+        jane notify info "Hostname: '$(hostname)'"
+        jane notify info "Domain: '$(dnsdomainname)'"
+        jane notify info "FQDN: '$(hostname --fqdn)'"
+    else
+        jane notify warning "Hostname change to '${REAL_HOSTNAME}' failed"
+    fi
 fi
-SCRIPT
 
-$bootstrap_ansible_debops = <<SCRIPT
-set -o nounset -o pipefail -o errexit
+ansible_from_debian=""
+ansible_from_pypi=""
+ansible_from_devel=""
+if [ "${PROVISION_ANSIBLE_FROM}" == "debian" ] ; then
+    ansible_from_debian="ansible"
+elif [ "${PROVISION_ANSIBLE_FROM}" == "pypi" ] ; then
+    ansible_from_pypi="ansible"
+else
+    ansible_from_devel="${PROVISION_ANSIBLE_FROM}"
+fi
 
+# Configure Ansible
 if ! type ansible > /dev/null 2>&1 ; then
-    sudo apt-get update
-    sudo DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends -yq install python-pip python-wheel python-setuptools vim ranger tree encfs sshfs git
-    sudo pip install pycodestyle unittest2 nose2 cov-core sphinx_rtd_theme yamllint ansible debops
+    jane notify warning "Ansible not found"
+
+    tee "/etc/apt/sources.list" > "/dev/null" <<EOF
+deb http://deb.debian.org/debian stretch main
+deb http://deb.debian.org/debian stretch-updates main
+deb http://deb.debian.org/debian stretch-backports main
+deb http://security.debian.org/ stretch/updates main
+EOF
+
+    tee "/etc/apt/preferences.d/provision_ansible.pref" > "/dev/null" <<EOF
+Package: ansible
+Pin: release a=stretch-backports
+Pin-Priority: 500
+EOF
+
+    jane notify cache "Refreshing APT cache"
+    apt-get update
+
+    if [ -n "${ansible_from_devel}" ] ; then
+        jane notify install "Installing Ansible from GitHub..."
+        /vagrant/ansible/roles/debops.debops/files/script/bootstrap-ansible.sh "${ansible_from_devel}"
+    fi
+
+    jane notify install "Installing Ansible requirements via APT..."
+    DEBIAN_FRONTEND=noninteractive apt-get -y \
+    --no-install-recommends install \
+        apt-transport-https \
+        encfs \
+        git \
+        haveged \
+        jo \
+        make \
+        python-apt \
+        python-jinja2 \
+        python-ldap \
+        python-nose2 \
+        python-nose2-cov \
+        python-openssl \
+        python-passlib \
+        python-pip \
+        python-pycodestyle \
+        python-pytest \
+        python-pytest-cov \
+        python-setuptools \
+        python-sphinx \
+        python-sphinx-rtd-theme \
+        python-unittest2 \
+        python-wheel \
+        python-yaml \
+        shellcheck \
+        yamllint ${ansible_from_debian}
+
+    jane notify cache "Cleaning up cache directories..."
+    find /var/lib/apt/lists -maxdepth 1 -type f ! -name 'lock' -delete
+    find /var/cache/apt/archives -maxdepth 1 -name '*.deb' -delete
+    rm -rf /root/.cache/* /tmp/*
+else
+    jane notify ok "Ansible found at '$(which ansible)'"
+    ansible --version
 fi
+
+# Update APT cache on the first boot after provisioning so that APT packages
+# can be installed correctly right away.
+if [ -z "${JANE_BOX_INIT:-}" ] ; then
+    jane notify cache "Refreshing APT cache"
+    apt-get update
+
+    # vagrant-libvirt executes virt-sysprep during box packaging.
+    # virt-sysprep zeroes out files in /usr/local/*, apparently.
+    # So we need to install PyPI packages on the real box, not the template.
+    jane notify install "Installing test requirements via PyPI..."
+    pip install debops testinfra ${ansible_from_pypi}
+    jane notify cache "Cleaning up cache directories..."
+    rm -rf /root/.cache/* /tmp/*
+fi
+
+jane notify success "Vagrant box provisioning complete"
 SCRIPT
 
-$setup_controller = <<SCRIPT
+$provision_node_box = <<SCRIPT
 set -o nounset -o pipefail -o errexit
+
+JANE_VAGRANT_INCEPTION="true"
+PROVISION_GITLAB_CI="#{ENV['GITLAB_CI']}"
+PROVISION_APT_HTTP_PROXY="#{ENV['APT_HTTP_PROXY']}"
+PROVISION_APT_HTTPS_PROXY="#{ENV['APT_HTTPS_PROXY']}"
+
+# Configure GitLab CI environment
+if [ -n "${PROVISION_GITLAB_CI}" ] && [ "${PROVISION_GITLAB_CI}" == "true" ] ; then
+    tee "/etc/profile.d/vagrant_vars.sh" > "/dev/null" <<EOF
+export JANE_INCEPTION="true"
+export CI="#{ENV['CI']}"
+export GITLAB_CI="#{ENV['GITLAB_CI']}"
+export CI_JOB_ID="#{ENV['CI_JOB_ID']}"
+export TERM="#{ENV['TERM']}"
+EOF
+fi
+
+# Install the CI supervisor script
+if ! type jane > /dev/null 2>&1 ; then
+    if [ -e "/vagrant/lib/tests/jane" ] ; then
+        cp /vagrant/lib/tests/jane /usr/local/bin/jane && chmod +x /usr/local/bin/jane
+        jane notify info "Jane installed"
+    else
+        tee "/usr/local/bin/jane" > "/dev/null" <<EOF
+#!/bin/sh
+
+# Fake Jane script
+printf "%s\\n" "JANE: \\${*}"
+EOF
+    chmod +x /usr/local/bin/jane
+    fi
+else
+    jane notify ok "Jane found at '$(which jane)'"
+
+    jane notify info "Refreshing APT sources"
+    apt-get -qq update
+fi
+
+# Configure hostname and domain
+REAL_HOSTNAME="ci-$(cat /proc/sys/kernel/random/uuid)"
+
+if [ -n "${REAL_HOSTNAME}" ] ; then
+    jane notify info "Changing box hostname to '${REAL_HOSTNAME}'..."
+    if [ -d /run/systemd/system ] ; then
+        hostnamectl set-hostname "${REAL_HOSTNAME}"
+        systemctl restart networking.service
+    else
+        hostname "${REAL_HOSTNAME}"
+        printf "%s\n" "${REAL_HOSTNAME}" > /etc/hostname
+        /etc/init.d/networking restart
+    fi
+    jane notify ok "Hostname changed to '$(hostname)'"
+    jane notify info "FQDN: '$(hostname --fqdn)'"
+    jane notify info "DOMAIN: '$(dnsdomainname)'"
+fi
+
+# Configure APT cache
+if [ -n "${PROVISION_APT_HTTP_PROXY}" ] ; then
+    jane notify info "Configuring APT cache at '${PROVISION_APT_HTTP_PROXY}'"
+    cat "/etc/apt/apt.conf.d/00aptproxy" <<EOF
+Acquire::http::Proxy "${PROVISION_APT_HTTP_PROXY}";
+EOF
+fi
+
+jane notify info "Vagrant node provisioning complete"
+SCRIPT
+
+$provision_controller = <<SCRIPT
+set -o nounset -o pipefail -o errexit
+
+jane notify info "Configuring Ansible Controller host..."
 
 if ! [ -e .local/share/debops/debops ] ; then
     mkdir -p src .local/share/debops
     if [ -d "/vagrant" ] ; then
+        jane notify info "Symlinking '/vagrant' to '~vagrant/.local/share/debops/debops'"
         ln -s /vagrant .local/share/debops/debops
     else
+        jane notify info "Installing DebOps monorepo to '~vagrant/.local/share/debops/debops'"
         debops-update
     fi
 fi
@@ -90,33 +391,67 @@ if ! [ -d src/controller ] ; then
     sed -i '/ansible_connection=local$/ s/^#//' src/controller/ansible/inventory/hosts
     mkdir -p "src/controller/ansible/inventory/host_vars/$(hostname)"
     if [ -z "#{ENV['CONTROLLER']}" ] || [ "#{ENV['CONTROLLER']}" != "true" ] ; then
-        echo "---\n\n# Use smaller DH parameters to speed up test runs\ndhparam__bits: [ '1024' ]" > "src/controller/ansible/inventory/host_vars/$(hostname)/dhparam.yml"
+        printf "%s\n" "---\n\n# Use smaller DH parameters to speed up test runs\ndhparam__bits: [ '1024' ]" > "src/controller/ansible/inventory/host_vars/$(hostname)/dhparam.yml"
     fi
 fi
+
+jane notify info "Ansible Controller provisioning complete"
 SCRIPT
+
+VAGRANT_NODES = ENV['VAGRANT_NODES'] || 0
+VAGRANT_NODE_BOX = ENV['VAGRANT_NODE_BOX'] || 'debian/stretch64'
 
 Vagrant.configure("2") do |config|
 
-  config.vm.box = ENV['VAGRANT_BOX'] || 'debian/stretch64'
+    config.vm.define "master", primary: true do |subconfig|
+        subconfig.vm.box = ENV['VAGRANT_BOX'] || 'debian/stretch64'
+        subconfig.vm.provision "shell", inline: $provision_box, keep_color: true, run: "always"
 
-  config.vm.provision "shell", inline: $set_environment_variables
-  config.vm.provision "shell", inline: $set_apt_cache
-  config.vm.provision "shell", inline: $set_hostname
-  config.vm.provision "shell", inline: $bootstrap_ansible_debops, privileged: false
-  config.vm.provision "shell", inline: $setup_controller, privileged: false
+        subconfig.vm.provider "libvirt" do |libvirt, override|
+            # On a libvirt provider, default sync method is NFS. If we switch
+            # it to 'rsync', this will drop the dependency on NFS on the host.
+            override.vm.synced_folder ENV['CI_PROJECT_DIR'] || ".", "/vagrant", type: "rsync"
 
-  if Vagrant.has_plugin? 'vagrant-cachier'
-    config.cache.enable :apt
-    config.cache.scope = :box
-  end
+            override.vm.network :public_network, :dev => ENV['VAGRANT_MASTER_PUBLIC_BRIDGE'] || 'br0', :type => 'bridge'
 
-  if Vagrant::Util::Platform.windows? then
-    # MS Windows doesn't support symlinks, so disable directory sync under it.
-    # DebOps will be installed normally, via 'debops-update'
-    config.vm.synced_folder ".", "/vagrant", disabled: true
-  end
+            libvirt.random_hostname = true
+            libvirt.memory = ENV['VAGRANT_MASTER_MEMORY'] || '512'
 
-  config.vm.post_up_message = "Thanks for trying DebOps! After logging in, run:
-      cd src/controller ; debops"
+            if ENV['VAGRANT_BOX'] || 'debian/stretch64' == 'debian/stretch64'
+                override.ssh.insert_key = false
+            end
+        end
+
+        if ENV['GITLAB_CI'] != "true"
+            subconfig.vm.provision "shell", inline: $provision_controller, keep_color: true, privileged: false
+        end
+
+        if Vagrant::Util::Platform.windows? then
+            # MS Windows doesn't support symlinks, so disable directory sync under it.
+            # DebOps will be installed normally, via 'debops-update'
+            subconfig.vm.synced_folder ".", "/vagrant", disabled: true
+        elsif ENV['GITLAB_CI'] == "true"
+            # We are running in a GitLab CI environment
+            subconfig.vm.synced_folder ENV['CI_PROJECT_DIR'] || ".", "/vagrant"
+        end
+
+        if ENV['CI'] != "true"
+            subconfig.vm.post_up_message = "Thanks for trying DebOps! After logging in, run:
+            cd src/controller ; debops"
+        end
+    end
+
+    if VAGRANT_NODES != 0
+        (1..VAGRANT_NODES).each do |i|
+            config.vm.define "node#{i}", autostart: false do |node|
+
+                node.vm.box = VAGRANT_NODE_BOX
+                node.vm.provision "shell", inline: $provision_node_box, keep_color: true, run: "always"
+
+                # Don't populate '/vagrant' directory on other nodes
+                node.vm.synced_folder ".", "/vagrant", disabled: true
+            end
+        end
+    end
 
 end

--- a/lib/tests/ansible.cfg
+++ b/lib/tests/ansible.cfg
@@ -1,0 +1,9 @@
+[defaults]
+force_color = 1
+retry_files_enabled = false
+roles_path = /vagrant/ansible/roles
+lookup_plugins = /vagrant/ansible/playbooks/lookup_plugins
+filter_plugins = /vagrant/ansible/playbooks/filter_plugins
+control_path       = /tmp/ansible-ssh-%%p-%%r
+allow_world_readable_tmpfiles = true
+pipelining = True

--- a/lib/tests/inventory/dnsmasq.json
+++ b/lib/tests/inventory/dnsmasq.json
@@ -1,0 +1,8 @@
+{
+   "ifupdown__host_interfaces": {
+      "br2": {
+         "inet": "static",
+         "address": "192.168.247.1/24"
+      }
+   }
+}

--- a/lib/tests/inventory/mariadb_server-client.json
+++ b/lib/tests/inventory/mariadb_server-client.json
@@ -1,0 +1,12 @@
+{
+   "mariadb__databases": [
+      "testdb"
+   ],
+   "mariadb__users": [
+      {
+         "name": "testuser",
+         "owner": "vagrant",
+         "home": "/home/vagrant"
+      }
+   ]
+}

--- a/lib/tests/inventory/postgresql_server-client.json
+++ b/lib/tests/inventory/postgresql_server-client.json
@@ -1,0 +1,32 @@
+{
+   "postgresql__roles": [
+      {
+         "name": "testrole"
+      },
+      {
+         "name": "testrole_production",
+         "flags": [
+            "NOLOGIN"
+         ]
+      }
+   ],
+   "postgresql__databases": [
+      {
+         "name": "testrole_production",
+         "owner": "testrole_production"
+      }
+   ],
+   "postgresql__groups": [
+      {
+         "roles": [ "testrole" ],
+         "groups": [ "testrole_production" ],
+         "database": "testrole_production"
+      }
+   ],
+   "postgresql__pgpass": [
+      {
+         "owner": "vagrant"
+      }
+   ],
+   "postgresql__delegate_to": "localhost"
+}

--- a/lib/tests/inventory/radvd.json
+++ b/lib/tests/inventory/radvd.json
@@ -1,0 +1,9 @@
+{
+   "ifupdown__host_interfaces": {
+      "br2": {
+         "inet": "static",
+         "inet6": "static",
+         "addresses": [ "192.168.247.1/24", "fd66:374a:d2c7:b899::1/64" ]
+      }
+   }
+}

--- a/lib/tests/inventory/sysfs.json
+++ b/lib/tests/inventory/sysfs.json
@@ -1,0 +1,12 @@
+{
+   "sysfs__attributes": [
+      {
+         "name": "ksm",
+         "state": "present"
+      },
+      {
+         "name": "transparent_hugepages",
+         "state": "present"
+      }
+   ]
+}

--- a/lib/tests/inventory/tinc-gateway.json
+++ b/lib/tests/inventory/tinc-gateway.json
@@ -1,0 +1,14 @@
+{
+   "ifupdown__host_interfaces": {
+      "br2": {
+         "inet": "static",
+         "address": "192.168.247.1/24",
+         "nat": true
+      }
+   },
+   "tinc__host_networks": {
+      "mesh0": {
+         "bridge": "br2"
+      }
+   }
+}

--- a/lib/tests/jane
+++ b/lib/tests/jane
@@ -1,0 +1,940 @@
+#!/usr/bin/env bash
+
+# jane: Just ANother Executor
+# Perform Ansible role tests using GitLab CI and Vagrant
+
+# Copyright (C) 2017 Maciej Delmanowski <drybjed@gmail.com>
+# Copyright (C) 2017 DebOps project https://debops.org/
+
+
+# This file is part of DebOps.
+#
+# DebOps is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# DebOps is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with DebOps. If not, see https://www.gnu.org/licenses/.
+
+
+set -o nounset -o pipefail -o errexit
+
+
+require_bash_4 () {
+    if (( BASH_VERSINFO[0] < 4 )) ; then
+        printf "Error: This script requires Bash 4.x\n"
+        exit 1
+    fi
+}
+
+require_bash_4
+
+
+readonly SCRIPTNAME="$( basename "${0}" )"
+readonly SCRIPTDIR="$( readlink -m "$( dirname "${0}" )" )"
+readonly SCRIPTPID="$$"
+readonly ARGS=( "${@:-}" )
+readonly PATH="${PATH}:${HOME}/.local/lib/${SCRIPTNAME}:/vagrant/lib/tests:/usr/local/lib/${SCRIPTNAME}:/usr/lib/${SCRIPTNAME}"
+
+readonly GLOBAL_LOCK_FILE="/var/tmp/${SCRIPTNAME}/global.lock"
+readonly GLOBAL_LOCK_FD="200"
+
+# Name of the Vagrant box which will be used as a base for the CI box
+readonly BASE_VAGRANT_BOX="${BASE_VAGRANT_BOX:-debian/stretch64}"
+
+# Name of the Vagrant box used for CI testing. This variable is used in
+# filenames, use only alphanumeric characters, and dashes
+readonly JANE_VAGRANT_BOX="${JANE_VAGRANT_BOX:-${SCRIPTNAME}-debops-stretch}"
+
+readonly JANE_KEEP_BOX="${JANE_KEEP_BOX:-}"
+
+readonly CI_JOB_ID="${CI_JOB_ID:-0}"
+readonly CI_JOB_NAME="${CI_JOB_NAME:-}"
+readonly CI_JOB_STAGE="${CI_JOB_STAGE:-}"
+readonly VAGRANT_DOTFILE_PATH="${VAGRANT_DOTFILE_PATH:-/var/tmp/vagrant-dotfile-${CI_JOB_ID}}"
+
+readonly JANE_DIFF_BASE_BRANCH="${JANE_DIFF_BASE_BRANCH:-master}"
+readonly JANE_DIFF_PATTERN="${JANE_DIFF_PATTERN:-.*}"
+readonly JANE_LOG_PATTERN="${JANE_LOG_PATTERN:-}"
+readonly JANE_FORCE_TESTS="${JANE_FORCE_TESTS:-}"
+readonly JANE_TEST_PLAY="${JANE_TEST_PLAY:-}"
+readonly JANE_ANSIBLE_CONFIG="${JANE_ANSIBLE_CONFIG:-/vagrant/lib/tests/ansible.cfg}"
+readonly JANE_ANSIBLE_INVENTORY="${JANE_ANSIBLE_INVENTORY:-/vagrant/lib/tests/jane}"
+readonly JANE_INVENTORY_GROUPS="${JANE_INVENTORY_GROUPS:-debops_all_hosts}"
+readonly JANE_INVENTORY_HOSTVARS="${JANE_INVENTORY_HOSTVARS:-}"
+
+declare -rA colors=(
+    ["black"]="$( tput setaf 0 )"
+    ["b_black"]="$( tput bold ; tput setaf 0 )"
+    ["red"]="$( tput setaf 1 )"
+    ["b_red"]="$( tput bold ; tput setaf 1 )"
+    ["green"]="$( tput setaf 2 )"
+    ["b_green"]="$( tput bold ; tput setaf 2 )"
+    ["yellow"]="$( tput setaf 3 )"
+    ["b_yellow"]="$( tput bold ; tput setaf 3 )"
+    ["lime_yellow"]="$( tput setaf 190 )"
+    ["b_lime_yellow"]="$( tput bold ; tput setaf 190 )"
+    ["powder_blue"]="$( tput setaf 153 )"
+    ["b_powder_blue"]="$( tput bold ; tput setaf 153 )"
+    ["blue"]="$( tput setaf 4 )"
+    ["b_blue"]="$( tput bold ; tput setaf 4 )"
+    ["magenta"]="$( tput setaf 5 )"
+    ["b_magenta"]="$( tput bold ; tput setaf 5 )"
+    ["cyan"]="$( tput setaf 6 )"
+    ["orange"]="$( tput setaf 172 )"
+    ["b_orange"]="$( tput bold ; tput setaf 172 )"
+    ["b_cyan"]="$( tput bold ; tput setaf 6 )"
+    ["white"]="$( tput setaf 7 )"
+    ["b_white"]="$( tput bold ; tput setaf 7 )"
+    ["bright"]="$( tput bold )"
+    ["blink"]="$( tput blink )"
+    ["reverse"]="$( tput smso )"
+    ["underline"]="$( tput smul )"
+    ["reset"]="\e[m"
+)
+
+
+sub__help () {
+    help_msg "${SCRIPTNAME} <command> [<args>]" \
+        "Manage Continuous Integration using GitLab CI and Vagrant"
+
+    local subcommand_list=( $( declare -F \
+                               | cut -d" " -f3 \
+                               | grep -E '^sub__' \
+                               | awk -F '__' '{print $2}' \
+                               | uniq ) )
+
+    if [ ${#subcommand_list[@]} -gt 1 ] ; then
+        printf "\nAvailable commands:\n"
+        for help_cmd in "${subcommand_list[@]}" ; do
+            if declare -f "sub__help__${help_cmd}" > /dev/null ; then
+                printf "    %-10s %s\n" \
+                    "${help_cmd}" "$("sub__help__${help_cmd}" brief)"
+            fi
+        done
+        printf "\nSee '%s help <command>' to read about a given command\n" \
+            "${SCRIPTNAME}"
+    fi
+}
+
+
+sub__help__colors () {
+    local help_mode="${1:-}"
+
+    case "${help_mode}" in
+        brief)
+            cat <<-EOF
+Display available colors and their names
+EOF
+            ;;
+        *)
+            help_msg "${SCRIPTNAME} colors" "$(sub__help__colors brief)"
+            cat <<-EOF
+
+You can use this command to check out available terminal colors. Set the TERM
+variable to different names (dumb, vt100, xterm, xterm-256color, etc.) to see
+different results.
+EOF
+            ;;
+    esac
+}
+
+sub__colors () {
+    for color_name in "${!colors[@]}" ; do
+        printf "%-16s \"${colors[${color_name}]}%s${colors["reset"]}\"\n" \
+            "${color_name}" "Quick brown fox jumps over the lazy dog"
+    done
+}
+
+
+sub__help__env () {
+    local help_mode="${1:-}"
+
+    case "${help_mode}" in
+        brief)
+            cat <<-EOF
+Display the environment variables
+EOF
+            ;;
+        *)
+            help_msg "${SCRIPTNAME} env [${SCRIPTNAME}|script]" \
+                "$(sub__help__env brief)"
+            ;;
+    esac
+}
+
+# Strip all ANSI control codes from environment variables and print them line
+# by line
+sub__env () {
+    local env_mode="${1:-}"
+
+    case "${env_mode}" in
+
+        ${SCRIPTNAME}|ci|script)
+            ( set -o posix ; set \
+              | while read line ; do
+                    printf "%s\n" "$(tr -d '[:cntrl:]' <<< "${line}")"
+                done
+            )
+            ;;
+        *)
+            env \
+              | while read line ; do
+                    printf "%s\n" "$(tr -d '[:cntrl:]' <<< "${line}")"
+                done
+            ;;
+    esac
+}
+
+
+sub__pip__install () {
+    status_msg info "pip install \"${*}\""
+}
+
+
+sub__help__notify () {
+    local help_mode="${1:-}"
+
+    case "${help_mode}" in
+        brief)
+            cat <<-EOF
+Print a short message with a severity level
+EOF
+            ;;
+        *)
+            help_msg "${SCRIPTNAME} notify <severity> <message>" \
+                "$(sub__help__notify brief)"
+            cat <<-EOF
+
+You can use this command to check out available terminal colors. Set the TERM
+variable to different names (dumb, vt100, xterm, xterm-256color, etc.) to see
+different results.
+EOF
+            ;;
+    esac
+}
+
+sub__notify () {
+    local notify_level="${1}" ; shift
+    local notify_message="${*}"
+
+    status_msg "${notify_level}" "${notify_message}"
+}
+
+
+sub__gitlab__before_script () {
+    local jane_diff_base_branch="${JANE_DIFF_BASE_BRANCH}"
+    local jane_diff_pattern="${JANE_DIFF_PATTERN}"
+    local jane_log_pattern="${JANE_LOG_PATTERN}"
+    local jane_force_tests="${JANE_FORCE_TESTS}"
+
+    status_msg trigger "Checking commits: $(git_rev_oldest_ancestor)~1..HEAD"
+
+    if [ -n "${jane_diff_pattern}" ] ; then
+        status_msg trigger "Changed file patterns: '${jane_diff_pattern}'"
+    fi
+
+    if [ -n "${jane_log_pattern}" ] ; then
+        status_msg trigger "Changed log patterns: '${jane_log_pattern}'"
+    fi
+
+    if [ -n "${jane_force_tests}" ] ; then
+        status_msg trigger "Forced tests: '${jane_force_tests}'"
+    fi
+
+    case "$(interesting_changes "${jane_force_tests}")" in
+
+        "file patterns found")
+            status_msg info "Found interesting file patterns, activating tests"
+            require_vagrant
+            require_vagrant_box
+            ;;
+
+        "log patterns found")
+            status_msg info "Found interesting log patterns, activating tests"
+            require_vagrant
+            require_vagrant_box
+            ;;
+
+        "nothing found")
+            status_msg ok "No interesting changes found, skipping tests"
+            ;;
+
+        "no base branch")
+            status_msg warning "Base branch '${jane_diff_base_branch}' not found, activating normal tests"
+            require_vagrant
+            require_vagrant_box
+            ;;
+
+        "forced tests")
+            status_msg info "Tests are forced by a variable, activating normal tests"
+            require_vagrant
+            require_vagrant_box
+            ;;
+
+        *)
+            status_msg error "Unknown error occured. Stop"
+            exit 1
+            ;;
+    esac
+}
+
+
+sub__gitlab__script () {
+    local jane_force_tests="${JANE_FORCE_TESTS}"
+
+    case "$(interesting_changes "${jane_force_tests}")" in
+
+        "file patterns found"|"log patterns found"|"no base branch"|"forced tests")
+            require_vagrant
+            execute_tests
+            ;;
+
+        "nothing found")
+            ;;
+
+        *)
+            status_msg error "Unknown error occured. Stop"
+            exit 1
+            ;;
+    esac
+}
+
+
+sub__gitlab__after_script () {
+    local jane_force_tests="${JANE_FORCE_TESTS}"
+
+    case "$(interesting_changes "${jane_force_tests}")" in
+
+        "file patterns found"|"log patterns found"|"no base branch"|"forced tests")
+            require_vagrant
+            cleanup_vagrant_box
+            ;;
+
+        "nothing found")
+            ;;
+
+        *)
+            status_msg error "Unknown error occured. Stop"
+            exit 1
+            ;;
+    esac
+}
+
+
+sub__box__create () {
+    require_vagrant
+    require_vagrant_box
+}
+
+
+sub__box__destroy () {
+    require_vagrant
+    destroy_vagrant_box
+}
+
+
+sub__ansible__playbook () {
+    local ANSIBLE_CONFIG="${JANE_ANSIBLE_CONFIG}"
+    local ANSIBLE_INVENTORY="${JANE_ANSIBLE_INVENTORY}"
+    local jane_test_play="${JANE_TEST_PLAY}"
+    local jane_inventory_groups="${JANE_INVENTORY_GROUPS}"
+    local jane_inventory_hostvars=( "${JANE_INVENTORY_HOSTVARS}" )
+    local -a test_playbooks
+
+    IFS=" " read -r -a test_playbooks <<< "${jane_test_play}"
+
+    export ANSIBLE_CONFIG
+    export ANSIBLE_INVENTORY
+
+    status_msg config "Ansible inventory: '${ANSIBLE_INVENTORY}'"
+    status_msg config "Ansible configuration file: '${ANSIBLE_CONFIG}'"
+
+    if type jo > /dev/null 2>&1 ; then
+        if [ -n "${jane_inventory_hostvars[@]}" ] ; then
+            if [ -r "${jane_inventory_hostvars[@]}" ] ; then
+                local parsed_hostvars="$(<"${jane_inventory_hostvars[@]}")"
+            else
+                local parsed_hostvars="$(jo -p "${jane_inventory_hostvars[@]}")"
+            fi
+        else
+            local parsed_hostvars=""
+        fi
+    else
+        local parsed_hostvars=""
+    fi
+
+    if [ -n "${jane_inventory_groups}" ] && [ "${jane_inventory_groups}" != "debops_all_hosts" ] ; then
+        status_msg config "Custom inventory Ansible groups:"
+        list_inventory_groups
+    fi
+
+    if [ -n "${parsed_hostvars}" ] ; then
+        status_msg config "Custom Ansible inventory variables:"
+        printf "%s\n" "${parsed_hostvars}"
+    fi
+
+    status_msg info "Performing Ansible syntax check..."
+    ansible-playbook "${test_playbooks[@]}" --syntax-check
+
+    status_msg info "First Ansible playbook run..."
+    ansible-playbook "${test_playbooks[@]}" --diff
+
+    status_msg info "Second Ansible playbook run to test idempotency..."
+    ansible-playbook "${test_playbooks[@]}" --diff | tee /tmp/ansible_idempotent.txt
+
+    if grep -qEm1 -e 'changed=0.*unreachable=0.*failed=0' /tmp/ansible_idempotent.txt ; then
+        status_msg ok "The playbook is idempotent"
+    else
+        status_msg error "The playbook is NOT IDEMPOTENT"
+        return 1
+    fi
+}
+
+
+interesting_changes () {
+    local jane_diff_base_branch="${JANE_DIFF_BASE_BRANCH}"
+    local ci_job_name="${CI_JOB_NAME}"
+    local ci_job_stage="${CI_JOB_STAGE}"
+    local forced_tests="${*:-}"
+
+    if [ "$(git cat-file -t "${jane_diff_base_branch}" 2>/dev/null)" == "commit" ] ; then
+        local file_patterns="$(git_diff_file_pattern)"
+        local log_patterns="$(git_log_pattern)"
+
+        if [ -n "${file_patterns}" ] ; then
+            local output="file patterns found"
+        elif [ -n "${log_patterns}" ] ; then
+            local output="log patterns found"
+        else
+            local output="nothing found"
+        fi
+
+    else
+        local output="no base branch"
+    fi
+
+    if [ -n "${forced_tests}" ] ; then
+        if [ "${forced_tests}" == "true" ] ; then
+            local output="forced tests"
+        elif [ "${forced_tests}" == "${ci_job_stage}" ] ; then
+            local output="forced tests"
+        elif [ "${forced_tests}" == "${ci_job_name}" ] ; then
+            local output="forced tests"
+        fi
+    fi
+
+    printf "%s\n" "${output}"
+}
+
+
+git_log_pattern () {
+    local jane_log_pattern="${JANE_LOG_PATTERN}"
+
+    if [ -n "${jane_log_pattern}" ] ; then
+        local log_patterns_found="$(git log --format="%B" "$(git_rev_oldest_ancestor)~1..HEAD" \
+            | grep -E "${jane_log_pattern}" || true)"
+        printf "%s\n" "${log_patterns_found}"
+    fi
+}
+
+
+git_diff_file_pattern () {
+    local jane_diff_pattern="${JANE_DIFF_PATTERN}"
+
+    local changed_files="$(git diff --name-only "$(git_rev_oldest_ancestor)~1..HEAD" \
+        | grep -E "${jane_diff_pattern}" || true)"
+    printf "%s\n" "${changed_files}"
+}
+
+
+git_rev_oldest_ancestor () {
+    local jane_diff_base_branch="${JANE_DIFF_BASE_BRANCH}"
+
+    local oldest_ancestor="$(diff --old-line-format='' --new-line-format='' \
+        <(git rev-list --first-parent "${jane_diff_base_branch}") \
+        <(git rev-list --first-parent "HEAD") | head -1)"
+
+    printf "%s\n" "${oldest_ancestor}"
+}
+
+
+execute_tests () {
+    local jane_vagrant_box="${JANE_VAGRANT_BOX}"
+    local jane_test_play="${JANE_TEST_PLAY}"
+
+    local VAGRANT_BOX="${jane_vagrant_box}"
+    export VAGRANT_BOX
+
+    status_msg info "Starting Vagrant box '${jane_vagrant_box}'..."
+    vagrant up
+
+    if [ -n "${jane_test_play}" ] ; then
+        status_msg info "Executing Ansible tests inside Vagrant box..."
+        vagrant ssh -c "${SCRIPTNAME} ansible playbook"
+    fi
+}
+
+
+require_vagrant () {
+    if ! type vagrant > /dev/null 2>&1 ; then
+        error_exit "Vagrant not found"
+    fi
+}
+
+
+require_vagrant_box () {
+    local jane_vagrant_box="${JANE_VAGRANT_BOX}"
+
+    if [ -n "${jane_vagrant_box}" ] ; then
+        if ! vagrant box list | grep -q "${jane_vagrant_box}" ; then
+
+            status_msg warning "Vagrant box '${jane_vagrant_box}' not found"
+
+            if ! acquire_global_lock ; then
+
+                status_msg info \
+                    "Vagrant box is being built by another instance, waiting..."
+                until acquire_global_lock ; do
+                    sleep 5
+                done
+
+                if ! vagrant box list | grep -q "${jane_vagrant_box}" ; then
+                    prepare_vagrant_box
+                else
+                    status_msg ok "Found new Vagrant box '${jane_vagrant_box}'"
+                fi
+                release_global_lock
+
+            else
+                prepare_vagrant_box
+                release_global_lock
+            fi
+        else
+            status_msg ok "Found existing Vagrant box '${jane_vagrant_box}'"
+        fi
+    fi
+}
+
+
+prepare_vagrant_box () {
+    local vagrant_dotfile_path="${VAGRANT_DOTFILE_PATH}"
+    local jane_vagrant_box="${JANE_VAGRANT_BOX}"
+    local base_vagrant_box="${BASE_VAGRANT_BOX}"
+
+    local VAGRANT_BOX="${base_vagrant_box}"
+    export VAGRANT_DOTFILE_PATH
+
+    status_msg info "Preparing Vagrant box using '${base_vagrant_box}'..."
+    vagrant up
+
+    # The current user needs to have access to the libvirt image to be able to
+    # package a Vagrant box out of it.
+    if vagrant_master_is_libvirt ; then
+        fix_libvirt_image_permissions
+    fi
+
+    status_msg info "Packaging modified Vagrant box as '${jane_vagrant_box}'..."
+    vagrant package --output="${jane_vagrant_box}.box"
+
+    status_msg info "Registering Vagrant box '${jane_vagrant_box}'..."
+    vagrant box add --name "${jane_vagrant_box}" "${jane_vagrant_box}.box"
+
+    status_msg info "Cleaning up Vagrant box..."
+    vagrant halt && vagrant destroy -f
+
+    if [ -n "${vagrant_dotfile_path}" ] ; then
+        rm --preserve-root -rf "${vagrant_dotfile_path}"
+    fi
+
+    status_msg success "Vagrant box '${jane_vagrant_box}' created"
+}
+
+
+vagrant_master_is_libvirt () {
+    if vagrant status master \
+        | grep '^master' \
+        | grep '(libvirt)$' \
+        | grep -q 'running' ; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+
+fix_libvirt_image_permissions () {
+    local vagrant_dotfile_path="${VAGRANT_DOTFILE_PATH}"
+    local domain_id_file="${vagrant_dotfile_path}/machines/master/libvirt/id"
+
+    if [ -r "${domain_id_file}" ] ; then
+        local libvirt_domain_uuid="$(<"${domain_id_file}")"
+        local libvirt_domain_name="$(virsh -c qemu:///system domname "${libvirt_domain_uuid}")"
+
+        sudo /usr/bin/env chmod a+r "/var/lib/libvirt/images/${libvirt_domain_name}.img"
+    fi
+}
+
+
+cleanup_vagrant_box () {
+    local vagrant_dotfile_path="${VAGRANT_DOTFILE_PATH}"
+    local jane_vagrant_box="${JANE_VAGRANT_BOX}"
+    local jane_keep_box="${JANE_KEEP_BOX}"
+    local ci_job_name="${CI_JOB_NAME}"
+
+    local VAGRANT_BOX="${jane_vagrant_box}"
+    export VAGRANT_BOX
+
+    status_msg info "Shutting down Vagrant box..."
+    vagrant halt
+
+    if [ -n "${jane_keep_box}" ] ; then
+
+        if [ "${jane_keep_box}" == "${ci_job_name}" ] ; then
+            status_msg info "Preserving Vagrant box of '${ci_job_name}' job for investigation"
+        else
+            status_msg info "Destroying Vagrant box..."
+            vagrant destroy -f
+
+            if [ -n "${vagrant_dotfile_path}" ] ; then
+                rm --preserve-root -rf "${vagrant_dotfile_path}"
+            fi
+        fi
+
+    else
+
+        status_msg info "Destroying Vagrant box..."
+        vagrant destroy -f
+
+        if [ -n "${vagrant_dotfile_path}" ] ; then
+            rm --preserve-root -rf "${vagrant_dotfile_path}"
+        fi
+
+    fi
+}
+
+
+destroy_vagrant_box () {
+    local vagrant_dotfile_path="${VAGRANT_DOTFILE_PATH}"
+    local jane_vagrant_box="${JANE_VAGRANT_BOX}"
+
+    if [ -n "${jane_vagrant_box}" ] ; then
+        if vagrant box list | grep -q "${jane_vagrant_box}" ; then
+
+            status_msg info "Vagrant box '${jane_vagrant_box}' found"
+
+            if ! acquire_global_lock ; then
+
+                status_msg info \
+                    "Vagrant box is being removed by another instance, waiting..."
+                until acquire_global_lock ; do
+                    sleep 5
+                done
+
+                if vagrant box list | grep -q "${jane_vagrant_box}" ; then
+
+                    status_msg info "Removing Vagrant box '${jane_vagrant_box}'..."
+                    vagrant box remove "${jane_vagrant_box}"
+
+                    if [ -n "${vagrant_dotfile_path}" ] ; then
+                        rm --preserve-root -rf "${vagrant_dotfile_path}"
+                    fi
+
+                else
+                    status_msg ok "Vagrant box '${jane_vagrant_box}' already removed"
+                fi
+                release_global_lock
+
+            else
+
+                status_msg info "Removing Vagrant box '${jane_vagrant_box}'..."
+                vagrant box remove "${jane_vagrant_box}"
+
+                if [ -n "${vagrant_dotfile_path}" ] ; then
+                    rm --preserve-root -rf "${vagrant_dotfile_path}"
+                fi
+
+                release_global_lock
+            fi
+        else
+            status_msg ok "Vagrant box '${jane_vagrant_box}' not found"
+        fi
+    fi
+}
+
+
+acquire_global_lock () {
+    local lock_fd="${GLOBAL_LOCK_FD}"
+    local lock_file="${GLOBAL_LOCK_FILE}"
+    local lock_dir="$( dirname "${lock_file}" )"
+
+    # Create lock file
+    mkdir -p "${lock_dir}"
+    eval "exec ${lock_fd}>${lock_file}"
+
+    # Acquire lock
+    if flock -n "${lock_fd}" ; then
+        trap "clean_up" EXIT
+        status_msg info "Global lock acquired"
+        return 0
+    else
+        return 1
+    fi
+}
+
+
+release_global_lock () {
+    local lock_fd="${GLOBAL_LOCK_FD}"
+    local lock_file="${GLOBAL_LOCK_FILE}"
+    local lock_dir="$( dirname "${lock_file}" )"
+
+    status_msg info "Releasing global lock"
+    flock -u "${lock_fd}"
+}
+
+
+clean_up () {
+    local lock_file="${GLOBAL_LOCK_FILE}"
+    local lock_dir="$( dirname "${lock_file}" )"
+
+    if [ -n "${lock_dir}" ] && [ -d "${lock_dir}" ] ; then
+        rm -rf "${lock_dir}"
+    fi
+}
+
+
+error_exit () {
+    local message="${*}"
+    local script="${SCRIPTNAME}"
+    local pid="${SCRIPTPID}"
+
+    if tty -s > /dev/null 2>&1 ; then
+        status_msg error "${message}"
+    elif type logger > /dev/null 2>&1 ; then
+        logger -t "${script}[${pid}]" "Error: ${message}"
+    fi
+
+    exit 1
+}
+
+
+status_msg () {
+    local msg_type="${1}" ; shift
+    local message="${*}"
+    local script="${SCRIPTNAME}"
+    local pid="${SCRIPTPID}"
+    local msg_color=""
+    local type_color=""
+    local prompt=""
+    local inception=""
+
+    prompt="${colors["green"]}${SCRIPTNAME^^}${colors["b_black"]}:${colors["reset"]}${colors["yellow"]}R${colors["b_black"]}:${colors["reset"]}"
+    inception="R"
+    if [ -n "${JANE_VAGRANT_INCEPTION:-}" ] ; then
+        prompt="${colors["magenta"]}${SCRIPTNAME^^}${colors["b_black"]}:${colors["reset"]}${colors["b_green"]}V${colors["b_black"]}:${colors["reset"]}"
+        inception="V"
+    elif [ -n "${JANE_INCEPTION:-}" ] ; then
+        prompt="${colors["magenta"]}${SCRIPTNAME^^}${colors["b_black"]}:${colors["reset"]}${colors["b_blue"]}B${colors["b_black"]}:${colors["reset"]}"
+        inception="B"
+    fi
+
+    case "${msg_type,,}" in
+
+        ok|good|success)
+            type_color="${colors["b_green"]}"
+            msg_color="${colors["reset"]}${colors["green"]}"
+            ;;
+
+        info|status|state)
+            type_color="${colors["b_cyan"]}"
+            msg_color="${colors["reset"]}${colors["cyan"]}"
+            ;;
+
+        trigger)
+            type_color="${colors["b_blue"]}"
+            msg_color="${colors["reset"]}${colors["b_blue"]}"
+            ;;
+
+        config)
+            type_color="${colors["b_magenta"]}"
+            msg_color="${colors["reset"]}${colors["magenta"]}"
+            ;;
+
+        warning)
+            type_color="${colors["b_yellow"]}"
+            msg_color="${colors["reset"]}${colors["yellow"]}"
+            ;;
+
+        error|fatal)
+            type_color="${colors["b_red"]}"
+            msg_color="${colors["reset"]}${colors["red"]}"
+            ;;
+
+        *)
+            type_color="${colors["b_white"]}"
+            msg_color="${colors["reset"]}"
+            ;;
+
+    esac
+
+    if [ -n "${message}" ] ; then
+        printf "${prompt}${type_color}%s${colors["reset"]}${colors["b_black"]}: ${msg_color}%s${colors["reset"]}\n" \
+            "${msg_type^^}" "${message}"
+        if type logger > /dev/null 2>&1 ; then
+            logger -t "${script}[${pid}]" "${inception}:${msg_type^^}: ${message}"
+        fi
+    fi
+}
+
+
+help_msg () {
+    local subcommand="${1}"
+    local help_text="${2}"
+
+    printf "${colors["reverse"]}%s${colors["reset"]}\n\n${colors["b_white"]}Usage: ${colors["b_blue"]}%s${colors["b_black"]}${colors["reset"]}\n" \
+           "${help_text}" "${subcommand}"
+}
+
+
+list_inventory_groups () {
+    local jane_inventory_groups="${JANE_INVENTORY_GROUPS}"
+    local -a inventory_groups
+
+    IFS="," read -r -a inventory_groups <<< "${jane_inventory_groups}"
+
+    for element in "${inventory_groups[@]}" ; do
+        printf "[%s]\n" "${element}"
+    done
+}
+
+generate_dynamic_inventory_groups () {
+    local jane_inventory_groups="${JANE_INVENTORY_GROUPS}"
+    local -a inventory_groups
+
+    IFS="," read -r -a inventory_groups <<< "${jane_inventory_groups}"
+
+    for element in "${inventory_groups[@]}" ; do
+        # jo needs to parse arguments as-is
+        # shellcheck disable=SC2046
+        printf "%s\n" "${element}=$(jo hosts='["localhost"]' \
+            vars=$(jo ansible_connection="local" dhparam__bits='["1024"]' \
+            secret="/tmp/secret" tcpwrappers__deny_all=false))"
+    done
+}
+
+dynamic_inventory_list () {
+    local jane_inventory_hostvars=( "${JANE_INVENTORY_HOSTVARS}" )
+
+    # Jan-Piet Mens is awesome
+    # http://jpmens.net/2016/03/05/a-shell-command-to-create-json-jo/
+    if type jo > /dev/null 2>&1 ; then
+        if [ -n "${jane_inventory_hostvars[@]}" ] ; then
+            if [ -r "${jane_inventory_hostvars[@]}" ] ; then
+                local parsed_hostvars="$(<"${jane_inventory_hostvars[@]}")"
+            else
+                local parsed_hostvars="$(jo ${jane_inventory_hostvars[*]})"
+            fi
+        else
+            local parsed_hostvars="{}"
+        fi
+
+        # jo needs to parse arguments as-is
+        # shellcheck disable=SC2046 disable=SC2086
+        jo -p $(generate_dynamic_inventory_groups) \
+            _meta=$(jo hostvars=$(jo localhost="${parsed_hostvars}"))
+    else
+        # Reasons for specific variables:
+        # 'ansible_connection'    - run Ansible locally, not remotely
+        # 'dhparam__bits'         - bigger DH parameters generate very slowly
+        # 'secret'                - move 'secret/' directory outside the git checkout
+        # 'tcpwrappers__deny_all' - otherwise Vagrant cannot access host via SSH to turn it off
+        #                           (needs better implementation in the 'debops.tcpwrappers' role)
+        cat<<EOF
+{
+  "debops_all_hosts": {
+    "hosts": [ "localhost" ],
+    "vars": {
+      "ansible_connection": "local",
+      "dhparam__bits": [ "1024" ],
+      "secret": "/tmp/secret",
+      "tcpwrappers__deny_all": false
+    }
+  },
+  "_meta": {
+    "hostvars": {
+      "localhost": {}
+    }
+  }
+}
+EOF
+    fi
+}
+
+
+dynamic_inventory_host () {
+    printf "%s\n" '{"_meta": {"hostvars": {}}}'
+}
+
+
+parse_subcommands () {
+    local main_command="${1:-}"
+    local main_subcommand="${2:-}"
+
+    if [ "${main_command}" == "--list" ] ; then
+
+        dynamic_inventory_list
+
+    elif [ "${main_command}" == "--host" ] ; then
+
+        dynamic_inventory_host
+
+    elif type "${SCRIPTNAME}-${main_command}" > /dev/null 2>&1 ; then
+
+        # Execute external subcommand
+        local func="${SCRIPTNAME}-${main_command}" ; shift
+        "${func}" "$@"
+
+    elif declare -f "sub__${main_command}__${main_subcommand}" > /dev/null ; then
+
+        # Execute command subcommand
+        func="sub__${main_command}__${main_subcommand}" ; shift ; shift
+        "${func}" "$@"
+
+    elif declare -f "sub__${main_command}" > /dev/null 2>&1; then
+
+        # Execute command
+        func="sub__${main_command}" ; shift
+        "${func}" "$@"
+
+    else
+      error_exit "'${main_command}' is not a ${SCRIPTNAME} command. See '${SCRIPTNAME} help'."
+    fi
+}
+
+
+jane_main () {
+    local args=( "${@}" )
+    local i
+
+    # Remove empty elements
+    for i in "${!args[@]}"; do
+        [ -n "${args[$i]}" ] || unset "args[$i]"
+    done
+
+    if [ ${#args[@]} -lt 1 ] ; then
+        sub__help
+        exit 1
+    fi
+
+    parse_subcommands "${args[@]}"
+}
+
+
+if [ "${1}" != "functions" ] ; then
+    jane_main "${ARGS[@]}"
+fi


### PR DESCRIPTION
The repository now includes configuration for GitLab CI, which uses
Vagrant, KVM (via libvirt) and LXC containers to perform tests on DebOps
roles and playbooks. This is the first iteration of the new test
framework, documentation and additional test code will be added at
a later date.