### PR TITLE
[debops.sshd] Don't block SSH access if standalone

### DIFF
--- a/ansible/roles/debops.sshd/defaults/main.yml
+++ b/ansible/roles/debops.sshd/defaults/main.yml
@@ -286,12 +286,11 @@ sshd__custom_options: ''
 #
 # List of UNIX system groups which allow connections to SSH service defined by
 # default. The ``root`` UNIX group is used for backup connections, temporarily.
-sshd__default_allow_groups: '{{ [ "root" ] +
-                                (ansible_local.system_groups.access.sshd
+sshd__default_allow_groups: '{{ ([ "root" ] + ansible_local.system_groups.access.sshd)
                                  if (ansible_local|d() and ansible_local.system_groups|d() and
                                      ansible_local.system_groups.access|d() and
                                      ansible_local.system_groups.access.sshd|d())
-                                 else []) }}'
+                                 else [] }}'
 
                                                                    # ]]]
 # .. envvar:: sshd__allow_groups [[[


### PR DESCRIPTION
The 'debops.sshd' role checks the Ansible local facts of the
'debops.system_groups' role to get the list of UNIX groups which are
allowed to login and configure them in the 'AllowGroups' parameter.

This change ensures that if the above facts are not set, ie.
'debops.sshd' role is used as standalone, the 'AllowGroups' will not be
set - otherwise this would result in locked down system access where
only 'root' account can login, which might not be enabled.

Fixes #333 