### PR TITLE
Remove superfluous mapping in debops.apt defaults

### DIFF
--- a/ansible/roles/debops.apt/defaults/main.yml
+++ b/ansible/roles/debops.apt/defaults/main.yml
@@ -183,7 +183,6 @@ apt__architecture: '{{ apt__architecture_map[ansible_architecture]
 # used.
 apt__architecture_map:
   'x86_64': 'amd64'
-  'i386':   'i386'
   'armv7l': 'armhf'
 
                                                                    # ]]]


### PR DESCRIPTION
Fix #123 