### PR TITLE
Support check_mode for system certificate configuration

### DIFF
--- a/ansible/roles/debops.pki/tasks/ca_certificates.yml
+++ b/ansible/roles/debops.pki/tasks/ca_certificates.yml
@@ -11,27 +11,32 @@
   shell: grep -E -e '^[^#].*$' /etc/ca-certificates.conf | sed -e 's/^!//'
   register: pki_register_ca_certificates_known
   changed_when: False
+  check_mode: False
 
 - name: Get list of untrusted certificates
   shell: grep -E -e '^!+' /etc/ca-certificates.conf | sed -e 's/^!//'
   register: pki_register_ca_certificates_untrusted
   changed_when: False
+  check_mode: False
 
 - name: Get list of trusted certificates
   shell: grep -E -e '^[^#!].*$' /etc/ca-certificates.conf | sed -e 's/^!//'
   register: pki_register_ca_certificates_trusted
   changed_when: False
+  check_mode: False
 
 - name: Get list of blacklisted certificates
   shell: grep -E -e '{{ pki_system_ca_certificates_blacklist | join("' -e '") }}' /etc/ca-certificates.conf | sed -e 's/^!//'
   register: pki_register_ca_certificates_blacklist
   changed_when: False
+  check_mode: False
   when: pki_system_ca_certificates_blacklist is defined and pki_system_ca_certificates_blacklist
 
 - name: Get list of whitelisted certificates
   shell: grep -E -e '{{ pki_system_ca_certificates_whitelist | join("' -e '") }}' /etc/ca-certificates.conf | sed -e 's/^!//'
   register: pki_register_ca_certificates_whitelist
   changed_when: False
+  check_mode: False
   when: pki_system_ca_certificates_whitelist is defined and pki_system_ca_certificates_whitelist
 
 - name: Configure system CA certificates


### PR DESCRIPTION
The shell commands which read the current list of system certificates
must be executed in check_mode as well. Otherwise check_mode would
indicate that the system certificate list would be changed even if there
are no actual changes.