### PR TITLE
Fix various deprecation warnings from Ansible v2.5

### DIFF
--- a/ansible/playbooks/agent.yml
+++ b/ansible/playbooks/agent.yml
@@ -1,3 +1,3 @@
 ---
 
-- include: agent/all.yml
+- import_playbook: agent/all.yml

--- a/ansible/playbooks/agent/all.yml
+++ b/ansible/playbooks/agent/all.yml
@@ -1,3 +1,3 @@
 ---
 
-- include: gitlab_runner.yml
+- import_playbook: gitlab_runner.yml

--- a/ansible/playbooks/app.yml
+++ b/ansible/playbooks/app.yml
@@ -1,3 +1,3 @@
 ---
 
-- include: app/all.yml
+- import_playbook: app/all.yml

--- a/ansible/playbooks/app/all.yml
+++ b/ansible/playbooks/app/all.yml
@@ -1,39 +1,39 @@
 ---
 
-- include: sks.yml
+- import_playbook: sks.yml
 
-- include: ipxe.yml
+- import_playbook: ipxe.yml
 
-- include: boxbackup.yml
+- import_playbook: boxbackup.yml
 
-- include: rsnapshot.yml
+- import_playbook: rsnapshot.yml
 
-- include: mailman.yml
+- import_playbook: mailman.yml
 
-- include: librenms.yml
+- import_playbook: librenms.yml
 
-- include: dokuwiki.yml
+- import_playbook: dokuwiki.yml
 
-- include: netbox.yml
+- import_playbook: netbox.yml
 
-- include: etherpad.yml
+- import_playbook: etherpad.yml
 
-- include: preseed.yml
+- import_playbook: preseed.yml
 
-- include: owncloud.yml
+- import_playbook: owncloud.yml
 
-- include: phpmyadmin.yml
+- import_playbook: phpmyadmin.yml
 
-- include: phpipam.yml
+- import_playbook: phpipam.yml
 
-- include: rstudio_server.yml
+- import_playbook: rstudio_server.yml
 
-- include: gitlab.yml
+- import_playbook: gitlab.yml
 
-- include: ansible.yml
+- import_playbook: ansible.yml
 
-- include: debops.yml
+- import_playbook: debops.yml
 
-- include: debops_api.yml
+- import_playbook: debops_api.yml
 
-- include: roundcube.yml
+- import_playbook: roundcube.yml

--- a/ansible/playbooks/common.yml
+++ b/ansible/playbooks/common.yml
@@ -11,13 +11,13 @@
     - name: Check for Ansible version without known vulnerabilities
       assert:
         that:
-          - 'ansible_version.full | version_compare("2.1.5.0", ">=")'
-          - '((ansible_version.minor == 2) and (ansible_version.full | version_compare("2.2.2.0", ">="))) or (ansible_version.minor != 2)'
+          - 'ansible_version.full is version_compare("2.1.5.0", ">=")'
+          - '((ansible_version.minor == 2) and (ansible_version.full is version_compare("2.2.2.0", ">="))) or (ansible_version.minor != 2)'
         msg: 'VULNERABLE or unsupported Ansible version DETECTED, please update to Ansible >= v2.1.5 or a newer Ansible release >= v2.2.2! To skip, add "--skip-tags play::security-assertions" parameter. Check the debops-playbook changelog for details. Exiting.'
       run_once: True
       delegate_to: 'localhost'
 
-- include: service/core.yml
+- import_playbook: service/core.yml
 
 - name: Common configuration for all hosts
   hosts: [ 'debops_all_hosts', '!debops_no_common' ]

--- a/ansible/playbooks/env.yml
+++ b/ansible/playbooks/env.yml
@@ -1,3 +1,3 @@
 ---
 
-- include: env/all.yml
+- import_playbook: env/all.yml

--- a/ansible/playbooks/env/all.yml
+++ b/ansible/playbooks/env/all.yml
@@ -1,15 +1,15 @@
 ---
 
-- include: nodejs.yml
+- import_playbook: nodejs.yml
 
-- include: ruby.yml
+- import_playbook: ruby.yml
 
-- include: golang.yml
+- import_playbook: golang.yml
 
-- include: java.yml
+- import_playbook: java.yml
 
-- include: cran.yml
+- import_playbook: cran.yml
 
-- include: php.yml
+- import_playbook: php.yml
 
-- include: fcgiwrap.yml
+- import_playbook: fcgiwrap.yml

--- a/ansible/playbooks/hw.yml
+++ b/ansible/playbooks/hw.yml
@@ -1,3 +1,3 @@
 ---
 
-- include: hw/all.yml
+- import_playbook: hw/all.yml

--- a/ansible/playbooks/hw/all.yml
+++ b/ansible/playbooks/hw/all.yml
@@ -1,5 +1,5 @@
 ---
 
-- include: hwraid.yml
+- import_playbook: hwraid.yml
 
-- include: grub.yml
+- import_playbook: grub.yml

--- a/ansible/playbooks/net.yml
+++ b/ansible/playbooks/net.yml
@@ -1,3 +1,3 @@
 ---
 
-- include: net/all.yml
+- import_playbook: net/all.yml

--- a/ansible/playbooks/net/all.yml
+++ b/ansible/playbooks/net/all.yml
@@ -1,17 +1,17 @@
 ---
 
-- include: ifupdown.yml
+- import_playbook: ifupdown.yml
 
-- include: radvd.yml
+- import_playbook: radvd.yml
 
-- include: dhcpd.yml
+- import_playbook: dhcpd.yml
 
-- include: unbound.yml
+- import_playbook: unbound.yml
 
-- include: dnsmasq.yml
+- import_playbook: dnsmasq.yml
 
-- include: tinc.yml
+- import_playbook: tinc.yml
 
-- include: stunnel.yml
+- import_playbook: stunnel.yml
 
-- include: avahi.yml
+- import_playbook: avahi.yml

--- a/ansible/playbooks/service/cryptsetup.yml
+++ b/ansible/playbooks/service/cryptsetup.yml
@@ -1,5 +1,5 @@
 ---
 
-- include: cryptsetup-plain.yml
+- import_playbook: cryptsetup-plain.yml
 
-- include: cryptsetup-persistent_paths.yml
+- import_playbook: cryptsetup-persistent_paths.yml

--- a/ansible/playbooks/service/dnsmasq.yml
+++ b/ansible/playbooks/service/dnsmasq.yml
@@ -1,5 +1,5 @@
 ---
 
-- include: dnsmasq-plain.yml
+- import_playbook: dnsmasq-plain.yml
 
-- include: dnsmasq-persistent_paths.yml
+- import_playbook: dnsmasq-persistent_paths.yml

--- a/ansible/playbooks/service/mosquitto.yml
+++ b/ansible/playbooks/service/mosquitto.yml
@@ -1,5 +1,5 @@
 ---
 
-- include: mosquitto-plain.yml
+- import_playbook: mosquitto-plain.yml
 
-- include: mosquitto-nginx.yml
+- import_playbook: mosquitto-nginx.yml

--- a/ansible/playbooks/service/owncloud.yml
+++ b/ansible/playbooks/service/owncloud.yml
@@ -1,5 +1,5 @@
 ---
 
-- include: owncloud-apache.yml
+- import_playbook: owncloud-apache.yml
 
-- include: owncloud-nginx.yml
+- import_playbook: owncloud-nginx.yml

--- a/ansible/playbooks/service/tinc.yml
+++ b/ansible/playbooks/service/tinc.yml
@@ -1,5 +1,5 @@
 ---
 
-- include: tinc-plain.yml
+- import_playbook: tinc-plain.yml
 
-- include: tinc-persistent_paths.yml
+- import_playbook: tinc-persistent_paths.yml

--- a/ansible/playbooks/site.yml
+++ b/ansible/playbooks/site.yml
@@ -9,45 +9,45 @@
   # - common services like SMTP server, administrative tasks, authentication
   # and authorization control, system services used by other applications like
   # firewall, etc.
-- include: common.yml
+- import_playbook: common.yml
 
   # This playbook manages internal system plumbing expected on the host by
   # services, like user accounts, NFS mounts from remote hosts, and so on.
   # Everything that is not common, but enabled on a per group/host basis.
-- include: sys.yml
+- import_playbook: sys.yml
 
   # This playbook manages different programming language environments available
   # on each host, enabled using Ansible groups.
-- include: env.yml
+- import_playbook: env.yml
 
   # This playbook manages network infrastructure, like creation and management
   # of separate subnets, DNS, DHCP services, routing configuration, etc.
-- include: net.yml
+- import_playbook: net.yml
 
   # This playbook manages system services enabled using Ansible groups, like
   # databases, webservers, application servers, and so on.
-- include: srv.yml
+- import_playbook: srv.yml
 
   # This playbook contains plays which install and manage more complex
   # applications which can use multiple services at a time, or are user-facing
   # applications like webservices.
-- include: app.yml
+- import_playbook: app.yml
 
   # This playbook manages virtualized environments installed on hosts, like
   # OpenVZ Hardware Nodes, support for LXC containers in a host, or support for
   # KVM virtual machines. This is meant for the host-side of the virtualization
   # support, guest-side is managed by the rest of the playbook without the use
   # of the plays contained here.
-- include: virt.yml
+- import_playbook: virt.yml
 
   # This playbook manages hardware-related roles - device management, disk
   # partitioning, hardware monitoring, kernel management, any roles that would
   # require a reboot.
-- include: hw.yml
+- import_playbook: hw.yml
 
   # This playbook manages services or applications that are used as agents by
   # other services, on local or remote hosts. These agents may contact their
   # parent services to register themselves or provide data about their
   # environment, therefore they should be executed after the hosts they run on
   # are configured.
-- include: agent.yml
+- import_playbook: agent.yml

--- a/ansible/playbooks/srv.yml
+++ b/ansible/playbooks/srv.yml
@@ -1,3 +1,3 @@
 ---
 
-- include: srv/all.yml
+- import_playbook: srv/all.yml

--- a/ansible/playbooks/srv/all.yml
+++ b/ansible/playbooks/srv/all.yml
@@ -1,73 +1,73 @@
 ---
 
-- include: etc_aliases.yml
+- import_playbook: etc_aliases.yml
 
-- include: hashicorp.yml
+- import_playbook: hashicorp.yml
 
-- include: apt_cacher_ng.yml
+- import_playbook: apt_cacher_ng.yml
 
-- include: docker_gen.yml
+- import_playbook: docker_gen.yml
 
-- include: gunicorn.yml
+- import_playbook: gunicorn.yml
 
-- include: postfix.yml
+- import_playbook: postfix.yml
 
-- include: saslauthd.yml
+- import_playbook: saslauthd.yml
 
-- include: dovecot.yml
+- import_playbook: dovecot.yml
 
-- include: postscreen.yml
+- import_playbook: postscreen.yml
 
-- include: postwhite.yml
+- import_playbook: postwhite.yml
 
-- include: postconf.yml
+- import_playbook: postconf.yml
 
-- include: opendkim.yml
+- import_playbook: opendkim.yml
 
-- include: apache.yml
+- import_playbook: apache.yml
 
-- include: nginx.yml
+- import_playbook: nginx.yml
 
-- include: mosquitto.yml
+- import_playbook: mosquitto.yml
 
-- include: snmpd.yml
+- import_playbook: snmpd.yml
 
-- include: monit.yml
+- import_playbook: monit.yml
 
-- include: tftpd.yml
+- import_playbook: tftpd.yml
 
-- include: samba.yml
+- import_playbook: samba.yml
 
-- include: tgt.yml
+- import_playbook: tgt.yml
 
-- include: mariadb_server.yml
+- import_playbook: mariadb_server.yml
 
-- include: mariadb.yml
+- import_playbook: mariadb.yml
 
-- include: postgresql_server.yml
+- import_playbook: postgresql_server.yml
 
-- include: postgresql.yml
+- import_playbook: postgresql.yml
 
-- include: elastic_co.yml
+- import_playbook: elastic_co.yml
 
-- include: elasticsearch.yml
+- import_playbook: elasticsearch.yml
 
-- include: kibana.yml
+- import_playbook: kibana.yml
 
-- include: rabbitmq_server.yml
+- import_playbook: rabbitmq_server.yml
 
-- include: rabbitmq_management.yml
+- import_playbook: rabbitmq_management.yml
 
-- include: memcached.yml
+- import_playbook: memcached.yml
 
-- include: redis.yml
+- import_playbook: redis.yml
 
-- include: reprepro.yml
+- import_playbook: reprepro.yml
 
-- include: smstools.yml
+- import_playbook: smstools.yml
 
-- include: salt.yml
+- import_playbook: salt.yml
 
-- include: fail2ban.yml
+- import_playbook: fail2ban.yml
 
-- include: prosody.yml
+- import_playbook: prosody.yml

--- a/ansible/playbooks/sys.yml
+++ b/ansible/playbooks/sys.yml
@@ -1,3 +1,3 @@
 ---
 
-- include: sys/all.yml
+- import_playbook: sys/all.yml

--- a/ansible/playbooks/sys/all.yml
+++ b/ansible/playbooks/sys/all.yml
@@ -1,27 +1,27 @@
 ---
 
-- include: sysnews.yml
+- import_playbook: sysnews.yml
 
-- include: kmod.yml
+- import_playbook: kmod.yml
 
-- include: sysfs.yml
+- import_playbook: sysfs.yml
 
-- include: swapfile.yml
+- import_playbook: swapfile.yml
 
-- include: lvm.yml
+- import_playbook: lvm.yml
 
-- include: nfs_server.yml
+- import_playbook: nfs_server.yml
 
-- include: nfs.yml
+- import_playbook: nfs.yml
 
-- include: gitusers.yml
+- import_playbook: gitusers.yml
 
-- include: sftpusers.yml
+- import_playbook: sftpusers.yml
 
-- include: slapd.yml
+- import_playbook: slapd.yml
 
-- include: iscsi.yml
+- import_playbook: iscsi.yml
 
-- include: cryptsetup.yml
+- import_playbook: cryptsetup.yml
 
-- include: persistent_paths.yml
+- import_playbook: persistent_paths.yml

--- a/ansible/playbooks/tools/dist-upgrade.yml
+++ b/ansible/playbooks/tools/dist-upgrade.yml
@@ -106,13 +106,13 @@
     - name: Remove all APT preferences for backported packages
       shell: >
               grep -lrIZ 'Pin: release .*={{ dist_upgrade_current_release }}-backports' /etc/apt/preferences.d | xargs -0 rm -f --
-      when: dist_upgrade_register_replace is defined and dist_upgrade_register_replace|changed
+      when: dist_upgrade_register_replace is defined and dist_upgrade_register_replace is changed
 
     - name: Create a lockfile
       file:
         path: '{{ dist_upgrade_lockfile }}'
         state: 'touch'
-      when: dist_upgrade_register_replace is defined and dist_upgrade_register_replace|changed
+      when: dist_upgrade_register_replace is defined and dist_upgrade_register_replace is changed
 
     - name: Perform apt-get dist-upgrade (this might take a while)
       apt:
@@ -120,7 +120,7 @@
         upgrade: 'dist'
       register: dist_upgrade_register_upgrade
       when: ((dist_upgrade_register_replace is defined and
-              dist_upgrade_register_replace|changed) or
+              dist_upgrade_register_replace is changed) or
              (dist_upgrade_register_lockfile is defined and
               dist_upgrade_register_lockfile.stat.exists))
 
@@ -142,20 +142,20 @@
       command: apt-get --yes autoremove
       register: dist_upgrade_register_autoremove
       when: dist_upgrade_register_upgrade is defined and
-            dist_upgrade_register_upgrade|changed
+            dist_upgrade_register_upgrade is changed
 
     - name: Clean APT package cache
       command: apt-get autoclean
       register: dist_upgrade_register_autoclean
       when: dist_upgrade_register_upgrade is defined and
-            dist_upgrade_register_upgrade|changed
+            dist_upgrade_register_upgrade is changed
 
     - name: Check if /etc/services.d exists
       stat:
         path: '/etc/services.d'
       register: dist_upgrade_register_etc_services
       when: dist_upgrade_register_upgrade is defined and
-            dist_upgrade_register_upgrade|changed
+            dist_upgrade_register_upgrade is changed
 
     - name: Assemble /etc/services
       assemble:
@@ -176,7 +176,7 @@
         charset: 'utf8'
         body: '{{ dist_upgrade_mail_body }}'
       when: dist_upgrade_register_upgrade is defined and
-            dist_upgrade_register_upgrade|changed
+            dist_upgrade_register_upgrade is changed
 
     - name: Remove the lockfile
       file:

--- a/ansible/playbooks/virt.yml
+++ b/ansible/playbooks/virt.yml
@@ -1,3 +1,3 @@
 ---
 
-- include: virt/all.yml
+- import_playbook: virt/all.yml

--- a/ansible/playbooks/virt/all.yml
+++ b/ansible/playbooks/virt/all.yml
@@ -1,13 +1,13 @@
 ---
 
-- include: lxc.yml
+- import_playbook: lxc.yml
 
-- include: docker.yml
+- import_playbook: docker.yml
 
-- include: libvirtd.yml
+- import_playbook: libvirtd.yml
 
-- include: libvirtd_qemu.yml
+- import_playbook: libvirtd_qemu.yml
 
-- include: libvirt.yml
+- import_playbook: libvirt.yml
 
-- include: openvz.yml
+- import_playbook: openvz.yml

--- a/ansible/roles/debops-contrib.apparmor/defaults/main.yml
+++ b/ansible/roles/debops-contrib.apparmor/defaults/main.yml
@@ -21,7 +21,7 @@ apparmor__base_packages:
   - 'apparmor-utils'
   - 'apparmor-profiles'
   - '{{ []
-        if (ansible_distribution == "Ubuntu" and not (ansible_distribution_version|version_compare("15.10", ">=")))
+        if (ansible_distribution == "Ubuntu" and not (ansible_distribution_version is version_compare("15.10", ">=")))
         else [ "apparmor-profiles-extra" ] }}'
 
                                                                    # ]]]

--- a/ansible/roles/debops-contrib.apparmor/tasks/main.yml
+++ b/ansible/roles/debops-contrib.apparmor/tasks/main.yml
@@ -134,14 +134,14 @@
 
 - name: Reload changed profiles
   command: apparmor_parser --replace "/etc/apparmor.d/{{ item.item.key }}"
-  when: (item|changed and not apparmor__register_tunables|changed)
+  when: (item is changed and apparmor__register_tunables is not changed)
   with_items: '{{ apparmor__register_local_config.results }}'
 
 - name: Reload AppArmor all profiles
   service:
     name: 'apparmor'
     state: 'reloaded'
-  when: apparmor__fact_apparmor_enabled_and_loaded|bool and apparmor__register_tunables|changed
+  when: apparmor__fact_apparmor_enabled_and_loaded|bool and apparmor__register_tunables is changed
 
 - name: Unload AppArmor profiles
   command: service apparmor teardown

--- a/ansible/roles/debops-contrib.bitcoind/handlers/main.yml
+++ b/ansible/roles/debops-contrib.bitcoind/handlers/main.yml
@@ -5,4 +5,4 @@
   systemd:
     name: 'bitcoind'
     state: 'restarted'
-  when: (not bitcoind__register_systemd_unit_state|changed and ansible_distribution_release not in ["trusty"])
+  when: (not bitcoind__register_systemd_unit_state is changed and ansible_distribution_release not in ["trusty"])

--- a/ansible/roles/debops-contrib.bitcoind/tasks/main.yml
+++ b/ansible/roles/debops-contrib.bitcoind/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Ensure upstream APT OpenPGP public key is in it's desired state
+- name: Ensure upstream APT OpenPGP public key is in a desired state
   apt_key:
     id: '{{ bitcoind__upstream_key_fingerprint | replace(" ","") }}'
     state: '{{ "present" if (bitcoind__deploy_state == "present") else "absent" }}'
@@ -75,6 +75,6 @@
     state: '{{ "started" if (bitcoind__deploy_state == "present") else "stopped" }}'
     enabled: True
     masked: False
-    daemon_reload: '{{ bitcoind__register_systemd_unit_file|changed }}'
+    daemon_reload: '{{ bitcoind__register_systemd_unit_file is changed }}'
   register: bitcoind__register_systemd_unit_state
   when: (bitcoind__deploy_state == "present" and ansible_distribution_release not in ["trusty"])

--- a/ansible/roles/debops-contrib.foodsoft/tasks/main.yml
+++ b/ansible/roles/debops-contrib.foodsoft/tasks/main.yml
@@ -92,7 +92,7 @@
     that:
       - 'foodsoft__register_secret_token.stdout|length > 120'
       - 'foodsoft__register_secret_token.stdout|length < 500'
-  when: foodsoft__register_secret_token|changed
+  when: foodsoft__register_secret_token is changed
   tags: [ 'role::foodsoft:gen_token' ]
 
 - name: Configure secret token for Foodsoft
@@ -103,7 +103,7 @@
     group: '{{ foodsoft__group }}'
     mode: '0640'
   tags: [ 'role::foodsoft:gen_token' ]
-  when: foodsoft__register_secret_token|changed
+  when: foodsoft__register_secret_token is changed
 
 - name: Create database schema and load defaults
   command: 'bundle exec rake db:setup'
@@ -149,5 +149,5 @@
 
 - name: Gather facts if they were modified
   action: setup
-  when: foodsoft__register_local_facts|changed
+  when: foodsoft__register_local_facts is changed
 # ]]]

--- a/ansible/roles/debops-contrib.homeassistant/tasks/main.yml
+++ b/ansible/roles/debops-contrib.homeassistant/tasks/main.yml
@@ -48,7 +48,7 @@
     extra_args: '--user --upgrade'
   become: True
   become_user: '{{ homeassistant__user }}'
-  when: homeassistant__virtualenv == False and homeassistant__register_git|changed
+  when: homeassistant__virtualenv == False and homeassistant__register_git is changed
   notify: [ 'Restart Home Assistant' ]
 
 - name: Install hass in virtualenv
@@ -60,7 +60,7 @@
     virtualenv_python: 'python3'
   become: True
   become_user: '{{ homeassistant__user }}'
-  when: homeassistant__virtualenv == True and homeassistant__register_git|changed
+  when: homeassistant__virtualenv == True and homeassistant__register_git is changed
   notify: [ 'Restart Home Assistant' ]
 
 - name: Ensure Home Assistant config dir exists
@@ -88,5 +88,5 @@
     state: '{{ "started" if (homeassistant__deploy_state == "present") else "stopped" }}'
     enabled: True
     masked: False
