### PR TITLE
[debops.mariadb_server] Fix failure with non-default datadir

### DIFF
--- a/ansible/roles/debops.mariadb_server/defaults/main.yml
+++ b/ansible/roles/debops.mariadb_server/defaults/main.yml
@@ -160,10 +160,16 @@ mariadb_server__allow: []
 mariadb_server__max_connections: '100'
 
                                                                    # ]]]
+# .. envvar:: mariadb_server__default_datadir [[[
+#
+# Default directory to store data
+mariadb_server__default_datadir: '/var/lib/mysql'
+
+                                                                   # ]]]
 # .. envvar:: mariadb_server__datadir [[[
 #
 # Directory to store data
-mariadb_server__datadir: '/var/lib/mysql'
+mariadb_server__datadir: '{{ mariadb_server__default_datadir }}'
 
                                                                    # ]]]
 # .. envvar:: mariadb_server__delegate_to [[[

--- a/ansible/roles/debops.mariadb_server/tasks/main.yml
+++ b/ansible/roles/debops.mariadb_server/tasks/main.yml
@@ -79,10 +79,10 @@
 
 - name: Move MariaDB data files to data directory
   shell:
-    'mv /var/lib/mysql/* {{ mariadb_server__datadir }}'
+    'mv {{ mariadb_server__default_datadir }}/* {{ mariadb_server__datadir }}'
   when: ((mariadb_server__register_version|d() and not mariadb_server__register_version.stdout) and
          (mariadb_server__register_install_status|d() and mariadb_server__register_install_status is changed) and
-         (mariadb_server__datadir != maridb_server__default_datadir))
+         (mariadb_server__datadir != mariadb_server__default_datadir))
 
 - name: Configure database client on first install
   template:

--- a/ansible/roles/debops.mariadb_server/tasks/main.yml
+++ b/ansible/roles/debops.mariadb_server/tasks/main.yml
@@ -49,6 +49,13 @@
     - '{{ "automysqlbackup" if mariadb_server__backup|bool else [] }}'
   register: mariadb_server__register_install_status
 
+- name: Stop database server on first install
+  service:
+    name: 'mysql'
+    state: 'stopped'
+  when: ((mariadb_server__register_version|d() and not mariadb_server__register_version.stdout) and
+         (mariadb_server__register_install_status|d() and mariadb_server__register_install_status is changed))
+
 - name: Add database server user to specified groups
   user:
     name: 'mysql'
@@ -70,6 +77,13 @@
     group: 'mysql'
     mode: '0755'
 
+- name: Move MariaDB data files to data directory
+  shell:
+    'mv /var/lib/mysql/* {{ mariadb_server__datadir }}'
+  when: ((mariadb_server__register_version|d() and not mariadb_server__register_version.stdout) and
+         (mariadb_server__register_install_status|d() and mariadb_server__register_install_status is changed) and
+         (mariadb_server__datadir != maridb_server__default_datadir))
+
 - name: Configure database client on first install
   template:
     src: 'etc/mysql/conf.d/client.cnf.j2'
@@ -83,10 +97,10 @@
   include: 'configure_server.yml'
   tags: [ 'role::mariadb_server:configure' ]
 
-- name: Restart database server on first install
+- name: Start database server on first install
   service:
     name: 'mysql'
-    state: 'restarted'
+    state: 'started'
   when: ((mariadb_server__register_version|d() and not mariadb_server__register_version.stdout) and
          (mariadb_server__register_install_status|d() and mariadb_server__register_install_status is changed))
 


### PR DESCRIPTION

Fix debops.mariadb_server role failure when `mariadb_server__datadir` have non-default value.

The database service gets started when packages are installed even if environment variable `RUNLEVEL=1` is set and files under default datadir (`/var/lib/mysql`) should be moved to new datadir,
so this fix performs following:
* Stop database server on first install
* Move files under default datadir to given datadir
