### PR TITLE
[debops.console] Remove '/etc/hosts' management

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,10 @@ Removed
 - [debops.console] Remove support for copying custom files from the role. This
   functionality is covered better by the :ref:`debops.resources` role.
 
+- [debops.console] Remove support for managing entries in the
+  :file:`/etc/hosts` database. This is now covered by the :ref:`debops.netbase`
+  Ansible role.
+
 
 `debops v0.7.2`_ - 2018-03-28
 -----------------------------

--- a/ansible/roles/debops.console/defaults/main.yml
+++ b/ansible/roles/debops.console/defaults/main.yml
@@ -39,23 +39,6 @@ console_fsckfix: 'yes'
 console_fsckfix_releases: [ 'wheezy', 'jessie', 'precise', 'trusty', 'xenial' ]
 
 
-# ---- /etc/hosts ----
-
-# Add or remove entries in /etc/hosts
-console_hosts: {}
-console_group_hosts: {}
-console_host_hosts: {}
-
-# Examples:
-# console_hosts:
-#   '192.0.2.1': 'hostname.example.com'
-#   '2001:db8::1': [ 'host.example.org', 'host' ]
-#
-#   # These entries will be removed
-#   '192.0.2.3': ''
-#   '192.0.2.4': []
-
-
 # ---- Filesystem mount points ----
 
 # You can use console_*_mounts lists to mout local or remote filesystems on

--- a/ansible/roles/debops.console/tasks/main.yml
+++ b/ansible/roles/debops.console/tasks/main.yml
@@ -45,15 +45,6 @@
     line: 'FSCKFIX={{ console_fsckfix }}'
   when: ansible_distribution_release in console_fsckfix_releases
 
-- name: Manage entries in /etc/hosts
-  lineinfile:
-    dest: '/etc/hosts'
-    regexp: '^{{ item.key | replace(".","\.") }}\s+'
-    line: "{{ item.key }}\t{{ item.value if (item.value is string) else (item.value|d() | join(' ')) }}"
-    state: '{{ "present" if item.value|d() else "absent" }}'
-  with_dict: '{{ console_hosts|combine(console_group_hosts,console_host_hosts) }}'
-  tags: [ 'role::console:hosts' ]
-
 - include: filesystem_mount.yml
   tags: [ 'role::console:mount' ]
   when: (

--- a/docs/news/upgrades.rst
+++ b/docs/news/upgrades.rst
@@ -17,8 +17,8 @@ Nothing new yet.
 v0.7.2 (2018-03-28)
 -------------------
 
-Inventory changes
-~~~~~~~~~~~~~~~~~
+Inventory variable changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - The ``console_preferred_editors`` list has been removed, configuration of the
   preferred :command:`vim` editor is now done in the :ref:`debops.apt_install`
@@ -29,6 +29,21 @@ Inventory changes
   role variables to copy custom files instead. The role is also included in the
   common playbook, although a bit earlier, which shouldn't impact normal use
   cases.
+
+- The management of the :file:`/etc/hosts` file has been removed from the
+  ``debops.console`` role and is now done via the :ref:`debops.netbase` role
+  which has to be enabled through the Ansible inventory. The variables have
+  been renamed:
+
+  +-------------------------+--------------------------------+---------------+
+  | Old variable name       | New variable name              | Changed value |
+  +=========================+================================+===============+
+  | ``console_hosts``       | :envvar:`netbase__hosts`       | No            |
+  +-------------------------+--------------------------------+---------------+
+  | ``console_group_hosts`` | :envvar:`netbase__group_hosts` | No            |
+  +-------------------------+--------------------------------+---------------+
+  | ``console_host_hosts``  | :envvar:`netbase__host_hosts`  | No            |
+  +-------------------------+--------------------------------+---------------+
 
 
 v0.7.1 (2018-03-28)


### PR DESCRIPTION
The '/etc/hosts' file can now be managed via the 'debops.netbase'
Ansible role.