### PR TITLE
[debops-contrib.tor] Automatic firewall config, Fix auto update of tor

### DIFF
--- a/ansible/debops-contrib-playbooks/service/tor.yml
+++ b/ansible/debops-contrib-playbooks/service/tor.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: FIXME
+- name: Manage Tor relay
   hosts: [ 'debops_service_tor' ]
   become: True
 
@@ -10,12 +10,20 @@
 
   roles:
 
+    - role: debops.secret
+      tags: [ 'role::tor' ]
+
     - role: debops.ferm
       tags: [ 'role::ferm' ]
       ferm__dependent_rules:
         - '{{ tor__ferm__dependent_rules }}'
 
+    - role: debops.unattended_upgrades
+      tags: [ 'role::unattended_upgrades' ]
+      unattended_upgrades__dependent_origins: '{{ tor__unattended_upgrades__dependent_origins }}'
+
     - role: nusenu.relayor
+      become: False
       tags: [ 'role::relayor' ]
 
     - role: debops-contrib.tor

--- a/ansible/roles/debops-contrib.tor/defaults/main.yml
+++ b/ansible/roles/debops-contrib.tor/defaults/main.yml
@@ -37,12 +37,24 @@ tor__deploy_state: 'present'
 tor__ferm__dependent_rules:
 
   - type: 'accept'
-    dport: [ 993, 465 ]
+    dport: '{{ ((tor_ports | map(attribute="orport") | list) + (tor_ports | map(attribute="dirport") | list)) | unique | sort }}'
     accept_any: True
     weight: '40'
     by_role: 'debops-contrib.tor'
     name: 'tor'
     rule_state: '{{ "present" if (tor__deploy_state != "purged") else "absent" }}'
+                                                                   # ]]]
+# .. envvar:: tor__ferm__dependent_rules [[[
+#
+# List of origin patterns managed by the :ref:`debops.unattended_upgrades` role.
+# https://trac.torproject.org/projects/tor/wiki/TorRelayGuide/DebianUbuntuUpdates
+tor__unattended_upgrades__dependent_origins:
+
+  - origin: 'origin=TorProject'
+    by_role: 'debops-contrib.tor'
+    state: '{{ "present"
+               if (tor__deploy_state == "present")
+               else "absent" }}'
                                                                    # ]]]
                                                                    # ]]]
                                                                    # ]]]

--- a/ansible/roles/debops-contrib.tor/docs/getting-started.rst
+++ b/ansible/roles/debops-contrib.tor/docs/getting-started.rst
@@ -20,6 +20,25 @@ be added to the ``[debops_service_tor]`` Ansible group in the inventory:
    [debops_service_tor]
    hostname
 
+It is proposed to change some of the nusenu.relayor defaults to better match DebOps Standards.
+The recommended way to do this adaption is to symlink the
+:file:`docs/inventory/debops_service_tor_global_role_vars` file shipped
+with this role in the documentation (:file:`ansible/roles/debops-contrib.tor/docs/inventory/debops_service_tor_global_role_vars`)` into your inventory under
+:file:`ansible/inventory/group_vars/debops_service_tor_global_role_vars`
+and include all hosts from the ``debops_service_tor`` in the
+``debops_service_tor_global_role_vars`` host group by adding this:
+
+.. code:: ini
+
+   [debops_service_tor_global_role_vars:children]
+   debops_service_tor
+
+into your host inventory which makes the following adjustments to the defaults
+variables of other roles:
+
+.. literalinclude:: inventory/debops_service_tor_global_role_vars
+   :language: yaml
+
 Example playbook
 ----------------
 

--- a/ansible/roles/debops-contrib.tor/docs/inventory/debops_service_tor_global_role_vars
+++ b/ansible/roles/debops-contrib.tor/docs/inventory/debops_service_tor_global_role_vars
@@ -1,0 +1,8 @@
+---
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+
+# Where do you want to store key material on the ansible control machine?
+tor_offline_masterkey_dir: '{{ secret + "/tor" }}'
+
+# No need to create a backup of the torrc on remote systems as etckeeper is used by default.
+tor_backup_torrc: False

--- a/ansible/roles/debops-contrib.tor/tasks/main.yml
+++ b/ansible/roles/debops-contrib.tor/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 
-- name: Ensure specified packages are in there desired state
-  package:
-    name: '{{ item }}'
-    state: '{{ "present" if (tor__deploy_state == "present") else "absent" }}'
-  with_flattened: '{{ tor__base_packages }}'
-  tags: [ 'role::tor:pkgs' ]
+# - name: Ensure specified packages are in there desired state
+#   package:
+#     name: '{{ item }}'
+#     state: '{{ "present" if (tor__deploy_state == "present") else "absent" }}'
+#   with_flattened: '{{ tor__base_packages }}'
+#   tags: [ 'role::tor:pkgs' ]


### PR DESCRIPTION
* Add automatic firewall config based on tor_ports
* Fix auto update of tor

This is still work in progress but it should be usable.

PS: I know `debops-contrib.tor` is not anywhere near the DebOps Standards and this role is unfinished but it is already usable and polishing will need to be done later. Note that it is technically still a DebOps Contrib role.

Tested on: Debian Stretch
Uses: https://github.com/nusenu/ansible-relayor/pull/163