### PR TITLE
[debops.rabbitmq_server] Manage rabbitmq-env.conf

### DIFF
--- a/ansible/roles/debops.rabbitmq_server/defaults/main.yml
+++ b/ansible/roles/debops.rabbitmq_server/defaults/main.yml
@@ -109,6 +109,49 @@ rabbitmq_server__amqp_allow: []
 rabbitmq_server__amqps_allow: []
                                                                    # ]]]
                                                                    # ]]]
+# RabbitMQ environment [[[
+# ------------------------
+
+# These variables define contents of the
+# :file:`/etc/rabbitmq/rabbitmq-env.conf` configuration file. This file is
+# sourced by the RabbitMQ init script and should contain shell environment
+# variables that should be defined in the server environment. Each variable is
+# a YAML dictionary, dictionary keys are variable names (they will be written
+# as uppercase automatically), dictionary values are environment values.
+
+# You can find the list of known environment variables in the RabbitMQ
+# documentation: https://www.rabbitmq.com/configure.html#define-environment-variables
+
+# .. envvar:: rabbitmq_server__environment [[[
+#
+# The RabbitMQ environment variables defined on all hosts in the Ansible
+# inventory.
+rabbitmq_server__environment: {}
+
+                                                                   # ]]]
+# .. envvar:: rabbitmq_server__group_environment [[[
+#
+# The RabbitMQ environment variables defined on hosts in a specific Ansible
+# inventory group.
+rabbitmq_server__group_environment: {}
+
+                                                                   # ]]]
+# .. envvar:: rabbitmq_server__host_environment [[[
+#
+# The RabbitMQ environment variables defined on specific hosts in the Ansible
+# inventory.
+rabbitmq_server__host_environment: {}
+
+                                                                   # ]]]
+# .. envvar:: rabbitmq_server__combined_environment [[[
+#
+# The variable which combines all of the environment variables and is used in
+# the configuration template.
+rabbitmq_server__combined_environment: '{{ rabbitmq_server__environment
+                                           | combine(rabbitmq_server__group_environment,
+                                                     rabbitmq_server__host_environment) }}'
+                                                                   # ]]]
+                                                                   # ]]]
 # RabbitMQ main configuration [[[
 # -------------------------------
 

--- a/ansible/roles/debops.rabbitmq_server/tasks/main.yml
+++ b/ansible/roles/debops.rabbitmq_server/tasks/main.yml
@@ -39,6 +39,24 @@
   notify: [ 'Restart rabbitmq-server' ]
   no_log: True
 
+- name: Ensure that configuration directory exists
+  file:
+    path: '/etc/rabbitmq'
+    state: 'directory'
+    owner: '{{ rabbitmq_server__user }}'
+    group: '{{ rabbitmq_server__group }}'
+    mode: '0755'
+
+- name: Generate RabbitMQ environment file
+  template:
+    src: 'etc/rabbitmq/rabbitmq-env.conf.j2'
+    dest: '/etc/rabbitmq/rabbitmq-env.conf'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  notify: [ 'Restart rabbitmq-server' ]
+  tags: [ 'role::rabbitmq_server:config' ]
+
 - name: Install RabbitMQ packages
   package:
     name: '{{ item }}'

--- a/ansible/roles/debops.rabbitmq_server/templates/etc/rabbitmq/rabbitmq-env.conf.j2
+++ b/ansible/roles/debops.rabbitmq_server/templates/etc/rabbitmq/rabbitmq-env.conf.j2
@@ -1,0 +1,7 @@
+# {{ ansible_managed }}}
+
+# Custom environment variables for RabbitMQ Server
+
+{% for env_key, env_value in rabbitmq_server__combined_environment.items() %}
+{{ '{}="{}"'.format(env_key | upper, env_value) }}
+{% endfor %}


### PR DESCRIPTION
This path adds management of the '/etc/rabbitmq/rabbitmq-env.conf'
configuration file which contains the environment variables for RabbitMQ
Server.