### PR TITLE
[debops.apt_proxy] Set timeout to 1s in get-reachable-apt-proxy

### DIFF
--- a/ansible/roles/debops.apt_proxy/files/usr/local/lib/get-reachable-apt-proxy
+++ b/ansible/roles/debops.apt_proxy/files/usr/local/lib/get-reachable-apt-proxy
@@ -79,7 +79,7 @@ def get_first_up_proxy(target_uri_raw):
 
             if proxy_uri.scheme in ['https', 'http']:
                 try:
-                    urlopen(proxy_uri_raw)
+                    urlopen(proxy_uri_raw, timeout=1)
                 except HTTPError as err:
                     LOG.debug("Proxy responded with: {}".format(err))
                     pass


### PR DESCRIPTION
> So it looks like Py_None, aka None, is the default timeout. In other
> words, urlopen never times out. At least not from the Python end. I
> guess a timeout can still occur if the networking functions supplied by
> the OS have timeouts themselves.

Ref: https://stackoverflow.com/questions/29649173/what-is-the-global-default-timeout/29649638#29649638