-    daemon_reload: '{{ homeassistant__register_systemd_unit_file|changed }}'
+    daemon_reload: '{{ homeassistant__register_systemd_unit_file is changed }}'
   when: (homeassistant__deploy_state == "present" and ansible_distribution_release not in ["trusty"])

--- a/ansible/roles/debops-contrib.neurodebian/tasks/main.yml
+++ b/ansible/roles/debops-contrib.neurodebian/tasks/main.yml
@@ -33,9 +33,9 @@
   # Not using a handler here as the handler would need to be flushed at this
   # point which is discouraged in DebOps because that would also flush all
   # other handlers notified up to this point.
-  when: neurodebian__register_apt_repository|changed or
-        neurodebian__register_apt_repository_absent|changed or
-        neurodebian__register_apt_key|changed
+  when: neurodebian__register_apt_repository is changed or
+        neurodebian__register_apt_repository_absent is changed or
+        neurodebian__register_apt_key is changed
 
 - name: Ensure specified packages are in there desired state
   package:

--- a/ansible/roles/debops-contrib.snapshot_snapper/tasks/main.yml
+++ b/ansible/roles/debops-contrib.snapshot_snapper/tasks/main.yml
@@ -42,7 +42,7 @@
   command: cp {{ item }}.dpkg-divert {{ item }}
   args:
     creates: '{{ item }}'
-  when: snapshot_snapper__updatedb_diverted_register|changed
+  when: snapshot_snapper__updatedb_diverted_register is changed
   with_flattened: '{{ snapshot_snapper__divert_files }}'
 
 - name: Check if snapshots are already excluded from updatedb
@@ -84,7 +84,7 @@
     path: '/etc/snapper/configs/{{ item.0.item.name }}'
     state: 'absent'
   tags: [ 'role::snapshot_snapper:reinit' ]
-  when: (not item.0|skipped and not item.1|skipped and item.0.stat.exists|d(item.0.stat.isreg) and not item.1.stat.exists)
+  when: (item.0 is not skipped and item.1 is not skipped and item.0.stat.exists|d(item.0.stat.isreg) and not item.1.stat.exists)
   register: snapshot_snapper__register_snapper_configs_delete
   with_together:
     - '{{ snapshot_snapper__register_snapper_configs.results }}'

--- a/ansible/roles/debops-contrib.volkszaehler/defaults/main.yml
+++ b/ansible/roles/debops-contrib.volkszaehler/defaults/main.yml
@@ -21,7 +21,7 @@ volkszaehler__base_packages:
 
   - '{{ [ "php-xml", "php-mbstring" ]
         if (ansible_local|d() and ansible_local.php|d() and
-            ansible_local.php.version|d() and ansible_local.php.version|version_compare("7", ">="))
+            ansible_local.php.version|d() and ansible_local.php.version is version_compare("7", ">="))
         else [] }}'
 
                                                                    # ]]]

--- a/ansible/roles/debops-contrib.volkszaehler/tasks/main.yml
+++ b/ansible/roles/debops-contrib.volkszaehler/tasks/main.yml
@@ -67,7 +67,7 @@
     PATH: '{{ ansible_env.PATH }}:/usr/local/bin'
   become: True
   become_user: '{{ volkszaehler__user }}'
-  when: volkszaehler__register_git|changed
+  when: volkszaehler__register_git is changed
 
 # Database initialization [[[
 - name: Write database initialization SQL dump
@@ -85,7 +85,7 @@
     name: '{{ volkszaehler__database_name }}'
     target: '{{ (volkszaehler__home_path + "/create_db.sql")|quote }}'
     state: 'import'
-  when: (volkszaehler__register_sql_init_dump|changed and volkszaehler__database in ['mariadb'])
+  when: (volkszaehler__register_sql_init_dump is changed and volkszaehler__database in ['mariadb'])
 
 - name: Insert demo data into database
   shell: cat {{ (volkszaehler__git_dest + "/misc/sql/demo.sql")|quote }} | mysql {{ volkszaehler__database_name }}
@@ -126,5 +126,5 @@
 
 - name: Gather facts if they were modified
   action: setup
-  when: volkszaehler__register_local_facts|changed
+  when: volkszaehler__register_local_facts is changed
 # ]]]

--- a/ansible/roles/debops.apache/env/tasks/main.yml
+++ b/ansible/roles/debops.apache/env/tasks/main.yml
@@ -30,4 +30,4 @@
 
 - name: Reload facts if they were modified
   action: setup
-  when: apache__register_facts|changed
+  when: apache__register_facts is changed

--- a/ansible/roles/debops.apache/tasks/main.yml
+++ b/ansible/roles/debops.apache/tasks/main.yml
@@ -4,8 +4,8 @@
 - name: Check for supported Ansible version
   assert:
     that:
-      - 'ansible_version.full | version_compare("2.1.5.0", ">=")'
-      - '((ansible_version.minor == 2) and (ansible_version.full | version_compare("2.2.2.0", ">="))) or (ansible_version.minor != 2)'
+      - 'ansible_version.full is version_compare("2.1.5.0", ">=")'
+      - '((ansible_version.minor == 2) and (ansible_version.full is version_compare("2.2.2.0", ">="))) or (ansible_version.minor != 2)'
     msg: 'VULNERABLE or unsupported Ansible version DETECTED, please update to Ansible >= v2.1.5 or a newer Ansible release >= v2.2.2! Exiting.'
   run_once: True
   delegate_to: 'localhost'

--- a/ansible/roles/debops.apache/templates/etc/apache2/conf-available/local-debops_apache.conf.j2
+++ b/ansible/roles/debops.apache/templates/etc/apache2/conf-available/local-debops_apache.conf.j2
@@ -34,7 +34,7 @@ LogLevel {{ apache__log_level }}
 <IfModule ssl_module>
 {{ apache__tpl_macros.get_default_tls_directives(item.value|d({})) }}
 
-{% if debops__tpl_macros.get_openssl_version()|version_compare("0.9.8h", ">=") %}
+{% if debops__tpl_macros.get_openssl_version() is version_compare("0.9.8h", ">=") %}
 SSLStaplingCache {{ apache__ocsp_stapling_cache | quote }}
 SSLStaplingResponseMaxAge {{ apache__ocsp_stapling_response_max_age|string }}
 {%   if apache__ocsp_stapling_force_url %}

--- a/ansible/roles/debops.apache/templates/etc/apache2/sites-available/apache__tpl_macros.j2
+++ b/ansible/roles/debops.apache/templates/etc/apache2/sites-available/apache__tpl_macros.j2
@@ -13,9 +13,9 @@
 #}
 {% set version = '==' if (version == '=') else version %}
 {% set apache__tpl_compare_operator_includes_equal = True if (compare_operator in ['>=', '<=', '==']) else False %}
-{% if (version | version_compare(debops__tpl_macros.get_apache_min_version(), compare_operator))
-    or (version | version_compare(debops__tpl_macros.get_apache_min_version(), ">")) %}
-{%   if apache__tpl_compare_operator_includes_equal and (version | version_compare(debops__tpl_macros.get_apache_min_version(), "==")) %}
+{% if (version is version_compare(debops__tpl_macros.get_apache_min_version(), compare_operator))
+    or (version is version_compare(debops__tpl_macros.get_apache_min_version(), ">")) %}
+{%   if apache__tpl_compare_operator_includes_equal and (version is version_compare(debops__tpl_macros.get_apache_min_version(), "==")) %}
 {{     content -}}
 {%   else %}
 <IfVersion {{ compare_operator }} {{ version }}>
@@ -53,7 +53,7 @@ Examples:
 {{     get_min_version_wrapped(fallback_content, version, apache__tpl_xor_compare_operator_map[compare_operator]) -}}
 {%   endif %}
 {% else %}
-{%   if debops__tpl_macros.get_apache_version() | version_compare(version, compare_operator) %}
+{%   if debops__tpl_macros.get_apache_version() is version_compare(version, compare_operator) %}
 {{     content -}}
 {%   elif fallback_content != False %}
 {{     fallback_content -}}
@@ -216,7 +216,7 @@ SSLCompression       {{ item.tls_compression|d(apache__tls_compression) | quote 
 # https://raymii.org/s/tutorials/Strong_SSL_Security_On_Apache2.html
 # https://github.com/sovereign/sovereign/issues/373
 #}
-{% if debops__tpl_macros.get_apache_version()|version_compare("2.4.8", ">=") and debops__tpl_macros.get_openssl_version()|version_compare("1.0.2", ">=") %}
+{% if debops__tpl_macros.get_apache_version() is version_compare("2.4.8", ">=") and debops__tpl_macros.get_openssl_version() is version_compare("1.0.2", ">=") %}
 # SSLOpenSSLConfCmd DHParameters {{ item.tls_dhparam_file|d(apache__tls_dhparam_file) | quote }}
 {% endif %}
 {% endmacro %}{# ]]] #}
@@ -229,7 +229,7 @@ SSLEngine on
 {% set apache__tpl_pki_realm_path = apache__pki_realm_path + "/" + apache__tpl_pki_realm %}
 SSLCertificateFile      {{ item.tls_crt | d(apache__tpl_pki_realm_path + "/" + (item.pki_crt|d(apache__pki_crt_filename))) | quote }}
 SSLCertificateKeyFile   {{ item.tls_key | d(apache__tpl_pki_realm_path + "/" + (item.pki_key|d(apache__pki_key_filename))) | quote }}
-{% if item.ocsp_stapling_enabled|d(apache__ocsp_stapling_enabled)|bool and debops__tpl_macros.get_openssl_version()|version_compare("0.9.8h", ">=") %}
+{% if item.ocsp_stapling_enabled|d(apache__ocsp_stapling_enabled)|bool and debops__tpl_macros.get_openssl_version() is version_compare("0.9.8h", ">=") %}
 SSLUseStapling on
 {% endif %}
 

--- a/ansible/roles/debops.apt/tasks/main.yml
+++ b/ansible/roles/debops.apt/tasks/main.yml
@@ -19,7 +19,7 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: (apt__enabled|bool and apt__register_facts|changed)
+  when: (apt__enabled|bool and apt__register_facts is changed)
 
 - name: Install required packages
   apt:
@@ -136,9 +136,9 @@
   apt:
     update_cache: True
     cache_valid_time: '{{ omit
-                         if (apt__register_sources_template|changed or
-                             apt__register_sources_diversion|changed or
-                             apt__register_repositories|changed)
+                         if (apt__register_sources_template is changed or
+                             apt__register_sources_diversion is changed or
+                             apt__register_repositories is changed)
                          else apt__cache_valid_time }}'
   when: apt__enabled|bool
 
@@ -154,4 +154,4 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: (apt__enabled|bool and apt__register_facts_status|changed)
+  when: (apt__enabled|bool and apt__register_facts_status is changed)

--- a/ansible/roles/debops.apt_cacher_ng/tasks/state_present.yml
+++ b/ansible/roles/debops.apt_cacher_ng/tasks/state_present.yml
@@ -43,7 +43,7 @@
   set_fact:
     apt_cacher_ng__cache_dir_permissions_change: '{{
       apt_cacher_ng__cache_dir_enforce_permissions != "disabled" and (
-        (apt_cacher_ng__register_cache_perms|d() and apt_cacher_ng__register_cache_perms|changed) or
+        (apt_cacher_ng__register_cache_perms|d() and apt_cacher_ng__register_cache_perms is changed) or
         apt_cacher_ng__cache_dir_enforce_permissions == "strict"
       ) }}'
 

--- a/ansible/roles/debops.apt_mark/tasks/main.yml
+++ b/ansible/roles/debops.apt_mark/tasks/main.yml
@@ -64,4 +64,4 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: apt_mark__register_facts|changed
+  when: apt_mark__register_facts is changed

--- a/ansible/roles/debops.atd/tasks/main.yml
+++ b/ansible/roles/debops.atd/tasks/main.yml
@@ -111,4 +111,4 @@
 - name: Gather Ansible facts if needed
   action: setup
   when: atd_register_facts|d() and
-        atd_register_facts.changed
+        atd_register_facts is changed

--- a/ansible/roles/debops.auth/tasks/etc_ldap_conf.yml
+++ b/ansible/roles/debops.auth/tasks/etc_ldap_conf.yml
@@ -3,7 +3,7 @@
 - name: Make sure libldap is installed
   apt:
     name: 'libldap-2.4-2'
-    state: 'installed'
+    state: 'present'
     install_recommends: False
 
 - name: Divert original LDAP configuration

--- a/ansible/roles/debops.auth/tasks/nss_pam_ldap.yml
+++ b/ansible/roles/debops.auth/tasks/nss_pam_ldap.yml
@@ -36,4 +36,4 @@
   service:
     name: 'nslcd'
     state: 'restarted'
-  when: auth_register_nslcd_conf is defined and auth_register_nslcd_conf.changed
+  when: auth_register_nslcd_conf is defined and auth_register_nslcd_conf is changed

--- a/ansible/roles/debops.avahi/tasks/avahi_alias.yml
+++ b/ansible/roles/debops.avahi/tasks/avahi_alias.yml
@@ -21,7 +21,7 @@
     group: 'root'
     mode: '0755'
     remote_src: True
-  when: avahi__register_alias_git|changed
+  when: avahi__register_alias_git is changed
 
 - name: Install avahi-alias.service
   template:
@@ -39,7 +39,7 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  when: avahi__register_alias_git|changed
+  when: avahi__register_alias_git is changed
 
 - name: Manage list of CNAME entries
   lineinfile:
@@ -54,10 +54,10 @@
 - name: Manage avahi-alias.service
   systemd:
     name: 'avahi-alias.service'
-    enabled: '{{ True if avahi__register_alias_git|changed else omit }}'
-    daemon_reload: '{{ True if (avahi__register_alias_git|changed or
-                                avahi__register_alias_service|changed) else omit }}'
-    state: '{{ "restarted" if (avahi__register_alias_git|changed or
-                               avahi__register_alias_service|changed or
-                               avahi__register_aliases|changed) else omit }}'
+    enabled: '{{ True if avahi__register_alias_git is changed else omit }}'
+    daemon_reload: '{{ True if (avahi__register_alias_git is changed or
+                                avahi__register_alias_service is changed) else omit }}'
+    state: '{{ "restarted" if (avahi__register_alias_git is changed or
+                               avahi__register_alias_service is changed or
+                               avahi__register_aliases is changed) else omit }}'
   when: ansible_service_mgr == 'systemd'

--- a/ansible/roles/debops.avahi/tasks/main.yml
+++ b/ansible/roles/debops.avahi/tasks/main.yml
@@ -38,7 +38,7 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  when: avahi__register_divert|changed
+  when: avahi__register_divert is changed
 
 # The rest of the role continues as normal.
 
@@ -103,4 +103,4 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: avahi__register_facts|changed
+  when: avahi__register_facts is changed

--- a/ansible/roles/debops.core/tasks/main.yml
+++ b/ansible/roles/debops.core/tasks/main.yml
@@ -71,6 +71,6 @@
 
 - name: Gather local facts if they changed
   action: setup
-  when: core__register_fact_files|changed or
-        core__register_core_fact|changed or
-        core__register_fact_scripts|changed
+  when: core__register_fact_files is changed or
+        core__register_core_fact is changed or
+        core__register_fact_scripts is changed

--- a/ansible/roles/debops.cran/tasks/main.yml
+++ b/ansible/roles/debops.cran/tasks/main.yml
@@ -63,4 +63,4 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: cran__register_facts|changed
+  when: cran__register_facts is changed

--- a/ansible/roles/debops.cron/tasks/main.yml
+++ b/ansible/roles/debops.cron/tasks/main.yml
@@ -95,4 +95,4 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: cron__register_facts|changed
+  when: cron__register_facts is changed

--- a/ansible/roles/debops.cryptsetup/tasks/main.yml
+++ b/ansible/roles/debops.cryptsetup/tasks/main.yml
@@ -6,7 +6,7 @@
 - name: Check for Ansible version without known vulnerabilities
   assert:
     that:
-      - 'ansible_version.full | version_compare("2.2.3.0", ">=")'
+      - 'ansible_version.full is version_compare("2.2.3.0", ">=")'
     msg: 'VULNERABLE or unsupported Ansible version DETECTED, please update to Ansible >= v2.2.3 or a newer! To skip, add "--skip-tags play::security-assertions" parameter. Refer to the changelog of debops.cryptsetup for details. Exiting.'
   run_once: True
   delegate_to: 'localhost'

--- a/ansible/roles/debops.cryptsetup/tasks/manage_devices.yml
+++ b/ansible/roles/debops.cryptsetup/tasks/manage_devices.yml
@@ -133,7 +133,7 @@
 - name: Fail when ciphertext block device does not exist but the keyfile has changed
   fail:
     msg: 'Ciphertext block device {{ item.0.ciphertext_block_device }} does not exist but the keyfile has just been generated. You will need to make the block device available during a later Ansible run so that the encryption and filesystem layer can be setup. You will not see this error on later runs but that does not mean that the encryption and filesystem setup was successfully until you make the block device available. See documentation for details.'
-  when: (item.0.state|d(cryptsetup__state) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ] and not item.1.stat.exists and item.2|changed)
+  when: (item.0.state|d(cryptsetup__state) in [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ] and not item.1.stat.exists and item.2 is changed)
   with_together:
     - '{{ cryptsetup__process_devices|d([]) }}'
     - '{{ cryptsetup__register_ciphertext_device.results|d([]) }}'
@@ -337,7 +337,7 @@
 - name: Enable swap devices
   command: swapon --priority {{ (item.item.priority | d(cryptsetup__swap_priority) | string) | quote }}
            {{ ("/dev/mapper/" + item.item.name) | quote }}
-  when: (item|changed and (item.item.swap|d(False) | bool) and
+  when: (item is changed and (item.item.swap|d(False) | bool) and
          (item.item.state|d(cryptsetup__state) in ['mounted', 'ansible_controller_mounted']))
   with_items: '{{ cryptsetup__register_swap_fstab.results|d([]) }}'
 ## ]]]
@@ -363,7 +363,7 @@
                    and cryptsetup__register_cryptdisks_stop.rc == 1)
                )
   when: (item.0.state|d(cryptsetup__state) in [ 'unmounted', 'absent' ] or
-          (item.0.state|d(cryptsetup__state) in [ 'present' ] and item.1|changed)
+          (item.0.state|d(cryptsetup__state) in [ 'present' ] and item.1 is changed)
         )
   with_together:
     - '{{ cryptsetup__process_devices|d([]) }}'

--- a/ansible/roles/debops.debops_fact/tasks/main.yml
+++ b/ansible/roles/debops.debops_fact/tasks/main.yml
@@ -48,4 +48,4 @@
 
 - name: Reload facts if they were modified
   action: setup
-  when: debops_fact__enabled|bool and debops_fact__register_facts|changed
+  when: debops_fact__enabled|bool and debops_fact__register_facts is changed

--- a/ansible/roles/debops.dhcpd/tasks/install.yml
+++ b/ansible/roles/debops.dhcpd/tasks/install.yml
@@ -28,4 +28,4 @@
   notify: [ 'Restart dhcp relay' ]
   when:
     - ansible_os_family == "Debian"
-    - dhcpd_register_relay_debconf|d() and dhcpd_register_relay_debconf.changed
+    - dhcpd_register_relay_debconf|d() and dhcpd_register_relay_debconf is changed

--- a/ansible/roles/debops.dhcpd/tasks/main.yml
+++ b/ansible/roles/debops.dhcpd/tasks/main.yml
@@ -37,7 +37,7 @@
   with_items: '{{ dhcpd_includes }}'
   notify: [ 'Restart dhcp server' ]
   when: ((item is defined and item) and dhcpd_mode == 'server' and
-         (dhcpd_register_config is defined and dhcpd_register_config.changed))
+         (dhcpd_register_config is defined and dhcpd_register_config is changed))
 
 - name: Make sure that IPv6 lease file exists
   command: touch /var/lib/dhcp/dhcpd6.leases creates=/var/lib/dhcp/dhcpd6.leases

--- a/ansible/roles/debops.dhparam/tasks/main.yml
+++ b/ansible/roles/debops.dhparam/tasks/main.yml
@@ -126,4 +126,4 @@
 
 - name: Gather facts if they changed
   action: setup
-  when: dhparam_register_facts|changed
+  when: dhparam_register_facts is changed

--- a/ansible/roles/debops.dnsmasq/tasks/main.yml
+++ b/ansible/roles/debops.dnsmasq/tasks/main.yml
@@ -123,5 +123,5 @@
 
 - name: Reload facts if they were modified
   action: setup
-  when: dnsmasq__register_facts|changed
+  when: dnsmasq__register_facts is changed
 # ]]]

--- a/ansible/roles/debops.docker/tasks/main.yml
+++ b/ansible/roles/debops.docker/tasks/main.yml
@@ -61,7 +61,7 @@
     - '/etc/default/docker'
     - '/etc/docker/daemon.json'
     - '/etc/systemd/system/docker.service.d/http-proxy.conf'
-  when: (docker__register_other_version_removed|changed)
+  when: (docker__register_other_version_removed is changed)
 
 - name: Install required packages
   apt:
@@ -137,7 +137,7 @@
     mode: '0644'
   notify: [ 'Restart docker' ]
   tags: [ 'role::docker:config' ]
-  when: (ansible_service_mgr != 'systemd' or docker__register_version.stdout | version_compare('1.10', '<'))
+  when: (ansible_service_mgr != 'systemd' or docker__register_version.stdout is version_compare('1.10', '<'))
 
 - name: Configure Docker systemd options
   template:
@@ -148,7 +148,7 @@
     mode: '0644'
   notify: [ 'Restart docker' ]
   tags: [ 'role::docker:config' ]
-  when: (ansible_service_mgr == 'systemd' and docker__register_version.stdout | version_compare('1.10', '>='))
+  when: (ansible_service_mgr == 'systemd' and docker__register_version.stdout is version_compare('1.10', '>='))
 
 - name: Install Debian systemd service unit
   template:
@@ -180,11 +180,11 @@
   notify: [ 'Restart docker']
   when: (ansible_service_mgr == 'systemd' and
          ((docker__register_systemd_service|d() and
-         docker__register_systemd_service|changed) or
+         docker__register_systemd_service is changed) or
          (docker__register_systemd_proxy_present|d() and
-         docker__register_systemd_proxy_present|changed) or
+         docker__register_systemd_proxy_present is changed) or
          (docker__register_systemd_proxy_absent|d() and
-         docker__register_systemd_proxy_absent|changed)))
+         docker__register_systemd_proxy_absent is changed)))
   tags: [ 'role::docker:config' ]
 
 - name: Add specified users to 'docker' group
