### PR TITLE
[debops.debops] Allow defining git repositories like user@host:repo

### DIFF
--- a/ansible/roles/debops.debops/tasks/main.yml
+++ b/ansible/roles/debops.debops/tasks/main.yml
@@ -39,7 +39,7 @@
     repo: '{{ debops__project_git_repo }}'
     dest: '{{ debops__project_name if debops__project_name else debops__project_git_repo | basename }}'
     update: True
-  when: debops__project_git_repo
+  when: debops__project_git_repo != ''
 
 - name: Initialize new project
   become: '{{ debops__install_systemwide|bool }}'
@@ -47,4 +47,4 @@
   args:
     creates: '{{ debops__project_name }}/.debops.cfg'
   when: debops__project_name|d() and
-        not debops__project_git_repo
+        debops__project_git_repo == ''


### PR DESCRIPTION
If you define a repository like user@host:repo, you get this error in when conditions:

`TASK [debops.debops : Clone project repository] ***************************************************************************************************************************************************************************************
fatal: [debops]: FAILED! => {"msg": "The conditional check 'debops__project_git_repo' failed. The error was: template error while templating string: unexpected char u'@' at ...`

With this fix it works.