### PR TITLE
[debops.kmod] Load missing kernel modules

### DIFF
--- a/ansible/roles/debops.kmod/tasks/main.yml
+++ b/ansible/roles/debops.kmod/tasks/main.yml
@@ -57,3 +57,16 @@
     mode: '0644'
   with_items: '{{ kmod__combined_load | parse_kv_items }}'
   when: kmod__enabled|bool and item.name|d() and item.state|d('present') not in [ 'absent', 'ignore' ]
+
+- name: Load missing kernel modules enabled at boot
+  modprobe:
+    name: '{{ item.name }}'
+    state: 'present'
+  with_items: '{{ kmod__combined_load | parse_kv_items }}'
+  register: kmod__register_load
+  when: kmod__enabled|bool and item.name|d() and item.state|d('present') not in [ 'config', 'absent', 'ignore' ] and
+        item.modules is undefined and item.name not in ansible_local.kmod.modules
+
+- name: Update Ansible facts if modules were loaded
+  action: setup
+  when: kmod__register_load is changed

--- a/docs/ansible/roles/debops.kmod/defaults-detailed.rst
+++ b/docs/ansible/roles/debops.kmod/defaults-detailed.rst
@@ -169,9 +169,11 @@ kmod__load
 ----------
 
 The ``kmod__*_load`` list variables can be used to specify which kernel modules
-should be loaded at boot time. The configuration is stored in the
-:file:`/etc/modules-load.d/` directory. Each list entry is a YAML dictionary
-with specific parameters:
+should be loaded at boot time. If a single module is specified, the role will
+try to load it if it's currently not present in the kernel.
+
+The configuration is stored in the :file:`/etc/modules-load.d/` directory. Each
+list entry is a YAML dictionary with specific parameters:
 
 ``name``
   Required. Name of the kernel module to manage. This parameter is used as
@@ -197,6 +199,10 @@ with specific parameters:
   ``present``   **Default if not specified.** Configuration will be present.
   ------------- -------------------------------------------------------------
   ``absent``    The configuration of a given kernel module will be removed.
+  ------------- -------------------------------------------------------------
+  ``config``    Specified kernel module configuration is set in the
+                configuration file, but the role will not try to load the
+                missing module into the kernel.
   ------------- -------------------------------------------------------------
   ``ignore``    Configuration entries with this state will not be evaluated
                 by the role and won't be merged with other entries with the


### PR DESCRIPTION
The role will now load any kernel modules enabled at boot that are not
loaded during Ansible execution (this only works for simgle modules at
present). This can be used to load kernel modules without extra
configuration options.