### PR TITLE
Add secret/salt encode/decode for Python3 compatibility

### DIFF
--- a/ansible/playbooks/filter_plugins/ldappassword.py
+++ b/ansible/playbooks/filter_plugins/ldappassword.py
@@ -42,17 +42,17 @@ def ldappassword(secret, schema='SHA', salt=None):
             'Unknown/unsupported storage schema: {}'.format(schema))
 
     h = hashlib.new(htype)
-    h.update(secret)
+    h.update(secret.encode())
 
     if schema in ('SSHA', 'SMD5'):
         if salt is None:
-            salt = os.urandom(4)
+            salt = base64.standard_b64encode(os.urandom(4))
         h.update(salt)
     else:
-        salt = ''
+        salt = ''.encode()
 
     rv = base64.standard_b64encode(h.digest()+salt)
-    return '{{{}}}{}'.format(schema, rv)
+    return '{{{}}}{}'.format(schema, rv.decode())
 
 
 class FilterModule(object):


### PR DESCRIPTION
The original version seems not to work with Python3 (throws error: "Unicode-objects must be encoded before hashing"). The proposed changes cure the problem and work with Python2 and Python3.

The salt gets now base64-encoded before being processed further. This might require some checking regarding potential security issues... I cannot judge on the implications.