### PR TITLE
[debops.sudo]: fix bashism in profile

### DIFF
--- a/ansible/roles/debops.sudo/templates/etc/profile.d/sudo_logind_session.sh.j2
+++ b/ansible/roles/debops.sudo/templates/etc/profile.d/sudo_logind_session.sh.j2
@@ -13,7 +13,7 @@
 # existing login session is present and the module refuses to create a new one.
 # More details: https://bugs.debian.org/825949, https://github.com/systemd/systemd/issues/7451
 
-if [ "${EUID}" -ne 0 ] && [ -n "${SUDO_USER}" ] && [ -z "${XDG_RUNTIME_DIR}" ] ; then
+if [ "`id -u`" -ne 0 ] && [ -n "${SUDO_USER}" ] && [ -z "${XDG_RUNTIME_DIR}" ] ; then
     XDG_RUNTIME_DIR="/run/user/${UID}"
     export XDG_RUNTIME_DIR
 fi


### PR DESCRIPTION
With user shell as dash I get:
$ sudo -i -u git
-sh: 16: [: Illegal number: