### PR TITLE
Refresh configuration of UNIX system groups used by DebOps

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1223,6 +1223,14 @@ stages:
     JANE_DIFF_PATTERN: '.*/debops.sudo/.*'
     JANE_LOG_PATTERN: '\[debops\.sudo\]'
 
+'system_groups role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/system_groups.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_system_groups'
+    JANE_DIFF_PATTERN: '.*/debops.system_groups/.*'
+    JANE_LOG_PATTERN: '\[debops\.system_groups\]'
+
 'swapfile role':
   <<: *test_role_no_deps
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -301,6 +301,13 @@ stages:
     JANE_DIFF_PATTERN: '.*/debops.debops_fact/.*'
     JANE_LOG_PATTERN: '\[debops\.debops_fact\]'
 
+'debops_legacy role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/debops_legacy.yml'
+    JANE_DIFF_PATTERN: '.*/debops.debops_legacy/.*'
+    JANE_LOG_PATTERN: '\[debops\.debops_legacy\]'
+
 'dhcpd role':
   <<: *test_role_no_deps
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -200,7 +200,7 @@ stages:
 # --- b --- [[[2
 
 'bootstrap role':
-  <<: *test_role_no_deps
+  <<: *test_role_2nd_deps
   variables:
     JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/bootstrap.yml'
     JANE_INVENTORY_HOSTVARS: 'ansible_become=true bootstrap__raw=false'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -68,6 +68,10 @@ Removed
   :file:`/etc/hosts` database. This is now covered by the :ref:`debops.netbase`
   Ansible role.
 
+- [debops.auth] Remove configuration of UNIX system groups and accounts in the
+  ``admins`` UNIX group. This is now done by the :ref:`debops.system_groups`
+  Ansible role.
+
 
 `debops v0.7.2`_ - 2018-03-28
 -----------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -76,6 +76,10 @@ Removed
   the :ref:`debops.bootstrap` role. The ``bootstrap.yml`` playbook now includes
   the :ref:`debops.sudo` role which configures :command:`sudo` service.
 
+- [debops.bootstrap] The UNIX system group management has been removed from the
+  role, the ``bootstrap.yml`` playbook now uses the :ref:`debops.system_groups`
+  role to create the UNIX groups used by DebOps during bootstrapping.
+
 
 `debops v0.7.2`_ - 2018-03-28
 -----------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,7 +30,7 @@ Added
     a host. The role is included in the ``common.yml`` playbook.
 
   - :ref:`debops.system_groups`: configure UNIX system groups used on DebOps
-    hosts.
+    hosts. The role is included in the ``common.yml`` playbook.
 
 - [debops.users] Selected UNIX accounts can now be configured to linger when
   not logged in via the ``item.linger`` parameter. This allows these accounts

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,6 +54,10 @@ Changed
   reflects its intended purpose. Variable names and their default values
   changed; see the :ref:`upgrade_notes` for more details.
 
+- [debops.sshd] The role will now check the :ref:`debops.system_groups` Ansible
+  local facts to define what UNIX groups are allowed to connect to the host via
+  the SSH service.
+
 Removed
 ~~~~~~~
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,10 @@ Added
   to maintain long-running services when not logged in via their own private
   :command:`systemd` instances.
 
+- [debops.sudo] You can now manage configuration files located in the
+  :file:`/etc/sudoers.d/` directory using :ref:`sudo__*_sudoers <sudo__ref_sudoers>`
+  inventory variables, with multiple level of conditional options.
+
 Changed
 ~~~~~~~
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,9 @@ Added
   - :ref:`debops.sudo`: install and manage :command:`sudo` configuration on
     a host. The role is included in the ``common.yml`` playbook.
 
+  - :ref:`debops.system_groups`: configure UNIX system groups used on DebOps
+    hosts.
+
 - [debops.users] Selected UNIX accounts can now be configured to linger when
   not logged in via the ``item.linger`` parameter. This allows these accounts
   to maintain long-running services when not logged in via their own private

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -72,6 +72,10 @@ Removed
   ``admins`` UNIX group. This is now done by the :ref:`debops.system_groups`
   Ansible role.
 
+- [debops.bootstrap] The :command:`sudo` configuration has been removed from
+  the :ref:`debops.bootstrap` role. The ``bootstrap.yml`` playbook now includes
+  the :ref:`debops.sudo` role which configures :command:`sudo` service.
+
 
 `debops v0.7.2`_ - 2018-03-28
 -----------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,11 @@ Added
   - :ref:`debops.system_groups`: configure UNIX system groups used on DebOps
     hosts. The role is included in the ``common.yml`` playbook.
 
+  - :ref:`debops.debops_legacy`: clean up legacy files, directories, APT
+    packages or :command:`dpkg-divert` diversions created by DebOps but no
+    longer used. This role needs to be executed manually, it's not included in
+    the main playbook.
+
 - [debops.users] Selected UNIX accounts can now be configured to linger when
   not logged in via the ``item.linger`` parameter. This allows these accounts
   to maintain long-running services when not logged in via their own private

--- a/ansible/playbooks/bootstrap.yml
+++ b/ansible/playbooks/bootstrap.yml
@@ -47,4 +47,8 @@
 
   roles:
 
+    - role: debops.sudo
+      tags: [ 'role::sudo' ]
+
     - role: debops.bootstrap
+      tags: [ 'role::bootstrap' ]

--- a/ansible/playbooks/bootstrap.yml
+++ b/ansible/playbooks/bootstrap.yml
@@ -48,7 +48,10 @@
   roles:
 
     - role: debops.sudo
-      tags: [ 'role::sudo' ]
+      tags: [ 'role::sudo', 'role::system_groups' ]
+
+    - role: debops.system_groups
+      tags: [ 'role::system_groups' ]
 
     - role: debops.bootstrap
       tags: [ 'role::bootstrap' ]

--- a/ansible/playbooks/common.yml
+++ b/ansible/playbooks/common.yml
@@ -82,6 +82,9 @@
     - role: debops.sudo
       tags: [ 'role::sudo' ]
 
+    - role: debops.system_groups
+      tags: [ 'role::system_groups' ]
+
     - role: debops.etc_services
       tags: [ 'role::etc_services' ]
       etc_services__dependent_list:

--- a/ansible/playbooks/service/debops_legacy.yml
+++ b/ansible/playbooks/service/debops_legacy.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Clean up legacy configuration
+  hosts: [ 'debops_all_hosts' ]
+  become: True
+
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
+
+  roles:
+
+    - role: debops.debops_legacy
+      tags: [ 'role::debops_legacy' ]

--- a/ansible/playbooks/service/system_groups.yml
+++ b/ansible/playbooks/service/system_groups.yml
@@ -1,0 +1,17 @@
+---
+
+- name: Configure UNIX system groups
+  hosts: [ 'debops_all_hosts', 'debops_service_system_groups' ]
+  become: True
+
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
+
+  roles:
+
+    - role: debops.sudo
+      tags: [ 'role::sudo' ]
+
+    - role: debops.system_groups
+      tags: [ 'role::system_groups' ]

--- a/ansible/roles/debops.auth/defaults/main.yml
+++ b/ansible/roles/debops.auth/defaults/main.yml
@@ -14,61 +14,6 @@
 auth_packages: [ 'libpam-cracklib' ]
 
                                                                    # ]]]
-# .. envvar:: auth_wheel_group [[[
-#
-# System group that will be granted unrestricted access to root account
-auth_wheel_group: 'admins'
-
-                                                                   # ]]]
-# .. envvar:: auth_admin_groups [[[
-#
-# List of UNIX system groups which allow unrestricted system administrator
-# access. They will be created if not present.
-auth_admin_groups: '{{ ansible_local.core.admin_groups
-                       if (ansible_local|d() and ansible_local.core|d() and
-                           ansible_local.core.admin_groups|d())
-                       else [ "admins" ] }}'
-
-                                                                   # ]]]
-# .. envvar:: auth_admin_users [[[
-#
-# List of UNIX system accounts which belong to system administrators. The role
-# will ensure that the accounts exist and are present in the specified
-# administrator groups.
-auth_admin_users: '{{ ansible_local.core.admin_users
-                      if (ansible_local|d() and ansible_local.core|d() and
-                          ansible_local.core.admin_users|d())
-                      else [] }}'
-
-                                                                   # ]]]
-# .. envvar:: auth_system_groups [[[
-#
-# List of default system accounts that are used in the playbook
-auth_system_groups:
-
-  # Global system administrators, unrestricted root access, unrestricted SSH
-  - 'admins'
-
-  # Users in this group can connect to the host using SSH service
-  - 'sshusers'
-
-  # Users in this group have access only to chrooted SFTP service (without full
-  # shell access) and cannot use SSH public keys in ~/.ssh/authorized_keys file
-  # (only keys in '/etc/ssh/authorized_keys.d/user' are allowed)
-  - 'sftponly'
-
-  # Users in this group can reload nginx service using sudo and have access to
-  # /etc/nginx/sites-local/ directory where they can put nginx vhost
-  # configuration files to be enabled by Ansible in nginx
-  # (this might be moved to 'nginx' role in the future)
-  - 'webadmins'
-
-  # This group grants full access to /proc filesystem when hidepid= option is
-  # active. You should add monitoring services to this group if they need full
-  # access to process information
-  - 'procadmins'
-
-                                                                   # ]]]
 # ---- nsswitch.conf options ----
 
 # .. envvar:: auth_nsswitch [[[

--- a/ansible/roles/debops.auth/tasks/main.yml
+++ b/ansible/roles/debops.auth/tasks/main.yml
@@ -10,33 +10,6 @@
     install_recommends: 'no'
   with_items: '{{ auth_packages }}'
 
