### PR TITLE
[debops.php] Set track_errors only for PHP<7.2

### DIFF
--- a/ansible/roles/debops.php/defaults/main.yml
+++ b/ansible/roles/debops.php/defaults/main.yml
@@ -318,7 +318,9 @@ php__default_configuration:
           error_reporting =        {{ (php__production|bool)|ternary('E_ALL & ~E_DEPRECATED & ~E_STRICT', 'E_ALL') }}
           display_errors =         {{ (php__production|bool)|ternary('Off', 'On') }}
           display_startup_errors = {{ (php__production|bool)|ternary('Off', 'On') }}
+          {% if php__version is version_compare("7.2","<") %}
           track_errors =           {{ (php__production|bool)|ternary('Off', 'On') }}
+          {% endif %}
           post_max_size =          {{  php__ini_post_max_size }}
           default_charset =        {{  php__ini_default_charset }}
           file_uploads =           {{ (php__ini_file_uploads|bool)|ternary('On', 'Off') }}


### PR DESCRIPTION
    track_errors has been deprecated in PHP 7.2.
    See: https://secure.php.net/manual/en/migration72.deprecated.php