### PR TITLE
fix error in evaluation of when-condition

### DIFF
--- a/ansible/roles/debops.dhcpd/tasks/main.yml
+++ b/ansible/roles/debops.dhcpd/tasks/main.yml
@@ -13,7 +13,7 @@
 - name: Convert list of nameservers to Ansible list
   set_fact:
     dhcpd_runtime_nameservers: "{{ dhcpd_register_nameservers.stdout_lines }}"
-  when: (dhcpd_register_nameservers is defined and dhcpd_register_nameservers.stdout)
+  when: (dhcpd_register_nameservers is defined and dhcpd_register_nameservers.stdout|d())
 
 - name: Configure DHCP server
   template:


### PR DESCRIPTION
as requested in https://github.com/debops/ansible-dhcpd/pull/30 filed against this repository

When running this role on a system with dhcp_mode=relay, execution fails:
```
TASK [debops.dhcpd : Convert list of nameservers to Ansible list] ********************************************************************************************
fatal: [router]: FAILED! => {"failed": true, "msg": "The conditional check '(dhcpd_register_nameservers is defined and dhcpd_register_nameservers.stdout)' failed. The error was: error while evaluating conditional ((dhcpd_register_nameservers is defined and dhcpd_register_nameservers.stdout and dhcpd_mode == 'server')): 'dict object' has no attribute 'stdout'\n\nThe error appears to have been in '/home/flo/.local/share/debops/debops-playbooks/roles/debops.dhcpd/tasks/main.yml': line 13, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Convert list of nameservers to Ansible list\n  ^ here\n"}
```

```dhcpd_register_nameservers``` wasn't registered, because the previous task is only run when ```dhcpd_mode == 'server'```. Apparently both conditions are being checked, even though the result was clear after the first one.

This can be solved by supplying an empty default for the non-defined variable.

(Happens with ansible 2.4.1.0)