-- name: Ensure common system groups exist
-  group:
-    name: '{{ item }}'
-    system: 'yes'
-    state: 'present'
-  with_items: '{{ (auth_system_groups + auth_admin_groups) | unique }}'
-  when: auth_system_groups
-
-- name: Include system administrator accounts in admin groups
-  user:
-    name: '{{ item }}'
-    state: 'present'
-    groups: '{{ ([ auth_admin_groups ] if auth_admin_groups is string else auth_admin_groups) | join(",") }}'
-    append: True
-  with_flattened: '{{ auth_admin_users }}'
-  when: auth_admin_users|d()
-
-- name: Configure admin access in sudo
-  template:
-    src: '{{ lookup("template_src", "etc/sudoers.d/admins.j2") }}'
-    dest: '/etc/sudoers.d/admins'
-    owner: 'root'
-    group: 'root'
-    mode: '0440'
-    validate: 'visudo -cf %s'
-  when: auth_wheel_group is defined and auth_wheel_group
-
 - name: Configure pam_cracklib
   template:
     src: 'usr/share/pam-configs/cracklib.j2'

--- a/ansible/roles/debops.auth/templates/etc/sudoers.d/admins.j2
+++ b/ansible/roles/debops.auth/templates/etc/sudoers.d/admins.j2
@@ -1,6 +1,0 @@
-# {{ ansible_managed }}
-
-Defaults: %{{ auth_wheel_group }} !requiretty
-Defaults: %{{ auth_wheel_group }} env_check += "SSH_CLIENT"
-%{{ auth_wheel_group }} ALL = (ALL:ALL) NOPASSWD: SETENV: ALL
-

--- a/ansible/roles/debops.bootstrap/defaults/main.yml
+++ b/ansible/roles/debops.bootstrap/defaults/main.yml
@@ -128,7 +128,11 @@ bootstrap__admin_users: []
 #
 # All new user accounts will have their home directories in the first group
 # listed here as well, to allow easier communication between administrators.
-bootstrap__admin_groups: [ 'admins', 'staff', 'adm', 'sudo' ]
+bootstrap__admin_groups: '{{ ansible_local.system_groups.access.root
+                             if (ansible_local|d() and ansible_local.system_groups|d() and
+                                 ansible_local.system_groups.access|d() and
+                                 ansible_local.system_groups.access.root|d())
+                             else [ "admins" ] }}'
 
                                                                    # ]]]
 # .. envvar:: bootstrap__admin_home_path [[[

--- a/ansible/roles/debops.bootstrap/defaults/main.yml
+++ b/ansible/roles/debops.bootstrap/defaults/main.yml
@@ -74,7 +74,6 @@ bootstrap__mandatory_packages:
 # Base packages installed during bootstrap.
 bootstrap__base_packages:
   - 'python-pip'
-  - 'sudo'
   - 'lsb-release'
   - 'dbus'
 
@@ -181,21 +180,6 @@ bootstrap__admin_shell: '/bin/bash'
 # which you don't like to be included, please modify the variable accordingly
 # to your requirements.
 bootstrap__admin_sshkeys: [ '{{ lookup("pipe","ssh-add -L | grep ^ssh || cat ~/.ssh/*.pub || true") }}' ]
-                                                                   # ]]]
-                                                                   # ]]]
-# Access to sudo commands [[[
-# ---------------------------
-
-# .. envvar:: bootstrap__sudo [[[
-#
-# Configure passwordless :command:`sudo` access for selected accounts.
-bootstrap__sudo: True
-
-                                                                   # ]]]
-# .. envvar:: bootstrap__sudo_group [[[
-#
-# A group which grants passwordless :command:`sudo` access.
-bootstrap__sudo_group: '{{ bootstrap__admin_groups[0] | default("") }}'
                                                                    # ]]]
                                                                    # ]]]
                                                                    # ]]]

--- a/ansible/roles/debops.bootstrap/tasks/admin_accounts.yml
+++ b/ansible/roles/debops.bootstrap/tasks/admin_accounts.yml
@@ -6,13 +6,6 @@
   with_items: '{{ lookup("template", "lookup/stat_home_path.j2") | from_yaml }}'
   register: bootstrap__register_home
 
-- name: Create required system groups
-  group:
-    name: '{{ item }}'
-    state: 'present'
-    system: True
-  with_items: '{{ bootstrap__admin_groups }}'
-
 - name: Create admin accounts
   user:
     name: '{{ item.name }}'

--- a/ansible/roles/debops.bootstrap/tasks/main.yml
+++ b/ansible/roles/debops.bootstrap/tasks/main.yml
@@ -38,40 +38,6 @@
   when: bootstrap__admin|bool
   tags: [ 'role::bootstrap:admin' ]
 
-# Access to sudo commands [[[
-- name: Configure system group with passwordless access in sudo
-  ## `lineinfile` is used instead of `template` to allow other roles to take
-  ## over `sudo` management and prevent one role reverting the work of the
-  ## other role.
-  lineinfile:
-    dest: '/etc/sudoers.d/{{ bootstrap__sudo_group }}'
-    regexp: '{{ item.regexp }}'
-    line: '{{ item.line }}'
-    state: 'present'
-    create: True
-    owner: 'root'
-    group: 'root'
-    mode: '0440'
-    validate: 'visudo -cf "%s"'
-  tags: [ 'role::bootstrap:admin' ]
-  with_items:
-    - regexp: '^Defaults: %{{ bootstrap__sudo_group }} !?requiretty'
-      line:    'Defaults: %{{ bootstrap__sudo_group }} !requiretty'
-    - regexp: '^Defaults: %{{ bootstrap__sudo_group }} env_check\s'
-      line:    'Defaults: %{{ bootstrap__sudo_group }} env_check += "SSH_CLIENT"'
-    - regexp: '^%{{ bootstrap__sudo_group }}\s'
-      line:    '%{{ bootstrap__sudo_group }} ALL = (ALL:ALL) NOPASSWD: SETENV: ALL'
-  when: bootstrap__sudo|bool
-
-- name: Ensure /etc/sudoers includes /etc/sudoers.d
-  lineinfile:
-    dest: '/etc/sudoers'
-    regexp: '^#includedir\s+/etc/sudoers.d$'
-    line: '#includedir /etc/sudoers.d'
-    state: 'present'
-    validate: 'visudo -cf "%s"'
-  tags: [ 'role::bootstrap:admin' ]
-
 # Hostname and domain [[[
 - name: Enforce new hostname
   hostname:

--- a/ansible/roles/debops.debops_legacy/COPYRIGHT
+++ b/ansible/roles/debops.debops_legacy/COPYRIGHT
@@ -1,0 +1,18 @@
+debops.debops_legacy - Clean up legacy content using Ansible
+
+Copyright (C) 2018 Maciej Delmanowski <drybjed@gmail.com>
+Copyright (C) 2018 DebOps https://debops.org/
+
+This Ansible role is part of DebOps.
+
+DebOps is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 3, as
+published by the Free Software Foundation.
+
+DebOps is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with DebOps. If not, see https://www.gnu.org/licenses/.

--- a/ansible/roles/debops.debops_legacy/defaults/main.yml
+++ b/ansible/roles/debops.debops_legacy/defaults/main.yml
@@ -1,0 +1,157 @@
+---
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+
+# debops.debops_legacy default variables
+# ======================================
+
+# .. contents:: Sections
+#    :local:
+
+
+# General configuration [[[
+# -------------------------
+
+# .. envvar:: debops_legacy__enabled [[[
+#
+# Enable or disable support for removing legacy files, packages and diversions
+# managed by DebOps.
+debops_legacy__enabled: True
+                                                                   # ]]]
+                                                                   # ]]]
+# Diversion cleanup [[[
+# ---------------------
+
+# These lists define what diversions created by the :command:`dpkg-divert`
+# command should be removed. The modified files specified here will be removed,
+# and the original files which were diverted will be moved back into place.
+# See :ref:`debops_legacy__ref_remove_diversions` for more details.
+
+# .. envvar:: debops_legacy__remove_default_diversions [[[
+#
+# The list of diversions to remove defined by the role.
+debops_legacy__remove_default_diversions: []
+
+                                                                   # ]]]
+# .. envvar:: debops_legacy__remove_diversions [[[
+#
+# The list of diversions to remove on all hosts in the Ansible inventory.
+debops_legacy__remove_diversions: []
+
+                                                                   # ]]]
+# .. envvar:: debops_legacy__remove_group_diversions [[[
+#
+# The list of diversions to remove on hosts in a specific Ansible inventory
+# group.
+debops_legacy__remove_group_diversions: []
+
+                                                                   # ]]]
+# .. envvar:: debops_legacy__remove_host_diversions [[[
+#
+# The list of diversions to remove on specific hosts in the Ansible inventory.
+debops_legacy__remove_host_diversions: []
+
+                                                                   # ]]]
+# .. envvar:: debops_legacy__remove_combined_diversions [[[
+#
+# The list which combines all of the diversion configuration variables and is
+# used in the role tasks.
+debops_legacy__remove_combined_diversions: '{{ debops_legacy__remove_default_diversions
+                                               + debops_legacy__remove_diversions
+                                               + debops_legacy__remove_group_diversions
+                                               + debops_legacy__remove_host_diversions }}'
+                                                                   # ]]]
+                                                                   # ]]]
+# APT package cleanup [[[
+# -----------------------
+
+# These lists define what APT packages should be removed on hosts managed by
+# DebOps. See :ref:`debops_legacy__ref_remove_packages` for more details.
+
+# .. envvar:: debops_legacy__remove_default_packages [[[
+#
+# List of APT packages to remove defined by the role.
+debops_legacy__remove_default_packages: []
+
+                                                                   # ]]]
+# .. envvar:: debops_legacy__remove_packages [[[
+#
+# List of APT packages to remove on all hosts in the Ansible inventory.
+debops_legacy__remove_packages: []
+
+                                                                   # ]]]
+# .. envvar:: debops_legacy__remove_group_packages [[[
+#
+# List of APT packages to remove on hosts in a specific Ansible inventory
+# group.
+debops_legacy__remove_group_packages: []
+
+                                                                   # ]]]
+# .. envvar:: debops_legacy__remove_host_packages [[[
+#
+# List of APT packages to remove on specific hosts in the Ansible inventory.
+debops_legacy__remove_host_packages: []
+
+                                                                   # ]]]
+# .. envvar:: debops_legacy__remove_combined_packages [[[
+#
+# The list which combines all of the APT package lists and is used in the role
+# tasks.
+debops_legacy__remove_combined_packages: '{{ debops_legacy__remove_default_packages
+                                             + debops_legacy__remove_packages
+                                             + debops_legacy__remove_group_packages
+                                             + debops_legacy__remove_host_packages }}'
+                                                                   # ]]]
+                                                                   # ]]]
+# File cleanup [[[
+# ----------------
+
+# These lists define what files or directories will be removed by the role on
+# hosts managed by DebOps. See :ref:`debops_legacy__ref_remove_files` for more
+# details.
+
+# .. envvar:: debops_legacy__remove_default_files [[[
+#
+# List of files or directories to remove defined by the role.
+debops_legacy__remove_default_files:
+
+  # This is a legacy file that configured 'sudo' to allow members of the
+  # 'admins' UNIX group privileged access without password authentication.
+  #
+  # The replacement file is: '/etc/sudoers.d/system_groups-admins'.
+  - name: '/etc/sudoers.d/admins'
+    state: '{{ "absent"
+               if (ansible_local|d() and ansible_local.system_groups|d() and
+                   (ansible_local.system_groups.configured|d()|bool))
+               else "ignore" }}'
+
+                                                                   # ]]]
+# .. envvar:: debops_legacy__remove_files [[[
+#
+# List of files or directories to remove on all hosts in the Ansible inventory.
+debops_legacy__remove_files: []
+
+                                                                   # ]]]
+# .. envvar:: debops_legacy__remove_group_files [[[
+#
+# List of files or directories to remove on hosts in a specific Ansible
+# inventory group.
+debops_legacy__remove_group_files: []
+
+                                                                   # ]]]
+# .. envvar:: debops_legacy__remove_host_files [[[
+#
+# List of files or directories to remove on specific hosts in the Ansible
+# inventory.
+debops_legacy__remove_host_files: []
+
+                                                                   # ]]]
+# .. envvar:: debops_legacy__remove_combined_files [[[
+#
+# The list which combines all of the file/directory lists and is used in the
+# role tasks.
+debops_legacy__remove_combined_files: '{{ debops_legacy__remove_default_files
+                                          + debops_legacy__remove_files
+                                          + debops_legacy__remove_group_files
+                                          + debops_legacy__remove_host_files }}'
+                                                                   # ]]]
+                                                                   # ]]]

