### PR TITLE
[debops.apache2] Implement `index` for apache__vhosts to match docs

### DIFF
--- a/ansible/roles/debops.apache/templates/etc/apache2/sites-available/apache__tpl_macros.j2
+++ b/ansible/roles/debops.apache/templates/etc/apache2/sites-available/apache__tpl_macros.j2
@@ -174,6 +174,9 @@ IncludeOptional {{ include_optional_file | quote }}
 {% if item.root|d(item.document_root|d()) %}
 DocumentRoot {{ item.root|d(item.document_root) | quote }}
 
+{% if item.index|d() %}
+DirectoryIndex {{ debops__tpl_macros.get_yaml_list_for_elem(item.index)|from_yaml | join(" ") }}
+{% endif %}
 {% if item.alias|d() %}
 {{ get_alias(item.alias, item.root|d(item.document_root)) }}
 {%- endif %}


### PR DESCRIPTION
Closes: #288