### PR TITLE
[debops.apt_proxy] Drop unneeded dependency `python3-future`

### DIFF
--- a/ansible/roles/debops.apt_proxy/defaults/main.yml
+++ b/ansible/roles/debops.apt_proxy/defaults/main.yml
@@ -15,7 +15,7 @@
 #
 # List of base packages to install.
 apt_proxy__base_packages:
-  - '{{ [ "python3-future", "python3-apt"  ]
+  - '{{ [ "python3-apt" ]
         if (apt_proxy__temporally_avoid_unreachable|bool)
         else [] }}'
                                                                    # ]]]

--- a/ansible/roles/debops.machine/defaults/main.yml
+++ b/ansible/roles/debops.machine/defaults/main.yml
@@ -89,7 +89,7 @@ machine__motd: ''
                                                                    # ]]]
 # .. envvar:: machine__etc_motd_state [[[
 #
-# Specofy the state of the :file:`/etc/motd` file, either ``present`` (the file
+# Specify the state of the :file:`/etc/motd` file, either ``present`` (the file
 # exists) or ``absent`` (the file will be removed).
 machine__etc_motd_state: '{{ "present" if machine__motd|d() else "absent" }}'
 


### PR DESCRIPTION
Closes #181