--- a/ansible/roles/debops.debops_legacy/meta/main.yml
+++ b/ansible/roles/debops.debops_legacy/meta/main.yml
@@ -1,0 +1,29 @@
+---
+
+dependencies:
+
+  - role: debops.ansible_plugins
+
+galaxy_info:
+  author: 'Maciej Delmanowski'
+  description: 'Clean up legacy files, directories, packages or diversions'
+  company: 'DebOps'
+  license: 'GPL-3.0'
+  min_ansible_version: '2.4.0'
+  platforms:
+    - name: Ubuntu
+      versions:
+        - precise
+        - trusty
+        - xenial
+        - bionic
+    - name: Debian
+      versions:
+        - wheezy
+        - jessie
+        - stretch
+        - buster
+  categories:
+    - system
+    - legacy
+    - cleanup

--- a/ansible/roles/debops.debops_legacy/tasks/main.yml
+++ b/ansible/roles/debops.debops_legacy/tasks/main.yml
@@ -1,0 +1,41 @@
+---
+
+- name: Check current diversions
+  environment:
+    LC_ALL: 'C'
+  shell: dpkg-divert --list | grep -E '^local diversion' | awk '{print $NF}'
+  register: debops_legacy__register_diversions
+  check_mode: False
+  changed_when: False
+
+- name: Show what diversions will be removed in check mode
+  file:
+    path: '{{ item.name }}'
+    state: 'absent'
+  with_items: '{{ debops_legacy__remove_combined_diversions | parse_kv_items }}'
+  when: (debops_legacy__enabled|bool and ansible_check_mode|bool and item.state|d('present') == 'absent' and
+         ((item.diversion | d(item.name + ".dpkg-divert")) in debops_legacy__register_diversions.stdout_lines))
+
+- name: Remove legacy diversions
+  shell: rm -f {{ item.name }} ; dpkg-divert --quiet --local --rename --remove {{ item.name }}
+  args:
+    executable: '/bin/sh'
+    removes: '{{ item.diversion | d(item.name + ".dpkg-divert") }}'
+    warn: False
+  with_items: '{{ debops_legacy__remove_combined_diversions | parse_kv_items }}'
+  when: (debops_legacy__enabled|bool and item.state|d('present') == 'absent' and
+         ((item.diversion | d(item.name + ".dpkg-divert")) in debops_legacy__register_diversions.stdout_lines))
+
+- name: Remove legacy packages
+  package:
+    name: '{{ item.name }}'
+    state: 'absent'
+  with_items: '{{ debops_legacy__remove_combined_packages | parse_kv_items }}'
+  when: debops_legacy__enabled|bool and item.state|d('present') == 'absent'
+
+- name: Remove legacy files and directories
+  file:
+    path: '{{ item.name }}'
+    state: 'absent'
+  with_items: '{{ debops_legacy__remove_combined_files | parse_kv_items }}'
+  when: debops_legacy__enabled|bool and item.state|d('present') == 'absent'

--- a/ansible/roles/debops.sshd/defaults/main.yml
+++ b/ansible/roles/debops.sshd/defaults/main.yml
@@ -282,10 +282,22 @@ sshd__custom_options: ''
 # Group-based access control [[[
 # ------------------------------
 
+# .. envvar:: sshd__default_allow_groups [[[
+#
+# List of UNIX system groups which allow connections to SSH service defined by
+# default. The ``root`` UNIX group is used for backup connections, temporarily.
+sshd__default_allow_groups: '{{ [ "root" ] +
+                                (ansible_local.system_groups.access.sshd
+                                 if (ansible_local|d() and ansible_local.system_groups|d() and
+                                     ansible_local.system_groups.access|d() and
+                                     ansible_local.system_groups.access.sshd|d())
+                                 else []) }}'
+
+                                                                   # ]]]
 # .. envvar:: sshd__allow_groups [[[
 #
 # List of UNIX groups which allow connections to SSH service (global).
-sshd__allow_groups: [ 'root', 'admins', 'sshusers', 'sftponly' ]
+sshd__allow_groups: []
 
                                                                    # ]]]
 # .. envvar:: sshd__group_allow_groups [[[
@@ -599,7 +611,8 @@ sshd__match_list: [ '{{ sshd__match_group_sftponly }}' ]
 # .. envvar:: sshd__match_group_sftponly [[[
 #
 # Default ``Match`` conditional block which defines configuration for SFTPonly
-# accounts.
+# accounts. The ``stfponly`` UNIX system group is created by the
+# :ref:`debops.system_groups` Ansible role.
 sshd__match_group_sftponly:
   match: 'Group sftponly'
   options: |

--- a/ansible/roles/debops.sshd/templates/etc/ssh/sshd_config.j2
+++ b/ansible/roles/debops.sshd/templates/etc/ssh/sshd_config.j2
@@ -155,8 +155,9 @@ Subsystem sftp internal-sftp
 # and ChallengeResponseAuthentication to 'no'.
 UsePAM yes
 
-{% if sshd__allow_groups|d() or sshd__group_allow_groups|d() or sshd__host_allow_groups|d() %}
+{% if sshd__default_allow_groups|d() or sshd__allow_groups|d() or sshd__group_allow_groups|d() or sshd__host_allow_groups|d() %}
 AllowGroups {{ (
+      (sshd__default_allow_groups|d([]) | list) +
       (sshd__allow_groups|d([]) | list) +
       (sshd__group_allow_groups|d([]) | list) +
       (sshd__host_allow_groups|d([]) | list)) | unique | join(" ") }}

--- a/ansible/roles/debops.sudo/defaults/main.yml
+++ b/ansible/roles/debops.sudo/defaults/main.yml
@@ -40,3 +40,39 @@ sudo__packages: []
 sudo__logind_session: True
                                                                    # ]]]
                                                                    # ]]]
+# Sudoers configuration [[[
+# -------------------------
+
+# These lists define what :command:`sudo` configuration will be present in the
+# :file:`/etc/sudoers.d/` directory. See :ref:`sudo__ref_sudoers` for more
+# details.
+
+# .. envvar:: sudo__sudoers [[[
+#
+# Configuration which should be present on all hosts in the Ansible inventory.
+sudo__sudoers: []
+
+                                                                   # ]]]
+# .. envvar:: sudo__group_sudoers [[[
+#
+# Configuration which should be present on hosts in a specific Ansible
+# inventory group.
+sudo__group_sudoers: []
+
+                                                                   # ]]]
+# .. envvar:: sudo__host_sudoers [[[
+#
+# Configuration which should be present on specific hosts in the Ansible
+# inventory.
+sudo__host_sudoers: []
+
+                                                                   # ]]]
+# .. envvar:: sudo__combined_sudoers [[[
+#
+# The variable which combines all other ``sudoers`` configuration variables and
+# is used in the role tasks.
+sudo__combined_sudoers: '{{ sudo__sudoers
+                            + sudo__group_sudoers
+                            + sudo__host_sudoers }}'
+                                                                   # ]]]
+                                                                   # ]]]

--- a/ansible/roles/debops.sudo/meta/main.yml
+++ b/ansible/roles/debops.sudo/meta/main.yml
@@ -1,6 +1,8 @@
 ---
 
-dependencies: []
+dependencies:
+
+  - role: debops.ansible_plugins
 
 galaxy_info:
   author: 'Maciej Delmanowski'
