### PR TITLE
Sphinx: Don't copy html static path over

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -172,7 +172,7 @@ html_favicon = '_static/favicon.ico'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied


### PR DESCRIPTION
This should fix a warning in the ReadTheDocs build of the documentation.