### PR TITLE
[debops.sshd] UsePrivilegeSeparation is deprecated

### DIFF
--- a/ansible/roles/debops.sshd/defaults/main.yml
+++ b/ansible/roles/debops.sshd/defaults/main.yml
@@ -268,7 +268,8 @@ sshd__compression: 'yes'
 #
 # Specify if ``sshd`` should use unprivileged processes for incoming session
 # authentication. Setting this to ``sandbox`` enables use of additional
-# kernel restrictions.
+# kernel restrictions. This option has no effect with ``sshd`` version 7.5+
+# since privilege separation became mandatory.
 sshd__privilege_separation: 'sandbox'
 
                                                                    # ]]]

--- a/ansible/roles/debops.sshd/templates/etc/ssh/sshd_config.j2
+++ b/ansible/roles/debops.sshd/templates/etc/ssh/sshd_config.j2
@@ -86,9 +86,11 @@ MACs {{ ([ sshd__tpl_macs|first ] + sshd__macs_additional) | unique | join(",") 
 MACs {{ sshd__tpl_macs | join(",") }}
 
 {% endif %}
+{% if sshd__register_version.stdout | version_compare('7.5', '<') %}
 # Privilege Separation is turned on for security
 UsePrivilegeSeparation {{ sshd__privilege_separation }}
 
+{% endif %}
 {% if sshd__register_version.stdout | version_compare('7.4', '<') %}
 # Lifetime and size of ephemeral version 1 server key
 KeyRegenerationInterval 3600


### PR DESCRIPTION
The 'UsePrivilegeSeparation' sshd_config option has been deprecated in
version 7.5, the privilege separation is now mandatory.