### PR TITLE
[debops.proc_hidepid]: Unconditionally stat /proc/sched_debug

### DIFF
--- a/ansible/roles/debops.proc_hidepid/tasks/main.yml
+++ b/ansible/roles/debops.proc_hidepid/tasks/main.yml
@@ -65,7 +65,6 @@
   stat:
     path: '/proc/sched_debug'
   register: proc_hidepid__register_sched
-  when: proc_hidepid__enabled|bool
 
 - name: Generate tmpfiles configuration for securing /proc/sched_debug
   template:


### PR DESCRIPTION
proc_hidepid__secure_scheduler_enabled requires
proc_hidepid__register_sched.stat to be defined.

It is not when we skip "Check /proc/sched_debug file attributes"
ie proc_hidepid__enabled is disabled.

Seems "and" cannot short-circuit this error:
proc_hidepid__secure_scheduler_enabled is processed and an error triggers.

Fixes:
TASK [debops.proc_hidepid : Generate tmpfiles configuration for securing /proc/sched_debug] ****************************************************************************************************************************************************fatal: [cyclope]: FAILED! => {"msg": "The conditional check 'proc_hidepid__enabled|bool and ansible_service_mgr == 'systemd' and proc_hidepid__secure_scheduler_enabled|bool' failed. The error was: error while evaluating conditional (proc_hidepid__enabled|bool and ansible_service_mgr == 'systemd' and proc_hidepid__secure_scheduler_enabled|bool): 'dict object' has no attribute 'stat'\n\nThe error appears to have been in '/home/prahal/.local/share/debops/debops/ansible/roles/debops.proc_hidepid/tasks/main.yml': line 70, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Generate tmpfiles configuration for securing /proc/sched_debug\n  ^ here\n"}