### PR TITLE
[debops.ifupdown] Add 'debops.kmod' dependency

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -77,6 +77,11 @@ Changed
 
 .. __: https://www.python.org/dev/peps/pep-0001/
 
+- [debops.ifupdown] The :ref:`debops.kmod` role is added as a dependency. The
+  :ref:`debops.ifupdown` role will generate :command:`modprobe` configuration
+  based on the type of configured network interfaces (bridges, VLANs, bonding)
+  and the kernel modules will be automatically loaded if missing.
+
 Removed
 ~~~~~~~
 

--- a/ansible/playbooks/service/ifupdown.yml
+++ b/ansible/playbooks/service/ifupdown.yml
@@ -13,6 +13,11 @@
     - role: debops.ifupdown/env
       tags: [ 'role::ifupdown', 'role::ferm' ]
 
+    - role: debops.kmod
+      tags: [ 'role::kmod' ]
+      kmod__dependent_load:
+        - '{{ ifupdown__env_kmod__dependent_load }}'
+
     - role: debops.ferm
       tags: [ 'role::ferm' ]
       ferm__dependent_rules:

--- a/ansible/roles/debops.ifupdown/defaults/main.yml
+++ b/ansible/roles/debops.ifupdown/defaults/main.yml
@@ -353,6 +353,13 @@ ifupdown__custom_dependent_files: []
 # Configuration for :ref:`debops.ferm`, generated dynamically from the
 # network interface configuration and passed to the role through a variable.
 ifupdown__ferm__dependent_rules: '{{ lookup("template", "lookup/ifupdown__ferm__dependent_rules.j2", convert_data=False) | from_yaml }}'
+
+                                                                   # ]]]
+# .. envvar:: ifupdown__kmod__dependent_load [[[
+#
+# Configuration for :ref:`debops.kmod`, generated dynamically from the
+# network interface configuration and passed to the role through a variable.
+ifupdown__kmod__dependent_load: '{{ lookup("template", "lookup/ifupdown__kmod__dependent_load.j2", convert_data=False) | from_yaml }}'
                                                                    # ]]]
                                                                    # ]]]
 # Role metadata [[[

--- a/ansible/roles/debops.ifupdown/env/tasks/main.yml
+++ b/ansible/roles/debops.ifupdown/env/tasks/main.yml
@@ -3,3 +3,4 @@
 - name: Prepare ferm configuration
   set_fact:
     ifupdown__env_ferm__dependent_rules: '{{ ifupdown__ferm__dependent_rules }}'
+    ifupdown__env_kmod__dependent_load:  '{{ ifupdown__kmod__dependent_load }}'

--- a/ansible/roles/debops.ifupdown/templates/lookup/ifupdown__kmod__dependent_load.j2
+++ b/ansible/roles/debops.ifupdown/templates/lookup/ifupdown__kmod__dependent_load.j2
@@ -1,0 +1,44 @@
+{% set ifupdown__tpl_packages = [] %}
+{% if ifupdown__combined_interfaces|d() %}
+{%   for interface, params in ifupdown__combined_interfaces.items() %}
+{%     if (params.state|d('present') == 'present' and params.type|d()) %}
+{%       if params.type == 'bonding' %}
+{%         if ansible_distribution_release == 'wheezy' %}
+{%           set _ = ifupdown__tpl_packages.append('ifenslave-2.6') %}
+{%         else %}
+{%           set _ = ifupdown__tpl_packages.append('ifenslave') %}
+{%         endif %}
+{%       elif params.type == 'bridge' %}
+{%         set _ = ifupdown__tpl_packages.append('bridge-utils') %}
+{%       elif params.type == 'vlan' %}
+{%         set _ = ifupdown__tpl_packages.append('vlan') %}
+{%       endif %}
+{%     endif %}
+{%   endfor %}
+{% endif %}
+{% set ifupdown__tpl_kmod__dependent_load = [] %}
+{% if 'ifenslave' in ifupdown__tpl_packages or 'ifenslave-2.6' in ifupdown__tpl_packages %}
+{%   set _ = ifupdown__tpl_kmod__dependent_load.append({
+  'name': 'bonding',
+  'comment': 'Load the bonding module for network interface bond configuration',
+  'filename': 'ifupdown-bonding.conf',
+  'state': 'present'
+}) %}
+{% endif %}
+{% if 'bridge-utils' in ifupdown__tpl_packages %}
+{%   set _ = ifupdown__tpl_kmod__dependent_load.append({
+  'name': 'bridge',
+  'comment': 'Load the bridge module for network interface bridge configuration',
+  'filename': 'ifupdown-bridge.conf',
+  'state': 'present'
+}) %}
+{% endif %}
+{% if 'vlan' in ifupdown__tpl_packages %}
+{%   set _ = ifupdown__tpl_kmod__dependent_load.append({
+  'name': '8021q',
+  'comment': 'Load the 8021q module for VLAN configuration',
+  'filename': 'ifupdown-vlan.conf',
+  'state': 'present'
+}) %}
+{% endif %}
+{{ ifupdown__tpl_kmod__dependent_load | to_yaml }}


### PR DESCRIPTION
Some of the network interface types (bridges, bonding, VLANs) require
additional kernel modules to be loaded at boot time or during
configuration. This can be handled by the operating system on demand,
however this results in warnings about missing modules and can cause
issues at boot time.

This patch adds the 'debops.kmod' role as a dependency of the
'debops.ifupdown' role. The 'debops.ifupdown' role will check what
network interfaces are to be configured on a host, and will dynamically
generate configuration for the 'debops.kmod' role which will then load
the missing kernel modules and mark them to be loaded at boot time.