@@ -215,4 +215,4 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: docker__register_facts|changed
+  when: docker__register_facts is changed

--- a/ansible/roles/debops.docker/templates/etc/docker/daemon.json.j2
+++ b/ansible/roles/debops.docker/templates/etc/docker/daemon.json.j2
@@ -3,7 +3,7 @@
 {%  if docker__bridge|d() -%}
 {%    set _ = docker__tpl_options.update({"bridge": docker__bridge}) %}
 {%- endif %}
-{%  if docker__live_restore|d() and docker__register_version.stdout | version_compare('1.12', '>=') -%}
+{%  if docker__live_restore|d() and docker__register_version.stdout is version_compare('1.12', '>=') -%}
 {%    set lv_value = true if docker__live_restore else false %}
 {%    set _  = docker__tpl_options.update({"live-restore": lv_value}) %}
 {%- endif %}
@@ -27,7 +27,7 @@
 {%-   endfor %}
 {%    set _ = docker__tpl_options.update({"dns-search": docker__tpl_dns_search}) %} 
 {%- endif %}
-{%  if docker__listen|d() and docker__register_version.stdout | version_compare('1.10', '>=') -%}
+{%  if docker__listen|d() and docker__register_version.stdout is version_compare('1.10', '>=') -%}
 {%    set docker__tpl_listen = [] %}
 {%    for element in docker__listen -%}
 {%      set _ = docker__tpl_listen.append(element) %} 

--- a/ansible/roles/debops.docker/templates/etc/systemd/system/docker.service.j2
+++ b/ansible/roles/debops.docker/templates/etc/systemd/system/docker.service.j2
@@ -11,9 +11,9 @@ Type=notify
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
-{% if docker__register_version.stdout | version_compare('1.12', '>=') %}
+{% if docker__register_version.stdout is version_compare('1.12', '>=') %}
 ExecStart=/usr/bin/dockerd {{ docker__options | join(" ") }}
-{% elif docker__register_version.stdout | version_compare('1.10', '>=') %}
+{% elif docker__register_version.stdout is version_compare('1.10', '>=') %}
 ExecStart=/usr/bin/docker daemon {{ docker__options | join(" ") }}
 {% else %}
 EnvironmentFile=-/etc/default/docker

--- a/ansible/roles/debops.docker_gen/tasks/main.yml
+++ b/ansible/roles/debops.docker_gen/tasks/main.yml
@@ -81,7 +81,7 @@
 - name: Reload systemd daemons
   command: systemctl daemon-reload
   when: ((ansible_local|d() and ansible_local.init|d() and ansible_local.init == 'systemd') and
-         (docker_gen__register_service|d() and docker_gen__register_service|changed))
+         (docker_gen__register_service|d() and docker_gen__register_service is changed))
 
 - name: Start docker-gen on install
   service:
@@ -89,4 +89,4 @@
     state: 'started'
     enabled: True
   when: docker_gen__register_install|d() and
-        docker_gen__register_install|changed
+        docker_gen__register_install is changed

--- a/ansible/roles/debops.elastic_co/tasks/main.yml
+++ b/ansible/roles/debops.elastic_co/tasks/main.yml
@@ -45,5 +45,5 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: (elastic_co__register_facts|changed or
-         elastic_co__register_install|changed)
+  when: (elastic_co__register_facts is changed or
+         elastic_co__register_install is changed)

--- a/ansible/roles/debops.elasticsearch/tasks/main.yml
+++ b/ansible/roles/debops.elasticsearch/tasks/main.yml
@@ -51,7 +51,7 @@
 
 - name: Reload systemd daemons
   command: systemctl daemon-reload
-  when: (elasticsearch__register_systemd|changed and
+  when: (elasticsearch__register_systemd is changed and
          ansible_service_mgr == 'systemd')
 
 - name: Generate Elasticsearch configuration
@@ -72,7 +72,7 @@
     group: '{{ elasticsearch__group }}'
     mode: '0660'
   notify: [ 'Restart elasticsearch' ]
-  when: elasticsearch__version | version_compare("5.0.0", ">=")
+  when: elasticsearch__version is version_compare("5.0.0", ">=")
   tags: [ 'role::elasticsearch:config' ]
 
 - name: Check state of installed Elasticsearch plugins
@@ -130,4 +130,4 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: elasticsearch__register_facts|changed
+  when: elasticsearch__register_facts is changed

--- a/ansible/roles/debops.etc_aliases/tasks/main.yml
+++ b/ansible/roles/debops.etc_aliases/tasks/main.yml
@@ -40,7 +40,7 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: etc_aliases__register_facts|changed
+  when: etc_aliases__register_facts is changed
 
 - name: Generate the /etc/aliases file
   template:

--- a/ansible/roles/debops.etc_aliases/templates/etc/aliases.j2
+++ b/ansible/roles/debops.etc_aliases/templates/etc/aliases.j2
@@ -17,7 +17,7 @@
 {%         if element.section == section.name and element.state|d('present') != 'absent' %}
 {%           set comment_prefix =   ('' if not section_loop else '\n') %}
 {%           set alias_name =       (('"' + (element.real_name | d(element.name)) + '"')
-                                     if (element.real_name | d(element.name)) | search('[^a-zA-Z0-9\-\_\.]')
+                                     if (element.real_name | d(element.name)) is search('[^a-zA-Z0-9\-\_\.]')
                                      else (element.real_name | d(element.name))) %}
 {%           if element.recipients|d() %}
 {%             set alias_recipients = ' ' + ([ element.recipients ] if element.recipients is string else element.recipients) | join(', ') %}

--- a/ansible/roles/debops.etherpad/tasks/main.yml
+++ b/ansible/roles/debops.etherpad/tasks/main.yml
@@ -65,7 +65,7 @@
     owner: '{{ etherpad_user }}'
     group: '{{ etherpad_group }}'
     mode: '0755'
-  when: (etherpad_register_source is defined and etherpad_register_source.changed == True) or
+  when: (etherpad_register_source is defined and etherpad_register_source is changed) or
         (etherpad_register_directory is defined and etherpad_register_directory.stat.exists == False)
   tags: [ 'role::etherpad:source' ]
 
@@ -76,7 +76,7 @@
     owner: '{{ etherpad_user }}'
     group: '{{ etherpad_group }}'
     mode: '0644'
-  when: (etherpad_register_source is defined and etherpad_register_source.changed == True) or
+  when: (etherpad_register_source is defined and etherpad_register_source is changed) or
         (etherpad_register_directory is defined and etherpad_register_directory.stat.exists == False)
   tags: [ 'role::etherpad:source' ]
 
@@ -89,7 +89,7 @@
   become_user: '{{ etherpad_user }}'
   register: etherpad_register_checkout
   notify: [ 'Restart etherpad-lite' ]
-  when: (etherpad_register_source is defined and etherpad_register_source.changed == True) or
+  when: (etherpad_register_source is defined and etherpad_register_source is changed) or
         (etherpad_register_directory is defined and etherpad_register_directory.stat.exists == False)
   tags: [ 'role::etherpad:source' ]
 
@@ -123,7 +123,7 @@
     chdir: '{{ etherpad_home + "/" + etherpad_repository }}'
     creates: '{{ etherpad_home }}/.node-gyp'
   become_user: '{{ etherpad_user }}'
-  when: etherpad_register_checkout|changed
+  when: etherpad_register_checkout is changed
 
 - name: Manage Etherpad plugins
   npm:
@@ -170,16 +170,16 @@
 - name: Reload systemd daemons
   command: systemctl daemon-reload
   when: (ansible_service_mgr == 'systemd' and
-         (etherpad__register_sysvinit|changed or
-          etherpad__register_systemd|changed))
+         (etherpad__register_sysvinit is changed or
+          etherpad__register_systemd is changed))
 
 - name: Ensure that etherpad-lite is started
   service:
     name: 'etherpad-lite'
     state: 'started'
     enabled: True
-  when: (etherpad__register_sysvinit|changed or
-         etherpad__register_systemd|changed)
+  when: (etherpad__register_sysvinit is changed or
+         etherpad__register_systemd is changed)
 
 - name: Wait for the API key file generation
   wait_for:
@@ -232,4 +232,4 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: etherpad__register_facts|changed
+  when: etherpad__register_facts is changed

--- a/ansible/roles/debops.fcgiwrap/tasks/configure_systemd.yml
+++ b/ansible/roles/debops.fcgiwrap/tasks/configure_systemd.yml
@@ -15,7 +15,7 @@
 
 - name: Reload systemd units
   command: 'systemctl daemon-reload'
-  when: fcgiwrap__register_systemd.changed|bool
+  when: fcgiwrap__register_systemd is changed
 
 - name: Enable and start systemd units
   service:
@@ -25,4 +25,4 @@
   with_nested:
     - '{{ fcgiwrap__instances }}'
     - [ 'socket', 'service' ]
-  when: fcgiwrap__instances and fcgiwrap__register_systemd.changed|bool
+  when: fcgiwrap__instances and fcgiwrap__register_systemd is changed

--- a/ansible/roles/debops.fcgiwrap/tasks/main.yml
+++ b/ansible/roles/debops.fcgiwrap/tasks/main.yml
@@ -41,7 +41,7 @@
     name: 'fcgiwrap'
     state: 'stopped'
     enabled: False
-  when: fcgiwrap__disable_default|bool and fcgiwrap__register_install.changed|bool
+  when: fcgiwrap__disable_default|bool and fcgiwrap__register_install is changed
 
 - name: Configure fcgiwrap instances in sysvinit
   include: configure_sysvinit.yml

--- a/ansible/roles/debops.fcgiwrap/templates/etc/default/fcgiwrap-instance.j2
+++ b/ansible/roles/debops.fcgiwrap/templates/etc/default/fcgiwrap-instance.j2
@@ -5,7 +5,7 @@
 
 {% set fcgiwrap__tpl_options = { 'value': '' } %}
 {% for key, value in fcgiwrap__options_map.items() %}
-{% if fcgiwrap__register_version.stdout|d() | version_compare(key, '>=') %}
+{% if fcgiwrap__register_version.stdout|d() is version_compare(key, '>=') %}
 {% set _ = fcgiwrap__tpl_options.update({ 'value': value }) %}
 {% endif %}
 {% endfor %}

--- a/ansible/roles/debops.fcgiwrap/templates/etc/systemd/system/fcgiwrap-instance.service.j2
+++ b/ansible/roles/debops.fcgiwrap/templates/etc/systemd/system/fcgiwrap-instance.service.j2
@@ -7,7 +7,7 @@ Requires=fcgiwrap-{{ item.0.name }}.socket
 
 {% set fcgiwrap__tpl_options = { 'value': '' } %}
 {% for key, value in fcgiwrap__options_map.items() %}
-{% if fcgiwrap__register_version.stdout|d() | version_compare(key, '>=') %}
+{% if fcgiwrap__register_version.stdout|d() is version_compare(key, '>=') %}
 {% set _ = fcgiwrap__tpl_options.update({ 'value': value }) %}
 {% endif %}
 {% endfor %}

--- a/ansible/roles/debops.ferm/tasks/main.yml
+++ b/ansible/roles/debops.ferm/tasks/main.yml
@@ -111,7 +111,7 @@
   with_items:
     - '{{ ferm__register_rules_removed.results }}'
     - '{{ ferm__register_rules_created.results }}'
-  when: (item.item.key|d() and item.changed|bool)
+  when: (item.item.key|d() and item is changed)
   tags: [ 'role::ferm:rules' ]
 
 - name: Remove iptables INPUT rules if requested
@@ -147,9 +147,9 @@
   service:
     name: 'ferm'
     state: 'restarted'
-  when: (ferm__enabled | bool and (ferm__register_files.changed|bool or
-         ferm__register_rules_created|changed or ferm__register_rules_removed|changed or
-         ferm__register_input_rules_del.changed|bool or ferm__register_input_rules_add.changed|bool))
+  when: (ferm__enabled | bool and (ferm__register_files is changed or
+         ferm__register_rules_created is changed or ferm__register_rules_removed is changed or
+         ferm__register_input_rules_del is changed or ferm__register_input_rules_add is changed))
 
 - name: Clear iptables rules if ferm is disabled
   service:
@@ -170,7 +170,7 @@
 
 - name: Reload sysctl configuration if modified
   command: sysctl -p /etc/sysctl.d/30-ferm.conf
-  when: ferm__register_sysctl.changed | bool
+  when: ferm__register_sysctl is changed
   tags: [ 'role::ferm:rules' ]
 
 - name: Remove deprecated ifupdown hook
@@ -205,4 +205,4 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: ferm__register_facts|changed
+  when: ferm__register_facts is changed

--- a/ansible/roles/debops.gitlab/defaults/main.yml
+++ b/ansible/roles/debops.gitlab/defaults/main.yml
@@ -63,7 +63,7 @@ gitlab_use_systemd: '{{ (ansible_local.gitlab.systemd_services
 # .. envvar:: gitlab_enable_pages [[[
 #
 # Whether to enable ``gitlab-pages``. Available in Gitlab 8.17 and newer.
-gitlab_enable_pages: '{{ gitlab_version | version_compare("8.17",
+gitlab_enable_pages: '{{ gitlab_version is version_compare("8.17",
                          operator="ge", strict=True) and gitlab_pages_domain != "" }}'
                                                                    # ]]]
                                                                    # ]]]
@@ -804,7 +804,7 @@ gitlab__gitaly_checkout: '{{ gitlab_app_root_path + "/gitaly" }}'
 #
 # Rake task which cleans GitLab static assets during upgrades.
 gitlab_assets_clean: '{{ "gitlab:assets:clean"
-                         if (gitlab_version | version_compare("8.17", operator="ge", strict=True))
+                         if (gitlab_version is version_compare("8.17", operator="ge", strict=True))
                          else "assets:clean" }}'
 
                                                                    # ]]]
@@ -813,7 +813,7 @@ gitlab_assets_clean: '{{ "gitlab:assets:clean"
 # Rake task which builds or rebuilds GitLab assets during installation or
 # upgrades.
 gitlab_assets_compile: '{{ "gitlab:assets:compile"
-                           if (gitlab_version | version_compare("8.17", operator="ge", strict=True))
+                           if (gitlab_version is version_compare("8.17", operator="ge", strict=True))
                            else "assets:precompile" }}'
 
                                                                    # ]]]

--- a/ansible/roles/debops.gitlab/tasks/configure_gitaly.yml
+++ b/ansible/roles/debops.gitlab/tasks/configure_gitaly.yml
@@ -92,12 +92,12 @@
   when: (ansible_local|d() and ansible_local.gitlab|d() and
          (ansible_local.gitlab.installed|d() | bool) and
          ansible_service_mgr == 'systemd' and
-         gitlab_register_gitlab__gitaly_checkout|changed)
+         gitlab_register_gitlab__gitaly_checkout is changed)
 
 - name: Setup gitaly
   make:
     chdir: '{{ gitlab__gitaly_checkout }}'
-  when: gitlab_register_gitlab__gitaly_checkout|changed
+  when: gitlab_register_gitlab__gitaly_checkout is changed
 
 - name: Start gitaly service after an upgrade
   service:
@@ -106,7 +106,7 @@
   when: (ansible_local|d() and ansible_local.gitlab|d() and
          (ansible_local.gitlab.installed|d() | bool) and
          ansible_service_mgr == 'systemd' and
-         gitlab_register_gitlab__gitaly_checkout|changed)
+         gitlab_register_gitlab__gitaly_checkout is changed)
 
 - name: Configure Gitaly
   template:

--- a/ansible/roles/debops.gitlab/tasks/configure_gitlab-pages.yml
+++ b/ansible/roles/debops.gitlab/tasks/configure_gitlab-pages.yml
@@ -100,4 +100,4 @@
     GOPATH: '{{ gitlab_app_root_path }}/go'
   become: True
   become_user: '{{ gitlab_user }}'
-  when: gitlab_register_pages_checkout|changed
+  when: gitlab_register_pages_checkout is changed

--- a/ansible/roles/debops.gitlab/tasks/configure_gitlab-shell.yml
+++ b/ansible/roles/debops.gitlab/tasks/configure_gitlab-shell.yml
@@ -117,4 +117,4 @@
   shell: ./bin/install ; test ! -x './bin/compile' || ./bin/compile
   args:
     chdir: '{{ gitlab_shell_git_checkout }}'
-  when: gitlab_register_shell_checkout|changed
+  when: gitlab_register_shell_checkout is changed

--- a/ansible/roles/debops.gitlab/tasks/configure_gitlab-workhorse.yml
+++ b/ansible/roles/debops.gitlab/tasks/configure_gitlab-workhorse.yml
@@ -95,4 +95,4 @@
     chdir: '{{ gitlab_workhorse_checkout }}'
   become: True
   become_user: '{{ gitlab_user }}'
-  when: gitlab_register_gitlab_workhorse_checkout|changed
+  when: gitlab_register_gitlab_workhorse_checkout is changed

--- a/ansible/roles/debops.gitlab/tasks/configure_gitlab_ce.yml
+++ b/ansible/roles/debops.gitlab/tasks/configure_gitlab_ce.yml
@@ -168,7 +168,7 @@
 - name: Install GitLab SysVinit script
   command: cp -f {{ gitlab_ce_git_checkout + "/lib/support/init.d/gitlab" }} /etc/init.d/gitlab
   register: gitlab__register_sysvinit_script
-  when: (gitlab_register_ce_checkout|changed and
+  when: (gitlab_register_ce_checkout is changed and
          (gitlab_use_systemd is defined and not gitlab_use_systemd))
 
 - name: Install GitLab systemd service files
@@ -181,9 +181,9 @@
     - 'gitlab-sidekiq.service'
     - 'gitlab-unicorn.service'
     - 'gitlab-workhorse.service'
-    - '{{ "gitlab-gitaly.service" if (gitlab_version | version_compare("9.0", operator="gt", strict=True)) else [] }}'
+    - '{{ "gitlab-gitaly.service" if (gitlab_version is version_compare("9.0", operator="gt", strict=True)) else [] }}'
   register: gitlab__register_systemd_services
-  when: (gitlab_register_ce_checkout|changed and
+  when: (gitlab_register_ce_checkout is changed and
          (gitlab_use_systemd is defined and gitlab_use_systemd))
 
 - name: Install GitLab Pages systemd service file
@@ -192,26 +192,26 @@
     dest: '/etc/systemd/system/gitlab-pages.service'
   register: gitlab__register_pages_systemd_services
   when: (gitlab_enable_pages and
-         gitlab_register_ce_checkout|changed and
+         gitlab_register_ce_checkout is changed and
          (gitlab_use_systemd is defined and gitlab_use_systemd))
 
 - name: Reload systemd daemons
   command: systemctl daemon-reload
   when: (ansible_service_mgr == "systemd" and
-         (gitlab__register_sysvinit_script|changed or
-          gitlab__register_systemd_services|changed or
-          gitlab__register_pages_systemd_services|changed))
+         (gitlab__register_sysvinit_script is changed or
+          gitlab__register_systemd_services is changed or
+          gitlab__register_pages_systemd_services is changed))
 
 - name: Enable GitLab SysVinit service
   service:
     name: 'gitlab'
     enabled: True
-  when: (gitlab_register_ce_checkout|changed and
+  when: (gitlab_register_ce_checkout is changed and
          ansible_service_mgr != 'systemd' and not gitlab_use_systemd|bool)
 
 - name: Enable GitLab SysVinit service (systemd)
   command: systemctl enable gitlab
-  when: (gitlab_register_ce_checkout|changed and
+  when: (gitlab_register_ce_checkout is changed and
          ansible_service_mgr == 'systemd' and not gitlab_use_systemd|bool)
 
 - name: Enable GitLab systemd services
@@ -224,8 +224,8 @@
     - 'gitlab-sidekiq.service'
     - 'gitlab-unicorn.service'
     - 'gitlab-workhorse.service'
-    - '{{ "gitlab-gitaly.service" if (gitlab_version | version_compare("9.0", operator="gt", strict=True)) else [] }}'
-  when: (gitlab_register_ce_checkout|changed and
+    - '{{ "gitlab-gitaly.service" if (gitlab_version is version_compare("9.0", operator="gt", strict=True)) else [] }}'
+  when: (gitlab_register_ce_checkout is changed and
          gitlab_use_systemd|bool)
 
 - name: Enable GitLab Pages systemd service
@@ -233,7 +233,7 @@
     name: 'gitlab-pages.service'
     enabled: True
   when: (gitlab_enable_pages and
-         gitlab_register_ce_checkout|changed and
+         gitlab_register_ce_checkout is changed and
          gitlab_use_systemd|bool)
 
 - name: Setup GitLab CE logrotate configuration
@@ -253,8 +253,8 @@
     chdir: '{{ gitlab_ce_git_checkout }}'
   become: True
   become_user: '{{ gitlab_user }}'
-  when: gitlab_version | version_compare("8.17", operator="lt", strict=True)
-        and gitlab_register_ce_checkout|changed
+  when: gitlab_version is version_compare("8.17", operator="lt", strict=True)
+        and gitlab_register_ce_checkout is changed
 
 - name: Yarn install
   command: yarn install --production
@@ -262,8 +262,8 @@
     chdir: '{{ gitlab_ce_git_checkout }}'
   become: True
   become_user: '{{ gitlab_user }}'
-  when: gitlab_version | version_compare("8.17", operator="ge", strict=True)
-        and gitlab_register_ce_checkout|changed
+  when: gitlab_version is version_compare("8.17", operator="ge", strict=True)
+        and gitlab_register_ce_checkout is changed
 
   # The RubyGems.org website has frequent timeouts, so we will try and install
   # everything again as long as there are errors.
@@ -274,7 +274,7 @@
     chdir: '{{ gitlab_ce_git_checkout }}'
   become: True
   become_user: '{{ gitlab_user }}'
-  when: gitlab_register_ce_checkout|changed
+  when: gitlab_register_ce_checkout is changed
 
 - name: Set default administrator email address and password
   replace:
@@ -303,7 +303,7 @@
           (ansible_local.gitlab is undefined or (ansible_local.gitlab is defined and
            (ansible_local.gitlab.installed is undefined or (ansible_local.gitlab.installed is defined and
             not ansible_local.gitlab.installed)))))) and
-         gitlab_register_ce_checkout|changed and
+         gitlab_register_ce_checkout is changed and
          gitlab__database == 'postgresql')
 
 - name: Reset default administrator email address and password
@@ -330,7 +330,7 @@
   notify: [ 'Restart gitlab', 'Restart gitlab.slice' ]
   when: (ansible_local|d() and ansible_local.gitlab|d() and
          (ansible_local.gitlab.installed|d() | bool) and
-         gitlab_register_ce_checkout|changed)
+         gitlab_register_ce_checkout is changed)
 
 - name: Clean GitLab assets
   command: bundle exec rake {{ gitlab_assets_clean }} RAILS_ENV=production
