### PR TITLE
[debops.gitlab] Don't rely on changed code to run tasks.

### DIFF
--- a/ansible/roles/debops.gitlab/tasks/configure_gitaly.yml
+++ b/ansible/roles/debops.gitlab/tasks/configure_gitaly.yml
@@ -87,7 +87,6 @@
     chdir: '{{ gitlab__gitaly_dest }}'
   become: True
   become_user: '{{ gitlab_user }}'
-  register: gitlab_register_gitlab__gitaly_checkout
   when: (gitlab_version_map[gitlab_version].gitaly != gitlab_register_gitaly_target_tag.stdout) or not gitlab_register_gitaly_cloned.stat.exists
 
 - name: Stop gitaly service for an upgrade
@@ -96,13 +95,11 @@
     state: 'stopped'
   when: (ansible_local|d() and ansible_local.gitlab|d() and
          (ansible_local.gitlab.installed|d() | bool) and
-         ansible_service_mgr == 'systemd' and
-         gitlab_register_gitlab__gitaly_checkout|changed)
+         ansible_service_mgr == 'systemd')
 
 - name: Setup gitaly
   make:
     chdir: '{{ gitlab__gitaly_checkout }}'
-  when: gitlab_register_gitlab__gitaly_checkout|changed
 
 - name: Start gitaly service after an upgrade
   service:
@@ -110,8 +107,7 @@
     state: 'started'
   when: (ansible_local|d() and ansible_local.gitlab|d() and
          (ansible_local.gitlab.installed|d() | bool) and
-         ansible_service_mgr == 'systemd' and
-         gitlab_register_gitlab__gitaly_checkout|changed)
+         ansible_service_mgr == 'systemd')
 
 - name: Configure Gitaly
   template:

--- a/ansible/roles/debops.gitlab/tasks/configure_gitlab-pages.yml
+++ b/ansible/roles/debops.gitlab/tasks/configure_gitlab-pages.yml
@@ -90,7 +90,6 @@
     chdir: '{{ gitlab_pages_dest }}'
   become: True
   become_user: '{{ gitlab_user }}'
-  register: gitlab_register_pages_checkout
   when: (gitlab_version_map[gitlab_version].pages|d() != gitlab_register_pages_target_tag.stdout|d()) or (gitlab_register_pages_cloned.stat|d() and not gitlab_register_pages_cloned.stat.exists)
 
 - name: Setup gitlab-pages
@@ -100,4 +99,3 @@
     GOPATH: '{{ gitlab_app_root_path }}/go'
   become: True
   become_user: '{{ gitlab_user }}'
-  when: gitlab_register_pages_checkout|changed

--- a/ansible/roles/debops.gitlab/tasks/configure_gitlab-shell.yml
+++ b/ansible/roles/debops.gitlab/tasks/configure_gitlab-shell.yml
@@ -92,7 +92,6 @@
     chdir: '{{ gitlab_shell_git_dest }}'
   become: True
   become_user: '{{ gitlab_user }}'
-  register: gitlab_register_shell_checkout
   when: ((gitlab_version_map[gitlab_version].shell != gitlab_register_shell_target_tag.stdout) or
          not gitlab_register_shell_cloned.stat.exists | bool)
 
@@ -119,4 +118,3 @@
     chdir: '{{ gitlab_shell_git_checkout }}'
   become: True
   become_user: '{{ gitlab_user }}'
-  when: gitlab_register_shell_checkout|changed

--- a/ansible/roles/debops.gitlab/tasks/configure_gitlab-workhorse.yml
+++ b/ansible/roles/debops.gitlab/tasks/configure_gitlab-workhorse.yml
@@ -87,7 +87,6 @@
     chdir: '{{ gitlab_workhorse_dest }}'
   become: True
   become_user: '{{ gitlab_user }}'
-  register: gitlab_register_gitlab_workhorse_checkout
   when: (gitlab_version_map[gitlab_version].gitlab_workhorse != gitlab_register_gitlab_workhorse_target_tag.stdout) or not gitlab_register_gitlab_workhorse_cloned.stat.exists
 
 - name: Setup gitlab-workhorse
@@ -95,4 +94,3 @@
     chdir: '{{ gitlab_workhorse_checkout }}'
   become: True
   become_user: '{{ gitlab_user }}'
-  when: gitlab_register_gitlab_workhorse_checkout|changed

--- a/ansible/roles/debops.gitlab/tasks/configure_gitlab_ce.yml
+++ b/ansible/roles/debops.gitlab/tasks/configure_gitlab_ce.yml
@@ -66,7 +66,6 @@
     chdir: '{{ gitlab_ce_git_dest }}'
   become: True
   become_user: '{{ gitlab_user }}'
