### PR TITLE
[debops.core] Ensure that 'root' is not admin

### DIFF
--- a/ansible/roles/debops.core/defaults/main.yml
+++ b/ansible/roles/debops.core/defaults/main.yml
@@ -122,11 +122,10 @@ core__admin_groups: [ 'admins' ]
 #
 # To override the admin accounts autodetected by Ansible, specify them in this
 # list.
-core__admin_users: '{{ (ansible_user
-                        if ansible_user|d()
-                        else (ansible_ssh_user
-                              if ansible_ssh_user|d()
-                              else lookup("env", "USER"))) }}'
+core__admin_users: [ '{{ (ansible_user
+                          if (ansible_user is defined and
+                              ansible_user != "root")
+                          else lookup("env", "USER")) }}' ]
 
                                                                    # ]]]
 # .. envvar:: core__admin_blacklist_default_users [[[


### PR DESCRIPTION
In case that the user sets the 'ansible_user=root' variable in the
inventory, we make sure that the root account is not added to the list
of admin accounts. Otherwise the root account might be added to some
additional UNIX groups, and we don't want that.