### PR TITLE
[debops.apt]: reverse the boolean for autoremove configurations

### DIFF
--- a/ansible/roles/debops.apt/templates/etc/apt/apt.conf.d/25no-recommends.conf.j2
+++ b/ansible/roles/debops.apt/templates/etc/apt/apt.conf.d/25no-recommends.conf.j2
@@ -4,6 +4,6 @@
 APT::Install-Recommends "{{ apt__install_recommends | bool | lower }}";
 APT::Install-Suggests "{{ apt__install_suggests | bool | lower }}";
 
-// Should APT autoremove recommended or suggested packages?
-APT::AutoRemove::RecommendsImportant "{{ apt__autoremove_recommends | bool | lower }}";
-APT::AutoRemove::SuggestsImportant "{{ apt__autoremove_suggests | bool | lower }}";
+// Should APT autoremove prevents removal of recommended or suggested packages?
+APT::AutoRemove::RecommendsImportant "{{ not (apt__autoremove_recommends | bool) | lower }}";
+APT::AutoRemove::SuggestsImportant "{{ not (apt__autoremove_suggests | bool) | lower }}";


### PR DESCRIPTION
APT::Autoremove::SuggestsImportant and APT::Autoremove::RecommendsImportant
value tells - when true - that we prevent removal of suggested or recommended
packages.

---
Speedup apt as it stop telling to autoremove recommanded packages while apt__autoremove_recommends: False.