### PR TITLE
[debops.postfix] Allow TLSv1 connections for now

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -62,6 +62,10 @@ Changed
   inside the LXC containers. You will need to remount the filesystems, restart
   services and LXC containers that rely on this functionality.
 
+- [debops.postfix] The role will allow TLSv1 SMTP connections by default. This
+  is done for backwards compatibility with older, third-party MTAs that don't
+  support newer protocols.
+
 Fixed
 ~~~~~
 

--- a/ansible/roles/debops.postfix/defaults/main.yml
+++ b/ansible/roles/debops.postfix/defaults/main.yml
@@ -526,27 +526,27 @@ postfix__tls_maincf:
     section: 'smtpd-tls'
 
   - name: 'smtpd_tls_protocols'
-    value: [ '!SSLv2', '!SSLv3', '!TLSv1', 'TLSv1.1', 'TLSv1.2' ]
+    value: [ '!SSLv2', '!SSLv3', 'TLSv1', 'TLSv1.1', 'TLSv1.2' ]
     section: 'smtpd-tls'
 
   - name: 'smtp_tls_protocols'
-    value: [ '!SSLv2', '!SSLv3', '!TLSv1', 'TLSv1.1', 'TLSv1.2' ]
+    value: [ '!SSLv2', '!SSLv3', 'TLSv1', 'TLSv1.1', 'TLSv1.2' ]
     section: 'smtp-tls'
 
   - name: 'lmtp_tls_protocols'
-    value: [ '!SSLv2', '!SSLv3', '!TLSv1', 'TLSv1.1', 'TLSv1.2' ]
+    value: [ '!SSLv2', '!SSLv3', 'TLSv1', 'TLSv1.1', 'TLSv1.2' ]
     section: 'lmtp-tls'
 
   - name: 'smtpd_tls_mandatory_protocols'
-    value: [ '!SSLv2', '!SSLv3', '!TLSv1', 'TLSv1.1', 'TLSv1.2' ]
+    value: [ '!SSLv2', '!SSLv3', 'TLSv1', 'TLSv1.1', 'TLSv1.2' ]
     section: 'smtpd-tls'
 
   - name: 'smtp_tls_mandatory_protocols'
-    value: [ '!SSLv2', '!SSLv3', '!TLSv1', 'TLSv1.1', 'TLSv1.2' ]
+    value: [ '!SSLv2', '!SSLv3', 'TLSv1', 'TLSv1.1', 'TLSv1.2' ]
     section: 'smtp-tls'
 
   - name: 'lmtp_tls_mandatory_protocols'
-    value: [ '!SSLv2', '!SSLv3', '!TLSv1', 'TLSv1.1', 'TLSv1.2' ]
+    value: [ '!SSLv2', '!SSLv3', 'TLSv1', 'TLSv1.1', 'TLSv1.2' ]
     section: 'lmtp-tls'
 
   - name: 'smtpd_tls_ciphers'


### PR DESCRIPTION
There are many third-party MTAs with older software that don't speak
newer protocols. This is an issue outside of DebOps control, therefore
to make the life of system administrators easier, TLSv1 protocol for
SMTP connections will be allowed for now.