### PR TITLE
debops.docker: set read permission on sources.list

### DIFF
--- a/ansible/roles/debops.docker/tasks/main.yml
+++ b/ansible/roles/debops.docker/tasks/main.yml
@@ -13,6 +13,7 @@
 - name: Configure upstream APT repository
   apt_repository:
     repo: '{{ docker__upstream_repository }}'
+    mode: '0644'
     state: 'present'
     update_cache: True
   when: docker__upstream|d() | bool


### PR DESCRIPTION
Clean version of the previous #330 to ensure to have read permissions on the sources.list file.