### PR TITLE
Additionally allow webadmins to start, stop, and restart Nginx/PHP

### DIFF
--- a/ansible/roles/debops.nginx/tasks/main.yml
+++ b/ansible/roles/debops.nginx/tasks/main.yml
@@ -123,7 +123,7 @@
     mode: '0775'
   when: (nginx__deploy_state in [ 'present' ])
 
-- name: Allow webadmins to reload nginx using sudo
+- name: Allow webadmins to start, stop, restart, and reload nginx using sudo
   template:
     src: 'etc/sudoers.d/nginx_webadmins.j2'
     dest: '/etc/sudoers.d/nginx_webadmins'

--- a/ansible/roles/debops.nginx/tasks/main.yml
+++ b/ansible/roles/debops.nginx/tasks/main.yml
@@ -123,7 +123,7 @@
     mode: '0775'
   when: (nginx__deploy_state in [ 'present' ])
 
-- name: Allow webadmins to start, stop, restart, and reload nginx using sudo
+- name: Allow webadmins to control nginx system service using sudo
   template:
     src: 'etc/sudoers.d/nginx_webadmins.j2'
     dest: '/etc/sudoers.d/nginx_webadmins'

--- a/ansible/roles/debops.nginx/templates/etc/sudoers.d/nginx_webadmins.j2
+++ b/ansible/roles/debops.nginx/templates/etc/sudoers.d/nginx_webadmins.j2
@@ -1,7 +1,18 @@
 # {{ ansible_managed }}
 
-Cmnd_Alias NGINX_RELOAD = /etc/init.d/nginx reload
+Cmnd_Alias NGINX_RELOAD = /etc/init.d/nginx reload, \
+			  /bin/systemctl reload nginx.service
+
+Cmnd_Alias NGINX_STOP = /etc/init.d/nginx stop, \
+			/bin/systemctl stop nginx.service
+
+Cmnd_Alias NGINX_START = /etc/init.d/nginx start, \
+			 /bin/systemctl start nginx.service
+
+Cmnd_Alias NGINX_RESTART = /etc/init.d/nginx restart, \
+			  /bin/systemctl restart nginx.service
 
 %{{ nginx_privileged_group }} ALL = (root) NOPASSWD: NGINX_RELOAD
-
-
+%{{ nginx_privileged_group }} ALL = (root) NOPASSWD: NGINX_STOP
+%{{ nginx_privileged_group }} ALL = (root) NOPASSWD: NGINX_START
+%{{ nginx_privileged_group }} ALL = (root) NOPASSWD: NGINX_RESTART

--- a/ansible/roles/debops.nginx/templates/etc/sudoers.d/nginx_webadmins.j2
+++ b/ansible/roles/debops.nginx/templates/etc/sudoers.d/nginx_webadmins.j2
@@ -3,6 +3,9 @@
 Cmnd_Alias NGINX_RELOAD = /etc/init.d/nginx reload, \
 			  /bin/systemctl reload nginx.service
 
+Cmnd_Alias NGINX_STATUS = /etc/init.d/nginx status, \
+			  /bin/systemctl status nginx.service
+
 Cmnd_Alias NGINX_STOP = /etc/init.d/nginx stop, \
 			/bin/systemctl stop nginx.service
 
@@ -10,9 +13,10 @@ Cmnd_Alias NGINX_START = /etc/init.d/nginx start, \
 			 /bin/systemctl start nginx.service
 
 Cmnd_Alias NGINX_RESTART = /etc/init.d/nginx restart, \
-			  /bin/systemctl restart nginx.service
+			   /bin/systemctl restart nginx.service
 
 %{{ nginx_privileged_group }} ALL = (root) NOPASSWD: NGINX_RELOAD
+%{{ nginx_privileged_group }} ALL = (root) NOPASSWD: NGINX_STATUS
 %{{ nginx_privileged_group }} ALL = (root) NOPASSWD: NGINX_STOP
 %{{ nginx_privileged_group }} ALL = (root) NOPASSWD: NGINX_START
 %{{ nginx_privileged_group }} ALL = (root) NOPASSWD: NGINX_RESTART

--- a/ansible/roles/debops.php/tasks/main.yml
+++ b/ansible/roles/debops.php/tasks/main.yml
@@ -48,7 +48,7 @@
     - '{{ php__etc_base }}/ansible'
     - '{{ php__etc_base }}/fpm/pool.d'
 
