### PR TITLE
[debops.sshd] Fix sshd config file

### DIFF
--- a/ansible/roles/debops.sshd/defaults/main.yml
+++ b/ansible/roles/debops.sshd/defaults/main.yml
@@ -425,12 +425,6 @@ sshd__kex_algorithms_additional: []
 # to weaker. Newer version supersedes older version.
 sshd__macs_map:
 
-  # It seems that the SSH in Debian Buster/Sid has issues with
-  # 'umac-128@openssh.com' MAC algorithm, unfortunately I wasn't able to find any
-  # sources for the reason why. See: https://github.com/debops/debops/issues/238
-  '7.6': [ 'hmac-sha2-512-etm@openssh.com', 'hmac-sha2-256-etm@openssh.com',
-           'umac-128-etm@openssh.com', 'hmac-sha2-512', 'hmac-sha2-256' ]
-
   # Source: https://wiki.mozilla.org/Security/Guidelines/OpenSSH
   '6.5': [ 'hmac-sha2-512-etm@openssh.com', 'hmac-sha2-256-etm@openssh.com',
            'umac-128-etm@openssh.com', 'hmac-sha2-512', 'hmac-sha2-256',

--- a/ansible/roles/debops.sshd/templates/etc/ssh/sshd_config.j2
+++ b/ansible/roles/debops.sshd/templates/etc/ssh/sshd_config.j2
@@ -67,12 +67,13 @@ KexAlgorithms {{ sshd__tpl_kex_algorithms | join(",") }}
 
 {% endif %}
 {% set sshd__tpl_macs = [] %}
-{% set sshd__tpl_macs_match = False %}
-{% for key, value in sshd__macs_map.items() %}
+{# workaround for jinja not beeing able to overwrite a variable inside the loop #}
+{% set sshd__tpl_macs_match = [] %}
+{% for key, value in sshd__macs_map|dictsort|reverse %}
 {%   if not sshd__tpl_macs_match and
         sshd__register_version.stdout|d() and
         sshd__register_version.stdout | version_compare(key, '>=') %}
-{%     set sshd__tpl_macs_match = True %}
+{%     set _ = sshd__tpl_macs_match.append(True) %}
 {%     for element in value %}
 {%       set _ = sshd__tpl_macs.append(element) %}
 {%     endfor %}


### PR DESCRIPTION
There were two problems:
* the dict was not ordered as inserted
* the flag wasn't overwritten inside the loop, resulting in all mac getting added

This also reverts ecfe618d0ff68474ff3423fd56a2ebb9ceef92c8

Closes: #238