### PR TITLE
Add python-setuptools to mosquitto packages

### DIFF
--- a/ansible/roles/debops.mosquitto/defaults/main.yml
+++ b/ansible/roles/debops.mosquitto/defaults/main.yml
@@ -39,7 +39,7 @@ mosquitto__upstream_repository:
 # .. envvar:: mosquitto__base_packages [[[
 #
 # List of base APT packages to install for Mosquitto support.
-mosquitto__base_packages: [ 'mosquitto', 'mosquitto-clients', 'python-pip' ]
+mosquitto__base_packages: [ 'mosquitto', 'mosquitto-clients', 'python-pip', 'python-setuptools' ]
 
                                                                    # ]]]
 # .. envvar:: mosquitto__packages [[[


### PR DESCRIPTION
I had a faliure when running the mosquitto role on a Debian 9 box because setuptools was not present. I am assuming this is the correct place to add it, and it won't have unintended concequences.