### PR TITLE
[debops.proc_hidepid] Fix base system support

### DIFF
--- a/ansible/roles/debops.proc_hidepid/defaults/main.yml
+++ b/ansible/roles/debops.proc_hidepid/defaults/main.yml
@@ -4,15 +4,45 @@
 # debops.proc_hidepid default variables
 # =====================================
 
+# .. contents:: Sections
+#    :local:
+
+
+# General configuration, APT packages [[[
+# ---------------------------------------
 
 # .. envvar:: proc_hidepid__enabled [[[
 #
 # Enable or disable support for managing the ``/proc`` ``hidepid=`` option
 # using Ansible.
-proc_hidepid__enabled: '{{ True
-                           if ((ansible_system_capabilities_enforced|bool and
+proc_hidepid__enabled: True
+
+                                                                   # ]]]
+# .. envvar:: proc_hidepid__base_packages [[[
+#
+# List of APT packages required for hidepid support.
+proc_hidepid__base_packages: [ 'libcap2-bin' ]
+
+                                                                   # ]]]
+# .. envvar:: proc_hidepid__packages [[[
+#
+# List of additional APT packages to install with hidepid support.
+proc_hidepid__packages: []
+                                                                   # ]]]
+                                                                   # ]]]
+# The ``/proc`` filesystem options [[[
+# ------------------------------------
+
+# .. envvar:: proc_hidepid__remount [[[
+#
+# When enabled, the role will try and remount the ``/proc`` filesystem to
+# enable the ``hidepid=`` options. This might not be possible in certain
+# environments like LXC/Docker containers, in which case the role will only
+# passively set up the required facts and other configuration.
+proc_hidepid__remount: '{{ True
+                           if (((ansible_system_capabilities_enforced|d())|bool and
                                 "cap_sys_admin" in ansible_system_capabilities) or
-                               not ansible_system_capabilities_enforced|bool)
+                               not (ansible_system_capabilities_enforced|d(True))|bool)
                            else False }}'
 
                                                                    # ]]]

--- a/ansible/roles/debops.proc_hidepid/tasks/main.yml
+++ b/ansible/roles/debops.proc_hidepid/tasks/main.yml
@@ -1,5 +1,19 @@
 ---
 
+- name: Install required packages
+  package:
+    name: '{{ item }}'
+    state: 'present'
+  with_flattened:
+    - '{{ proc_hidepid__base_packages }}'
+    - '{{ proc_hidepid__packages }}'
+  register: proc_hidepid__register_install
+  when: proc_hidepid__enabled|bool
+
+- name: Update Ansible facts if they were modified
+  action: setup
+  when: proc_hidepid__register_install|changed
+
 - name: Ensure that UNIX system group with /proc access exists
   group:
     name: '{{ proc_hidepid__group }}'
@@ -15,7 +29,7 @@
     fstype: 'proc'
     opts: 'defaults,hidepid={{ proc_hidepid__level }},gid={{ proc_hidepid__group }}'
     state: 'mounted'
-  when: proc_hidepid__enabled|bool
+  when: proc_hidepid__enabled|bool and proc_hidepid__remount|bool
 
   # This is a workaround for Ubuntu bug: https://bugs.launchpad.net/ubuntu/+source/mountall/+bug/1039887
 - name: Remount /proc from rc.local when needed
@@ -25,7 +39,7 @@
     line: 'mount -o remount,hidepid={{ proc_hidepid__level }},gid={{ proc_hidepid__group }} /proc'
     insertbefore: 'exit 0'
     state: 'present'
-  when: (proc_hidepid__enabled|bool and
+  when: (proc_hidepid__enabled|bool and proc_hidepid__remount|bool and
          (ansible_distribution in [ 'Ubuntu' ] and
           ansible_distribution_release in [ 'trusty' ]))
 


### PR DESCRIPTION
The role should now correctly setup the hidepid support on systems that
don't have the 'libcap2-bin' package installed.