### PR TITLE
Enable shell script linting using 'shellcheck'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
   - 'sudo apt-get install -yq graphviz'
   - 'pip install --upgrade pip six setuptools wheel'
   - 'pip install pycodestyle unittest2 nose2 cov-core ansible sphinx sphinx-autobuild sphinx_rtd_theme yamllint'
+  - './lib/tests/travis-shellcheck'
 
 install:
   - 'pip list'

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@ docs: test-docs
 pep8:           ## Test Python PEP8 compliance
 pep8: test-pep8
 
+.PHONY: shell
+shell:           ## Test shell script syntax
+shell: test-shell
+
 .PHONY: syntax
 syntax:         ## Check Ansible playbook syntax
 syntax: test-playbook-syntax
@@ -81,13 +85,18 @@ twine-upload:    ## Upload Python packages to PyPI
 	@twine upload dist/*
 
 .PHONY: test-all
-test-all: clean-tests test-pep8 test-debops-tools test-docs test-playbook-syntax test-yaml test-docker-build
+test-all: clean-tests test-pep8 test-debops-tools test-docs test-playbook-syntax test-yaml test-shell test-docker-build
 
 .PHONY: test-pep8
 test-pep8:
 	@printf "%s\n" "Testing PEP8 compliance using pycodestyle..."
 	@pycodestyle --show-source --statistics .
 	@./lib/tests/check-pep8 || true
+
+.PHONY: test-shell
+test-shell:
+	@printf "%s\n" "Testing shell syntax using shellcheck..."
+	@./lib/tests/check-shell || true
 
 .PHONY: test-docker-build
 test-docker-build:

--- a/lib/tests/check-shell
+++ b/lib/tests/check-shell
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Find all shell scripts and check their compliance using shellcheck
+
+# Copyright (C) 2018 Maciej Delmanowski <drybjed@gmail.com>
+# Copyright (C) 2018 DebOps https://debops.org/
+
+
+set -o nounset -o pipefail -o errexit
+
+declare -a file_list
+
+if ! type shellcheck > /dev/null 2>&1 ; then
+    printf "%s\n" "Error: shellcheck not found"
+    exit 1
+fi
+
+printf "%s " "Searching for shell scripts"
+
+counter=0
+
+while read in ; do
+    if file "${in}" | grep -q -E 'Bourne-Again shell script|bash script' ; then
+        file_list+=("${in}")
+        counter=$(( counter + 1 ))
+        counter_state=$(( counter % 5 ))
+        if [ ${counter_state} -eq 0 ] ; then
+            printf "%s" "."
+        fi
+    fi
+done < <(find . -type f)
+
+printf " %s\n" "found ${#file_list[@]} shell scripts"
+
+shellcheck "${file_list[@]}"

--- a/lib/tests/travis-shellcheck
+++ b/lib/tests/travis-shellcheck
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Install shellcheck in Travis CI environment
+# https://github.com/koalaman/shellcheck/wiki/TravisCI
+
+set -o nounset -o pipefail -o errexit
+
+install_shellcheck () {
+    printf "Installing shellcheck from Debian Sid.\n"
+    curl -sSL "https://ftp-master.debian.org/keys/archive-key-7.0.asc" | sudo -E apt-key add -
+    printf "deb http://ftp.us.debian.org/debian unstable main contrib non-free\n" | sudo tee /etc/apt/sources.list.d/sid.list
+
+    sudo apt-get -qq update
+    sudo apt-get -yq install -t sid shellcheck
+
+    # Disable Debian Sid to not interfere with other packages
+    sudo rm -f /etc/apt/sources.list.d/sid.list
+    sudo apt-get -qq update
+}
+
+install_shellcheck


### PR DESCRIPTION
The result of the shell script linting is currently ignored, it will be
enabled when all of the issues with various shell scripts in DebOps are
resolved.