### PR TITLE
[debops.fail2ban] Add 'fail2ban_dbpurgeage' setting

### DIFF
--- a/ansible/roles/debops.fail2ban/CHANGES.rst
+++ b/ansible/roles/debops.fail2ban/CHANGES.rst
@@ -24,6 +24,11 @@ Changed
 
 - Enable SSH jail via default configuration of :envvar:`fail2ban_jails`. [ganto_]
 
+Added
+~~~~~
+
+- Added dbpurgeage setting [gardouille]
+
 
 `debops.fail2ban v0.1.1`_ - 2016-12-01
 --------------------------------------

--- a/ansible/roles/debops.fail2ban/defaults/main.yml
+++ b/ansible/roles/debops.fail2ban/defaults/main.yml
@@ -23,6 +23,12 @@ fail2ban_loglevel: 'WARNING'
 fail2ban_logtarget: '/var/log/fail2ban.log'
 
 
+# .. envvar:: fail2ban_dbpurgeage
+#
+# Age at which bans should be purged from the database (by default, 86400 ; 24h)
+fail2ban_dbpurgeage: '{{ (60 * 60 * 24) }}'
+
+
 # ---------------------------------------
 #   Default configuration for all jails
 # ---------------------------------------
@@ -158,7 +164,7 @@ fail2ban_actions: []
 
 # .. envvar:: fail2ban_filters
 #
-# List of dicts which define custom local ``fail2ban`` filters. See 
+# List of dicts which define custom local ``fail2ban`` filters. See
 # :ref:`fail2ban_filters` for more details.
 fail2ban_filters: []
 

--- a/ansible/roles/debops.fail2ban/templates/etc/fail2ban/fail2ban.local.j2
+++ b/ansible/roles/debops.fail2ban/templates/etc/fail2ban/fail2ban.local.j2
@@ -5,3 +5,4 @@
 loglevel     = {{ fail2ban_loglevel }}
 logtarget    = {{ fail2ban_logtarget }}
 
+dbpurgeage   = {{ fail2ban_dbpurgeage }}


### PR DESCRIPTION
In order to enable 'recidive' jail, the 'dbpurgeage' setting should be
increase to keep the (ex)banned IP addresses longer in the database
(/var/lib/fail2ban/fail2ban.sqlite3).