### PR TITLE
Fix Bash arithmetic starting with zero

### DIFF
--- a/ansible/roles/debops.slapd/files/usr/local/sbin/slapd-snapshot
+++ b/ansible/roles/debops.slapd/files/usr/local/sbin/slapd-snapshot
@@ -25,7 +25,7 @@ if [ "${period}" == "daily" ] ; then
     DATABASE="${BACKUP_PATH}/database-${period}-${counter}.ldif"
 
 elif [ "${period}" == "weekly" ] ; then
-    counter="$((($(date +%d)-1)/7+1))"
+    counter="$((($(date +%_d)-1)/7+1))"
 
     CNCONFIG="${BACKUP_PATH}/config-${period}-${counter}.ldif"
     DATABASE="${BACKUP_PATH}/database-${period}-${counter}.ldif"


### PR DESCRIPTION
Bash fails with `/usr/local/sbin/slapd-snapshot: line 28: (08: value too great for base (error token is "08")` when trying to do arithmetic with number starting with 0:

```
echo $((08+1))
-bash: 08: value too great for base (error token is "08")

echo $(( 8+1))
9
```

(Original PR debops/ansible-slapd#43)