### PR TITLE
Improve database privileges control

### DIFF
--- a/ansible/roles/debops.postgresql/tasks/main.yml
+++ b/ansible/roles/debops.postgresql/tasks/main.yml
@@ -99,7 +99,8 @@
   become_user: '{{ postgresql__user }}'
   delegate_to: '{{ postgresql__delegate_to }}'
   when: (((item.name|d() and item.name) or (item.database|d() and item.database)) and
-         (item.state is undefined or item.state != 'absent'))
+         (item.state is undefined or item.state != 'absent') and
+         (item.create_db is undefined or item.create_db))
 
 - name: Enable specified database extensions
   postgresql_ext:
@@ -118,11 +119,11 @@
   postgresql_privs:
     roles: '{{ item.owner }}'
     port: '{{ item.port | d(postgresql__port if postgresql__port else omit) }}'
-    type: 'schema'
+    type: '{{ item.type | d("schema") }}'
     database: '{{ item.name | d(item.database) }}'
-    objs: 'public'
-    privs: 'ALL'
-    grant_option: 'yes'
+    objs: '{{ item.objs | d("public") }}'
+    privs: '{{ item.public_privs | d(["ALL"]) | join(",") }}'
+    grant_option: '{{ item.grant_option | d("yes") }}'
     state: 'present'
   with_flattened:
     - '{{ postgresql__databases }}'

--- a/docs/ansible/roles/debops.postgresql/defaults-detailed.rst
+++ b/docs/ansible/roles/debops.postgresql/defaults-detailed.rst
@@ -233,6 +233,21 @@ parameters:
 ``encoding``
   Optional. Default encoding used by a given database.
 
+``create_db``
+  Optional. Set this to False when granting a role specific privileges on an existing database.
+
+``type``
+  Optional. Type of database object to set privileges on. Default: schema.
+
+``objs``
+  Optional. Comma separated list of database objects to set privileges on. Default: public.
+
+``privs``
+  Optional. Comma separated list of privileges to grant. Default: ALL.
+
+``grant_option``
+  Optional. Whether role (``owner``) may grant/revoke the specified privileges to others. Default: yes.
+
 Examples
 ~~~~~~~~
 
@@ -243,6 +258,21 @@ Create database owned by a specified role:
    postgresql__databases:
      - name: 'gamma'
        owner: 'gamma'
+
+Create database owned by a specified role and grant select privilege on all tables in schema public to another role:
+
+.. code-block:: yaml
+
+   postgresql__databases:
+     - name: 'gamma'
+       owner: 'gamma'
+     - name: 'gamma'
+       owner: 'alpha'
+       create_db: False
+       type: 'table'
+       objs: 'ALL_IN_SCHEMA'
+       public_privs: [ 'SELECT' ]
+       grant_option: 'no'
 
 .. _postgresql__ref_extensions:
 


### PR DESCRIPTION
Fix debops/debops#116

I tested this with postgresql__dependent_roles and postgresql__dependent_databases variables. Appears to work as intended and maintain previously expected behavior.