@@ -340,7 +340,7 @@
   become_user: '{{ gitlab_user }}'
   when: (ansible_local|d() and ansible_local.gitlab|d() and
          (ansible_local.gitlab.installed|d() | bool) and
-         gitlab_register_bundle_migrate|changed)
+         gitlab_register_bundle_migrate is changed)
 
 - name: Precompile GitLab assets
   command: bundle exec rake {{ gitlab_assets_compile }} RAILS_ENV=production NODE_ENV=production
@@ -349,8 +349,8 @@
   become: True
   become_user: '{{ gitlab_user }}'
   notify: [ 'Restart gitlab', 'Restart gitlab.slice' ]
-  when: gitlab_register_bundle_setup_postgresql|changed or
-        gitlab_register_bundle_migrate|changed
+  when: gitlab_register_bundle_setup_postgresql is changed or
+        gitlab_register_bundle_migrate is changed
 
 - name: Clear GitLab cache
   command: bundle exec rake cache:clear RAILS_ENV=production
@@ -360,7 +360,7 @@
   become_user: '{{ gitlab_user }}'
   when: (ansible_local|d() and ansible_local.gitlab|d() and
          (ansible_local.gitlab.installed|d() | bool) and
-         gitlab_register_bundle_migrate|changed)
+         gitlab_register_bundle_migrate is changed)
 
 - name: Configure periodical GitLab backups
   cron:

--- a/ansible/roles/debops.gitlab/tasks/main.yml
+++ b/ansible/roles/debops.gitlab/tasks/main.yml
@@ -63,7 +63,7 @@
 - include: configure_gitlab_ce.yml
 
 - include: configure_gitaly.yml
-  when: gitlab_version | version_compare("9.0", operator="gt", strict=True)
+  when: gitlab_version is version_compare("9.0", operator="gt", strict=True)
 
 - include: start_gitlab_ce.yml
 

--- a/ansible/roles/debops.gitlab/templates/var/local/git/gitconfig.j2
+++ b/ansible/roles/debops.gitlab/templates/var/local/git/gitconfig.j2
@@ -7,7 +7,7 @@
 	name		= {{ gitlab_email_name | default('GitLab') }}
 	email		= {{ gitlab_email_from | default('git@' + gitlab_domain[0]) }}
 
-{% if gitlab_version | version_compare("8.7", operator="ge", strict=True) %}
+{% if gitlab_version is version_compare("8.7", operator="ge", strict=True) %}
 [gc]
 	auto		= 0
 {% endif %}

--- a/ansible/roles/debops.gitlab/templates/var/local/git/gitlab/config/gitlab.yml.j2
+++ b/ansible/roles/debops.gitlab/templates/var/local/git/gitlab/config/gitlab.yml.j2
@@ -581,7 +581,7 @@ test:
     path: tmp/tests/gitlab-satellites/
   repositories:
     storages:
-{% if gitlab_version | version_compare("9.0", operator="ge", strict=True) %}
+{% if gitlab_version is version_compare("9.0", operator="ge", strict=True) %}
       default:
         path: tmp/tests/repositories/
 {% else %}

--- a/ansible/roles/debops.grub/tasks/main.yml
+++ b/ansible/roles/debops.grub/tasks/main.yml
@@ -93,7 +93,7 @@
   no_log: True
   changed_when: False
   register: grub_register_pw_hashes
-  when: (item.0.name|d() and item.1|changed)
+  when: (item.0.name|d() and item.1 is changed)
   with_together:
     - '{{ grub_combined_users }}'
     - '{{ grub_register_pw_plain.results|d({}) }}'
@@ -106,7 +106,7 @@
   become: False
   delegate_to: 'localhost'
   no_log: True
-  when: (not item.1|skipped)
+  when: (item.1 is not skipped)
   with_together:
     - '{{ grub_combined_users }}'
     - '{{ grub_register_pw_hashes.results|d({}) }}'
@@ -142,7 +142,7 @@
 
 - name: Copy /etc/grub.d/10_linux.dpkg-divert to its original location
   command: cp /etc/grub.d/10_linux.dpkg-divert /etc/grub.d/10_linux
-  when: grub__register_linux_divert|changed
+  when: grub__register_linux_divert is changed
 
 - name: Apply patch to allow to configure the default menu entry parameters
   replace:

--- a/ansible/roles/debops.gunicorn/tasks/main.yml
+++ b/ansible/roles/debops.gunicorn/tasks/main.yml
@@ -37,4 +37,4 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: gunicorn__register_facts|changed
+  when: gunicorn__register_facts is changed

--- a/ansible/roles/debops.gunicorn/tasks/newer_releases.yml
+++ b/ansible/roles/debops.gunicorn/tasks/newer_releases.yml
@@ -116,9 +116,9 @@
 - name: Reload systemd configuration
   command: systemctl daemon-reload
   when: (ansible_service_mgr == 'systemd' and
-         (gunicorn__register_systemd_config|changed or
-          gunicorn__register_systemd_remove|changed or
-          gunicorn__register_systemd_per_instance|changed))
+         (gunicorn__register_systemd_config is changed or
+          gunicorn__register_systemd_remove is changed or
+          gunicorn__register_systemd_per_instance is changed))
 
 - name: Remove Unicorn instance configuration
   file:

--- a/ansible/roles/debops.hashicorp/tasks/main.yml
+++ b/ansible/roles/debops.hashicorp/tasks/main.yml
@@ -210,7 +210,7 @@
   with_together:
     - '{{ (hashicorp__applications + hashicorp__dependent_applications) | unique }}'
     - '{{ hashicorp__register_unpack.results }}'
-  when: (item.1|changed or (ansible_local|d() and
+  when: (item.1 is changed or (ansible_local|d() and
          (ansible_local.hashicorp is not defined or
           (ansible_local.hashicorp|d() and ansible_local.hashicorp.applications|d() and
            (ansible_local.hashicorp.applications[item.0] is not defined or
@@ -224,7 +224,7 @@
   args:
     warn: False
   with_items: '{{ (hashicorp__applications + hashicorp__dependent_applications) | unique }}'
-  when: (hashicorp__consul_webui|bool and item == 'consul' and hashicorp__register_unpack_webui|changed)
+  when: (hashicorp__consul_webui|bool and item == 'consul' and hashicorp__register_unpack_webui is changed)
 
 
 # Ansible local facts [[[1
@@ -251,4 +251,4 @@
 - name: Reload facts if they were modified
   action: setup
   when: ((hashicorp__applications or hashicorp__dependent_applications) and
-         hashicorp__register_facts|changed)
+         hashicorp__register_facts is changed)

--- a/ansible/roles/debops.ifupdown/tasks/divert_interfaces.yml
+++ b/ansible/roles/debops.ifupdown/tasks/divert_interfaces.yml
@@ -8,7 +8,7 @@
 
 - name: Provide original interface configuration temporarily
   command: cp /etc/network/interfaces.dpkg-divert {{ ifupdown__reconfigure_init_file }}
-  when: ifupdown__register_divert|changed
+  when: ifupdown__register_divert is changed
 
 - name: Remove redundant configuration
   lineinfile:
@@ -19,7 +19,7 @@
     - '^source /etc/network/interfaces.d/*'
     - '^auto lo'
     - '^iface lo inet loopback'
-  when: ifupdown__register_divert|changed
+  when: ifupdown__register_divert is changed
 
 - name: Create /etc/network/interfaces
   template:
@@ -38,5 +38,5 @@
     group: 'root'
     mode: '0644'
   notify: [ 'Apply ifupdown configuration' ]
-  when: (ifupdown__register_divert|changed or
-         ifupdown__register_main_config|changed)
+  when: (ifupdown__register_divert is changed or
+         ifupdown__register_main_config is changed)

--- a/ansible/roles/debops.ifupdown/tasks/ifup_systemd.yml
+++ b/ansible/roles/debops.ifupdown/tasks/ifup_systemd.yml
@@ -21,7 +21,7 @@
 
 - name: Reload systemd services
   command: systemctl daemon-reload
-  when: ansible_service_mgr == 'systemd' and ifupdown__register_systemd_services|changed
+  when: ansible_service_mgr == 'systemd' and ifupdown__register_systemd_services is changed
 
   ## https://stackoverflow.com/a/28888474
 - name: Test if Ansible is running in check mode
@@ -34,4 +34,4 @@
     name: '{{ item }}'
     enabled: True
   with_items: [ 'ifup-wait-all-auto', 'ifup-allow-boot' ]
-  when: (ansible_service_mgr == 'systemd' and not ifupdown__register_check_mode|skipped)
+  when: (ansible_service_mgr == 'systemd' and ifupdown__register_check_mode is not skipped)

--- a/ansible/roles/debops.ifupdown/tasks/main.yml
+++ b/ansible/roles/debops.ifupdown/tasks/main.yml
@@ -19,7 +19,7 @@
   when: (ansible_local|d() and ansible_local.debops_fact|d() and
          ansible_local.debops_fact.enabled|bool and
          (ansible_local.debops_fact.version is undefined or
-          (ansible_local.debops_fact.version.ifupdown|d("0.0.0") | version_compare("0.3.0","<"))))
+          (ansible_local.debops_fact.version.ifupdown|d("0.0.0") is version_compare("0.3.0","<"))))
 
 - name: Create configuration directories
   file:
@@ -61,7 +61,7 @@
   with_items:
     - '{{ ifupdown__register_interfaces_removed.results }}'
     - '{{ ifupdown__register_interfaces_created.results }}'
-  when: (item.item.key|d() and item|changed)
+  when: (item.item.key|d() and item is changed)
 
 - name: Mark modified interfaces for processing
   copy:
@@ -89,7 +89,7 @@
     - '{{ ifupdown__register_interfaces_removed.results }}'
     - '{{ ifupdown__register_interfaces_created.results }}'
   notify: [ 'Apply ifupdown configuration' ]
-  when: (item.item.key|d() and item|changed)
+  when: (item.item.key|d() and item is changed)
 
 - name: Remove custom configuration files
   file:

--- a/ansible/roles/debops.ifupdown/templates/etc/systemd/system/iface@.service.j2
+++ b/ansible/roles/debops.ifupdown/templates/etc/systemd/system/iface@.service.j2
@@ -16,7 +16,7 @@ IgnoreOnIsolate=yes
 
 [Service]
 {# https://bugs.debian.org/761909 #}
-{% if ansible_service_mgr == 'systemd' and ifupdown__tpl_systemd_version | version_compare('228.0', '>=') %}
+{% if ansible_service_mgr == 'systemd' and ifupdown__tpl_systemd_version is version_compare('228.0', '>=') %}
 # avoid stopping on shutdown via stopping system-iface.slice
 Slice=system.slice
 {% endif %}

--- a/ansible/roles/debops.ipxe/tasks/debian_pxeboot.yml
+++ b/ansible/roles/debops.ipxe/tasks/debian_pxeboot.yml
@@ -42,7 +42,7 @@
   command: cp {{ ipxe_tftp_root }}/debian-installer/amd64/initrd.gz {{ ipxe_debian_pxeboot_workdir }}/
   args:
     creates: '{{ ipxe_debian_pxeboot_workdir + "/initrd.gz" }}'
-  when: ipxe_register_debian_netinst|d() and ipxe_register_debian_netinst.changed
+  when: ipxe_register_debian_netinst|d() and ipxe_register_debian_netinst is changed
 
 - name: Download non-free firmware
   get_url:
@@ -56,16 +56,16 @@
     src: '{{ ipxe_debian_pxeboot_workdir + "/" + (ipxe_debian_pxeboot_firmware_url | basename) }}'
     dest: '{{ ipxe_debian_pxeboot_workdir + "/firmware" }}'
     copy: False
-  when: ipxe_register_firmware|d() and ipxe_register_firmware.changed
+  when: ipxe_register_firmware|d() and ipxe_register_firmware is changed
 
 - name: Create firmware cpio archive
   shell: pax -x sv4cpio -s'%{{ ipxe_debian_pxeboot_workdir }}/firmware%/firmware%'
          -w {{ ipxe_debian_pxeboot_workdir }}/firmware |
          gzip -c > {{ ipxe_debian_pxeboot_workdir }}/firmware.cpio.gz
-  when: ipxe_register_firmware|d() and ipxe_register_firmware.changed
+  when: ipxe_register_firmware|d() and ipxe_register_firmware is changed
 
 - name: Create Debian netboot initrd with firmware
   shell: cat {{ ipxe_debian_pxeboot_workdir + "/initrd.gz" }}
              {{ ipxe_debian_pxeboot_workdir + "/firmware.cpio.gz" }} >
              {{ ipxe_tftp_root + "/debian-installer/amd64/initrd.gz" }}
-  when: ipxe_register_firmware|d() and ipxe_register_firmware.changed
+  when: ipxe_register_firmware|d() and ipxe_register_firmware is changed

--- a/ansible/roles/debops.iscsi/tasks/main.yml
+++ b/ansible/roles/debops.iscsi/tasks/main.yml
@@ -32,7 +32,7 @@
   service:
     name:  'open-iscsi'
     state: 'restarted'
-  when: iscsi__enabled|d() and iscsi__register_initiatorname|d() and iscsi__register_initiatorname.changed
+  when: iscsi__enabled|d() and iscsi__register_initiatorname|d() and iscsi__register_initiatorname is changed
 
 - name: Generate iSCSI interface configuration
   shell: iscsiadm -m iface -I {{ item }} -o new ;

--- a/ansible/roles/debops.java/tasks/main.yml
+++ b/ansible/roles/debops.java/tasks/main.yml
@@ -35,4 +35,4 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: java__register_facts|changed
+  when: java__register_facts is changed

--- a/ansible/roles/debops.kibana/tasks/main.yml
+++ b/ansible/roles/debops.kibana/tasks/main.yml
@@ -96,4 +96,4 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: kibana__register_facts|changed
+  when: kibana__register_facts is changed

--- a/ansible/roles/debops.librenms/defaults/main.yml
+++ b/ansible/roles/debops.librenms/defaults/main.yml
@@ -523,7 +523,7 @@ librenms__logrotate__dependent_config:
 librenms__php__dependent_packages:
   - [ 'mysql', 'gmp', 'gd', 'snmp', 'curl', 'mcrypt', 'json' ]
   - '{{ [ "xml", "mbstring", "zip" ]
-        if (php__version | version_compare("7.0",">=")) else [] }}'
+        if (php__version is version_compare("7.0",">=")) else [] }}'
 
                                                                    # ]]]
 # .. envvar:: librenms__php__dependent_pools [[[

--- a/ansible/roles/debops.librenms/tasks/main.yml
+++ b/ansible/roles/debops.librenms/tasks/main.yml
@@ -138,7 +138,7 @@
   args:
     chdir: '{{ librenms__install_path }}'
   become_user: '{{ librenms__user }}'
-  when: (librenms__register_database_status|d() and librenms__register_database_status.changed)
+  when: (librenms__register_database_status|d() and librenms__register_database_status is changed)
   tags: [ 'role::librenms:database' ]
 
 - name: Get list of existing users from LibreNMS database

--- a/ansible/roles/debops.libvirt/tasks/manage_pools.yml
+++ b/ansible/roles/debops.libvirt/tasks/manage_pools.yml
@@ -18,7 +18,7 @@
     mode: '{{ item.item.mode | d(omit) }}'
   with_flattened: '{{ libvirt__register_stop.results }}'
   become: False
-  when: (item.changed|d() and item.item.name|d() and item.item.delete|d(False) and
+  when: (item is changed and item.item.name|d() and item.item.delete|d(False) and
          item.item.state|d() in [ 'undefined' ] and
          item.item.type in [ 'dir', 'nfs', 'logical' ])
 
@@ -50,7 +50,7 @@
     mode: '{{ item.item.mode | d(omit) }}'
   with_flattened: '{{ libvirt__register_define.results }}'
   become: False
-  when: (item.changed|d() and item.item.name|d() and
+  when: (item is changed and item.item.name|d() and
          (item.item.state|d('active') not in [ 'undefined', 'absent' ]) and
          (item.item.build|d(True)) and
          (item.item.type in [ 'dir', 'nfs' ] or

--- a/ansible/roles/debops.libvirtd/tasks/main.yml
+++ b/ansible/roles/debops.libvirtd/tasks/main.yml
@@ -42,7 +42,7 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: libvirtd__register_facts|changed
+  when: libvirtd__register_facts is changed
 
 - name: Divert managed configuration files
   command: 'dpkg-divert --quiet --local --divert {{ item }}.dpkg-divert --rename {{ item }}'

--- a/ansible/roles/debops.locales/tasks/main.yml
+++ b/ansible/roles/debops.locales/tasks/main.yml
@@ -30,7 +30,7 @@
 
 - name: Update /etc/default/locale
   command: 'update-locale LANG={{ locales__system_lang }}'
-  when: ansible_pkg_mgr == 'apt' and locales__register_system_lang|changed
+  when: ansible_pkg_mgr == 'apt' and locales__register_system_lang is changed
 
 - name: Make sure that Ansible local facts directory exists
   file:
@@ -51,4 +51,4 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: locales__register_facts|changed
+  when: locales__register_facts is changed

--- a/ansible/roles/debops.lvm/tasks/manage_lvm.yml
+++ b/ansible/roles/debops.lvm/tasks/manage_lvm.yml
@@ -2,8 +2,8 @@
 
 - name: Rescan LVM Volume Groups
   command: vgscan
-  when: ((lvm__register_devices_filter|d() and lvm__register_devices_filter.changed) or
-         (lvm__register_devices_global_filter|d() and lvm__register_devices_global_filter.changed))
+  when: ((lvm__register_devices_filter|d() and lvm__register_devices_filter is changed) or
+         (lvm__register_devices_global_filter|d() and lvm__register_devices_global_filter is changed))
 
 - name: Unmount filesystems if requested
   mount:

--- a/ansible/roles/debops.lxc/tasks/install_kernel_from_backports.yml
+++ b/ansible/roles/debops.lxc/tasks/install_kernel_from_backports.yml
@@ -15,7 +15,7 @@
 - name: Check status of available LXC containers
   command: lxc-ls -f
   register: lxc_list_status
-  when: lxc_register_kernel_upgrade|changed
+  when: lxc_register_kernel_upgrade is changed
 
 - name: Send mail to administrator about new or updated kernel
   mail:
@@ -24,4 +24,4 @@
     to: '{{ lxc_kernel_mail_to | join(",") }}'
     charset: 'utf8'
     body: '{{ lxc_kernel_mail_body }}'
-  when: lxc_register_kernel_upgrade|changed
+  when: lxc_register_kernel_upgrade is changed

--- a/ansible/roles/debops.lxc/tasks/main.yml
+++ b/ansible/roles/debops.lxc/tasks/main.yml
@@ -18,7 +18,7 @@
 # Configure LXC support when correct version is installed
 - include: configure_lxc.yml
   when: (lxc_register_package_version is defined and
-         lxc_register_package_version.stdout | version_compare('1.0','>='))
+         lxc_register_package_version.stdout is version_compare('1.0','>='))
 
 # Install backported Linux kernel on Debian Wheezy
 - include: install_kernel_from_backports.yml
@@ -28,7 +28,7 @@
 # Manage LXC containers via Ansible when correct kernel is installed
 - include: manage_containers.yml
   when: (lxc_containers is defined and lxc_containers) and
-        ansible_kernel | version_compare('3.10','>')
+        ansible_kernel is version_compare('3.10','>')
 
 - name: Make sure that Ansible local facts directory exists
   file:
@@ -49,7 +49,7 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: lxc__register_facts|changed
+  when: lxc__register_facts is changed
 
 - name: DebOps post_tasks hook
   include: "{{ lookup('task_src', 'lxc/post_main.yml') }}"

--- a/ansible/roles/debops.machine/tasks/main.yml
+++ b/ansible/roles/debops.machine/tasks/main.yml
@@ -76,7 +76,7 @@
 - name: Create /run/motd.dynamic symlink
   command: systemd-tmpfiles --create
   when: machine__enabled|bool and ansible_service_mgr == 'systemd' and
-        machine__register_tmpfiles|changed
+        machine__register_tmpfiles is changed
 
 - name: Check current MOTD diversions
   environment:
@@ -130,7 +130,7 @@
     - '{{ machine__register_motd_scripts_removed.results }}'
     - '{{ machine__register_motd_scripts_created.results }}'
   when: (item.item.name|d() and not (item.item.divert|d())|bool and
-         item.item.filename is undefined and item.changed|bool)
+         item.item.filename is undefined and item is changed)
 
 - name: Revert packaged MOTD scripts
   shell: rm -f /etc/update-motd.d/{{ item.filename | d(("%02d" | format(item.weight|int))|string + "-" + item.name) }} ; dpkg-divert --quiet --local --rename --remove /etc/update-motd.d/{{ item.filename | d(("%02d" | format(item.weight|int))|string + "-" + item.name) }}
@@ -163,4 +163,4 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: machine__register_facts|changed
+  when: machine__register_facts is changed

--- a/ansible/roles/debops.mailman/tasks/main.yml
+++ b/ansible/roles/debops.mailman/tasks/main.yml
@@ -48,17 +48,17 @@
 - name: Reconfigure mailman package
   shell: dpkg-reconfigure --frontend noninteractive mailman
   register: mailman__package_reconfigure
-  when: (mailman__register_debconf_question1.changed|bool or
-         mailman__register_debconf_question2.changed|bool)
+  when: (mailman__register_debconf_question1 is changed or
+         mailman__register_debconf_question2 is changed)
   tags: [ 'role::mailman:lang' ]
 
 - name: Run language pack conversion script
   script: scripts/convert-mailman-to-utf8 {{ (mailman__default_languages + mailman__languages + mailman__register_debconf.current["mailman/used_languages"].split(" ") | unique) | join(' ') }}
   register: mailman__register_convert_script
   changed_when: mailman__register_convert_script.stdout
-  when: ((mailman__register_patches|d() and mailman__register_patches.changed|bool) or
-         (mailman__register_debconf_question1|d() and mailman__register_debconf_question1.changed|bool) or
-         (mailman__register_debconf_question2|d() and mailman__register_debconf_question2.changed|bool))
+  when: ((mailman__register_patches|d() and mailman__register_patches is changed) or
+         (mailman__register_debconf_question1|d() and mailman__register_debconf_question1 is changed) or
+         (mailman__register_debconf_question2|d() and mailman__register_debconf_question2 is changed))
   tags: [ 'role::mailman:patch', 'role::mailman:lang' ]
 
 - name: Configure Mailman
@@ -81,7 +81,7 @@
 
 - name: Generate postfix_transport map
   command: /usr/sbin/postmap /etc/mailman/postfix_transport
-  when: mailman__register_postfix_transport.changed|bool
+  when: mailman__register_postfix_transport is changed
 
 - name: Create Mailman site list
   shell: echo | newlist {{ '' if (mailman__site_list_notify|bool) else '--quiet' }} --language={{ mailman__site_language }} {{ mailman__site_list }} {{ mailman__site_admin }}
@@ -96,12 +96,12 @@
 
 - name: Set site administrator password
   command: mmsitepass {{ lookup('password', secret + '/credentials/' + ansible_fqdn + '/mailman/site/site_administrator_password chars=ascii,numbers,digits,hexdigits length=' + mailman__site_password_length) }}
-  when: mailman__register_site_list.changed|bool
+  when: mailman__register_site_list is changed
   no_log: True
 
 - name: Set list creator password
   command: mmsitepass -c {{ lookup('password', secret + '/credentials/' + ansible_fqdn + '/mailman/site/list_creator_password chars=ascii,numbers,digits,hexdigits length=' + mailman__site_password_length) }}
-  when: mailman__register_site_list.changed|bool
+  when: mailman__register_site_list is changed
   no_log: True
 
 - name: Remove Mailman lists if requested
@@ -160,4 +160,4 @@
 
 - name: Re-read local facts if they have been modified
   action: setup
-  when: mailman__register_facts|changed
+  when: mailman__register_facts is changed

--- a/ansible/roles/debops.mariadb/tasks/main.yml
+++ b/ansible/roles/debops.mariadb/tasks/main.yml
@@ -97,7 +97,7 @@
 
 - name: Re-read local facts if they have been modified
   action: setup
-  when: mariadb__register_local_facts.changed|bool
+  when: mariadb__register_local_facts is changed
 
 - name: Manage database contents
   include: 'manage_contents.yml'

--- a/ansible/roles/debops.mariadb/tasks/manage_contents.yml
+++ b/ansible/roles/debops.mariadb/tasks/manage_contents.yml
@@ -35,7 +35,7 @@
   when: ((item.0.database|d(False) or item.0.name|d(False)) and
          (item.0.state is undefined or item.0.state != 'absent') and
          (item.0.source|d(False) and item.0.target|d(False)) and
-         (item.0.name == item.1.db and item.1.changed))
+         (item.0.name == item.1.db and item.1 is changed))
 
 - name: Import source file contents into database
   mysql_db:
@@ -48,7 +48,7 @@
   delegate_to: '{{ mariadb__delegate_to }}'
   when: ((item.0.database|d(False) or item.0.name|d(False)) and
          (item.0.state is undefined or item.0.state != 'absent') and
-         item.0.target|d(False) and (item.0.name == item.1.db and item.1.changed))
+         item.0.target|d(False) and (item.0.name == item.1.db and item.1 is changed))
 
 - name: Remove source files
   file:

--- a/ansible/roles/debops.mariadb_server/tasks/main.yml
+++ b/ansible/roles/debops.mariadb_server/tasks/main.yml
@@ -88,7 +88,7 @@
     name: 'mysql'
     state: 'restarted'
   when: ((mariadb_server__register_version|d() and not mariadb_server__register_version.stdout) and
-         (mariadb_server__register_install_status|d() and mariadb_server__register_install_status|changed))
+         (mariadb_server__register_install_status|d() and mariadb_server__register_install_status is changed))
 
 - name: Secure database server
   include: 'secure_installation.yml'