-  register: gitlab_register_ce_checkout
   when: (gitlab_register_ce_source.before is undefined or
          (gitlab_register_ce_source.before is defined and
           gitlab_register_ce_target_branch.stdout is defined and
@@ -168,8 +167,7 @@
 - name: Install GitLab SysVinit script
   command: cp -f {{ gitlab_ce_git_checkout + "/lib/support/init.d/gitlab" }} /etc/init.d/gitlab
   register: gitlab__register_sysvinit_script
-  when: (gitlab_register_ce_checkout|changed and
-         (gitlab_use_systemd is defined and not gitlab_use_systemd))
+  when: (gitlab_use_systemd is defined and not gitlab_use_systemd)
 
 - name: Install GitLab systemd service files
   template:
@@ -183,8 +181,7 @@
     - 'gitlab-workhorse.service'
     - '{{ "gitlab-gitaly.service" if (gitlab_version | version_compare("9.0", operator="gt", strict=True)) else [] }}'
   register: gitlab__register_systemd_services
-  when: (gitlab_register_ce_checkout|changed and
-         (gitlab_use_systemd is defined and gitlab_use_systemd))
+  when: (gitlab_use_systemd is defined and gitlab_use_systemd)
 
 - name: Install GitLab Pages systemd service file
   template:
@@ -192,7 +189,6 @@
     dest: '/etc/systemd/system/gitlab-pages.service'
   register: gitlab__register_pages_systemd_services
   when: (gitlab_enable_pages and
-         gitlab_register_ce_checkout|changed and
          (gitlab_use_systemd is defined and gitlab_use_systemd))
 
 - name: Reload systemd daemons
@@ -206,13 +202,11 @@
   service:
     name: 'gitlab'
     enabled: True
-  when: (gitlab_register_ce_checkout|changed and
-         ansible_service_mgr != 'systemd' and not gitlab_use_systemd|bool)
+  when: (ansible_service_mgr != 'systemd' and not gitlab_use_systemd|bool)
 
 - name: Enable GitLab SysVinit service (systemd)
   command: systemctl enable gitlab
-  when: (gitlab_register_ce_checkout|changed and
-         ansible_service_mgr == 'systemd' and not gitlab_use_systemd|bool)
+  when: (ansible_service_mgr == 'systemd' and not gitlab_use_systemd|bool)
 
 - name: Enable GitLab systemd services
   service:
@@ -225,15 +219,13 @@
     - 'gitlab-unicorn.service'
     - 'gitlab-workhorse.service'
     - '{{ "gitlab-gitaly.service" if (gitlab_version | version_compare("9.0", operator="gt", strict=True)) else [] }}'
-  when: (gitlab_register_ce_checkout|changed and
-         gitlab_use_systemd|bool)
+  when: gitlab_use_systemd|bool
 
 - name: Enable GitLab Pages systemd service
   service:
     name: 'gitlab-pages.service'
     enabled: True
   when: (gitlab_enable_pages and
-         gitlab_register_ce_checkout|changed and
          gitlab_use_systemd|bool)
 
 - name: Setup GitLab CE logrotate configuration
@@ -254,7 +246,6 @@
   become: True
   become_user: '{{ gitlab_user }}'
   when: gitlab_version | version_compare("8.17", operator="lt", strict=True)
-        and gitlab_register_ce_checkout|changed
 
 - name: Yarn install
   command: yarn install --production
@@ -263,7 +254,6 @@
   become: True
   become_user: '{{ gitlab_user }}'
   when: gitlab_version | version_compare("8.17", operator="ge", strict=True)
-        and gitlab_register_ce_checkout|changed
 
   # The RubyGems.org website has frequent timeouts, so we will try and install
   # everything again as long as there are errors.
@@ -274,7 +264,6 @@
     chdir: '{{ gitlab_ce_git_checkout }}'
   become: True
   become_user: '{{ gitlab_user }}'
-  when: gitlab_register_ce_checkout|changed
 
 - name: Set default administrator email address and password
   replace:
@@ -303,7 +292,6 @@
           (ansible_local.gitlab is undefined or (ansible_local.gitlab is defined and
            (ansible_local.gitlab.installed is undefined or (ansible_local.gitlab.installed is defined and
             not ansible_local.gitlab.installed)))))) and
-         gitlab_register_ce_checkout|changed and
          gitlab__database == 'postgresql')
 
 - name: Reset default administrator email address and password
@@ -329,8 +317,7 @@
   register: gitlab_register_bundle_migrate
   notify: [ 'Restart gitlab', 'Restart gitlab.slice' ]
   when: (ansible_local|d() and ansible_local.gitlab|d() and
-         (ansible_local.gitlab.installed|d() | bool) and
-         gitlab_register_ce_checkout|changed)
+         (ansible_local.gitlab.installed|d() | bool))
 
 - name: Clean GitLab assets
   command: bundle exec rake {{ gitlab_assets_clean }} RAILS_ENV=production


### PR DESCRIPTION
Don't check if the code of the projects has changed before running tasks,
because it can result in an inconsistent and hard to debug state when a
previous run managed to update the code but failed somewhere after that.