### PR TITLE
[debops.librenms] Fix resources loading for sublevel pages

### DIFF
--- a/ansible/roles/debops.librenms/defaults/main.yml
+++ b/ansible/roles/debops.librenms/defaults/main.yml
@@ -67,7 +67,7 @@ librenms__domain: '{{ ansible_local.core.domain
 #
 # You can use this to force a particular hostname or port in LibreNMS, to for
 # example publish it behind a HTTP proxy.
-librenms__base_url: ''
+librenms__base_url: '/'
 
                                                                    # ]]]
 # .. envvar:: librenms__nginx_auth_realm [[[


### PR DESCRIPTION
Set base_url to upstream default '/'.

Resources are relative to base_url. With an empty one
they end up relative to the current subfolder we are
in which fails for pages below home, ie /devices/ or
such.