@@ -113,4 +113,4 @@
 
 - name: Re-read local facts if they have been modified
   action: setup
-  when: mariadb_server__register_local_facts|changed
+  when: mariadb_server__register_local_facts is changed

--- a/ansible/roles/debops.mariadb_server/tasks/secure_installation.yml
+++ b/ansible/roles/debops.mariadb_server/tasks/secure_installation.yml
@@ -36,4 +36,4 @@
     db: 'test'
     state: 'absent'
   when: ((mariadb_server__register_version|d() and not mariadb_server__register_version.stdout) and
-         (mariadb_server__register_install_status|d() and mariadb_server__register_install_status|changed))
+         (mariadb_server__register_install_status|d() and mariadb_server__register_install_status is changed))

--- a/ansible/roles/debops.monit/tasks/main.yml
+++ b/ansible/roles/debops.monit/tasks/main.yml
@@ -48,4 +48,4 @@
 
 - name: Re-read local facts if they have been modified
   action: setup
-  when: monit__register_facts|changed
+  when: monit__register_facts is changed

--- a/ansible/roles/debops.mosquitto/tasks/main.yml
+++ b/ansible/roles/debops.mosquitto/tasks/main.yml
@@ -90,7 +90,7 @@
     - '{{ mosquitto__auth_host_users }}'
   when: (mosquitto__password|bool and item.state|d('present') == 'absent' and
          (item.name | d(item) in mosquitto__register_passwd.stdout_lines) and
-         mosquitto__version | version_compare('1.4.0', '>='))
+         mosquitto__version is version_compare('1.4.0', '>='))
   notify: [ 'Reload mosquitto' ]
   tags: [ 'role::mosquitto:passwd' ]
   no_log: '{{ secret__no_log | bool }}'
@@ -105,7 +105,7 @@
     - '{{ mosquitto__auth_host_users }}'
   when: (mosquitto__password|bool and item.state|d('present') != 'absent' and
          (item.name | d(item) not in mosquitto__register_passwd.stdout_lines) and
-         mosquitto__version | version_compare('1.4.0', '>='))
+         mosquitto__version is version_compare('1.4.0', '>='))
   notify: [ 'Reload mosquitto' ]
   tags: [ 'role::mosquitto:passwd' ]
   no_log: '{{ secret__no_log | bool }}'
@@ -231,5 +231,5 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: mosquitto__register_facts|changed
+  when: mosquitto__register_facts is changed
   tags: [ 'role::mosquitto:passwd' ]

--- a/ansible/roles/debops.netbox/tasks/main.yml
+++ b/ansible/roles/debops.netbox/tasks/main.yml
@@ -45,8 +45,8 @@
   become: True
   become_user: '{{ netbox__user }}'
   register: netbox__register_virtualenv
-  changed_when: (netbox__register_virtualenv|success and
-                 netbox__register_virtualenv.stdout|search('New python executable in'))
+  changed_when: (netbox__register_virtualenv is success and
+                 netbox__register_virtualenv.stdout is search('New python executable in'))
 
 - name: Clone NetBox source code
   git:
@@ -122,7 +122,7 @@
     executable: '/bin/sh'
   become: True
   become_user: '{{ netbox__user }}'
-  when: netbox__register_checkout|changed
+  when: netbox__register_checkout is changed
 
 - name: Clean up stale Python bytecode
   shell: find . -name '*.pyc' -delete
@@ -131,7 +131,7 @@
     executable: '/bin/sh'
   become: True
   become_user: '{{ netbox__user }}'
-  when: netbox__register_checkout|changed
+  when: netbox__register_checkout is changed
 
 - name: Install NetBox requirements in virtualenv
   pip:
@@ -141,7 +141,7 @@
   become: True
   become_user: '{{ netbox__user }}'
   notify: [ 'Restart gunicorn for netbox', 'Restart netbox internal appserver' ]
-  when: netbox__register_checkout|changed
+  when: netbox__register_checkout is changed
 
 - name: Install additional Python modules in virtualenv
   pip:
@@ -151,7 +151,7 @@
   become: True
   become_user: '{{ netbox__user }}'
   with_flattened: '{{ netbox__virtualenv_pip_packages }}'
-  when: netbox__register_checkout|changed and
+  when: netbox__register_checkout is changed and
         item.state|d('present') not in [ 'absent', 'ignore' ]
 
 - name: Generate NetBox configuration
@@ -174,7 +174,7 @@
     executable: '/bin/sh'
   become: True
   become_user: '{{ netbox__user }}'
-  when: netbox__register_checkout|changed
+  when: netbox__register_checkout is changed
   register: netbox__register_migration
 
 - name: Create superuser account
@@ -193,7 +193,7 @@
   become: True
   become_user: '{{ netbox__user }}'
   when: (not netbox__register_installed.stat.exists|bool and
-         not netbox__register_migration.stdout|search('No migrations to apply.'))
+         not netbox__register_migration.stdout is search('No migrations to apply.'))
   no_log: True
 
 - name: Generate static assets
@@ -206,7 +206,7 @@
     executable: '/bin/sh'
   become: True
   become_user: '{{ netbox__user }}'
-  when: netbox__register_checkout|changed
+  when: netbox__register_checkout is changed
 
 - name: Load initial data
   environment:
@@ -219,7 +219,7 @@
   become: True
   become_user: '{{ netbox__user }}'
   when: (netbox__load_initial_data|bool and not netbox__register_installed.stat.exists|bool and
-         not netbox__register_migration.stdout|search('No migrations to apply.'))
+         not netbox__register_migration.stdout is search('No migrations to apply.'))
 
 - name: Generate systemd service unit
   template:
@@ -235,7 +235,7 @@
 - name: Reload systemd configuration
   command: systemctl daemon-reload
   when: (ansible_service_mgr == 'systemd' and
-         netbox__register_systemd|changed)
+         netbox__register_systemd is changed)
 
 - name: Enable and start netbox internal appserver
   service:
@@ -243,7 +243,7 @@
     state: 'started'
     enabled: True
   when: (netbox__app_internal_appserver|bool and ansible_service_mgr == 'systemd' and
-         netbox__register_systemd|changed and not netbox__register_installed.stat.exists|bool)
+         netbox__register_systemd is changed and not netbox__register_installed.stat.exists|bool)
 
 - name: Make sure that Ansible local facts directory exists
   file:
@@ -264,4 +264,4 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: netbox__register_facts|changed
+  when: netbox__register_facts is changed

--- a/ansible/roles/debops.nfs/tasks/main.yml
+++ b/ansible/roles/debops.nfs/tasks/main.yml
@@ -23,7 +23,7 @@
   service:
     name: 'nfs-common'
     state: 'restarted'
-  when: nfs__register_config|changed and
+  when: nfs__register_config is changed and
         ansible_distribution == 'Debian' and
         ansible_distribution_release in [ 'wheezy', 'jessie' ]
 

--- a/ansible/roles/debops.nginx/tasks/main.yml
+++ b/ansible/roles/debops.nginx/tasks/main.yml
@@ -227,7 +227,7 @@
 
 - name: Gather facts if they were modified
   action: setup
-  when: (nginx_register_local_facts.changed and nginx__deploy_state in [ 'present' ])
+  when: (nginx_register_local_facts is changed and nginx__deploy_state in [ 'present' ])
 
 - include: 'nginx_htpasswd.yml'
   when: (nginx__deploy_state in [ 'present' ])
@@ -274,7 +274,7 @@
 
 - name: Gather facts if they were modified
   action: setup
-  when: (nginx_register_local_facts.changed and nginx__deploy_state in [ 'present' ])
+  when: (nginx_register_local_facts is changed and nginx__deploy_state in [ 'present' ])
 
 - name: DebOps post_tasks hook
   include: '{{ lookup("task_src", "nginx/post_main.yml") }}'

--- a/ansible/roles/debops.nginx/tasks/nginx_servers.yml
+++ b/ansible/roles/debops.nginx/tasks/nginx_servers.yml
@@ -178,7 +178,7 @@
 
 - name: Save fact if Ansible is running in check mode in variable
   set_fact:
-    nginx__fact_check_mode: '{{ nginx__register_check_mode|skipped }}'
+    nginx__fact_check_mode: '{{ nginx__register_check_mode is skipped }}'
 
 - name: Enable nginx server configuration
   file:

--- a/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/default.conf.j2
+++ b/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/default.conf.j2
@@ -533,7 +533,7 @@ server {
 
 {%     endif                                                %}
 {%     for port in nginx_tpl_listen_ssl                     %}
-        listen {{ port }} ssl{% if nginx_version | version_compare('1.9.5','>=') %} http2{% elif nginx_version | version_compare('1.4','>=') %} spdy{% endif %}{% if nginx_tpl_default_server_ssl %} {{ nginx_tpl_default_server_ssl | join(" ") }}{% endif %}{% if (loop.first and nginx_tpl_ipv6only_ssl) %} {{ nginx_tpl_ipv6only_ssl | join(" ") }}{% endif %};
+        listen {{ port }} ssl{% if nginx_version is version_compare('1.9.5','>=') %} http2{% elif nginx_version is version_compare('1.4','>=') %} spdy{% endif %}{% if nginx_tpl_default_server_ssl %} {{ nginx_tpl_default_server_ssl | join(" ") }}{% endif %}{% if (loop.first and nginx_tpl_ipv6only_ssl) %} {{ nginx_tpl_ipv6only_ssl | join(" ") }}{% endif %};
 {%     endfor                                               %}
 
         ssl_certificate           {{ nginx_tpl_ssl_certificate }};
@@ -547,7 +547,7 @@ server {
 {%     if item.ssl_curve | default(nginx_default_ssl_curve) %}
         ssl_ecdh_curve            {{ item.ssl_curve | default(nginx_default_ssl_curve) }};
 {%     endif                                                %}
-{%     if nginx_version | version_compare('1.4','>=') and (item.ocsp | d(nginx_ocsp)) | bool %}
+{%     if nginx_version is version_compare('1.4','>=') and (item.ocsp | d(nginx_ocsp)) | bool %}
         ssl_stapling              on;
 {%         if (item.ocsp_verify | d(nginx_ocsp_verify)) | bool  %}
         ssl_stapling_verify       on;
@@ -575,10 +575,10 @@ server {
         add_header                Content-Security-Policy-Report-Only "{{ item.csp_report|d(item.csp|d("default-src https: ;")) + (" " + item.csp_append|d(nginx__http_csp_append) if (item.csp_append|d(nginx__http_csp_append)) else "") }}";
 {% endif %}
 {%     if item.content_type_options|d(True) != omit             %}
-        add_header                X-Content-Type-Options "{{ item.content_type_options | d('nosniff') }}"{% if nginx_version | version_compare('1.7.5','>=') %} always{% endif %};
+        add_header                X-Content-Type-Options "{{ item.content_type_options | d('nosniff') }}"{% if nginx_version is version_compare('1.7.5','>=') %} always{% endif %};
 {%     endif                                                    %}
 {%     if item.frame_options|d() != omit                        %}
-        add_header                X-Frame-Options "{{ item.frame_options | d('SAMEORIGIN') }}"{% if nginx_version | version_compare('1.7.5','>=') %} always{% endif %};
+        add_header                X-Frame-Options "{{ item.frame_options | d('SAMEORIGIN') }}"{% if nginx_version is version_compare('1.7.5','>=') %} always{% endif %};
 {%     endif                                                    %}
 {%     if item.xss_protection | d(nginx__http_xss_protection) != omit %}
         add_header                X-XSS-Protection "{{ item.xss_protection | d(nginx__http_xss_protection) }}";

--- a/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/php.conf.j2
+++ b/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/php.conf.j2
@@ -59,7 +59,7 @@
                 try_files $script_name =404;
 
 {%     if item.php_include|d(True) %}
-{%       if (nginx_version|d() and nginx_version | version_compare('1.6.1','<')) %}
+{%       if (nginx_version|d() and nginx_version is version_compare('1.6.1','<')) %}
                 include {{ item.php_include | d('fastcgi_params') }};
 {%       else %}
 {%         if nginx_flavor in [ 'passenger', 'nginx.org' ] %}

--- a/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/php5.conf.j2
+++ b/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/php5.conf.j2
@@ -103,7 +103,7 @@
                 try_files $script_name =404;
 
 {% if (item.php5_include is undefined or (item.php5_include is defined and item.php5_include)) %}
-{% if (nginx_version is defined and nginx_version | version_compare('1.6.1','<')) %}
+{% if (nginx_version is defined and nginx_version is version_compare('1.6.1','<')) %}
                 include {{ item.php5_include | default('fastcgi_params') }};
 {% else %}
 {% if nginx_flavor in [ 'passenger', 'nginx.org' ] %}

--- a/ansible/roles/debops.nodejs/tasks/main.yml
+++ b/ansible/roles/debops.nodejs/tasks/main.yml
@@ -76,7 +76,7 @@
   command: '{{ nodejs__npm_git_install_command }}'
   args:
     chdir: '{{ nodejs__npm_git_dest }}'
-  when: nodejs__npm_git_enabled|bool and nodejs__register_npm_git|changed
+  when: nodejs__npm_git_enabled|bool and nodejs__register_npm_git is changed
 
 - name: Install NPM packages
   npm:
@@ -115,4 +115,4 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: nodejs__register_facts|changed
+  when: nodejs__register_facts is changed

--- a/ansible/roles/debops.nsswitch/tasks/main.yml
+++ b/ansible/roles/debops.nsswitch/tasks/main.yml
@@ -19,7 +19,7 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: nsswitch__register_facts|changed
+  when: nsswitch__register_facts is changed
 
 - name: Generate Name Service Switch configuration
   template:

--- a/ansible/roles/debops.ntp/tasks/timezone.yml
+++ b/ansible/roles/debops.ntp/tasks/timezone.yml
@@ -37,7 +37,7 @@
     path: '/etc/localtime'
     src: '/usr/share/zoneinfo/{{ ntp__timezone }}'
     state: 'link'
-  when: (ntp__register_etc_timezone|changed and
+  when: (ntp__register_etc_timezone is changed and
          ntp__register_etc_localtime.stat.islnk|bool)
 
 - name: Configure timezone with timedatectl
@@ -47,10 +47,10 @@
         (ansible_local is undefined or
             (ansible_local|d() and ansible_local.timezone|d() and
                 ntp__timezone != ansible_local.timezone) or
-            (ntp__register_etc_timezone|d() and ntp__register_etc_timezone|changed))
+            (ntp__register_etc_timezone|d() and ntp__register_etc_timezone is changed))
 
 - name: Reconfigure tzdata
   shell: dpkg-reconfigure --frontend noninteractive tzdata
-  when: ((ntp__register_debconf_set_area|d() and ntp__register_debconf_set_area|changed) or
-         (ntp__register_debconf_set_zone|d() and ntp__register_debconf_set_zone|changed) or
-         (ntp__register_etc_timezone|d() and ntp__register_etc_timezone|changed))
+  when: ((ntp__register_debconf_set_area|d() and ntp__register_debconf_set_area is changed) or
+         (ntp__register_debconf_set_zone|d() and ntp__register_debconf_set_zone is changed) or
+         (ntp__register_etc_timezone|d() and ntp__register_etc_timezone is changed))

--- a/ansible/roles/debops.opendkim/tasks/main.yml
+++ b/ansible/roles/debops.opendkim/tasks/main.yml
@@ -35,7 +35,7 @@
 
 - name: Re-read local facts if they have been modified
   action: setup
-  when: opendkim__register_facts|changed
+  when: opendkim__register_facts is changed
 
 - name: Generate OpenDKIM configuration
   template:
@@ -75,7 +75,7 @@
   when: (ansible_service_mgr == 'systemd' and
          ansible_distribution_release not in
          [ 'wheezy', 'jessie', 'precise', 'trusty', 'xenial' ] and
-         opendkim__register_pid_socket|changed)
+         opendkim__register_pid_socket is changed)
 
 - name: Ensure that DomainKey directory exists
   file:

--- a/ansible/roles/debops.openvz/tasks/configure_kernel.yml
+++ b/ansible/roles/debops.openvz/tasks/configure_kernel.yml
@@ -18,13 +18,13 @@
 - name: Update grub
   shell: update-grub 2>&1
   register: openvz_grub_status
-  when: (openvz_kernel_status is defined and openvz_kernel_status.changed) or
-        (openvz_grub_configuration is defined and openvz_grub_configuration.changed)
+  when: (openvz_kernel_status is defined and openvz_kernel_status is changed) or
+        (openvz_grub_configuration is defined and openvz_grub_configuration is changed)
 
 - name: List current OpenVZ containers
   shell: vzlist --all 2>&1
   register: openvz_vzlist_status
-  when: openvz_kernel_status is defined and openvz_kernel_status.changed
+  when: openvz_kernel_status is defined and openvz_kernel_status is changed
 
 - name: Send mail to administrator about new or updated kernel
   mail:
@@ -33,4 +33,4 @@
     to: '{{ openvz_mail_to | join(",") }}'
     charset: 'utf8'
     body: '{{ openvz_mail_kernel_body }}'
-  when: openvz_kernel_status is defined and openvz_kernel_status.changed
+  when: openvz_kernel_status is defined and openvz_kernel_status is changed

--- a/ansible/roles/debops.owncloud/defaults/main.yml
+++ b/ansible/roles/debops.owncloud/defaults/main.yml
@@ -47,7 +47,7 @@ owncloud__base_packages:
 
   ## Useful for debugging. Refer to `owncloud__base_php_packages` for the PHP packages
   - '{{ [ "smbclient" ] if (owncloud__smb_support|bool) else [] }}'
-  - '{{ [ "libsmbclient" ] if (owncloud__smb_support|bool and owncloud__release | version_compare("9.0", ">=")) else [] }}'
+  - '{{ [ "libsmbclient" ] if (owncloud__smb_support|bool and owncloud__release is version_compare("9.0", ">=")) else [] }}'
 
 
 # .. envvar:: owncloud__required_php_packages
@@ -107,10 +107,10 @@ owncloud__base_php_packages:
   ## PHP Warning: PHP Startup: Unable to load dynamic library '/usr/lib/php/20151012/redis.so'
   ## - /usr/lib/php/20151012/redis.so: undefined symbol: igbinary_serialize in Unknown on line 0
   - '{{ [ "igbinary" ]
-        if (not (ansible_distribution == "Ubuntu" and (ansible_distribution_version|version_compare("15.10", "<"))))
+        if (not (ansible_distribution == "Ubuntu" and (ansible_distribution_version is version_compare("15.10", "<"))))
         else [] }}'
 
-  - '{{ [ "libsmbclient" ] if (owncloud__smb_support|bool and owncloud__release | version_compare("8.9.9", "<=")) else [] }}'
+  - '{{ [ "libsmbclient" ] if (owncloud__smb_support|bool and owncloud__release is version_compare("8.9.9", "<=")) else [] }}'
 
   ## Included in normal PHP installations but require it here because it is
   ## used internally by the role:
@@ -1037,7 +1037,7 @@ owncloud__smb_support: False
 #      ## Create an additional admin account.
 #      - command: 'user:add --password-from-env --display-name="Administrator" --group="admin" admin'
 #        ## Does not work with ownCloud 8.0 or below so don’t run it there.
