### PR TITLE
[debops.gitlab] Run gitlab-pages' bin/install as root.

### DIFF
--- a/ansible/roles/debops.gitlab/tasks/configure_gitlab-shell.yml
+++ b/ansible/roles/debops.gitlab/tasks/configure_gitlab-shell.yml
@@ -117,6 +117,4 @@
   shell: ./bin/install ; test ! -x './bin/compile' || ./bin/compile
   args:
     chdir: '{{ gitlab_shell_git_checkout }}'
-  become: True
-  become_user: '{{ gitlab_user }}'
   when: gitlab_register_shell_checkout|changed


### PR DESCRIPTION
Run bin/install as root because it needs to install libraries system-wide.