### PR TITLE
[debops.nginx] Fix old bug with Jinja2 >= 2.9.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,6 +50,13 @@ Fixed
   configuration file with correct path to the Ansible roles provided with the
   DebOps Python package.
 
+- [debops.nginx] Fix a long standing bug in the role with Ansible failing
+  during welcome page template generation with Jinja2 >= 2.9.4. It was related
+  to `non-backwards compatible change in Jinja`__ that modified how variables
+  are processed in a loop.
+
+.. __: https://github.com/pallets/jinja/issues/659
+
 
 `debops v0.7.0`_ - 2018-02-11
 -----------------------------

--- a/ansible/roles/debops.nginx/tasks/nginx_servers.yml
+++ b/ansible/roles/debops.nginx/tasks/nginx_servers.yml
@@ -39,6 +39,26 @@
          (item.delete is undefined or not item.delete|bool) and
          (item.welcome|d() | bool))
 
+- name: Copy 'normalize.css' CSS file for welcome page
+  template:
+    src: 'srv/www/sites/welcome/public/normalize.css'
+    dest: '{{ nginx_www }}/sites/{{ item.name if item.name is string else item.name[0] | d("default") }}/public/normalize.css'
+    owner: '{{ item.owner | d(nginx_webroot_owner) }}'
+    group: '{{ item.owner | d(nginx_webroot_group) }}'
+    force: '{{ item.welcome_force|d() | bool }}'
+  with_flattened:
+    - '{{ nginx__servers }}'
+    - '{{ nginx__default_servers }}'
+    - '{{ nginx__internal_servers }}'
+    - '{{ nginx__dependent_servers }}'
+    - '{{ nginx_servers | d([]) }}'
+    - '{{ nginx_default_servers | d([]) }}'
+    - '{{ nginx_internal_servers | d([]) }}'
+    - '{{ nginx_dependent_servers | d([]) }}'
+  when: (nginx_webroot_create|bool and item.state|d('present') != 'absent' and
+         (item.delete is undefined or not item.delete|bool) and
+         (item.welcome|d() | bool))
+
 - name: Remove nginx server configuration if requested
   file:
     path: '/etc/nginx/sites-available/{{ item.filename | d(item.name if item.name is string else item.name[0] | d("default")) }}.conf'

--- a/ansible/roles/debops.nginx/templates/srv/www/sites/welcome/public/index.html.j2
+++ b/ansible/roles/debops.nginx/templates/srv/www/sites/welcome/public/index.html.j2
@@ -13,9 +13,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ nginx_tpl_domain|d("CompanyName.website") }}</title>
 {% if item.welcome_css|d(True) | bool %}
-    <style type="text/css" media="screen">
-{% include "normalize.css" %}
-    </style>
+    <link rel="stylesheet" type="text/css" media="screen" href="normalize.css">
     <style type="text/css" media="screen">
 html {
   font-size: 17px;


### PR DESCRIPTION
This patch fixes the bug with backwards-incompatible change in Jinja2 >=
2.9.4 which breaks use of the 'import' keyword in loops. More details:

    https://github.com/pallets/jinja/issues/659

In this case, the 'normalize.css' file cannot be directly included in
the 'index.html' welcome page, therefore it will be copied alongside it
instead.