-#        when: '{{ owncloud__release | version_compare("8.1", ">=") }}'
+#        when: '{{ owncloud__release is version_compare("8.1", ">=") }}'
 #        env:
 #          OC_PASS: "{{ lookup('password', secret + '/credentials/' +
 #                       ansible_fqdn + '/owncloud/admin/' + 'admin' +
@@ -1046,7 +1046,7 @@ owncloud__smb_support: False
 #      ## Create an regular user. Note that you probably want to use an existing
 #      ## user database like LDAP.
 #      - command: 'user:add --password-from-env --display-name="Normal user" user'
-#        when: '{{ owncloud__release | version_compare("8.1", ">=") }}'
+#        when: '{{ owncloud__release is version_compare("8.1", ">=") }}'
 #        env:
 #          OC_PASS: "{{ lookup('password', secret + '/credentials/' +
 #                       ansible_fqdn + '/owncloud/users/' + 'user' +
@@ -1064,7 +1064,7 @@ owncloud__role_occ_cmd_list:
   ## is setup by this role using packages.
   ## Since ownCloud 9 it is called `updatenotification`.
   - command: 'app:disable updater'
-    when: '{{ owncloud__release | version_compare("8.2", "<=") }}'
+    when: '{{ owncloud__release is version_compare("8.2", "<=") }}'
 
   - command: 'app:enable user_ldap'
     when: '{{ owncloud__ldap_enabled|bool }}'
@@ -1896,7 +1896,7 @@ owncloud__nginx__dependent_servers:
 
     robots_tag: [ 'none' ]
     permitted_cross_domain_policies: 'none'
-    frame_options: '{{ omit if (owncloud__variant in ["nextcloud"] and owncloud__release | version_compare("12.0", ">=")) else "SAMEORIGIN" }}'
+    frame_options: '{{ omit if (owncloud__variant in ["nextcloud"] and owncloud__release is version_compare("12.0", ">=")) else "SAMEORIGIN" }}'
 
     options: |
       add_header X-Download-Options noopen;
@@ -1973,7 +1973,7 @@ owncloud__nginx__dependent_servers:
 
           fastcgi_intercept_errors on;
 
-          {% if (ansible_local.nginx.version if (ansible_local|d() and ansible_local.nginx|d() and ansible_local.nginx.version|d()) else "0.0") | version_compare("1.7.11",'>=') %}
+          {% if (ansible_local.nginx.version if (ansible_local|d() and ansible_local.nginx|d() and ansible_local.nginx.version|d()) else "0.0") is version_compare("1.7.11",'>=') %}
           fastcgi_request_buffering off;
           {% endif %}
 
@@ -1993,7 +1993,7 @@ owncloud__nginx__dependent_servers:
           add_header Cache-Control "public, max-age=7200";
 
           add_header X-Content-Type-Options nosniff;
-          {% if not (owncloud__variant in ["nextcloud"] and owncloud__release | version_compare("12.0", ">=")) %}
+          {% if not (owncloud__variant in ["nextcloud"] and owncloud__release is version_compare("12.0", ">=")) %}
           add_header X-Frame-Options "SAMEORIGIN";
           {% endif %}
           add_header X-XSS-Protection "1; mode=block";
@@ -2059,7 +2059,7 @@ owncloud__php__dependent_configuration:
   - filename: '10-owncloud'
     by_role: 'debops.owncloud'
     state: '{{ "present"
-               if ((owncloud__apcu_enabled|bool) and (owncloud__release | match("8\.1")))
+               if ((owncloud__apcu_enabled|bool) and (owncloud__release is match("8\.1")))
                else "absent" }}'
     options: |
       ; Workaround for: https://github.com/owncloud/core/issues/17329

--- a/ansible/roles/debops.owncloud/env/tasks/main.yml
+++ b/ansible/roles/debops.owncloud/env/tasks/main.yml
@@ -60,5 +60,5 @@
 
 - name: Gather facts if they were modified
   action: setup
-  when: owncloud__register_local_facts|changed
+  when: owncloud__register_local_facts is changed
                                                                    # ]]]

--- a/ansible/roles/debops.owncloud/tasks/copy.yml
+++ b/ansible/roles/debops.owncloud/tasks/copy.yml
@@ -57,7 +57,7 @@
   include: 'run_occ.yml'
   loop_control:
     loop_var: 'owncloud__files_scan_item'
-  when: owncloud__files_scan_item|changed
+  when: owncloud__files_scan_item is changed
   with_items: '{{ (owncloud__register_create_user_files.results|d([]) + owncloud__register_delete_user_files.results|d([]))
-                  if (owncloud__register_create_user_files is defined and not owncloud__register_create_user_files|skipped)
+                  if (owncloud__register_create_user_files is defined and owncloud__register_create_user_files is not skipped)
                   else [] }}'

--- a/ansible/roles/debops.owncloud/tasks/run_occ.yml
+++ b/ansible/roles/debops.owncloud/tasks/run_occ.yml
@@ -35,7 +35,7 @@
   environment: '{{ owncloud__occ_item.env|d({}) }}'
   ## TODO: Upstream needs to fix this. See above.
   changed_when: False
-  # changed_when: (owncloud__occ_item.command|d(omit) | match("config:app:set") and
+  # changed_when: (owncloud__occ_item.command|d(omit) is match("config:app:set") and
   ## Has changed in ownCloud 9.0 and does not work anymore.
   # changed_when: ('No such app enabled:' not in owncloud__occ_run.stdout and
                   # ' already ' not in owncloud__occ_run.stdout)

--- a/ansible/roles/debops.owncloud/tasks/setup_owncloud.yml
+++ b/ansible/roles/debops.owncloud/tasks/setup_owncloud.yml
@@ -81,7 +81,7 @@
   set_fact:
     owncloud__do_autosetup: '{{ (owncloud__autosetup and
                                  owncloud__admin_username != "" and
-                                 (not owncloud__register_occ_check|skipped) and
+                                 (owncloud__register_occ_check is not skipped) and
                                  "is not installed" in owncloud__register_occ_check.stdout) }}'
 
 - name: Automatically finish setup via the occ tool
@@ -201,6 +201,6 @@
   changed_when: False
   # As of ownCloud 9.0.4, the results from `occ` don’t match the web interface output?
   # Seems to work with ownCloud 9.0.8 and Nextcloud 11.
-  when: (owncloud__release | version_compare("9.0.8", ">="))
+  when: (owncloud__release is version_compare("9.0.8", ">="))
 
 # ]]]

--- a/ansible/roles/debops.owncloud/tasks/system_package_management.yml
+++ b/ansible/roles/debops.owncloud/tasks/system_package_management.yml
@@ -63,7 +63,7 @@
 - name: Update APT repository cache
   apt:
     update_cache: True
-  when: owncloud__register_apt_key|changed or owncloud__register_apt_repository|changed
+  when: owncloud__register_apt_key is changed or owncloud__register_apt_repository is changed
 
   ## Use filename when available (2.1.0) https://github.com/ansible/ansible-modules-core/pull/2696
   ## To avoid multiple of those source files.
@@ -113,6 +113,6 @@
   args:
     executable: '/bin/sh'
   when: (owncloud__variant in ["owncloud"] and
-         owncloud__register_apt_install|changed and
+         owncloud__register_apt_install is changed and
          (ansible_local|d() and ansible_local.owncloud|d() and
          ansible_local.owncloud.auto_security_updates_enabled|d()|bool))

--- a/ansible/roles/debops.owncloud/tasks/tarballs.yml
+++ b/ansible/roles/debops.owncloud/tasks/tarballs.yml
@@ -107,7 +107,7 @@
                  owncloud__variant + "-" + owncloud__register_full_version.stdout_lines[0] + ".zip" }}'
         dest: '{{ owncloud__src + "/" + owncloud__variant + "/" + owncloud__register_full_version.stdout_lines[0] }}'
         checksum: 'sha512:{{ (owncloud__register_checksum.stdout_lines[0]).split(" ") | first }}'
-      when: owncloud__register_download_assurance|changed
+      when: owncloud__register_download_assurance is changed
       tags: [ 'role::nextcloud:download', 'role::nextcloud:verify' ]
 
     - name: Verify OpenPGP signature

--- a/ansible/roles/debops.persistent_paths/tasks/main.yml
+++ b/ansible/roles/debops.persistent_paths/tasks/main.yml
@@ -52,5 +52,5 @@
 
 - name: Reload facts if they were modified
   action: setup
-  when: persistent_paths__register_facts|changed
+  when: persistent_paths__register_facts is changed
 # ]]]

--- a/ansible/roles/debops.php/defaults/main.yml
+++ b/ansible/roles/debops.php/defaults/main.yml
@@ -88,7 +88,7 @@ php__base_packages:
   - 'curl'
   - 'gd'
   - '{{ "mcrypt"
-        if (php__version | version_compare("7.2","<"))
+        if (php__version is version_compare("7.2","<"))
         else [] }}'
 
                                                                    # ]]]
@@ -708,7 +708,7 @@ php__logrotate__dependent_config:
       compress
       delaycompress
     postrotate: |
-      {% if php__long_version | version_compare("5.5","<") %}
+      {% if php__long_version is version_compare("5.5","<") %}
       invoke-rc.d php{{ php__version }}-fpm reopen-logs > /dev/null
       {% else %}
       {{ php__logrotate_lib_base }}/php{{ php__version }}-fpm-reopenlogs

--- a/ansible/roles/debops.php/env/tasks/main.yml
+++ b/ansible/roles/debops.php/env/tasks/main.yml
@@ -32,7 +32,7 @@
 
 - name: Gather facts on reset
   action: setup
-  when: php__register_local_facts_reset|changed
+  when: php__register_local_facts_reset is changed
 
 - name: Detect PHP version from available packages
   environment:
@@ -68,16 +68,16 @@
 - name: Set PHP base paths
   set_fact:
     php__etc_base: '{{ ("/etc/php/" + php__version)
-                       if (php__version | version_compare("7.0", ">=") or php__sury|bool)
+                       if (php__version is version_compare("7.0", ">=") or php__sury|bool)
                        else "/etc/php5" }}'
     php__lib_base: '{{ ("/usr/lib/php/" + php__version)
-                       if (php__version | version_compare("7.0", ">=") or php__sury|bool)
+                       if (php__version is version_compare("7.0", ">=") or php__sury|bool)
                        else "/usr/lib/php5" }}'
     php__run_base: '{{ "/run/php"
-                       if (php__version | version_compare("7.0", ">=") or php__sury|bool)
+                       if (php__version is version_compare("7.0", ">=") or php__sury|bool)
                        else "/run" }}'
     php__logrotate_lib_base: '{{ "/usr/lib/php"
-                                 if (php__version | version_compare("7.0", ">=") or php__sury|bool)
+                                 if (php__version is version_compare("7.0", ">=") or php__sury|bool)
                                  else "/usr/lib/php5" }}'
   tags: [ 'role::php:pools', 'role::php:config' ]
 

--- a/ansible/roles/debops.php/tasks/main.yml
+++ b/ansible/roles/debops.php/tasks/main.yml
@@ -216,5 +216,5 @@
 
 - name: Gather facts if they were modified
   action: setup
-  when: php__register_local_facts|changed
+  when: php__register_local_facts is changed
                                                                    # ]]]

--- a/ansible/roles/debops.php/tasks/packages_absent_for_version.yml
+++ b/ansible/roles/debops.php/tasks/packages_absent_for_version.yml
@@ -3,7 +3,7 @@
 
 - name: Ensure older PHP packages are absent on reset for given PHP version
   apt:
-    name: '{{ item|search("php.*-")|ternary(item, php__version_absent + "-" + item) }}'
+    name: '{{ item is search("php.*-")|ternary(item, php__version_absent + "-" + item) }}'
     state: 'absent'
   with_flattened:
     - '{{ php__server_api_packages }}'

--- a/ansible/roles/debops.php/templates/etc/php/fpm/pool.d/pool.conf.j2
+++ b/ansible/roles/debops.php/templates/etc/php/fpm/pool.d/pool.conf.j2
@@ -57,7 +57,7 @@ listen = {{ item.listen | d('/run/php' + php__version + '-fpm-' + item.name + '.
 listen.owner = {{ item.listen_owner | d(php__fpm_listen_owner) }}
 listen.group = {{ item.listen_group | d(php__fpm_listen_group) }}
 listen.mode  = {{ item.listen_mode  | d(php__fpm_listen_mode) }}
-{% if (php__version | version_compare('7.0', '>=') and (item.listen_acl_users|d() or item.listen_acl_groups|d())) %}
+{% if (php__version is version_compare('7.0', '>=') and (item.listen_acl_users|d() or item.listen_acl_groups|d())) %}
 {#
 ; When POSIX Access Control Lists are supported you can set them using
 ; these options, value is a comma separated list of user/group names.
@@ -408,7 +408,7 @@ catch_workers_output = yes
 ; Default Value: yes
 ; Feature was introduced in PHP 5.6.0: https://secure.php.net/ChangeLog-5.php
 #}
-{% if php__long_version | version_compare('5.6.0', '>=') %}
+{% if php__long_version is version_compare('5.6.0', '>=') %}
 clear_env = {{ 'yes' if ((item.clear_env|d() and item.clear_env|bool) or php__fpm_clear_env|bool) else 'no' }}
 {% endif %}
 

--- a/ansible/roles/debops.phpipam/tasks/phpipam-scripts.yml
+++ b/ansible/roles/debops.phpipam/tasks/phpipam-scripts.yml
@@ -20,7 +20,7 @@
   args:
     chdir: '{{ phpipam_scripts_git_dest }}'
   when: phpipam_register_scripts_src is defined and
-        phpipam_register_scripts_src.changed
+        phpipam_register_scripts_src is changed
 
 - name: Configure phpipam-scripts
   template:

--- a/ansible/roles/debops.phpipam/tasks/phpipam.yml
+++ b/ansible/roles/debops.phpipam/tasks/phpipam.yml
@@ -116,7 +116,7 @@
     state: 'import'
     target: '{{ phpipam_database_schema }}'
   when: (phpipam_database_host == 'localhost' and
-         (phpipam_register_database_status is defined and phpipam_register_database_status.changed) and
+         (phpipam_register_database_status is defined and phpipam_register_database_status is changed) and
          (phpipam_register_configuration is defined and not phpipam_register_configuration.stat.exists))
 
 - name: Configure phpIPAM

--- a/ansible/roles/debops.phpmyadmin/tasks/main.yml
+++ b/ansible/roles/debops.phpmyadmin/tasks/main.yml
@@ -18,7 +18,7 @@
 - name: Import PHPMyAdmin schema
   mysql_db: name={{ phpmyadmin_control_database | default('phpmyadmin') }} state=import
             target=/usr/share/dbconfig-common/data/phpmyadmin/install/mysql
-  when: phpmyadmin_database is defined and phpmyadmin_database.changed == True
+  when: phpmyadmin_database is defined and phpmyadmin_database is changed
 
 - name: Create PHPMyAdmin control user
   mysql_user: name={{ phpmyadmin_control_user | default('phpmyadmin') }} state=present

--- a/ansible/roles/debops.pki/tasks/acme_tiny.yml
+++ b/ansible/roles/debops.pki/tasks/acme_tiny.yml
@@ -33,7 +33,7 @@
 
 - name: Install acme-tiny script
   command: cp -f {{ pki_acme_tiny_src }}/acme-tiny/acme_tiny.py {{ pki_acme_tiny_bin }}
-  when: pki_register_acme_tiny_src|changed
+  when: pki_register_acme_tiny_src is changed
 
 - name: Ensure that acme-tiny is executable
   file:

--- a/ansible/roles/debops.pki/tasks/main.yml
+++ b/ansible/roles/debops.pki/tasks/main.yml
@@ -65,8 +65,8 @@
 - name: Assert that required dependencies are met as documented
   assert:
     that:
-      - 'pki__register_bash_version.stdout | regex_replace("[^0-9.]", "") | version_compare("4.3.0", ">=")'
-      - 'pki__register_crypto_library_version.stdout | regex_replace("[a-z]", "") | version_compare("1.0.1" if (pki_ca_library == "openssl") else pki__register_crypto_library_version.stdout, ">=")'
+      - 'pki__register_bash_version.stdout | regex_replace("[^0-9.]", "") is version_compare("4.3.0", ">=")'
+      - 'pki__register_crypto_library_version.stdout | regex_replace("[a-z]", "") is version_compare("1.0.1" if (pki_ca_library == "openssl") else pki__register_crypto_library_version.stdout, ">=")'
   delegate_to: 'localhost'
   become: False
   run_once: True
@@ -519,7 +519,7 @@
 
 - name: Flush handlers for PKI if needed
   meta: flush_handlers
-  when: pki_register_facts|changed
+  when: pki_register_facts is changed
 
 - name: DebOps post_tasks hook
   include: "{{ lookup('task_src', 'pki/post_main.yml') }}"

--- a/ansible/roles/debops.postconf/tasks/main.yml
+++ b/ansible/roles/debops.postconf/tasks/main.yml
@@ -19,4 +19,4 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: postconf__register_facts|changed
+  when: postconf__register_facts is changed

--- a/ansible/roles/debops.postfix/defaults/main.yml
+++ b/ansible/roles/debops.postfix/defaults/main.yml
@@ -306,7 +306,7 @@ postfix__original_maincf:
       fresh installs.
     section: 'base'
     state: '{{ "present"
-               if (postfix__version | version_compare("3.0.0", ">="))
+               if (postfix__version is version_compare("3.0.0", ">="))
                else "ignore" }}'
 
   - name: 'smtpd_tls_cert_file'
@@ -340,7 +340,7 @@ postfix__original_maincf:
   - name: 'smtpd_relay_restrictions'
     section: 'base'
     state: '{{ "present"
-               if (postfix__version | version_compare("2.10.0", ">="))
+               if (postfix__version is version_compare("2.10.0", ">="))
                else "ignore" }}'
     value:
 
@@ -437,7 +437,7 @@ postfix__default_maincf:
     value: True
     section: 'base'
     state: '{{ "present"
-               if (postfix__version | version_compare("2.9.0", ">="))
+               if (postfix__version is version_compare("2.9.0", ">="))
                else "ignore" }}'
 
                                                                    # ]]]
@@ -609,7 +609,7 @@ postfix__tls_maincf:
     value: 'NO_COMPRESSION'
     section: 'tls'
     state: '{{ "present"
-              if (postfix__version | version_compare("2.11.0", ">="))
+              if (postfix__version is version_compare("2.11.0", ">="))
               else "ignore" }}'
 
                                                                    # ]]]
@@ -674,7 +674,7 @@ postfix__restrictions_maincf:
     copy_id_from: 'smtpd_sender_restrictions'
     weight: 40
     state: '{{ "present"
-               if (postfix__version | version_compare("2.10.0", ">="))
+               if (postfix__version is version_compare("2.10.0", ">="))
                else "ignore" }}'
 
   - name: 'smtpd_recipient_restrictions'
@@ -884,7 +884,7 @@ postfix__original_mastercf:
       - name: 'smtpd_relay_restrictions'
         value: [ 'permit_sasl_authenticated', 'reject' ]
         state: '{{ "present"
-                  if (postfix__version | version_compare("2.10.0", ">="))
+                  if (postfix__version is version_compare("2.10.0", ">="))
                   else "ignore" }}'
 
       - milter_macro_daemon_name: 'ORIGINATING'
@@ -919,7 +919,7 @@ postfix__original_mastercf:
       - name: 'smtpd_relay_restrictions'
         value: [ 'permit_sasl_authenticated', 'reject' ]
         state: '{{ "present"
-                  if (postfix__version | version_compare("2.10.0", ">="))
+                  if (postfix__version is version_compare("2.10.0", ">="))
                   else "ignore" }}'
 
       - milter_macro_daemon_name: 'ORIGINATING'

--- a/ansible/roles/debops.postfix/tasks/main.yml
+++ b/ansible/roles/debops.postfix/tasks/main.yml
@@ -90,7 +90,7 @@
 
 - name: Re-read local facts if they have been modified
   action: setup
-  when: postfix__register_facts|changed
+  when: postfix__register_facts is changed
 
 - name: Configure /etc/mailname
   copy:

--- a/ansible/roles/debops.postfix/templates/etc/postfix/master.cf.j2
+++ b/ansible/roles/debops.postfix/templates/etc/postfix/master.cf.j2
@@ -6,7 +6,7 @@
 #
 # Do not forget to execute "postfix reload" after editing this file.
 #
-{% set postfix__tpl_default_chroot = ((postfix__version | version_compare("3.0.0", "<")) | ternary('yes', 'no')) %}
+{% set postfix__tpl_default_chroot = ((postfix__version is version_compare("3.0.0", "<")) | ternary('yes', 'no')) %}
 # ==========================================================================
 # service type  private unpriv  chroot  wakeup  maxproc command + args
 {{ "# {:<8}{:<6}{:<8}{:<8}{:<8}{:<8}{}".format('', '', '(yes)', '(yes)', '(' + postfix__tpl_default_chroot + ')', '(never)', '(100)') }}
@@ -52,7 +52,7 @@
 {%     set element_unpriv =   set_value(element.unpriv) | from_json %}
 {%     set element_chroot =   set_value(element.chroot) | from_json %}
 {%     if element_chroot == postfix__tpl_default_chroot[0] %}
-{%       if postfix__version | version_compare("3.0.0", "<") %}
+{%       if postfix__version is version_compare("3.0.0", "<") %}
 {%         set element_chroot = '-' %}
 {%       endif %}
 {%     endif %}

--- a/ansible/roles/debops.postfix/templates/lookup/postfix__init_maincf.j2
+++ b/ansible/roles/debops.postfix/templates/lookup/postfix__init_maincf.j2
@@ -2,7 +2,7 @@
 {% for entry in postfix__combined_maincf %}
 {%   if 'section' not in entry.keys() %}
 {%     set entry_name = (entry.name | d(entry.keys()[0])) %}
-{%     if entry_name | search('_sasl_') %}
+{%     if entry_name is search('_sasl_') %}
 {%       set _ = postfix__tpl_init_maincf.append({'name': entry_name, 'state': 'init', 'section': 'auth'}) %}
 {%     elif entry_name.startswith('smtpd_tls_') %}
 {%       set _ = postfix__tpl_init_maincf.append({'name': entry_name, 'state': 'init', 'section': 'smtpd-tls'}) %}

