### PR TITLE
[debops.kmod] Fix undefined variable abortion when tasks are skipped; [debops.etckeeper] Drop orphan reference to old debops-contrib.etckeeper

### DIFF
--- a/ansible/debops-contrib-playbooks/service/all.yml
+++ b/ansible/debops-contrib-playbooks/service/all.yml
@@ -9,7 +9,6 @@
 - include: foodsoft.yml
 - include: volkszaehler.yml
 - include: fuse.yml
-- include: etckeeper.yml
 - include: checkmk_agent.yml
 - include: snapshot_snapper.yml
 - include: x2go_server.yml

--- a/ansible/roles/debops.kmod/tasks/main.yml
+++ b/ansible/roles/debops.kmod/tasks/main.yml
@@ -38,6 +38,7 @@
   include_tasks: 'modprobe.yml'
   loop_control:
     loop_var: 'module'
+  register: kmod__register_modprobe_tasks
   with_items: '{{ kmod__combined_modules | parse_kv_items }}'
   when: kmod__enabled|bool
 
@@ -60,5 +61,4 @@
 
 - name: Update Ansible facts if the list of load kernel modules might have changed
   action: setup
-  when: (kmod__register_module_config_delete is changed or
-         kmod__register_module_config_create is changed)
+  when: kmod__register_modprobe_tasks is changed


### PR DESCRIPTION
Fixing my own mistakes :)