@@ -9,17 +11,17 @@ galaxy_info:
   license: 'GPL-3.0'
   min_ansible_version: '2.4.0'
   platforms:
-  - name: Ubuntu
-    versions:
-    - xenial
-    - bionic
-  - name: Debian
-    versions:
-    - jessie
-    - stretch
-    - buster
+    - name: Ubuntu
+      versions:
+        - xenial
+        - bionic
+    - name: Debian
+      versions:
+        - jessie
+        - stretch
+        - buster
   galaxy_tags:
-  - sudo
-  - authentication
-  - authorization
-  - security
+    - sudo
+    - authentication
+    - authorization
+    - security

--- a/ansible/roles/debops.sudo/tasks/main.yml
+++ b/ansible/roles/debops.sudo/tasks/main.yml
@@ -19,6 +19,28 @@
     validate: 'visudo -cf "%s"'
   when: sudo__enabled|bool
 
+- name: Remove sudoers configuration if requested
+  file:
+    path: '/etc/sudoers.d/{{ item.filename | d(item.name) }}'
+    state: 'absent'
+  with_items: '{{ sudo__combined_sudoers | parse_kv_items }}'
+  register: sudo__register_sudoers_removed
+  when: sudo__enabled|bool and
+        item.name|d() and item.state|d('present') == 'absent'
+
+- name: Configure sudoers
+  template:
+    src: 'etc/sudoers.d/config.j2'
+    dest: '/etc/sudoers.d/{{ item.filename | d(item.name) }}'
+    owner: 'root'
+    group: 'root'
+    mode: '0440'
+    validate: '/usr/sbin/visudo -cf %s'
+  with_items: '{{ sudo__combined_sudoers | parse_kv_items }}'
+  register: sudo__register_sudoers_created
+  when: sudo__enabled|bool and
+        item.name|d() and item.state|d('present') not in [ 'init', 'absent', 'ignore' ]
+
 - name: Configure workaround for logind sessions via sudo
   template:
     src: 'etc/profile.d/sudo_logind_session.sh.j2'
@@ -47,4 +69,6 @@
 
 - name: Update Ansible facts if they were modified
   action: setup
-  when: sudo__register_facts is changed
+  when: sudo__register_facts is changed or
+        sudo__register_sudoers_removed is changed or
+        sudo__register_sudoers_created is changed

--- a/ansible/roles/debops.sudo/tasks/main.yml
+++ b/ansible/roles/debops.sudo/tasks/main.yml
@@ -9,6 +9,16 @@
     - '{{ sudo__packages }}'
   when: sudo__enabled|bool
 
+- name: Ensure that '/etc/sudoers' includes '/etc/sudoers.d'
+  lineinfile:
+    dest: '/etc/sudoers'
+    regexp: '^#includedir\s+/etc/sudoers.d$'
+    line: '#includedir /etc/sudoers.d'
+    insertafter: 'EOF'
+    state: 'present'
+    validate: 'visudo -cf "%s"'
+  when: sudo__enabled|bool
+
 - name: Configure workaround for logind sessions via sudo
   template:
     src: 'etc/profile.d/sudo_logind_session.sh.j2'

--- a/ansible/roles/debops.sudo/templates/etc/ansible/facts.d/sudo.fact.j2
+++ b/ansible/roles/debops.sudo/templates/etc/ansible/facts.d/sudo.fact.j2
@@ -5,7 +5,17 @@
 from __future__ import print_function
 from json import dumps
 from sys import exit
+import os
 
-output = {'installed': True}
 
-print(dumps(output, sort_keys=True, indent=2))
+def cmd_exists(cmd):
+    return any(
+        os.access(os.path.join(path, cmd), os.X_OK)
+        for path in os.environ["PATH"].split(os.pathsep)
+    )
+
+
+output = {'configured': True,
+          'installed': cmd_exists('sudo')}
+
+print(dumps(output, sort_keys=True, indent=4))

--- a/ansible/roles/debops.sudo/templates/etc/sudoers.d/config.j2
+++ b/ansible/roles/debops.sudo/templates/etc/sudoers.d/config.j2
@@ -1,0 +1,26 @@
+# {{ ansible_managed }}
+
+{% if item.comment|d() %}
+{{ item.comment | regex_replace('\n$','') | comment(prefix='', postfix='\n') -}}
+{% endif %}
+{% if item.options|d() %}
+{%   for element in item.options %}
+{%     if element is mapping %}
+{%       if element.name|d() and element.value|d() and element.state|d('present') != 'absent' %}
+{%         if not loop.first %}
+
+{%         endif %}
+{%         if element.comment|d() %}
+{%         if not loop.first %}
+
+{%         endif %}
+{{ element.comment | regex_replace('\n$','') | comment(prefix='', postfix='') -}}
+{%         endif %}
+{{ element.value -}}
+{%       endif %}
+{%     endif %}
+{%   endfor %}
+{% endif %}
+{% if item.raw|d() %}
+{{ item.raw -}}
+{% endif %}

--- a/ansible/roles/debops.system_groups/COPYRIGHT
+++ b/ansible/roles/debops.system_groups/COPYRIGHT
@@ -1,0 +1,18 @@
+debops.system_groups - Manage UNIX system groups with Ansible
+
+Copyright (C) 2018 Maciej Delmanowski <drybjed@gmail.com>
+Copyright (C) 2018 DebOps https://debops.org/
+
+This Ansible role is part of DebOps.
+
+DebOps is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 3, as
+published by the Free Software Foundation.
+
+DebOps is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with DebOps. If not, see https://www.gnu.org/licenses/.

--- a/ansible/roles/debops.system_groups/defaults/main.yml
+++ b/ansible/roles/debops.system_groups/defaults/main.yml
@@ -1,0 +1,188 @@
+---
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+
+# debops.system_groups default variables
+# ======================================
+
+# .. contents:: Sections
+#    :local:
+
+
+# General configuration [[[
+# -------------------------
+
+# .. envvar:: system_groups__enabled [[[
+#
+# Enable or disable support for managing UNIX system groups.
+system_groups__enabled: True
+
+                                                                   # ]]]
+# .. envvar:: system_groups__admins_sudo_nopasswd [[[
+#
+# If enabled, the role will add the ``NOPASSWD:`` tag in the ``sudoers``
+# configuration of the ``admins`` and ``wheel`` UNIX groups. This allows
+# execution of :command:`sudo` commands without password authentication.
+# See :man:`sudoers(5)` for more details.
+#
+# You can disable this and configure the ``ansible_become_pass`` variable in
+# the Ansible inventory for each affected host to provide password
+# authentication. You can use the Ansible Vault functionality to encrypt the
+# password in inventory variables, or store the password in the :file:`secret/`
+# directory and use the ``lookup('file')`` module to retrieve it.
+# See :ref:`debops.secret` documentation for details.
+system_groups__admins_sudo_nopasswd: True
+                                                                   # ]]]
+                                                                   # ]]]
+# UNIX system groups [[[
+# ----------------------
+
+# These lists define what UNIX system groups should be present on
+# DebOps-managed hosts and configure additional facilities like :command:`sudo`
+# access. See :ref:`system_groups__ref_list` for more details.
+
+# .. envvar:: system_groups__default_list [[[
+#
+# List of UNIX system groups defined by default by the role.
+system_groups__default_list:
+
+  # This is the current default UNIX group which grants unrestricted 'root'
+  # shell access via the `sudo` command.
+  #
+  # Users in the 'admins' UNIX group are allowed to connect to the host via SSH
+  # service and gain shell access on the host. They can also use the `sudo`
+  # command to execute commands as any UNIX account or gain superuser ('root')
+  # access.
+  - name: 'admins'
+    sudoers: |
+      # This might be required to allow Ansible pipelining connections
+      Defaults: %admins !requiretty
+
+      # This variable is used to configure access by Ansible Controller hosts
+      Defaults: %admins env_check += "SSH_CLIENT"
+
+      # Allow execution of any command as any user on the system.
+      # This is required for Ansible operation.
+      %admins ALL = (ALL:ALL) {{ 'NOPASSWD: ' if system_groups__admins_sudo_nopasswd|bool else '' }}ALL
+    members: '{{ ansible_local.core.admin_users
+                 if (ansible_local|d() and ansible_local.core|d() and
+                     ansible_local.core.admin_users|d())
+                 else [] }}'
+    access: [ 'root', 'sshd' ]
+
+
+  # This might be a new future UNIX system group that grants admin access, it
+  # is not currently created on the hosts.
+  # See https://en.wikipedia.org/wiki/Wheel_(Unix_term) for rationale.
+  #
+  # Users in the 'wheel' UNIX group are allowed to connect to the host via SSH
+  # service and gain shell access on the host. They can also use the `sudo`
+  # command to execute commands as any UNIX account or gain superuser ('root')
+  # access.
+  - name: 'wheel'
+    sudoers: |
+      # This might be required to allow Ansible pipelining connections
+      Defaults: %wheel !requiretty
+
+      # This variable is used to configure access by Ansible Controller hosts
+      Defaults: %wheel env_check += "SSH_CLIENT"
+
+      # Allow execution of any command as any user on the system.
+      # This is required for Ansible operation.
+      %wheel ALL = (ALL:ALL) {{ 'NOPASSWD: ' if system_groups__admins_sudo_nopasswd|bool else '' }}ALL
+    members: '{{ ansible_local.core.admin_users
+                 if (ansible_local|d() and ansible_local.core|d() and
+                     ansible_local.core.admin_users|d())
+                 else [] }}'
+    access: [ 'root', 'sshd' ]
+    state: 'init'
+
+
+  # This group is present on Debian installations by default.
+  #
+  # Users in the 'adm' UNIX group have read-only access to various log files in
+  # the '/var/log/' directory as well as firewall configuration in the
+  # '/etc/ferm/' directory.
+  - name: 'adm'
+    members: '{{ ansible_local.core.admin_users
+                 if (ansible_local|d() and ansible_local.core|d() and
+                     ansible_local.core.admin_users|d())
+                 else [] }}'
+
+
+  # This group is present on Debian installations by default.
+  #
+  # Users in the 'staff' UNIX group have write access to the '/usr/local/' and
+  # '/var/local/' directories and can manage content inside of them.
+  - name: 'staff'
+    members: '{{ ansible_local.core.admin_users
+                 if (ansible_local|d() and ansible_local.core|d() and
+                     ansible_local.core.admin_users|d())
+                 else [] }}'
+
+
+  # Users in the 'sshusers' UNIX group are allowed to connect to the host via
+  # SSH service and gain shell access on the host.  See the 'debops.sshd' role
+  # for more details.
+  - name: 'sshusers'
+    access: [ 'sshd' ]
+
+
+  # Users in the 'sftponly' UNIX group have access to chrooted SFTP service,
+  # without full shell access. They cannot use SSH public keys in the
+  # '~/.ssh/authorized_keys' file, only keys in the
+  # '/etc/ssh/authorized_keys.d/<user>' file are allowed.
+  # See the 'debops.sshd' and 'debops.authorized_keys' roles for more details.
+  - name: 'sftponly'
+    access: [ 'sshd' ]
+
+
+  # This is a UNIX group used in multiple DebOps roles. Its configuration will
+  # be conditional in the future so that it's not created on DebOps hosts that
+  # don't provide webserver services.
+  #
+  # Users in the 'webadmins' UNIX group can reload webserver services using
+  # specific `sudo` commands. See the 'debops.nginx' or 'debops.php' roles for
+  # more details.
+  - name: 'webadmins'
+    access: [ 'webserver' ]
+
+                                                                   # ]]]
+# .. envvar:: system_groups__list [[[
+#
+# List of UNIX system groups that should be present on all hosts in the Ansible
+# inventory.
+system_groups__list: []
+
+                                                                   # ]]]
+# .. envvar:: system_groups__group_list [[[
+#
+# List of UNIX system groups that should be present on hosts in a specific
+# Ansible inventory group.
+system_groups__group_list: []
+
+                                                                   # ]]]
+# .. envvar:: system_groups__host_list [[[
+#
+# List of UNIX system groups that should be present on specific hosts in the
+# Ansible inventory.
+system_groups__host_list: []
+
+                                                                   # ]]]
+# .. envvar:: system_groups__dependent_list [[[
+#
+# List of UNIX system groups that are defined by other Ansible roles via role
+# dependent variables.
+system_groups__dependent_list: []
+
+                                                                   # ]]]
+# .. envvar:: system_groups__combined_list [[[
+#
+# List which combines all of the other UNIX group lists and is used in the role
+# tasks.
+system_groups__combined_list: '{{ system_groups__default_list
+                                  + system_groups__dependent_list
+                                  + system_groups__list
+                                  + system_groups__group_list
+                                  + system_groups__host_list }}'
+                                                                   # ]]]
+                                                                   # ]]]

