### PR TITLE
[debops-tools] Don't quote paths with spaces

### DIFF
--- a/lib/debops-tools/bin/debops
+++ b/lib/debops-tools/bin/debops
@@ -119,7 +119,7 @@ def gen_ansible_cfg(filename, config, project_root, playbooks_path,
         plugin_type = plugin_type+"_plugins"
         defaults[plugin_type] = PATHSEP.join(custom_paths(plugin_type))
 
-        if ansible.__version__ >= "1.7":
+        if ansible.__version__ >= "1.7" and ansible.__version__ < "2.0":
             # work around a bug obviously introduced in 1.7, see
             # https://github.com/ansible/ansible/issues/8555
             if ' ' in defaults[plugin_type]:


### PR DESCRIPTION
Between Ansible version 1.7 and 2.0, on MacOS there were issues when
paths with space characeters were used; this was apparently fixed after
Ansible 2.0 release.

Bug found and solution proposed by Joshua Aune (luken)

Fixes https://github.com/debops/debops-tools/issues/200