### PR TITLE
[debops.librenms] Add PHP Composer support

### DIFF
--- a/ansible/roles/debops.librenms/defaults/main.yml
+++ b/ansible/roles/debops.librenms/defaults/main.yml
@@ -21,6 +21,7 @@ librenms__base_packages:
         if (ansible_local|d() and ansible_local.apt|d() and
             (ansible_local.apt.nonfree|d())|bool)
         else [] }}'
+  - '{{ "composer" if not librenms__composer_phar|bool else [] }}'
 
                                                                    # ]]]
 # .. envvar:: librenms__monitoring_packages [[[
@@ -166,6 +167,33 @@ librenms__install_version: 'master'
 #
 # Enable or disable daily upgrades pulled from LibreNMS ``git`` repository.
 librenms__update: True
+                                                                   # ]]]
+                                                                   # ]]]
+# PHP Composer support [[[
+# ------------------------
+
+# .. envvar:: librenms__composer_phar [[[
+#
+# If this is set to ``True`` the ``composer.phar`` script will be downloaded
+# from the :envvar:`librenms__composer_phar_url` and used to install the
+# missing PHP packages. If this is set to ``False`` the system-wide
+# :command:`composer` is used.
+# WARNING: Setting this variable to ``True`` has some security implications as
+# the download is not cryptographically verified. This is only meant to be a
+# work-around for old distribution releases not supporting the downstream
+# packaged :command:`composer`.
+librenms__composer_phar: '{{ True
+                             if ansible_distribution_release in [ "jessie", "trusty" ]
+                             else False }}'
+
+                                                                   # ]]]
+# .. envvar:: librenms__composer_phar_url [[[
+#
+# URL to the file:`composer.phar` script which will be used to install PHP
+# packages not available in the APT repository on distribution releases which
+# don't package PHP composer. If this is set to ``False``, :command:`composer`
+# will be installed via APT package manager.
+librenms__composer_phar_url: 'https://getcomposer.org/composer.phar'
                                                                    # ]]]
                                                                    # ]]]
 # Database configuration [[[

--- a/ansible/roles/debops.librenms/tasks/main.yml
+++ b/ansible/roles/debops.librenms/tasks/main.yml
@@ -106,6 +106,33 @@
     mode: '0600'
   tags: [ 'role::librenms:config', 'role::librenms:database' ]
 
+- name: Download composer.phar if requested
+  get_url:
+    url: '{{ librenms__composer_phar_url }}'
+    dest: '{{ librenms__install_path }}'
+    mode: '0640'
+  become: True
+  become_user: '{{ librenms__user }}'
+  when: librenms__composer_phar|bool
+
+- name: Install missing PHP packages via composer.phar
+  command: php composer.phar install
+  args:
+    chdir: '{{ librenms__install_path }}'
+  become: True
+  become_user: '{{ librenms__user }}'
+  when: librenms__composer_phar|bool
+  register: librenms__register_composer_phar
+  changed_when: not "Nothing to install or update" in librenms__register_composer_phar.stderr|d('')
+
+- name: Install missing PHP packages via system-wide composer
+  composer:
+    command: install
+    working_dir: '{{ librenms__install_path }}'
+  become: True
+  become_user: '{{ librenms__user }}'
+  when: not librenms__composer_phar|bool
+
 - name: Initialize database
   command: php build-base.php
   args:


### PR DESCRIPTION
LibreNMS requires PHP Composer to complete installation. The role will
use the 'composer' package from OS release archives on newer OS
releases, otherwise an upstream PHP Compoer will be downloaded to the
application directory to perform package installation.