### PR TITLE
[debops.sshd] Fix usage in Ansible check mode

### DIFF
--- a/ansible/roles/debops.sshd/tasks/main.yml
+++ b/ansible/roles/debops.sshd/tasks/main.yml
@@ -133,6 +133,7 @@
   register: sshd__register_known_hosts
   changed_when: False
   failed_when: False
+  check_mode: False
   tags: [ 'role::sshd:known_hosts' ]
 
 - name: Scan SSH fingerprints of specified hosts


### PR DESCRIPTION
The 'debops.sshd' role should now work correctly in Ansible '--check'
mode when a list of known SSH hosts to scan is specified.