--- a/ansible/roles/debops.postgresql/tasks/main.yml
+++ b/ansible/roles/debops.postgresql/tasks/main.yml
@@ -237,4 +237,4 @@
 - name: Re-read local facts if they have been modified
   action: setup
   when: postgresql__register_local_facts|d() and
-        postgresql__register_local_facts.changed
+        postgresql__register_local_facts is changed

--- a/ansible/roles/debops.postgresql_server/tasks/main.yml
+++ b/ansible/roles/debops.postgresql_server/tasks/main.yml
@@ -98,5 +98,5 @@
 - name: Re-read local facts if they have been modified
   action: setup
   when: postgresql_server__register_local_facts|d() and
-        postgresql_server__register_local_facts.changed
+        postgresql_server__register_local_facts is changed
   tags: [ 'role::postgresql_server:config' ]

--- a/ansible/roles/debops.postgresql_server/tasks/manage_clusters.yml
+++ b/ansible/roles/debops.postgresql_server/tasks/manage_clusters.yml
@@ -177,8 +177,8 @@
     - '{{ postgresql_server__register_config_ident.results }}'
     - '{{ postgresql_server__register_trusted.results }}'
   when: (ansible_service_mgr != 'systemd' and
-         ((item.changed|d() and item.changed) and
-          (item.item.start_conf is undefined or item.item.start_conf == 'auto')))
+         ((item is changed and
+          (item.item.start_conf is undefined or item.item.start_conf == 'auto'))))
   tags: [ 'role::postgresql_server:config' ]
 
 - name: Reload PostgreSQL clusters when needed (systemd)
@@ -191,6 +191,6 @@
     - '{{ postgresql_server__register_config_ident.results }}'
     - '{{ postgresql_server__register_trusted.results }}'
   when: (ansible_service_mgr == 'systemd' and
-         ((item.changed|d() and item.changed) and
-          (item.item.start_conf is undefined or item.item.start_conf == 'auto')))
+         ((item is changed and
+          (item.item.start_conf is undefined or item.item.start_conf == 'auto'))))
   tags: [ 'role::postgresql_server:config' ]

--- a/ansible/roles/debops.postgresql_server/templates/etc/postgresql/postgresql.conf.j2
+++ b/ansible/roles/debops.postgresql_server/templates/etc/postgresql/postgresql.conf.j2
@@ -25,7 +25,7 @@ port = {{ item.port }}
 max_connections = {{ item.max_connections | d(postgresql_server__max_connections) }}
 superuser_reserved_connections = {{ item.superuser_reserved_connections | d('3') }}
 
-{% if ((item.version | d(postgresql_server__version)) | version_compare('9.1','<=')) %}
+{% if ((item.version | d(postgresql_server__version)) is version_compare('9.1','<=')) %}
 unix_socket_directory = '{{ item.unix_socket_directories | d("/var/run/postgresql") }}'
 {% else %}
 unix_socket_directories = '{{ item.unix_socket_directories | d("/var/run/postgresql") }}'
@@ -43,17 +43,17 @@ authentication_timeout = {{ item.authentication_timeout | d('1min') }}
 
 ssl = {{ item.ssl | d(postgresql_server__pki | bool | lower) }}
 
-{% if (item.version | d(postgresql_server__version)) | version_compare('8.2','>') %}
+{% if (item.version | d(postgresql_server__version)) is version_compare('8.2','>') %}
 {# https://www.postgresql.org/docs/current/static/release-8-3.html #}
 ssl_ciphers = '{{ item.ssl_ciphers | d(postgresql_server__ssl_ciphers) }}'
 
-{% if (item.version | d(postgresql_server__version)) | version_compare('9.5','<') %}
+{% if (item.version | d(postgresql_server__version)) is version_compare('9.5','<') %}
 {# https://www.postgresql.org/docs/current/static/release-9-5.html #}
 ssl_renegotiation_limit = {{ item.ssl_renegotiation_limit | d('512MB') }}
 {% endif %}
 {% endif %}
 
-{% if ((item.version | d(postgresql_server__version)) | version_compare('9.1','>')) %}
+{% if ((item.version | d(postgresql_server__version)) is version_compare('9.1','>')) %}
 {# ref: https://www.postgresql.org/docs/current/static/release-9-2.html #}
 ssl_cert_file = '{{ item.ssl_cert_file | d(((item.pki_path | d(postgresql_server__pki_path)) + "/" + (item.pki_realm | d(postgresql_server__pki_realm)) + "/" + (item.pki_crt | d(postgresql_server__pki_crt))) if (postgresql_server__pki|d() and postgresql_server__pki | bool) else "") }}'
 ssl_key_file = '{{ item.ssl_key_file | d(((item.pki_path | d(postgresql_server__pki_path)) + "/" + (item.pki_realm | d(postgresql_server__pki_realm)) + "/" + (item.pki_key | d(postgresql_server__pki_key))) if (postgresql_server__pki|d() and postgresql_server__pki | bool) else "") }}'
@@ -61,7 +61,7 @@ ssl_ca_file = '{{ item.ssl_ca_file | d(((item.pki_path | d(postgresql_server__pk
 #ssl_crl_file = ''
 {% endif %}
 
-{% if ((item.version | d(postgresql_server__version)) | version_compare('9.3','>')) %}
+{% if ((item.version | d(postgresql_server__version)) is version_compare('9.3','>')) %}
 {# https://www.postgresql.org/docs/current/static/release-9-4.html #}
 ssl_prefer_server_ciphers = {{ item.ssl_prefer_server_ciphers | d('on') }}
 ssl_ecdh_curve = {{ item.ssl_ecdh_curve | d('prime256v1') }}
@@ -111,19 +111,19 @@ max_prepared_transactions = {{ item.max_prepared_transactions | d('0') }}
 work_mem = {{ item.work_mem | d('1MB') }}
 maintenance_work_mem = {{ item.maintenance_work_mem | d('16MB') }}
 max_stack_depth = {{ item.max_stack_depth | d('2MB') }}
-{% if (item.version | d(postgresql_server__version)) | version_compare('9.4','>=') %}
+{% if (item.version | d(postgresql_server__version)) is version_compare('9.4','>=') %}
 huge_pages = {{ item.huge_pages | d('try') }}
 autovacuum_work_mem = {{ item.autovacuum_work_mem | d('-1') }}
 {% endif %}
 
-{% if (item.version | d(postgresql_server__version)) | version_compare('9.3','>') %}
+{% if (item.version | d(postgresql_server__version)) is version_compare('9.3','>') %}
 {% if postgresql_server__register_shm|d() and postgresql_server__register_shm.stdout %}
 dynamic_shared_memory_type = {{ item.dynamic_shared_memory_type | d('posix') }}
 {% else %}
 dynamic_shared_memory_type = {{ item.dynamic_shared_memory_type | d('sysv') }}
 {% endif %}
 {% endif %}
-{% if (item.version | d(postgresql_server__version)) | version_compare('9.1','>') %}
+{% if (item.version | d(postgresql_server__version)) is version_compare('9.1','>') %}
 
 # - Disk -
 
@@ -155,7 +155,7 @@ bgwriter_lru_multiplier = {{ item.bgwriter_lru_multiplier | d('2.0') }}
 # - Asynchronous Behavior -
 
 effective_io_concurrency = {{ item.effective_io_concurrency | d('1') }}
-{% if (item.version | d(postgresql_server__version)) | version_compare('9.4','>=') %}
+{% if (item.version | d(postgresql_server__version)) is version_compare('9.4','>=') %}
 max_worker_processes = {{ item.max_worker_processes | d('8') }}
 {% endif %}
 
@@ -173,7 +173,7 @@ wal_sync_method = {{ item.wal_sync_method | d('fsync') }}
 full_page_writes = {{ item.full_page_writes | d('on') }}
 wal_buffers = {{ item.wal_buffers | d('-1') }}
 wal_writer_delay = {{ item.wal_writer_delay | d('200ms') }}
-{% if (item.version | d(postgresql_server__version)) | version_compare('9.3','>') %}
+{% if (item.version | d(postgresql_server__version)) is version_compare('9.3','>') %}
 wal_log_hints = {{ item.wal_log_hints | d('off') }}
 {% endif %}
 
@@ -183,11 +183,11 @@ commit_siblings = {{ item.commit_siblings | d('5') }}
 
 # - Checkpoints -
 
-{% if (item.version | d(postgresql_server__version)) | version_compare('9.5','<') %}
+{% if (item.version | d(postgresql_server__version)) is version_compare('9.5','<') %}
 checkpoint_segments = {{ item.checkpoint_segments | d('3') }}
 {% endif %}
 checkpoint_timeout = {{ item.checkpoint_timeout | d('5min') }}
-{% if (item.version | d(postgresql_server__version)) | version_compare('9.5','>=') %}
+{% if (item.version | d(postgresql_server__version)) is version_compare('9.5','>=') %}
 min_wal_size = {{ item.min_wal_size | d('80MB') }}
 max_wal_size = {{ item.max_wal_size | d('1GB') }}
 {% endif %}
@@ -219,10 +219,10 @@ archive_timeout = {{ item.archive_timeout | d('0') }}
 # Set these on the master and on any standby that will send replication data
 max_wal_senders = {{ item.max_wal_senders | d('0') }}
 wal_keep_segments = {{ item.wal_keep_segments | d('0') }}
-{% if (item.version | d(postgresql_server__version)) | version_compare('9.1','>') %}
+{% if (item.version | d(postgresql_server__version)) is version_compare('9.1','>') %}
 wal_sender_timeout = {{ item.wal_sender_timeout | d('60s') }}
 {% endif %}
-{% if (item.version | d(postgresql_server__version)) | version_compare('9.3','>') %}
+{% if (item.version | d(postgresql_server__version)) is version_compare('9.3','>') %}
 max_replication_slots = {{ item.max_replication_slots | d('0') }}
 {% endif %}
 
@@ -241,7 +241,7 @@ max_standby_archive_delay = {{ item.max_standby_archive_delay | d('30s') }}
 max_standby_streaming_delay = {{ item.max_standby_streaming_delay | d('30s') }}
 wal_receiver_status_interval = {{ item.wal_receiver_status_interval | d('10s') }}
 hot_standby_feedback = {{ item.hot_standby_feedback | d('off') }}
-{% if (item.version | d(postgresql_server__version)) | version_compare('9.1','>') %}
+{% if (item.version | d(postgresql_server__version)) is version_compare('9.1','>') %}
 wal_receiver_timeout = {{ item.wal_receiver_timeout | d('60s') }}
 {% endif %}
 
@@ -256,7 +256,7 @@ enable_bitmapscan = {{ item.enable_bitmapscan | d('on') }}
 enable_hashagg = {{ item.enable_hashagg | d('on') }}
 enable_hashjoin = {{ item.enable_hashjoin | d('on') }}
 enable_indexscan = {{ item.enable_indexscan | d('on') }}
-{% if (item.version | d(postgresql_server__version)) | version_compare('9.1','>') %}
+{% if (item.version | d(postgresql_server__version)) is version_compare('9.1','>') %}
 enable_indexonlyscan = {{ item.enable_indexonlyscan | d('on') }}
 {% endif %}
 enable_material = {{ item.enable_material | d('on') }}
@@ -356,13 +356,13 @@ log_timezone = '{{ item.log_timezone | d(postgresql_server__timezone) }}'
 
 track_activities = {{ item.track_activities | d('on') }}
 track_counts = {{ item.track_counts | d('on') }}
-{% if (item.version | d(postgresql_server__version)) | version_compare('9.1','>') %}
+{% if (item.version | d(postgresql_server__version)) is version_compare('9.1','>') %}
 track_io_timing = {{ item.track_io_timing | d('off') }}
 {% endif %}
 track_functions = {{ item.track_functions | d('none') }}
 track_activity_query_size = {{ item.track_activity_query_size | d('1024') }}
 update_process_title = {{ item.update_process_title | d('on') }}
-{% if (item.version | d(postgresql_server__version)) | version_compare('9.1','>') %}
+{% if (item.version | d(postgresql_server__version)) is version_compare('9.1','>') %}
 stats_temp_directory = '{{ item.stats_temp_directory | d("/var/run/postgresql/" + (item.version | d(postgresql_server__version)) + "-" + item.name + ".pg_stat_tmp") }}'
 {% else %}
 stats_temp_directory = '{{ item.stats_temp_directory | d("pg_stat_tmp") }}'
@@ -390,7 +390,7 @@ autovacuum_analyze_threshold = {{ item.autovacuum_analyze_threshold | d('50') }}
 autovacuum_vacuum_scale_factor = {{ item.autovacuum_vacuum_scale_factor | d('0.2') }}
 autovacuum_analyze_scale_factor = {{ item.autovacuum_analyze_scale_factor | d('0.1') }}
 autovacuum_freeze_max_age = {{ item.autovacuum_freeze_max_age | d('200000000') }}
-{% if (item.version | d(postgresql_server__version)) | version_compare('9.1','>') %}
+{% if (item.version | d(postgresql_server__version)) is version_compare('9.1','>') %}
 autovacuum_multixact_freeze_max_age = {{ item.autovacuum_multixact_freeze_max_age | d('400000000') }}
 {% endif %}
 autovacuum_vacuum_cost_delay = {{ item.autovacuum_vacuum_cost_delay | d('20ms') }}
@@ -412,12 +412,12 @@ default_transaction_read_only = {{ item.default_transaction_read_only | d('off')
 default_transaction_deferrable = {{ item.default_transaction_deferrable | d('off') }}
 session_replication_role = '{{ item.session_replication_role | d("origin") }}'
 statement_timeout = {{ item.statement_timeout | d('0') }}
-{% if (item.version | d(postgresql_server__version)) | version_compare('9.1','>') %}
+{% if (item.version | d(postgresql_server__version)) is version_compare('9.1','>') %}
 lock_timeout = {{ item.lock_timeout | d('0') }}
 {% endif %}
 vacuum_freeze_min_age = {{ item.vacuum_freeze_min_age | d('50000000') }}
 vacuum_freeze_table_age = {{ item.vacuum_freeze_table_age | d('150000000') }}
-{% if (item.version | d(postgresql_server__version)) | version_compare('9.1','>') %}
+{% if (item.version | d(postgresql_server__version)) is version_compare('9.1','>') %}
 vacuum_multixact_freeze_min_age = {{ item.vacuum_multixact_freeze_min_age | d('5000000') }}
 vacuum_multixact_freeze_table_age = {{ item.vacuum_multixact_freeze_table_age | d('150000000') }}
 {% endif %}
@@ -451,7 +451,7 @@ default_text_search_config = '{{ item.default_text_search_config | d("pg_catalog
 
 dynamic_library_path = '{{ item.dynamic_library_path | d("$libdir") }}'
 local_preload_libraries = '{{ item.local_preload_libraries | d("") }}'
-{% if (item.version | d(postgresql_server__version)) | version_compare('9.3','>') %}
+{% if (item.version | d(postgresql_server__version)) is version_compare('9.3','>') %}
 session_preload_libraries = '{{ item.session_preload_libraries | d("") }}'
 {% endif %}
 
@@ -477,7 +477,7 @@ default_with_oids = {{ item.default_with_oids | d('off') }}
 escape_string_warning = {{ item.escape_string_warning | d('on') }}
 lo_compat_privileges = {{ item.lo_compat_privileges | d('off') }}
 quote_all_identifiers = {{ item.quote_all_identifiers | d('off') }}
-{% if ((item.version | d(postgresql_server__version)) | version_compare('10','<')) %}
+{% if ((item.version | d(postgresql_server__version)) is version_compare('10','<')) %}
 sql_inheritance = {{ item.sql_inheritance | d('on') }}
 {% endif %}
 standard_conforming_strings = {{ item.standard_conforming_strings | d('on') }}

--- a/ansible/roles/debops.postscreen/tasks/main.yml
+++ b/ansible/roles/debops.postscreen/tasks/main.yml
@@ -31,4 +31,4 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: postscreen__register_facts|changed
+  when: postscreen__register_facts is changed

--- a/ansible/roles/debops.postwhite/tasks/main.yml
+++ b/ansible/roles/debops.postwhite/tasks/main.yml
@@ -122,4 +122,4 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: postwhite__register_facts|changed
+  when: postwhite__register_facts is changed

--- a/ansible/roles/debops.rabbitmq_server/tasks/main.yml
+++ b/ansible/roles/debops.rabbitmq_server/tasks/main.yml
@@ -89,7 +89,7 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: rabbitmq_server__register_facts|changed
+  when: rabbitmq_server__register_facts is changed
 
 - name: Generate RabbitMQ configuration
   template:

--- a/ansible/roles/debops.rabbitmq_server/templates/etc/rabbitmq/rabbitmq.config.j2
+++ b/ansible/roles/debops.rabbitmq_server/templates/etc/rabbitmq/rabbitmq.config.j2
@@ -144,9 +144,9 @@
 {{ '{}'.format(elements.value | to_json) -}}
 {%   elif elements.type == 'atom' %}
 {%     if elements.value is string %}
-{%       if elements.value | search('^[A-Z].+') %}
+{%       if elements.value is search('^[A-Z].+') %}
 {{ "'{}'".format(elements.value) -}}
-{%       elif elements.value | search('[^a-zA-Z0-9@_].+') %}
+{%       elif elements.value is search('[^a-zA-Z0-9@_].+') %}
 {{ "'{}'".format(elements.value) -}}
 {%       else %}
 {{ '{}'.format(elements.value) -}}
@@ -154,9 +154,9 @@
 {%     elif elements.value is not string and elements.value is not mapping %}
 {%       set rabbitmq_server__tpl_atom_list = [] %}
 {%       for thing in elements.value %}
-{%         if thing | search('^[A-Z].+') %}
+{%         if thing is search('^[A-Z].+') %}
 {%           set _ = rabbitmq_server__tpl_atom_list.append("'{}'".format(thing)) %}
-{%         elif thing | search('[^a-zA-Z0-9@_].+') %}
+{%         elif thing is search('[^a-zA-Z0-9@_].+') %}
 {%          set _ = rabbitmq_server__tpl_atom_list.append("'{}'".format(thing)) %}
 {%         else %}
 {%           set _ = rabbitmq_server__tpl_atom_list.append('{}'.format(thing)) %}

--- a/ansible/roles/debops.radvd/tasks/main.yml
+++ b/ansible/roles/debops.radvd/tasks/main.yml
@@ -36,4 +36,4 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: radvd__register_facts|changed
+  when: radvd__register_facts is changed

--- a/ansible/roles/debops.rails_deploy/tasks/deploy.yml
+++ b/ansible/roles/debops.rails_deploy/tasks/deploy.yml
@@ -17,7 +17,7 @@
            chdir={{ rails_deploy_src }}
   when: register_rails_deploy_public_deploy_page.stat.exists and
         rails_deploy_register_repo_status is defined and
-        rails_deploy_register_repo_status | changed
+        rails_deploy_register_repo_status is changed
   changed_when: False
   become_user: '{{ rails_deploy_service }}'
 
@@ -26,7 +26,7 @@
            chdir={{ rails_deploy_src }}
   changed_when: False
   when: rails_deploy_register_repo_status is defined and
-        rails_deploy_register_repo_status | changed
+        rails_deploy_register_repo_status is changed
   become_user: '{{ rails_deploy_service }}'
 
 - name: Restart the background worker asynchronously
@@ -34,17 +34,17 @@
   async: 90
   when: rails_deploy_worker_enabled and
         rails_deploy_register_repo_status is defined and
-        rails_deploy_register_repo_status | changed
+        rails_deploy_register_repo_status is changed
 
 - name: Prepare the database
   shell: '{{ rails_deploy_env_source }} && bundle exec rake db:schema:load db:seed
            chdir={{ rails_deploy_src }}'
   when: (rails_deploy_database_create and rails_deploy_register_database_created is defined and
-        rails_deploy_register_database_created | changed and
+        rails_deploy_register_database_created is changed and
         rails_app_database_prepare) and
         inventory_hostname == rails_deploy_hosts_master and
         rails_deploy_register_repo_status is defined and
-        rails_deploy_register_repo_status | changed
+        rails_deploy_register_repo_status is changed
   become_user: '{{ rails_deploy_service }}'
 
 - name: Store mtime of the config folder
@@ -63,7 +63,7 @@
   shell: '{{ rails_deploy_env_source }} && {{ item }} chdir={{ rails_deploy_src }}'
   when: rails_deploy_pre_migrate_shell_commands and rails_deploy_git_location and
         rails_deploy_register_repo_status is defined and
-        rails_deploy_register_repo_status | changed
+        rails_deploy_register_repo_status is changed
   with_items: rails_deploy_pre_migrate_shell_commands
   become_user: '{{ rails_deploy_service }}'
 
@@ -72,7 +72,7 @@
   when: inventory_hostname == rails_deploy_hosts_master and
         (rails_deploy_database_force_migrate or
         (rails_deploy_register_repo_status is defined and
-        rails_deploy_register_repo_status | changed and
+        rails_deploy_register_repo_status is changed and
         (rails_deploy_register_mtime_schema.stat.mtime != ansible_local.rails_deploy[rails_deploy_service].mtime.schema) or
         ansible_local.rails_deploy[rails_deploy_service].mtime.schema is undefined))
   register: rails_deploy_register_migration
@@ -82,17 +82,17 @@
   shell: '{{ rails_deploy_env_source }} && {{ item }} chdir={{ rails_deploy_src }}'
   when: rails_deploy_post_migrate_shell_commands and rails_deploy_git_location and
         rails_deploy_register_repo_status is defined and
-        rails_deploy_register_repo_status | changed
+        rails_deploy_register_repo_status is changed
   with_items: rails_deploy_post_migrate_shell_commands
   become_user: '{{ rails_deploy_service }}'
 
 - name: Reload the backend server
   service: name={{ rails_deploy_service }} state=reloaded
   when: rails_deploy_backend and (rails_deploy_register_repo_status is defined and
-        rails_deploy_register_repo_status | changed and
+        rails_deploy_register_repo_status is changed and
         (inventory_hostname == rails_deploy_hosts_master or
         inventory_hostname != item) and
-        not rails_deploy_register_migration | changed and
+        not rails_deploy_register_migration is changed and
         rails_deploy_register_mtime_config.stat.mtime == ansible_local.rails_deploy[rails_deploy_service].mtime.config and
         not rails_deploy_backend_always_restart)
   delegate_to: '{{ item }}'
@@ -102,14 +102,14 @@
   service: name={{ rails_deploy_service }} state=restarted
   when: rails_deploy_backend and (rails_deploy_database_force_migrate or
         ((rails_deploy_register_repo_status is defined and
-        rails_deploy_register_repo_status | changed) and rails_deploy_register_migration | changed) and
+        rails_deploy_register_repo_status is changed) and rails_deploy_register_migration is changed) and
         (inventory_hostname == rails_deploy_hosts_master or
         inventory_hostname != item)
         or
         rails_deploy_register_mtime_config.stat.mtime != ansible_local.rails_deploy[rails_deploy_service].mtime.config or
         (rails_deploy_backend_always_restart and rails_deploy_git_location and
         rails_deploy_register_repo_status is defined and
-        rails_deploy_register_repo_status | changed))
+        rails_deploy_register_repo_status is changed))
   delegate_to: '{{ item }}'
   with_items: groups[rails_deploy_hosts_group]
 
@@ -117,7 +117,7 @@
   service: name={{ item.name }}
            state={{ item.changed_state | default('reloaded') }}
   when: rails_deploy_register_repo_status is defined and
-        rails_deploy_register_repo_status | changed and rails_deploy_extra_services
+        rails_deploy_register_repo_status is changed and rails_deploy_extra_services
   with_items: rails_deploy_extra_services
 
 - name: Set the initial backend server state
@@ -145,7 +145,7 @@
   shell: '{{ rails_deploy_env_source }} && {{ item }} chdir={{ rails_deploy_src }}'
   when: rails_deploy_post_restart_shell_commands and rails_deploy_git_location and
         rails_deploy_register_repo_status is defined and
-        rails_deploy_register_repo_status | changed
+        rails_deploy_register_repo_status is changed
   with_items: rails_deploy_post_restart_shell_commands
   become_user: '{{ rails_deploy_service }}'
 
@@ -153,6 +153,6 @@
   command: rm -f public/index.html chdir={{ rails_deploy_src }}
   when: register_rails_deploy_public_deploy_page.stat.exists and
         rails_deploy_register_repo_status is defined and
-        rails_deploy_register_repo_status | changed
+        rails_deploy_register_repo_status is changed
   changed_when: False
   become_user: '{{ rails_deploy_service }}'

--- a/ansible/roles/debops.redis/tasks/main.yml
+++ b/ansible/roles/debops.redis/tasks/main.yml
@@ -119,7 +119,7 @@
     name: 'redis-sentinel'
     state: 'restarted'
     enabled: True
-  when: redis__sentinel_enabled|bool and redis__register_sentinel_init|changed
+  when: redis__sentinel_enabled|bool and redis__register_sentinel_init is changed
 
 - name: Make sure Ansible fact directory exists
   file:
@@ -140,4 +140,4 @@
 
 - name: Reload facts if they were modified
   action: setup
-  when: redis__register_facts|changed
+  when: redis__register_facts is changed

--- a/ansible/roles/debops.redis/tasks/redis-sentinel.yml
+++ b/ansible/roles/debops.redis/tasks/redis-sentinel.yml
@@ -18,11 +18,11 @@
 
 - name: Reload systemd daemons
   command: systemctl daemon-reload
-  when: redis__register_sentinel_unit_install|changed
+  when: redis__register_sentinel_unit_install is changed
 
 - name: Start redis-sentinel service
   service:
     name: 'redis-sentinel'
     state: 'started'
     enabled: True
-  when: redis__register_sentinel_unit_install|changed
+  when: redis__register_sentinel_unit_install is changed

--- a/ansible/roles/debops.redis/tasks/redis-server.yml
+++ b/ansible/roles/debops.redis/tasks/redis-server.yml
@@ -11,7 +11,7 @@
 
 - name: Apply dynamic redis-server configuration
   command: /etc/redis/ansible-redis-dynamic.conf config
-  when: redis__register_config_ansible_redis_dynamic|changed
+  when: redis__register_config_ansible_redis_dynamic is changed
 
 - name: Generate Ansible redis-server static configuration
   template:
@@ -27,7 +27,7 @@
     dest: '/etc/redis/redis.conf'
     regexp: '^include\s+/etc/redis/ansible-redis-static.conf'
     state: 'absent'
-  when: redis__register_config_ansible_redis_static|changed
+  when: redis__register_config_ansible_redis_static is changed
 
 - name: Include Ansible configuration in redis.conf
   lineinfile:
@@ -43,12 +43,12 @@
     name: 'redis-server'
     state: 'restarted'
   register: redis__register_server_restart
-  when: (redis__register_config_ansible_redis_static|changed or
-         redis__register_config_redis|changed)
+  when: (redis__register_config_ansible_redis_static is changed or
+         redis__register_config_redis is changed)
 
 - name: Rewrite dynamic redis-server configuration
   command: /etc/redis/ansible-redis-dynamic.conf rewrite
-  when: redis__register_server_restart|changed
+  when: redis__register_server_restart is changed
 
 - name: Set Redis instance as slave on first install
   redis:

--- a/ansible/roles/debops.redis/templates/etc/redis/ansible-redis-dynamic.conf.j2
+++ b/ansible/roles/debops.redis/templates/etc/redis/ansible-redis-dynamic.conf.j2
@@ -13,7 +13,7 @@ readarray -t redis_dynamic_config_map << EOF
 {% macro print_config(configuration) %}
 {%   if configuration is mapping %}
 {%     for config_key in configuration.keys() %}
-{%       if (config_key not in redis__server_static_options and (config_key not in redis__server_version_config_map or (redis__tpl_version | version_compare(redis__server_version_config_map[config_key], '>=')))) %}
+{%       if (config_key not in redis__server_static_options and (config_key not in redis__server_version_config_map or (redis__tpl_version is version_compare(redis__server_version_config_map[config_key], '>=')))) %}
 {%         if configuration[config_key] is string and not configuration[config_key] | bool %}
 {%           if configuration[config_key]|d() %}
 {{ config_key }}={{ configuration[config_key] }}

--- a/ansible/roles/debops.redis/templates/etc/redis/ansible-redis-static.conf.j2
+++ b/ansible/roles/debops.redis/templates/etc/redis/ansible-redis-static.conf.j2
@@ -4,7 +4,7 @@
 {% macro print_config(configuration) %}
 {%   if configuration is mapping %}
 {%     for config_key in configuration.keys() %}
-{%       if (config_key in redis__server_static_options and (config_key not in redis__server_version_config_map.keys() or (redis__tpl_version | version_compare(redis__server_version_config_map[config_key], '>=')))) %}
+{%       if (config_key in redis__server_static_options and (config_key not in redis__server_version_config_map.keys() or (redis__tpl_version is version_compare(redis__server_version_config_map[config_key], '>=')))) %}
 {%         if configuration[config_key] is string and not configuration[config_key] | bool %}
 {%           if configuration[config_key]|d() %}
 {{ config_key }} {{ configuration[config_key] }}

--- a/ansible/roles/debops.reprepro/tasks/configure_inoticoming.yml
+++ b/ansible/roles/debops.reprepro/tasks/configure_inoticoming.yml
@@ -24,7 +24,7 @@
 - name: Reload systemd configuration
   command: systemctl daemon-reload
   when: (ansible_service_mgr == 'systemd' and
-         reprepro_register_inotincoming_init|changed)
+         reprepro_register_inotincoming_init is changed)
 
 - name: Enable inoticoming service
   service:

--- a/ansible/roles/debops.reprepro/tasks/reprepro_init.yml
+++ b/ansible/roles/debops.reprepro/tasks/reprepro_init.yml
@@ -5,7 +5,7 @@
   become: True
   become_user: '{{ reprepro_user }}'
   when: reprepro_register_conf_distributions is defined and
-        reprepro_register_conf_distributions.changed
+        reprepro_register_conf_distributions is changed
 
 - name: Generate reprepro symlinks
   command: reprepro --delete createsymlinks chdir=~

--- a/ansible/roles/debops.root_account/tasks/main.yml
+++ b/ansible/roles/debops.root_account/tasks/main.yml
@@ -80,4 +80,4 @@
 
 - name: Reload facts if they were modified
   action: setup
-  when: root_account__register_facts|changed
+  when: root_account__register_facts is changed

--- a/ansible/roles/debops.roundcube/tasks/configure_mysql.yml
+++ b/ansible/roles/debops.roundcube/tasks/configure_mysql.yml
@@ -15,4 +15,4 @@
     login_user: '{{ roundcube__database_map[roundcube__database].dbuser }}'
     login_password: '{{ roundcube__database_map[roundcube__database].dbpass }}'
     login_host: '{{ ansible_local.mariadb.server }}'
-  when: (roundcube__register_database_status|d() is defined and roundcube__register_database_status.changed)
+  when: (roundcube__register_database_status|d() is defined and roundcube__register_database_status is changed)

--- a/ansible/roles/debops.roundcube/tasks/main.yml
+++ b/ansible/roles/debops.roundcube/tasks/main.yml
@@ -83,8 +83,8 @@
   register: roundcube__register_updatedb
   changed_when: not roundcube__register_updatedb.stdout == ''
   when: (not roundcube__register_version.stdout == '' and
-         roundcube__git_version | version_compare(roundcube__register_version.stdout, '>')) or
-        (not roundcube__register_version_old | skipped and
+         roundcube__git_version is version_compare(roundcube__register_version.stdout, '>')) or
+        (roundcube__register_version_old is not skipped and
          not roundcube__register_version_old.stdout == '')
   tags: [ 'role::roundcube:database' ]
 

--- a/ansible/roles/debops.rsnapshot/templates/etc/rsnapshot/external-server/rsnapshot.conf.j2
+++ b/ansible/roles/debops.rsnapshot/templates/etc/rsnapshot/external-server/rsnapshot.conf.j2
@@ -172,7 +172,7 @@ lockfile	/var/run/rsnapshot-{{ rsnapshot_tpl_host }}.pid
 #
 {% if ansible_distribution == 'Debian' and ansible_distribution_release == 'jessie'
    and not (rsnapshot_register_version is defined
-   and rsnapshot_register_version.stdout | version_compare('1.4.0', '>=')) %}
+   and rsnapshot_register_version.stdout is version_compare('1.4.0', '>=')) %}
 # In Debian Jessie, rsnapshot has a bug related to 'ssh_args' option,
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=717451
 # Until a bugfix is released, 'ssh_args' option is disabled by default to allow