--- a/ansible/roles/debops.system_groups/defaults/main.yml
+++ b/ansible/roles/debops.system_groups/defaults/main.yml
@@ -17,6 +17,15 @@
 system_groups__enabled: True
 
                                                                    # ]]]
+# .. envvar:: system_groups__sudo_enabled [[[
+#
+# Enable or disable support for :file:`/etc/sudoers.d/` configuration.
+system_groups__sudo_enabled: '{{ True
+                                 if (ansible_local|d() and ansible_local.sudo|d() and
+                                     (ansible_local.sudo.installed|d()|bool))
+                                 else False }}'
+
+                                                                   # ]]]
 # .. envvar:: system_groups__admins_sudo_nopasswd [[[
 #
 # If enabled, the role will add the ``NOPASSWD:`` tag in the ``sudoers``

--- a/ansible/roles/debops.system_groups/meta/main.yml
+++ b/ansible/roles/debops.system_groups/meta/main.yml
@@ -1,0 +1,32 @@
+---
+
+dependencies:
+
+  - role: debops.ansible_plugins
+
+galaxy_info:
+  author: 'Maciej Delmanowski'
+  description: 'Manage UNIX system groups'
+  company: 'DebOps'
+  license: 'GPL-3.0'
+  min_ansible_version: '2.4.0'
+  platforms:
+    - name: Ubuntu
+      versions:
+        - precise
+        - trusty
+        - xenial
+        - bionic
+    - name: Debian
+      versions:
+        - wheezy
+        - jessie
+        - stretch
+        - buster
+  categories:
+    - system
+    - access
+    - authz
+    - acl
+    - sudo
+    - ssh

--- a/ansible/roles/debops.system_groups/tasks/main.yml
+++ b/ansible/roles/debops.system_groups/tasks/main.yml
@@ -28,7 +28,7 @@
     path: '/etc/sudoers.d/{{ item.sudoers_filename | d("system_groups-" + item.name) }}'
     state: 'absent'
   with_items: '{{ system_groups__combined_list | parse_kv_items }}'
-  when: system_groups__enabled|bool and
+  when: system_groups__enabled|bool and system_groups__sudo_enabled|bool and
         item.name|d() and item.state|d('present') not in [ 'init', 'absent', 'ignore' ] and
         not item.sudoers|d()
 
@@ -41,7 +41,7 @@
     mode: '0440'
     validate: '/usr/sbin/visudo -cf %s'
   with_items: '{{ system_groups__combined_list | parse_kv_items }}'
-  when: system_groups__enabled|bool and
+  when: system_groups__enabled|bool and system_groups__sudo_enabled|bool and
         item.name|d() and item.state|d('present') not in [ 'init', 'absent', 'ignore' ] and
         item.sudoers|d()
 

--- a/ansible/roles/debops.system_groups/tasks/main.yml
+++ b/ansible/roles/debops.system_groups/tasks/main.yml
@@ -1,0 +1,94 @@
+---
+
+- name: Ensure that requested UNIX system groups exist
+  group:
+    name: '{{ item.name }}'
+    gid: '{{ item.gid | d(omit) }}'
+    state: 'present'
+    system: '{{ item.system | d(True) }}'
+  with_items: '{{ system_groups__combined_list | parse_kv_items }}'
+  when: system_groups__enabled|bool and
+        item.name|d() and item.state|d('present') not in [ 'init', 'absent', 'ignore' ]
+
+- name: Get list of existing UNIX accounts
+  getent:
+    database: 'passwd'
+  when: system_groups__enabled|bool
+
+- name: Add specified UNIX accounts to system groups if present
+  user:
+    name: '{{ item.name }}'
+    append: '{{ item.append }}'
+    groups: '{{ item.groups }}'
+  with_items: '{{ lookup("template", "lookup/system_groups_members.j2") | from_yaml }}'
+  when: system_groups__enabled|bool
+
+- name: Remove sudo configuration if not specified
+  file:
+    path: '/etc/sudoers.d/{{ item.sudoers_filename | d("system_groups-" + item.name) }}'
+    state: 'absent'
+  with_items: '{{ system_groups__combined_list | parse_kv_items }}'
+  when: system_groups__enabled|bool and
+        item.name|d() and item.state|d('present') not in [ 'init', 'absent', 'ignore' ] and
+        not item.sudoers|d()
+
+- name: Configure sudo for UNIX system groups
+  template:
+    src: 'etc/sudoers.d/system_groups.j2'
+    dest: '/etc/sudoers.d/{{ item.sudoers_filename | d("system_groups-" + item.name) }}'
+    owner: 'root'
+    group: 'root'
+    mode: '0440'
+    validate: '/usr/sbin/visudo -cf %s'
+  with_items: '{{ system_groups__combined_list | parse_kv_items }}'
+  when: system_groups__enabled|bool and
+        item.name|d() and item.state|d('present') not in [ 'init', 'absent', 'ignore' ] and
+        item.sudoers|d()
+
+- name: Remove tmpfiles configuration if not specified
+  file:
+    path: '/etc/tmpfiles.d/{{ item.tmpfiles_filename | d("system_groups-" + item.name + ".conf") }}'
+    state: 'absent'
+  with_items: '{{ system_groups__combined_list | parse_kv_items }}'
+  when: system_groups__enabled|bool and ansible_service_mgr == 'systemd' and
+        item.name|d() and item.state|d('present') not in [ 'init', 'absent', 'ignore' ] and
+        not item.tmpfiles|d()
+
+- name: Generate tmpfiles configuration for UNIX system groups
+  template:
+    src: 'etc/tmpfiles.d/system_groups.conf.j2'
+    dest: '/etc/tmpfiles.d/{{ item.tmpfiles_filename | d("system_groups-" + item.name + ".conf") }}'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  with_items: '{{ system_groups__combined_list | parse_kv_items }}'
+  register: system_groups__register_tmpfiles
+  when: system_groups__enabled|bool and ansible_service_mgr == 'systemd' and
+        item.name|d() and item.state|d('present') not in [ 'init', 'absent', 'ignore' ] and
+        item.tmpfiles|d()
+
+- name: Ensure that missing tmpfiles are present
+  command: systemd-tmpfiles --create
+  when: system_groups__enabled|bool and ansible_service_mgr == 'systemd' and
+        system_groups__register_tmpfiles is changed
+
+- name: Make sure that Ansible local facts directory exists
+  file:
+    path: '/etc/ansible/facts.d'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+
+- name: Save system groups local facts
+  template:
+    src: 'etc/ansible/facts.d/system_groups.fact.j2'
+    dest: '/etc/ansible/facts.d/system_groups.fact'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+  register: system_groups__register_facts
+
+- name: Update Ansible facts if they were modified
+  action: setup
+  when: system_groups__register_facts is changed

