### PR TITLE
Allow disabling the nginx maintenance page

### DIFF
--- a/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/default.conf.j2
+++ b/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/default.conf.j2
@@ -242,6 +242,7 @@
 {%         endif                                                                    %}
 
 {%     endif                                                                        %}
+{%     if item.maintenance|d(True)|bool                                             %}
         if (-f $document_root/{{ item.maintenance_file | d('maintenance.html') }}) {
                 return 503;
         }
@@ -250,6 +251,7 @@
                 rewrite ^(.*)$ /{{ item.maintenance_file | d('maintenance.html') }} break;
         }
 
+{%     endif                                                                        %}
 {%     if item.error_pages|d()                                                      %}
 {%         for code, location in item.error_pages.items()                       %}
         error_page {{ code }} {{ location }};

--- a/docs/ansible/roles/debops.nginx/defaults-detailed.rst
+++ b/docs/ansible/roles/debops.nginx/defaults-detailed.rst
@@ -596,6 +596,11 @@ Error pages
          location_options: |
            internal;
 
+``maintenance``
+  Optional, boolean. Defaults to ``True``.
+  Specifies if the maintenance HTML page configuration should be added to the
+  server or not.
+
 ``maintenance_file``
   Optional. Path of the maintenance HTML page (by default
   :file:`maintenance.html`) located in the website's document root directory.


### PR DESCRIPTION
While the maintenance page is generally a nice thing under some
circumstance it's not needed or desired. Eg. if another mechanism is
used to show a maintenance page.