### PR TITLE
[debops.cryptsetup] Support an macOS Ansible controller. Fixes #31.

### DIFF
--- a/ansible/roles/debops.cryptsetup/tasks/manage_devices.yml
+++ b/ansible/roles/debops.cryptsetup/tasks/manage_devices.yml
@@ -34,7 +34,7 @@
 ## Generate keyfile and copy it to the remote system [[[
 
 - name: Generate binary keyfile on the Ansible controller
-  command: dd if={{ cryptsetup__keyfile_source_dev | quote }} of={{ (item.keyfile | d(cryptsetup__secret_path + "/" + item.name + "/keyfile.raw")) | quote }} bs={{ ((512/8) if (item.key_size|d(cryptsetup__key_size) == "default") else ((item.key_size|d(cryptsetup__key_size))/8)) | int }} count=1 iflag=fullblock
+  shell: head --byte {{ ((512/8) if (item.key_size|d(cryptsetup__key_size) == "default") else ((item.key_size|d(cryptsetup__key_size))/8)) | int }} {{ cryptsetup__keyfile_source_dev | quote }} > {{ (item.keyfile | d(cryptsetup__secret_path + "/" + item.name + "/keyfile.raw")) | quote }}
   args:
     creates: '{{ item.keyfile | d(cryptsetup__secret_path + "/" + item.name + "/keyfile.raw") }}'
   become: False

--- a/ansible/roles/debops.cryptsetup/tasks/manage_devices.yml
+++ b/ansible/roles/debops.cryptsetup/tasks/manage_devices.yml
@@ -34,7 +34,7 @@
 ## Generate keyfile and copy it to the remote system [[[
 
 - name: Generate binary keyfile on the Ansible controller
-  shell: head --byte {{ ((512/8) if (item.key_size|d(cryptsetup__key_size) == "default") else ((item.key_size|d(cryptsetup__key_size))/8)) | int }} {{ cryptsetup__keyfile_source_dev | quote }} > {{ (item.keyfile | d(cryptsetup__secret_path + "/" + item.name + "/keyfile.raw")) | quote }}
+  shell: head -c {{ ((512/8) if (item.key_size|d(cryptsetup__key_size) == "default") else ((item.key_size|d(cryptsetup__key_size))/8)) | int }} {{ cryptsetup__keyfile_source_dev | quote }} > {{ (item.keyfile | d(cryptsetup__secret_path + "/" + item.name + "/keyfile.raw")) | quote }}
   args:
     creates: '{{ item.keyfile | d(cryptsetup__secret_path + "/" + item.name + "/keyfile.raw") }}'
   become: False


### PR DESCRIPTION
It has been checked that `head --byte` behaves like `iflag=fullblock` and the role has been locally tested with this change.

Fixes: #31 

I don’t think this needs to be merged right away. I would rather have some times and ideally multiple reviewers. Mandatory is one DebOps Developer and one guy using macOS.

Note that support for macOS in DebOps is provided on best effort bases. No DebOps Developer uses macOS.

@jinnko Can you try that this works on macOS?