### PR TITLE
Significant changes in NodeJS support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -102,6 +102,13 @@ Changed
   allow NPM to work correctly - on Debian Jessie, Stretch and Ubuntu Xenial.
   Otherwise, a NPM from the ``latest`` branch will be installed, as before.
 
+- [debops.nodejs] Instead of NodeJS 6.x release, the role will now install
+  NodeJS 8.x release upstream APT packages by default. This is due to the
+  NodeJS 6.x release `switching to a Maintenance LTS mode`__. NodeJS 8.x will
+  be supported as a LTS release until April 2019.
+
+  .. __: https://github.com/nodejs/Release
+
 Removed
 ~~~~~~~
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -109,6 +109,17 @@ Changed
 
   .. __: https://github.com/nodejs/Release
 
+- [debops.nodejs] The role will install upstrean NodeSource APT packages by
+  default. This is due to `no security support in Debian Stable`__, therefore
+  an upstream packages should be considered more secure. The upstream NodeJS
+  packages include a compatible NPM release, therefore it won't be separately
+  installed from GitHub.
+
+  .. __: https://www.debian.org/releases/stretch/amd64/release-notes/ch-information.en.html#libv8
+
+  The existing installations shouldn't be affected, since the role will select
+  OS/upstream package versions based on existing Ansible local facts.
+
 Removed
 ~~~~~~~
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -92,6 +92,16 @@ Changed
   based on the type of configured network interfaces (bridges, VLANs, bonding)
   and the kernel modules will be automatically loaded if missing.
 
+- [debops.nodejs] Recent versions of NPM `require NodeJS 6.0.0+`__ and don't
+  work with other releases. Because of that the newest NPM release is not
+  installable on hosts that use NodeJS packages from older OS releases.
+
+  .. __: https://github.com/npm/npm/issues/20425
+
+  The 'debops.nodejs' role will install NPM v5.10.0 version in this case to
+  allow NPM to work correctly - on Debian Jessie, Stretch and Ubuntu Xenial.
+  Otherwise, a NPM from the ``latest`` branch will be installed, as before.
+
 Removed
 ~~~~~~~
 

--- a/ansible/roles/debops.nodejs/COPYRIGHT
+++ b/ansible/roles/debops.nodejs/COPYRIGHT
@@ -1,8 +1,8 @@
 debops.nodejs - Manage NodeJS environment using Ansible
 
-Copyright (C) 2015-2017 Maciej Delmanowski <drybjed@gmail.com>
+Copyright (C) 2015-2018 Maciej Delmanowski <drybjed@gmail.com>
 Copyright (C) 2016 Patrick Heeney <patrickheeney@gmail.com>
-Copyright (C) 2015-2017 DebOps https://debops.org/
+Copyright (C) 2015-2018 DebOps https://debops.org/
 
 This Ansible role is part of DebOps.
 

--- a/ansible/roles/debops.nodejs/defaults/main.yml
+++ b/ansible/roles/debops.nodejs/defaults/main.yml
@@ -100,9 +100,30 @@ nodejs__npm_git_repo: 'https://github.com/npm/npm'
                                                                    # ]]]
 # .. envvar:: nodejs__npm_git_version [[[
 #
-# The default NPM version to checkout. This is the current stable release at
-# the install time.
-nodejs__npm_git_version: 'latest'
+# The branch or tag to check out from the NPM :command:`git` repository. By
+# default the fixed releases will be chedked out if found, otherwise latest NPM
+# release will be installed.
+nodejs__npm_git_version: '{{ nodejs__npm_git_version_map[ansible_distribution_release]
+                             | d(nodejs__npm_git_release) }}'
+
+                                                                   # ]]]
+# .. envvar:: nodejs__npm_git_version_map [[[
+#
+# YAML dictionary which maps fixed NPM releases to specific OS releases.
+# NPM v6.0.0+ doesn't work with NodeJS 4.x anymore, therefore on OS releases
+# with older NodeJS it is fixed to the last working release.
+nodejs__npm_git_version_map:
+  'jessie':  'v5.10.0'
+  'stretch': 'v5.10.0'
+  'xenial':  'v5.10.0'
+
+                                                                   # ]]]
+# .. envvar:: nodejs__npm_git_release [[[
+#
+# The default NPM rolling release branch which will install the latest version
+# released by upstream. This version might be upgraded automatically by Ansible
+# runs.
+nodejs__npm_git_release: 'latest'
 
                                                                    # ]]]
 # .. envvar:: nodejs__npm_git_dest [[[

--- a/ansible/roles/debops.nodejs/defaults/main.yml
+++ b/ansible/roles/debops.nodejs/defaults/main.yml
@@ -14,12 +14,12 @@
 # .. envvar:: nodejs__upstream [[[
 #
 # Enable or disable support for NodeSource APT repositories. By default the