--- a/ansible/roles/debops.rstudio_server/tasks/main.yml
+++ b/ansible/roles/debops.rstudio_server/tasks/main.yml
@@ -123,4 +123,4 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: rstudio_server__register_facts|changed
+  when: rstudio_server__register_facts is changed

--- a/ansible/roles/debops.saslauthd/tasks/main.yml
+++ b/ansible/roles/debops.saslauthd/tasks/main.yml
@@ -108,4 +108,4 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: saslauthd__register_facts|changed
+  when: saslauthd__register_facts is changed

--- a/ansible/roles/debops.slapd/tasks/tls.yml
+++ b/ansible/roles/debops.slapd/tasks/tls.yml
@@ -17,7 +17,7 @@
 - name: Create random temporary directory for ldif file
   command: mktemp -d
   register: slapd_register_tempdir
-  when: slapd_pki|d() and slapd_pki | bool and not (slapd_register_tls_cert_search.stdout | search("olcTLSCertificateFile:"))
+  when: slapd_pki|d() and slapd_pki | bool and not (slapd_register_tls_cert_search.stdout is search("olcTLSCertificateFile:"))
 
 - name: Prepare temporary ldif file
   template:
@@ -26,17 +26,17 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  when: slapd_pki|d() and slapd_pki | bool and not (slapd_register_tls_cert_search.stdout | search("olcTLSCertificateFile:"))
+  when: slapd_pki|d() and slapd_pki | bool and not (slapd_register_tls_cert_search.stdout is search("olcTLSCertificateFile:"))
 
 - name: Restart slapd (first time only)
   service:
     name: 'slapd'
     state: 'restarted'
-  when: slapd_pki|d() and slapd_pki | bool and not (slapd_register_tls_cert_search.stdout | search("olcTLSCertificateFile:"))
+  when: slapd_pki|d() and slapd_pki | bool and not (slapd_register_tls_cert_search.stdout is search("olcTLSCertificateFile:"))
 
 - name: Configure TLS certificates (first time only)
   shell: 'ldapmodify -Y EXTERNAL -H ldapi:/// -f {{ slapd_register_tempdir.stdout|d() + "/configure_tlscerts.ldif" }}'
-  when: slapd_pki|d() and slapd_pki | bool and not (slapd_register_tls_cert_search.stdout | search("olcTLSCertificateFile:"))
+  when: slapd_pki|d() and slapd_pki | bool and not (slapd_register_tls_cert_search.stdout is search("olcTLSCertificateFile:"))
 
 - name: Configure TLS certificates
   ldap_attr:

--- a/ansible/roles/debops.slapd/templates/lookup/slapd_ldap_access_control_list.j2
+++ b/ansible/roles/debops.slapd/templates/lookup/slapd_ldap_access_control_list.j2
@@ -1,5 +1,5 @@
 {% set disable_counter = False %}
-{% if slapd_ldap_access_control_list|d([]) and slapd_ldap_access_control_list[0] | search("^{") %}
+{% if slapd_ldap_access_control_list|d([]) and slapd_ldap_access_control_list[0] is search("^{") %}
 {% set disable_counter = True %}
 {% endif %}
 {% for item in slapd_ldap_access_control_list %}

--- a/ansible/roles/debops.smstools/tasks/main.yml
+++ b/ansible/roles/debops.smstools/tasks/main.yml
@@ -81,7 +81,7 @@
 
 - name: Fix permissions manually if installed
   command: /usr/local/lib/smstools/fix-device-permissions
-  when: smstools_register_fixpermissions is defined and smstools_register_fixpermissions.changed
+  when: smstools_register_fixpermissions is defined and smstools_register_fixpermissions is changed
 
 - name: Configure SMS gateway test on reboot
   cron: name="SMS gateway test on reboot" user={{ smstools_service_user }}

--- a/ansible/roles/debops.sshd/tasks/main.yml
+++ b/ansible/roles/debops.sshd/tasks/main.yml
@@ -86,13 +86,13 @@
     chdir: '/etc/ssh'
     creates: '/etc/ssh/ssh_host_ed25519_key'
   when: sshd__register_version.stdout|d() and
-        sshd__register_version.stdout | version_compare('6.5', '>=')
+        sshd__register_version.stdout is version_compare('6.5', '>=')
   tags: [ 'role::sshd:config' ]
 
 - name: Configure authorized_keys lookup
   include: authorized_keys_lookup.yml
   when: sshd__register_version.stdout|d() and
-        sshd__register_version.stdout | version_compare('6.2', '>=') and
+        sshd__register_version.stdout is version_compare('6.2', '>=') and
         sshd__authorized_keys_lookup|bool
   tags: [ 'role::sshd:config' ]
 
@@ -180,7 +180,7 @@
 - name: Reload Ansible local facts
   setup:
     filter: ansible_local
-  when: sshd__register_fact_script|changed
+  when: sshd__register_fact_script is changed
 
 - name: Post hooks
   include: '{{ lookup("task_src", "sshd/post_main.yml") }}'

--- a/ansible/roles/debops.sshd/templates/etc/ssh/sshd_config.j2
+++ b/ansible/roles/debops.sshd/templates/etc/ssh/sshd_config.j2
@@ -31,7 +31,7 @@ HostKey /etc/ssh/ssh_host_{{ hostkey }}_key
 {% for key, value in sshd__ciphers_map.items() %}
 {%   if not sshd__tpl_ciphers_match and
         sshd__register_version.stdout|d() and
-        sshd__register_version.stdout | version_compare(key, '>=') %}
+        sshd__register_version.stdout is version_compare(key, '>=') %}
 {%     set sshd__tpl_ciphers_match = True %}
 {%     for element in value %}
 {%       set _ = sshd__tpl_ciphers.append(element) %}
@@ -51,7 +51,7 @@ Ciphers {{ sshd__tpl_ciphers | join(",") }}
 {% for key, value in sshd__kex_algorithms_map.items() %}
 {%   if not sshd__tpl_kex_algorithms_match and
       sshd__register_version.stdout|d() and
-      sshd__register_version.stdout | version_compare(key, '>=') %}
+      sshd__register_version.stdout is version_compare(key, '>=') %}
 {%   set sshd__tpl_kex_algorithms_match = True %}
 {%     for element in value %}
 {%       set _ = sshd__tpl_kex_algorithms.append(element) %}
@@ -72,7 +72,7 @@ KexAlgorithms {{ sshd__tpl_kex_algorithms | join(",") }}
 {% for key, value in sshd__macs_map|dictsort|reverse %}
 {%   if not sshd__tpl_macs_match and
         sshd__register_version.stdout|d() and
-        sshd__register_version.stdout | version_compare(key, '>=') %}
+        sshd__register_version.stdout is version_compare(key, '>=') %}
 {%     set _ = sshd__tpl_macs_match.append(True) %}
 {%     for element in value %}
 {%       set _ = sshd__tpl_macs.append(element) %}
@@ -87,12 +87,12 @@ MACs {{ ([ sshd__tpl_macs|first ] + sshd__macs_additional) | unique | join(",") 
 MACs {{ sshd__tpl_macs | join(",") }}
 
 {% endif %}
-{% if sshd__register_version.stdout | version_compare('7.5', '<') %}
+{% if sshd__register_version.stdout is version_compare('7.5', '<') %}
 # Privilege Separation is turned on for security
 UsePrivilegeSeparation {{ sshd__privilege_separation }}
 
 {% endif %}
-{% if sshd__register_version.stdout | version_compare('7.4', '<') %}
+{% if sshd__register_version.stdout is version_compare('7.4', '<') %}
 # Lifetime and size of ephemeral version 1 server key
 KeyRegenerationInterval 3600
 ServerKeyBits 1024
@@ -112,14 +112,14 @@ ClientAliveCountMax {{ sshd__client_alive_count_max }}
 PermitRootLogin {{ sshd__permit_root_login }}
 StrictModes yes
 
-{% if sshd__register_version.stdout | version_compare('7.4', '<') %}
+{% if sshd__register_version.stdout is version_compare('7.4', '<') %}
 RSAAuthentication yes
 {% endif %}
 PubkeyAuthentication yes
 
 {% if sshd__authorized_keys_lookup|bool and
       sshd__register_version.stdout|d() and
-      sshd__register_version.stdout | version_compare('6.2', '>=') %}
+      sshd__register_version.stdout is version_compare('6.2', '>=') %}
 AuthorizedKeysCommand /etc/ssh/authorized_keys_lookup
 AuthorizedKeysCommandUser {{ sshd__authorized_keys_lookup_user }}
 
@@ -129,7 +129,7 @@ AuthorizedKeysFile {{ sshd__authorized_keys | join(" ") }}
 # Don't read the user's ~/.rhosts and ~/.shosts files
 IgnoreRhosts yes
 
-{% if sshd__register_version.stdout | version_compare('7.4', '<') %}
+{% if sshd__register_version.stdout is version_compare('7.4', '<') %}
 # For this to work you will also need host keys in /etc/ssh_known_hosts
 RhostsRSAAuthentication no
 

--- a/ansible/roles/debops.swapfile/tasks/main.yml
+++ b/ansible/roles/debops.swapfile/tasks/main.yml
@@ -35,12 +35,12 @@
   command: mkswap {{ item.item.path | d(item.item) }}
   register: swapfile__register_init
   with_items: '{{ swapfile__register_allocation.results|d([]) }}'
-  when: (item|changed and item.state|d("present") != 'absent')
+  when: (item is changed and item.state|d("present") != 'absent')
 
 - name: Enable swap files
   command: swapon -p {{ item.item.priority | d(swapfile__priority) }} {{ item.item.path | d(item.item) }}
   with_items: '{{ swapfile__register_allocation.results|d([]) }}'
-  when: (item|changed and item.state|d("present") != 'absent' and
+  when: (item is changed and item.state|d("present") != 'absent' and
           (ansible_local|d() and (ansible_local.cap12s|d() and (not ansible_local.cap12s.enabled | bool or
            (ansible_local.cap12s.enabled | bool and 'cap_sys_admin' in ansible_local.cap12s.list)))))
 

--- a/ansible/roles/debops.sysfs/tasks/main.yml
+++ b/ansible/roles/debops.sysfs/tasks/main.yml
@@ -68,7 +68,7 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: sysfs__register_facts|changed
+  when: sysfs__register_facts is changed
 
 - name: Save dependent configuration on Ansible Controller
   template:

--- a/ansible/roles/debops.sysnews/tasks/main.yml
+++ b/ansible/roles/debops.sysnews/tasks/main.yml
@@ -72,4 +72,4 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: sysnews__register_facts|changed
+  when: sysnews__register_facts is changed

--- a/ansible/roles/debops.tftpd/tasks/main.yml
+++ b/ansible/roles/debops.tftpd/tasks/main.yml
@@ -18,4 +18,4 @@
 
 - name: Reconfigure TFTP server
   command: dpkg-reconfigure --frontend=noninteractive tftpd-hpa
-  when: tftpd_register_template is defined and tftpd_register_template.changed
+  when: tftpd_register_template is defined and tftpd_register_template is changed

--- a/ansible/roles/debops.tinc/tasks/main.yml
+++ b/ansible/roles/debops.tinc/tasks/main.yml
@@ -71,7 +71,7 @@
     state: '{{ (item.state|d("present") in ["absent"]) | ternary("started", "stopped") }}'
   with_dict: '{{ tinc__combined_networks }}'
   when: tinc__systemd|bool and item.value.state|d('present') == 'absent' and
-        not tinc__register_install|changed
+        not tinc__register_install is changed
 
 - name: Remove tinc network configuration if requested
   file:
@@ -294,13 +294,13 @@
 
 - name: Reload systemd daemon configuration
   shell: systemctl daemon-reload ; systemctl enable tinc.service
-  when: tinc__register_systemd|changed
+  when: tinc__register_systemd is changed
 
 - name: Start tinc VPN networks on first install
   service:
     name: 'tinc'
     state: 'restarted'
-  when: not tinc__systemd|bool and tinc__register_install|changed
+  when: not tinc__systemd|bool and tinc__register_install is changed
 
 - name: Configure tinc network services in systemd
   service:
@@ -334,4 +334,4 @@
 
 - name: Reload facts if they were modified
   action: setup
-  when: tinc__register_facts|changed
+  when: tinc__register_facts is changed

--- a/ansible/roles/debops.unbound/tasks/main.yml
+++ b/ansible/roles/debops.unbound/tasks/main.yml
@@ -90,4 +90,4 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: unbound__register_facts|changed
+  when: unbound__register_facts is changed


### PR DESCRIPTION
This patch fixes deprecation warnings reported by Ansible v2.5:

- warning about usage of 'include' instead of 'import_playbook' to
  include additional playbooks;

- warning about usage of various tests as filters in Jinja expressions;