--- a/ansible/roles/debops.system_groups/templates/etc/ansible/facts.d/system_groups.fact.j2
+++ b/ansible/roles/debops.system_groups/templates/etc/ansible/facts.d/system_groups.fact.j2
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+# {{ ansible_managed }}
+
+from __future__ import print_function
+from json import loads, dumps
+from sys import exit
+
+# A workaround for Jinja templates in Python scripts
+"""
+{% set system_groups__tpl_acl = {} %}
+{% set system_groups__tpl_access = (
+  ansible_local.system_groups.access
+  if (ansible_local|d() and ansible_local.system_groups|d() and
+      ansible_local.system_groups.access|d()) else {}) %}
+{% for element in (system_groups__combined_list | parse_kv_items) %}
+{%   if (element.name|d() and element.state|d('present') not in
+         [ 'init', 'absent', 'ignore' ]) %}
+{%     if element.access|d() %}
+{%       for token in ([ element.access ]
+                         if element.access is string
+                         else element.access) %}
+{%         set _ = system_groups__tpl_access.update(
+               {token:
+                (((system_groups__tpl_access[token]|d([]))
+                  + [ element.name ]) | unique)}) %}
+{%       endfor %}
+{%     endif %}
+{%     if element.allow|d() %}
+{%       for token in ([ element.allow ]
+                         if element.allow is string
+                         else element.allow) %}
+{%         set _ = system_groups__tpl_access.update(
+               {token:
+                (((system_groups__tpl_access[token]|d([]))
+                  + [ element.name ]) | unique)}) %}
+{%       endfor %}
+{%     endif %}
+{%     if element.deny|d() %}
+{%       for token in ([ element.deny ]
+                         if element.deny is string
+                         else element.deny) %}
+{%         if element.name in (system_groups__tpl_access[token]|d([])) %}
+{%           set _ = system_groups__tpl_access[token].remove(element.name) %}
+{%         endif %}
+{%       endfor %}
+{%     endif %}
+{%   endif %}
+{% endfor %}
+{% for element, group_list in system_groups__tpl_access.items() %}
+{%   if group_list %}
+{%     set _ = system_groups__tpl_acl.update({element: group_list}) %}
+{%   endif %}
+{% endfor %}
+"""
+
+output = loads("""{{ {'configured': True,
+                      'enabled': system_groups__enabled|bool,
+                      'access': system_groups__tpl_acl
+                     } | to_nice_json }}""")
+
+print(dumps(output, sort_keys=True, indent=4))

--- a/ansible/roles/debops.system_groups/templates/etc/sudoers.d/system_groups.j2
+++ b/ansible/roles/debops.system_groups/templates/etc/sudoers.d/system_groups.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+
+# Configuration managed by the 'debops.system_groups' Ansible role
+
+{{ item.sudoers }}

--- a/ansible/roles/debops.system_groups/templates/etc/tmpfiles.d/system_groups.conf.j2
+++ b/ansible/roles/debops.system_groups/templates/etc/tmpfiles.d/system_groups.conf.j2
@@ -1,0 +1,6 @@
+# {{ ansible_managed }}
+
+# Configuration managed by the 'debops.system_groups' Ansible role
+
+#Type Path              Mode UID     GID     Age Argument
+{{ item.tmpfiles }}

--- a/ansible/roles/debops.system_groups/templates/lookup/system_groups_members.j2
+++ b/ansible/roles/debops.system_groups/templates/lookup/system_groups_members.j2
@@ -1,0 +1,19 @@
+{% set system_groups__tpl_items = [] %}
+{% for account in getent_passwd.keys() %}
+{%   set system_groups__tpl_append_groups = [] %}
+{%   for element in (system_groups__combined_list | parse_kv_items) %}
+{%     if element.name|d() and element.state|d('present') not in [ 'init', 'absent', 'ignore' ] %}
+{%       if (element.members|d() and account in ([ element.members ] if element.members is string else element.members)) %}
+{%         set _ = system_groups__tpl_append_groups.append(element.name) %}
+{%       endif %}
+{%     endif %}
+{%   endfor %}
+{%   if system_groups__tpl_append_groups %}
+{%     set _ = system_groups__tpl_items.append({
+  "name": account,
+  "append": True,
+  "groups": (system_groups__tpl_append_groups | join(','))
+}) %}
+{%   endif %}
+{% endfor %}
+{{ system_groups__tpl_items | to_yaml }}

--- a/docs/ansible/role-index.rst
+++ b/docs/ansible/role-index.rst
@@ -217,6 +217,7 @@ packages.
 - :ref:`debops.apt_mark`
 - :ref:`debops.apt_preferences`
 - :ref:`debops.apt_proxy`
+- :ref:`debops.debops_legacy`
 - :ref:`debops.unattended_upgrades`
 - ``debops.reprepro``
 
@@ -242,6 +243,7 @@ System configuration
 
 - :ref:`debops.atd`
 - :ref:`debops.cron`
+- :ref:`debops.debops_legacy`
 - :ref:`debops.environment`
 - :ref:`debops.etc_services`
 - :ref:`debops.etckeeper`

--- a/docs/ansible/role-index.rst
+++ b/docs/ansible/role-index.rst
@@ -231,6 +231,7 @@ Security
 - :ref:`debops.proc_hidepid`
 - :ref:`debops.sshd`
 - :ref:`debops.sudo`
+- :ref:`debops.system_groups`
 - :ref:`debops.tcpwrappers`
 - ``debops-contrib.apparmor``
 - ``debops-contrib.firejail``
@@ -257,6 +258,7 @@ System configuration
 - :ref:`debops.sysctl`
 - :ref:`debops.sysfs`
 - :ref:`debops.sysnews`
+- :ref:`debops.system_groups`
 - :ref:`debops.users`
 - ``debops.console``
 - ``debops.gitusers``

--- a/docs/ansible/roles/debops.debops_legacy/defaults-detailed.rst
+++ b/docs/ansible/roles/debops.debops_legacy/defaults-detailed.rst
@@ -1,0 +1,127 @@
+Default variable details
+========================
+
+Some of ``debops.debops_legacy`` default variables have more extensive configuration
+than simple strings or lists, here you can find documentation and examples for
+them.
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+.. _debops_legacy__ref_remove_diversions:
+
+debops_legacy__remove_diversions
+--------------------------------
+
+The ``debops_legacy__remove_*_diversions`` variables define the
+:command:`dpkg-divert` diversions that will be removed by the role. The
+existing files will be deleted and the original files diverted by DebOps will
+be moved back into place.
+
+The variables are list with YAML dictionaries, each dictionary defines one file
+with specific parameters:
+
+``name``
+  Required. Absolute path of the file that will be reverted. This parameter is
+  used as a key for merging different configuration entries together.
+
+``diversion``
+  Optional. Absolute path of the diverted file to revert into its original
+  place. If not specified, the filename is defined as:
+
+  .. code-block:: none
+
+     {{ item.name }}.dpkg-divert
+
+``state``
+  Optional. If not specified or ``present``, the existing diversion will be
+  kept in place. If ``absent``, the diversion will be removed.
+
+  If ``ignore``, a given configuration entry will not be evaluated by the role
+  during execution, allowing conditional activation of the tasks.
+
+Examples
+~~~~~~~~
+
+Remove existing diversion of a configuration file:
+
+.. code-block:: yaml
+
+   debops_legacy__remove_diversions:
+
+     - name: '/etc/default/application'
+       state: 'absent'
+
+
+.. _debops_legacy__ref_remove_packages:
+
+debops_legacy__remove_packages
+------------------------------
+
+The ``debops_legacy__remove_*_packages`` variables define the
+APT packages which should be removed by the role. The variables are list of
+YAML entries, each entry defines one APT package to remove using specific
+parameters:
+
+``name``
+  Required. Name of the APT package to remove.
+
+``state``
+  Optional. If not specified or ``present``, the existing APT package will be
+  kept in place, or installed if it's not present. If ``absent``, existing APT
+  package will be removed.
+
+  If ``ignore``, a given configuration entry will not be evaluated by the role
+  during execution, allowing conditional activation of the task.
+
+Examples
+~~~~~~~~
+
+Remove existing package conditionally, else leave the existing state
+(installed/uninstalled) as is:
+
+.. code-block:: yaml
+
+   debops_legacy__remove_packages:
+
+     - name: 'application'
+       state: '{{ "absent"
+                  if (ansible_hostname == "example")
+                  else "ignore" }}'
+
+
+.. _debops_legacy__ref_remove_files:
+
+debops_legacy__remove_files
+---------------------------
+
+The ``debops_legacy__remove_*_files`` variables define the files or directories
+which should be removed by the role. The variables are list of YAML entries,
+each entry defines one file or directory to remove using specific parameters:
+
+``name``
+  Required. Absolute path of the file or directory to remove.
+
+``state``
+  Optional. If not specified or ``present``, the existing file will be left in
+  place. Non-existent files or directories will result in an error. If
+  ``absent``, existing file or directory will be removed.
+
+  If ``ignore``, a given configuration entry will not be evaluated by the role
+  during execution, allowing conditional activation of the task.
+
+Examples
+~~~~~~~~
+
+Remove existing file conditionally based on Ansible facts:
+
+.. code-block:: yaml
+
+   debops_legacy__remove_files:
+
+     - name: '/etc/default/application'
+       state: '{{ "absent"
+                  if (ansible_hostname == "example")
+                  else "ignore" }}'

--- a/docs/ansible/roles/debops.debops_legacy/getting-started.rst
+++ b/docs/ansible/roles/debops.debops_legacy/getting-started.rst
@@ -1,0 +1,40 @@
+Getting started
+===============
+
+.. contents::
+   :local:
+
+
+Example inventory
+-----------------
+
+The ``debops.debops_legacy`` role doesn't need to be enabled in Ansible
+inventory, since its playbook by default works against the hosts in the
+``[debops_all_hosts]`` Ansible inventory group. However the role is not
+included in the ``site.yml`` playbook and needs to be executed specifically by
+the system administrator to perform work.
+
+
+Example playbook
+----------------
+
+If you are using this role without DebOps, here's an example Ansible playbook
+that uses the ``debops.debops_legacy`` role:
+
+.. literalinclude:: ../../../../ansible/playbooks/service/debops_legacy.yml
+   :language: yaml
+
+
+Ansible tags
+------------
+
+You can use Ansible ``--tags`` or ``--skip-tags`` parameters to limit what
+tasks are performed during Ansible run. This can be used after a host was first
+configured to speed up playbook execution, when you are sure that most of the
+configuration is already in the desired state.
+
+Available role tags:
+
+``role::debops_legacy``
+  Main role tag, should be used in the playbook to execute all of the role
+  tasks as well as role dependencies.

