### PR TITLE
[debops.php] Add a version condition for the mcrypt package

### DIFF
--- a/ansible/roles/debops.php/defaults/main.yml
+++ b/ansible/roles/debops.php/defaults/main.yml
@@ -83,7 +83,7 @@ php__server_api_packages: [ 'cli', 'fpm' ]
 # .. envvar:: php__base_packages [[[
 #
 # Install set of standard PHP packages.
-php__base_packages: [ '{{ "php" + php__version }}', 'curl', 'gd', 'mcrypt' ]
+php__base_packages: [ '{{ "php" + php__version }}', 'curl', 'gd', '{{ "mcrypt" if php__version | version_compare("7.2","<") else None }}' ]
 
                                                                    # ]]]
 # .. envvar:: php__packages [[[

--- a/ansible/roles/debops.php/defaults/main.yml
+++ b/ansible/roles/debops.php/defaults/main.yml
@@ -83,7 +83,13 @@ php__server_api_packages: [ 'cli', 'fpm' ]
 # .. envvar:: php__base_packages [[[
 #
 # Install set of standard PHP packages.
-php__base_packages: [ '{{ "php" + php__version }}', 'curl', 'gd', '{{ "mcrypt" if php__version | version_compare("7.2","<") else None }}' ]
+php__base_packages:
+  - '{{ "php" + php__version }}'
+  - 'curl'
+  - 'gd'
+  - '{{ "mcrypt"
+        if (php__version | version_compare("7.2","<"))
+        else [] }}'
 
                                                                    # ]]]
 # .. envvar:: php__packages [[[


### PR DESCRIPTION
In PHP 7.2 the MCrypt extension was moved out from core to PECL.
A condition was added to only include the mcrypt package if the PHP
version is lower than 7.2.

The [issue was originally raised](https://github.com/debops/ansible-php/issues/43) in the ansible-php repo.