### PR TITLE
Correct the gmail example

### DIFF
--- a/docs/ansible/roles/debops.nullmailer/defaults-detailed.rst
+++ b/docs/ansible/roles/debops.nullmailer/defaults-detailed.rst
@@ -113,8 +113,8 @@ Configure GMail as remote SMTP server with options specified manually:
 
    nullmailer__remotes:
      - host: 'smtp.gmail.com'
-       options: [ '--starttls', '--port 587', '--auth-login',
-                  '--user username', '--pass password' ]
+       options: [ '--starttls', '--port=587', '--auth-login',
+                  '--user=username', '--pass=password' ]
 
 
 .. _nullmailer__ref_configuration_files:


### PR DESCRIPTION
Without the `=` between the option name and the value, I get this error:

```
nullmailer-send[25293]: /usr/lib/nullmailer/smtp: option --port requires a value.
nullmailer-send[25293]: Sending failed: Unspecified temporary error
```

Adding an `=` between option name and value does not have this problem.