-- name: Allow webadmins to start, stop, restart, and reload php-fpm using sudo
+- name: Allow webadmins to control PHP-FPM system service using sudo
   template:
     src: 'etc/sudoers.d/php-fpm_webadmins.j2'
     dest: '/etc/sudoers.d/php-fpm_webadmins'

--- a/ansible/roles/debops.php/tasks/main.yml
+++ b/ansible/roles/debops.php/tasks/main.yml
@@ -48,7 +48,7 @@
     - '{{ php__etc_base }}/ansible'
     - '{{ php__etc_base }}/fpm/pool.d'
 
-- name: Allow webadmins to reload php-fpm using sudo
+- name: Allow webadmins to start, stop, restart, and reload php-fpm using sudo
   template:
     src: 'etc/sudoers.d/php-fpm_webadmins.j2'
     dest: '/etc/sudoers.d/php-fpm_webadmins'

--- a/ansible/roles/debops.php/templates/etc/sudoers.d/php-fpm_webadmins.j2
+++ b/ansible/roles/debops.php/templates/etc/sudoers.d/php-fpm_webadmins.j2
@@ -3,4 +3,16 @@
 Cmnd_Alias PHP_FPM_RELOAD = /etc/init.d/php{{ php__version }}-fpm reload, \
                             /bin/systemctl reload php{{ php__version }}-fpm.service
 
+Cmnd_Alias PHP_FPM_STOP = /etc/init.d/php{{ php__version }}-fpm stop, \
+                            /bin/systemctl stop php{{ php__version }}-fpm.service
+
+Cmnd_Alias PHP_FPM_START = /etc/init.d/php{{ php__version }}-fpm start, \
+                            /bin/systemctl start php{{ php__version }}-fpm.service
+
+Cmnd_Alias PHP_FPM_RESTART = /etc/init.d/php{{ php__version }}-fpm restart, \
+                            /bin/systemctl restart php{{ php__version }}-fpm.service
+
 %{{ php__fpm_privileged_group }} ALL = (root) NOPASSWD: PHP_FPM_RELOAD
+%{{ php__fpm_privileged_group }} ALL = (root) NOPASSWD: PHP_FPM_STOP
+%{{ php__fpm_privileged_group }} ALL = (root) NOPASSWD: PHP_FPM_START
+%{{ php__fpm_privileged_group }} ALL = (root) NOPASSWD: PHP_FPM_RESTART

--- a/ansible/roles/debops.php/templates/etc/sudoers.d/php-fpm_webadmins.j2
+++ b/ansible/roles/debops.php/templates/etc/sudoers.d/php-fpm_webadmins.j2
@@ -3,16 +3,20 @@
 Cmnd_Alias PHP_FPM_RELOAD = /etc/init.d/php{{ php__version }}-fpm reload, \
                             /bin/systemctl reload php{{ php__version }}-fpm.service
 
+Cmnd_Alias PHP_FPM_STATUS = /etc/init.d/php{{ php__version }}-fpm status, \
+                            /bin/systemctl status php{{ php__version }}-fpm.service
+
 Cmnd_Alias PHP_FPM_STOP = /etc/init.d/php{{ php__version }}-fpm stop, \
-                            /bin/systemctl stop php{{ php__version }}-fpm.service
+                          /bin/systemctl stop php{{ php__version }}-fpm.service
 
 Cmnd_Alias PHP_FPM_START = /etc/init.d/php{{ php__version }}-fpm start, \
-                            /bin/systemctl start php{{ php__version }}-fpm.service
+                           /bin/systemctl start php{{ php__version }}-fpm.service
 
 Cmnd_Alias PHP_FPM_RESTART = /etc/init.d/php{{ php__version }}-fpm restart, \
-                            /bin/systemctl restart php{{ php__version }}-fpm.service
+                             /bin/systemctl restart php{{ php__version }}-fpm.service
 
 %{{ php__fpm_privileged_group }} ALL = (root) NOPASSWD: PHP_FPM_RELOAD
+%{{ php__fpm_privileged_group }} ALL = (root) NOPASSWD: PHP_FPM_STATUS
 %{{ php__fpm_privileged_group }} ALL = (root) NOPASSWD: PHP_FPM_STOP
 %{{ php__fpm_privileged_group }} ALL = (root) NOPASSWD: PHP_FPM_START
 %{{ php__fpm_privileged_group }} ALL = (root) NOPASSWD: PHP_FPM_RESTART


### PR DESCRIPTION
Services might crash, so webadmins should have the ability to start a service, etc.