--- a/docs/ansible/roles/debops.debops_legacy/index.rst
+++ b/docs/ansible/roles/debops.debops_legacy/index.rst
@@ -1,0 +1,38 @@
+.. _debops.debops_legacy:
+
+debops.debops_legacy
+====================
+
+The ``debops.debops_legacy`` Ansible role can be used to clean up legacy files,
+directories, APT packages or :command:`dpkg-divert` diversions created by
+DebOps but no longer used.
+
+The role is not included in the main DebOps playbook to not cause data
+destruction by mistake. You are advised to use it with caution - it will
+destroy data on your DebOps hosts. To check the changes that will be done
+before implementing them, you can run the role against DebOps hosts with:
+
+.. code-block:: console
+
+   debops service/debops_legacy -l <host> --diff --check
+
+Any changes that the role will create on the hosts can be overridden via the
+Ansible inventory if needed.
+
+.. toctree::
+   :maxdepth: 2
+
+   getting-started
+   defaults
+   defaults-detailed
+
+Copyright
+---------
+
+.. literalinclude:: ../../../../ansible/roles/debops.debops_legacy/COPYRIGHT
+
+..
+ Local Variables:
+ mode: rst
+ ispell-local-dictionary: "american"
+ End:

--- a/docs/ansible/roles/debops.sudo/defaults-detailed.rst
+++ b/docs/ansible/roles/debops.sudo/defaults-detailed.rst
@@ -1,0 +1,117 @@
+Default variable details
+========================
+
+Some of ``debops.sudo`` default variables have more extensive configuration
+than simple strings or lists, here you can find documentation and examples for
+them.
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+.. _sudo__ref_sudoers:
+
+sudo__sudoers
+-------------
+
+The ``sudo__*_sudoers`` variables define :command:`sudo` configuration located
+in :file:`/etc/sudoers.d/` directory. Each variable is a list of YAML
+dictionaries, with specific parameters:
+
+``name``
+  Required. Name of the configuration section, used as a filename, and as
+  a marker which merges multiple configuration entries together.
+
+``filename``
+  Optional. Set custom filename for a given configuration file, located in
+  :file:`/etc/sudoers.d/` directory.
+
+``comment``
+  Optional. A string or YAML text block with comments added at the beginning of
+  the configuration file.
+
+``state``
+  Optional. If not defined or ``present`` (default), the configuration file
+  will be generated.  if ``absent``, the configuration file will be removed.
+
+  If ``init``, the configuration for a given entry will be prepared but not
+  actually present on the host. It can be activated conditionally in a later
+  entry.
+
+  If ``ignore``, a given configuration entry will not be evaluated by the role.
+
+``raw``
+  Optional. A string or YAML text block with :man:`sudoers(5)` configuration
+  added at the end of the configuration file as-is.
+
+``options``
+  Optional. A list of :man:`sudoers(5)` configuration snippets specified as
+  YAML dictionaries. Each dictionary can have specific parameters:
+
+  ``name``
+    Required. Name of a configuration section, only used as a handle for
+    merging options from multiple configuration entries.
+
+  ``value``
+    Required. A string or YAML text block that contains the :man:`sudoers(5)`
+    configuration snippet. Values from different configuration entries will be
+    merged into one list and present in the configuration file.
+
+  ``comment``
+    Optional. A string or YAML text block with a comment about a given option.
+
+  ``weight``
+    Optional. A positive or negative number which influences the order in which
+    the entries will be present in the configuration file. The lower the
+    number, the higher in the file a given option will be present.
+
+  ``state``
+    Optional. If not defined or ``present``, a given configuration option will
+    be added in the configuration file. If ``absent``, a given option will be
+    removed from the configuration file.
+
+Examples
+~~~~~~~~
+
+Allow user ``ray`` on host ``rushmore`` to run specific commands with elevated
+privileges without password confirmation:
+
+.. code-block:: yaml
+
+   sudo__sudoers:
+
+     - name: 'ray-nopasswd-commands'
+       raw: |
+         ray   rushmore = NOPASSWD: /bin/kill, /bin/ls, /usr/bin/lprm
+
+Override some of the built-in defaults conditionally:
+
+.. code-block:: yaml
+
+   sudo__sudoers:
+
+     - name: '00-defaults-override'
+       options:
+
+         - name: 'syslog-auth'
+           comment: 'Log events to syslog via "auth" facility'
+           value: 'Defaults    syslog=auth'
+
+         - name: 'disable-lecture'
+           comment: "Don't show the default lecture on specific hosts"
+           value: |
+             Defaults    !lecture
+           state: '{{ "present"
+                      if (ansible_hostname == 'bastion')
+                      else "absent" }}'
+
+On the contrary, don't create the above defaults file when a host is in
+a specific Ansible inventory group:
+
+.. code-block:: yaml
+
+   sudo__group_sudoers:
+
+     - name: '00-defaults-override'
+       state: 'absent'

--- a/docs/ansible/roles/debops.sudo/index.rst
+++ b/docs/ansible/roles/debops.sudo/index.rst
@@ -13,6 +13,7 @@ package will be installed.
 
    getting-started
    defaults
+   defaults-detailed
 
 Copyright
 ---------

--- a/docs/ansible/roles/debops.system_groups/defaults-detailed.rst
+++ b/docs/ansible/roles/debops.system_groups/defaults-detailed.rst
@@ -1,0 +1,179 @@
+Default variable details
+========================
+
+Some of ``debops.system_groups`` default variables have more extensive
+configuration than simple strings or lists, here you can find documentation and
+examples for them.
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+.. _system_groups__ref_list:
+
+system_groups__list
+-------------------
+
+The ``system_groups__*_list`` variables define what UNIX system groups should
+be present on a given host, and can optionally create or modify configuration
+of selected services. The variables are list of YAML dictionaries, each
+dictionary defining one UNIX group.
+
+The lists are combined together in the order specified by the
+:envvar:`system_groups__combined_list` variable and the entries with the same
+``name`` parameters will be merged. This can be used to change the
+configuration of existing entries via Ansible inventory.
+
+Each entry can specify a set of parameters:
+
+``name``
+  Required. The name of the UNIX group to manage. This should be an
+  alphanumeric string, you can check the :man:`groupadd(8)` manpage for allowed
+  characters. This parameter is used as a key for merging multiple
+  configuration entries together in order of appearance.
+
+``gid``
+  Optional. Specify the group ID (GID) of a given UNIX group. If not specified,
+  it will be selected automatically.
+
+``system``
+  Optional, boolean. If ``True`` (default), the created UNIX group will be
+  a "system" group with GID < 1000.
+
+``state``
+  Optional. If ``present``, the specified UNIX group will be created and its
+  configuration in different services will be set. If ``absent``, the UNIX
+  group will not be created, but existing configuration will be left in place.
+
+  If ``init``, the configuration for a given UNIX group will be prepared but it
+  will not be active - this can be done conditionally in a later configuration
+  entry. If ``ignore``, a given configuration entry will be ignored by the role
+  and its parameters will not affect a given UNIX group.
+
+``members``
+  Optional. List of UNIX accounts that should be the members of a given UNIX
+  group. Only existing UNIX accounts will be added by the role.
+
+``sudoers``
+  Optional. A string or YAML text block which specifies the :command:`sudo`
+  configuration for a given UNIX group. It will be saved as
+  :file:`/etc/sudoers.d/system_groups-<group>` configuration file.
+
+  If the value is ``False``, or the parameter is not specified, the
+  :command:`sudo` configuration file will be removed.
+
+  See :man:`sudoers(5)` manual page for information about the configuration
+  syntax. The role does not ensure that the configuration is related to the
+  specified UNIX group, you should ensure that independently using the
+  :command:`sudo` configuration options.
+
+``sudoers_filename``
+  Optional. Override the filename of the :command:`sudo` configuration file in
+  the :file:`/etc/sudoers.d/` directory. This might be useful if you need to
+  change the order of the :command:`sudo` configuration options. You shouldn't
+  change the filename of existing configuration, because the role will lose
+  track of it.
+
+``tmpfiles``
+  Optional. A string or YAML text block which specifies the configuration of
+  temporary files and directories maintained by the :command:`system-tmpfiles`
+  command. It will be saved as
+  :file:`/etc/tmpfiles.d/system_groups-<group>.conf` configuration file.
+
+  If the value is ``False``, or the parameter is not specified, the
+  :command:`systemd-tmpfiles` configuration file will be removed.
+
+  See :man:`tmpfiles.d(5)` manual page for information about the configuration
+  syntax. The role does not ensure that the configuration is related to the
+  specified UNIX group, you should ensure that independently using the
+  :command:`systemd-tmpfiles` configuration options.
+
+``tmpfiles_filename``
+  Optional. Override the filename of the :command:`systemd-tmpfiles`
+  configuration file in the :file:`/etc/tmpfiles.d/` directory. This might be
+  useful if you need to change the order of the :command:`systemd-tmpfiles`
+  configuration options. You shouldn't change the filename of existing
+  configuration, because the role will lose track of it. The filename should
+  contain the ``.conf`` suffix, otherwise it will be ignored by
+  :command:`systemd-tmpfiles` command.
+
+The role maintains a simple :ref:`Access Control List <system_groups__ref_acl>`
+using Ansible local facts which can be used by other Ansible roles to augment
+their configuration. The parameters below control the ACL configuration.
+
+``access``
+  Optional. A string or a list of resources which correspond to Access Control
+  List entries. A given UNIX group will be added to all of the ACL entries with
+  corresponding resources.
+
+  The ``access`` parameter should be used in default or initial configuration,
+  using it in the inventory will override the default list of resources of
+  a given UNIX group.
+
+``allow``
+  Optional. A string or a list of resources which correspond to Access Control
+  List entries. A given UNIX group will be added to all of the ACL entries with
+  corresponding resources.
+
+  The ``allow`` parameter should be used in additional configuration entries to
+  augment an existing ACL entries. Currently the configuration of ACL from
+  multiple entries is not merged automatically, but existing ACL entries are
+  preserved.
+
+``deny``
+  Optional. A string or a list of resources which corresdpond to Access Control
+  List entries. A given UNIX group will be removed from all of the ACL entries
+  specified here.
+
+  The ``deny`` parameter should be used in additional configuration entries to
+  augment an existing ACL entries. Currently the configuration of ACL from
+  multiple entries is not merged automatically, but existing ACL entries are
+  preserved.
+
+Examples
+~~~~~~~~
+
+Create a system UNIX group for an application that is composed of multiple UNIX
+accounts for better access control. The group will use a temporary directory as
+a shared communication channel and will allow its members to reload system
+services via :command:`sudo` commands. Members of the group will be allowed to
+connect to the host via SSH.
+
+.. code-block:: yaml
+
+   system_groups__list:
+
+     - name: 'application'
+       members: [ 'app-core', 'app-webui', 'app-admin1', 'app-admin2' ]
+       sudoers: |
+         User_Alias  APP_ADMINS   = app-admin1, app-admin2
+         Runas_Alias APP_SERVICES = app-core, app-webui
+
+         Cmnd_Alias  APP_RELOAD   = /bin/systemctl reload app-core.service,\
+                                    /bin/systemctl reload app-webui.service
+
+         Cmnd_Alias  APP_RESTART  = /bin/systemctl restart app-core.service,\
+                                    /bin/systemctl restart app-webui.service
+
+         Cmnd_Alias  APP_STATUS   = /bin/systemctl status app-core.service,\
+                                    /bin/systemctl status app-webui.service
+
+         # Allow service reloads for all members, even services
+         %application ALL = (root) NOPASSWD: APP_RELOAD
+
+         # Allow more control over services for application administrators
+         APP_ADMINS ALL = (root) NOPASSWD: APP_RESTART, APP_STATUS
+
+         # Allow administrators to switch to the service UNIX accounts and run
+         # commands on their behalf, after authentication
+         APP_ADMINS ALL = (APP_SERVICES) ALL
+       tmpfiles: |
+         # Temporary directory for UNIX sockets
+         d   /run/application   2771 root application  - -
+       access: [ 'sshd' ]
+
+You might need to add the individual accounts to the UNIX group in your role if
+they don't exist before the ``debops.system_groups`` role is executed,
+afterwards the role will ensure that the specified members are present in the
+group.

