### PR TITLE
[debops.nginx] Fix order in nginx.conf.j2 template in order to allow …

### DIFF
--- a/ansible/roles/debops.nginx/templates/etc/nginx/nginx.conf.j2
+++ b/ansible/roles/debops.nginx/templates/etc/nginx/nginx.conf.j2
@@ -39,6 +39,10 @@ http {
         server_names_hash_bucket_size {{ nginx_http_server_names_hash_bucket_size | default('64') }};
         server_names_hash_max_size {{ nginx_http_server_names_hash_max_size | default('512') }};
 
+{% if nginx_http_options|d() and nginx_http_options %}
+{{ nginx_http_options | indent(8, true) | regex_replace("(?m)^\s*$", "") }}
+
+{% endif %}
 {% block nginx_tpl_block_log %}
 {%      set nginx_tpl_access_log_format = '' %}
 {%      if nginx_access_log_format is defined %}
@@ -51,10 +55,6 @@ http {
 
         add_header X-Clacks-Overhead "GNU Terry Pratchett";
 
-{% if nginx_http_options|d() and nginx_http_options %}
-{{ nginx_http_options | indent(8, true) | regex_replace("(?m)^\s*$", "") }}
-
-{% endif %}
 {% if nginx_http_client_max_body_size|d() and nginx_http_client_max_body_size %}
         client_max_body_size {{ nginx_http_client_max_body_size }};
 


### PR DESCRIPTION
Example for use a custom log_format

```
nginx_http_options: |
  log_format timed_combined '$remote_addr - $remote_user [$time_local] '
                    '"$request" $status $body_bytes_sent '
                    '"$http_referer" "$http_user_agent" '
                    '$request_time $upstream_response_time $pipe';

nginx_access_log_format: 'timed_combined'
```
You need to define a log format before you can reference it, so `nginx_http_options` must to be written before `access_log` definitions.
