### PR TITLE
Fix 289470424c067e5974bc5332c52771d21c9e6f35 Drop `python3-future`

### DIFF
--- a/ansible/roles/debops.apt_proxy/files/usr/local/lib/get-reachable-apt-proxy
+++ b/ansible/roles/debops.apt_proxy/files/usr/local/lib/get-reachable-apt-proxy
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-# Copyright (C) 2017 Robin Schneider <ypid@riseup.net>
+# Copyright (C) 2017-2018 Robin Schneider <ypid@riseup.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -36,15 +36,14 @@ from __future__ import (print_function, unicode_literals,
 import argparse
 import logging
 
-from future.standard_library import install_aliases
+#  from future.standard_library import install_aliases
+#  install_aliases()
 
 from urllib.parse import urlparse
 from urllib.request import urlopen
 from urllib.error import URLError, HTTPError
 
 import apt_pkg
-
-install_aliases()
 
 __license__ = 'AGPL-3.0'
 __author__ = 'Robin Schneider <ypid@riseup.net>'


### PR DESCRIPTION
289470424c067e5974bc5332c52771d21c9e6f35 was incomplete. This commit fixes.

Now the script only works with Python 3 which was explicitly set in the shebang all the time. No regressions are expected.

Updates: #189
Fixes: #181