-# OS-distributed package will be installed.
-nodejs__upstream: '{{ True
+# upstream package will be installed due to no security support in Debian
+# Stable release.
+nodejs__upstream: '{{ ansible_local.nodejs.upstream|bool
                       if (ansible_local|d() and ansible_local.nodejs|d() and
-                          ansible_local.nodejs.upstream is defined and
-                          ansible_local.nodejs.upstream|bool)
-                      else False }}'
+                          ansible_local.nodejs.upstream is defined)
+                      else True }}'
 
                                                                    # ]]]
 # .. envvar:: nodejs__upstream_release [[[

--- a/ansible/roles/debops.nodejs/defaults/main.yml
+++ b/ansible/roles/debops.nodejs/defaults/main.yml
@@ -40,7 +40,7 @@ nodejs__upstream: '{{ True
 #
 # If you switch to the ``iojs`` release, you need to update the list of
 # installed APT packages manually.
-nodejs__upstream_release: 'node_6.x'
+nodejs__upstream_release: 'node_8.x'
 
                                                                    # ]]]
 # .. envvar:: nodejs__upstream_key_id [[[

--- a/ansible/roles/debops.nodejs/defaults/main.yml
+++ b/ansible/roles/debops.nodejs/defaults/main.yml
@@ -24,19 +24,15 @@ nodejs__upstream: '{{ True
                                                                    # ]]]
 # .. envvar:: nodejs__upstream_release [[[
 #
-# Specify the NodeSource APT repository to configure. Available versions:
-#
-# - ``node_0.10``
-#
-# - ``node_0.12``
-#
-# - ``node_4.x``
-#
-# - ``node_5.x``
+# Specify the NodeJS release to install from the NodeSource APT repository.
+# See https://github.com/nodejs/Release for the current release and maintenance
+# shedule. Available releases:
 #
 # - ``node_6.x``
 #
-# - ``node_7.x``
+# - ``node_8.x``
+#
+# - ``node_10.x``
 #
 # - ``iojs_1.x``
 #

--- a/ansible/roles/debops.nodejs/defaults/main.yml
+++ b/ansible/roles/debops.nodejs/defaults/main.yml
@@ -250,7 +250,7 @@ nodejs__npm_production_mode: True
 # Configuration for the :ref:`debops.apt_preferences` Ansible role.
 nodejs__apt_preferences__dependent_list:
 
-  - packages: [ 'nodejs', 'nodejs-*', 'node-*', 'libssl1.0.0' ]
+  - packages: [ 'nodejs', 'nodejs-*', 'node-*', 'libssl1.0.0', 'libssl-dev' ]
     backports: [ 'jessie' ]
     reason: 'Unsupported NodeJS version, parity with next Debian release'
     by_role: 'debops_nodejs'

--- a/ansible/roles/debops.nodejs/defaults/main.yml
+++ b/ansible/roles/debops.nodejs/defaults/main.yml
@@ -22,7 +22,7 @@ nodejs__upstream: '{{ True
                       else False }}'
 
                                                                    # ]]]
-# .. envvar:: nodejs__upstream_version [[[
+# .. envvar:: nodejs__upstream_release [[[
 #
 # Specify the NodeSource APT repository to configure. Available versions:
 #
@@ -42,9 +42,9 @@ nodejs__upstream: '{{ True
 #
 # - ``iojs_2.x``
 #
-# If you switch to the ``iojs`` version, you need to update the list of
+# If you switch to the ``iojs`` release, you need to update the list of
 # installed APT packages manually.
-nodejs__upstream_version: 'node_6.x'
+nodejs__upstream_release: 'node_6.x'
 
                                                                    # ]]]
 # .. envvar:: nodejs__upstream_key_id [[[
@@ -56,7 +56,7 @@ nodejs__upstream_key_id: '9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280'
 # .. envvar:: nodejs__upstream_repository [[[
 #
 # URL of the NodeSource APT repository in ``sources.list`` format.
-nodejs__upstream_repository: 'deb https://deb.nodesource.com/{{ nodejs__upstream_version }} {{ ansible_distribution_release }} main'
+nodejs__upstream_repository: 'deb https://deb.nodesource.com/{{ nodejs__upstream_release }} {{ ansible_distribution_release }} main'
                                                                    # ]]]
                                                                    # ]]]
 # NPM installation via git [[[

--- a/docs/news/upgrades.rst
+++ b/docs/news/upgrades.rst
@@ -88,6 +88,9 @@ Inventory variable changes
   :ref:`debops.apt_install` role. Use the :ref:`debops.python` Ansible role to
   install Python packages.
 
+- The ``nodejs__upstream_version`` variable has been renamed to
+  :envvar:`nodejs__upstream_release` to better represent the contents, which is
+  not a specific NodeJS version, but a specific major release.
 
 v0.7.2 (2018-03-28)
 -------------------


### PR DESCRIPTION
- Install upstream NodeSource APT packages by default
- Install NodeJS 8.x by default
- With older releases, install fixed NPM version from GitHub which works on older NodeJS