--- a/docs/ansible/roles/debops.system_groups/getting-started.rst
+++ b/docs/ansible/roles/debops.system_groups/getting-started.rst
@@ -1,0 +1,90 @@
+Getting started
+===============
+
+.. contents::
+   :local:
+
+
+.. _system_groups__ref_acl:
+
+Access Control List
+-------------------
+
+The ``debops.system_groups`` role maintains a simple Access Control List in the
+Ansible local facts, under ``ansible_local.system_groups.access.*`` variable
+hierarchy. Other roles can inspect it to get a list of UNIX group names which
+they can use to configure access in their respective applications.
+
+The ``ansible_local.system_groups.access`` variable is a YAML dictionary. Each
+key of this dictionary corresponds to a particular resource, and the value is
+a list of UNIX group names. The resources are user-defined, by default the role
+creates:
+
+``root``
+  Members of these UNIX groups have full, privileged access to the ``root``
+  account on a given host. This resource should be reserved to system
+  administrators.
+
+``sshd``
+  Members of these UNIX groups can login to the host via the SSH service.
+  See :ref:`debops.sshd` role for more details.
+
+``webserver``
+  Members of these UNIX groups can manipulate various webserver-related
+  services. See :ref:`debops.nginx` and :ref:`debops.php` roles for more
+  details.
+
+
+Example inventory
+-----------------
+
+The ``debops.system_groups`` role is included by default in the ``common.yml``
+DebOps playbook; you don't need to add hosts to any Ansible groups to enable
+it.
+
+
+Example playbook
+----------------
+
+If you are using this role without DebOps, here's an example Ansible playbook
+that uses the ``debops.system_groups`` role:
+
+.. literalinclude:: ../../../../ansible/playbooks/service/system_groups.yml
+   :language: yaml
+
+
+Ansible tags
+------------
+
+You can use Ansible ``--tags`` or ``--skip-tags`` parameters to limit what
+tasks are performed during Ansible run. This can be used after a host was first
+configured to speed up playbook execution, when you are sure that most of the
+configuration is already in the desired state.
+
+Available role tags:
+
+``role::system_groups``
+  Main role tag, should be used in the playbook to execute all of the role
+  tasks as well as role dependencies.
+
+
+Other resources
+---------------
+
+List of other useful resources related to the ``debops.system_groups`` Ansible
+role:
+
+- Manual pages: :man:`group(5)`, :man:`sudoers(5)`, :man:`tmpfiles.d(5)`
+- `Debian System Groups`__ documentation on Debian Wiki
+- `UNIX permissions`__ documentation on Debian Wiki
+- `User Private Groups`__ documentation on Debian Wiki
+- `Security privileges`__ documentation on Ubuntu Wiki
+- `Multi User Management`__ documentation on Ubuntu Wiki
+- `UNIX group identifier`__ page on Wikipedia
+
+.. __: https://wiki.debian.org/SystemGroups
+.. __: https://wiki.debian.org/Permissions
+.. __: https://wiki.debian.org/UserPrivateGroups
+.. __: https://wiki.ubuntu.com/Security/Privileges
+.. __: https://wiki.ubuntu.com/MultiUserManagement
+.. __: https://en.wikipedia.org/wiki/Group_identifier

--- a/docs/ansible/roles/debops.system_groups/index.rst
+++ b/docs/ansible/roles/debops.system_groups/index.rst
@@ -1,0 +1,39 @@
+.. _debops.system_groups:
+
+debops.system_groups
+====================
+
+The UNIX system groups are used on Linux hosts for low level access control
+mechanism for different system services. Debian by default creates a
+`a set of UNIX system groups`__ which control access to various parts of the
+system.
+
+The ``debops.system_groups`` Ansible role is used to configure additional UNIX
+system groups that are used on hosts managed by DebOps. It can also be used to
+define :command:`sudo` and :command:`systemd-tmpfiles` configuration for these
+UNIX groups.
+
+Additionally, a simple Access Control List managed by the role in the Ansible
+local facts can be used by other Ansible roles to configure access for selected
+UNIX groups to the services managed by these roles.
+
+.. __: https://wiki.debian.org/SystemGroups
+
+
+.. toctree::
+   :maxdepth: 2
+
+   getting-started
+   defaults
+   defaults-detailed
+
+Copyright
+---------
+
+.. literalinclude:: ../../../../ansible/roles/debops.system_groups/COPYRIGHT
+
+..
+ Local Variables:
+ mode: rst
+ ispell-local-dictionary: "american"
+ End:

--- a/docs/news/upgrades.rst
+++ b/docs/news/upgrades.rst
@@ -76,6 +76,10 @@ Inventory variable changes
   groups with ``root`` access defined by the :ref:`debops.system_groups` via
   Ansible local facts.
 
+- The contents of the :envvar:`sshd__allow_groups` variable have been moved to
+  the new :envvar:`sshd__default_allow_groups` variable. The new variable also
+  uses the :ref:`debops.system_groups` Ansible local facts as a data source.
+
 
 v0.7.2 (2018-03-28)
 -------------------

--- a/docs/news/upgrades.rst
+++ b/docs/news/upgrades.rst
@@ -11,6 +11,15 @@ perform the upgrades between different stable releases.
 Unreleased
 ----------
 
+UNIX account and group configuration
+------------------------------------
+
+- Configuration of UNIX system groups and accounts included in the ``admins``
+  UNIX group has been removed from the :ref:`debops.auth` role. This
+  functionality is now done by the :ref:`debops.system_groups` role. The
+  variable names and their values changed, see the :ref:`debops.system_groups`
+  role documentation for details.
+
 Inventory variable changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/news/upgrades.rst
+++ b/docs/news/upgrades.rst
@@ -67,6 +67,11 @@ Inventory variable changes
   configuration via :ref:`debops.apt_mark` role, the autoremoval will be
   enabled automatically.
 
+- The ``bootstrap__sudo`` and ``bootstrap__sudo_group`` variables have been
+  removed from the :ref:`debops.bootstrap` role. The ``bootstrap.yml`` playbook
+  now uses the :ref:`debops.sudo` role to configure :command:`sudo` service on
+  a host, use its variables instead to control the service in question.
+
 
 v0.7.2 (2018-03-28)
 -------------------

--- a/docs/news/upgrades.rst
+++ b/docs/news/upgrades.rst
@@ -72,6 +72,10 @@ Inventory variable changes
   now uses the :ref:`debops.sudo` role to configure :command:`sudo` service on
   a host, use its variables instead to control the service in question.
 
+- The :envvar:`bootstrap__admin_groups` variable will now use list of UNIX
+  groups with ``root`` access defined by the :ref:`debops.system_groups` via
+  Ansible local facts.
+
 
 v0.7.2 (2018-03-28)
 -------------------


### PR DESCRIPTION
This set of patches cleans up and reorganizes the custom UNIX system groups used by various DebOps roles for access control of different services. The patch includes enchancements to the 'debops.sudo' role, 'bootstrap.yml' playbook, clean up of the 'debops.auth' role and introduces the 'debops.system_groups' and 'debops.debops_legacy' Ansible roles.

Fixes #252