### PR TITLE
[debops.postgresql]: Fix pgpass escaping - password field

### DIFF
--- a/ansible/roles/debops.postgresql/tasks/main.yml
+++ b/ansible/roles/debops.postgresql/tasks/main.yml
@@ -204,7 +204,7 @@
   lineinfile:
     dest: '{{ "~" + item.owner }}/.pgpass'
     regexp: '^{{ (item.server | d(postgresql__server if postgresql__server else "localhost")) | replace(".","\.") }}:{{ item.port | d(postgresql__port) }}:{{ item.database | d("*") }}:{{ item.role | d("*") }}:'
-    line: '{{ item.server | d(postgresql__server if postgresql__server else "localhost") }}:{{ item.port | d(postgresql__port) }}:{{ item.database | d("*") }}:{{ item.role | d(item.owner) }}:{{ item.password | d(lookup("password", secret + "/postgresql/" + (item.server | d(postgresql__server if postgresql__server else ansible_fqdn)) + "/" + (item.port | d(postgresql__port)) + "/credentials/" + item.name | d(item.role | d(item.owner)) + "/password length=" + postgresql__password_length)) }}'
+    line: '{{ item.server | d(postgresql__server if postgresql__server else "localhost") }}:{{ item.port | d(postgresql__port) }}:{{ item.database | d("*") }}:{{ item.role | d(item.owner) }}:{{ item.password | d(lookup("password", secret + "/postgresql/" + (item.server | d(postgresql__server if postgresql__server else ansible_fqdn)) + "/" + (item.port | d(postgresql__port)) + "/credentials/" + item.name | d(item.role | d(item.owner)) + "/password length=" + postgresql__password_length)) | regex_replace("\\", "\\\\" ) | regex_replace(":", "\:" ) }}'
     state: 'present'
     create: True
     owner: '{{ item.owner }}'


### PR DESCRIPTION
pgpass fields colon and backslash should be escaped by mean of a backslash
https://www.postgresql.org/docs/current/static/libpq-pgpass.html

before 9.2 the fields where not unescaped properly though:
https://www.postgresql.org/message-id/20111217082754.GB30887%40rice.edu

Note: I only apply it to password as other fields are unlikely to
have colon or backspace in them.