### PR TITLE
Update the arch linux package for Python 3

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -24,8 +24,8 @@ pkgdesc="Your Debian-based data center in a box"
 arch=('any')
 url="https://github.com/debops/debops/"
 license=('GPL3')
-depends=('python2' 'ansible' 'python2-netaddr' 'python2-ldap' 'python2-passlib' 'util-linux' 'encfs' 'gnupg')
-makedepends=('python2-setuptools' 'git')
+depends=('python' 'ansible' 'python-netaddr' 'python-ldap' 'python-passlib' 'util-linux' 'encfs' 'gnupg')
+makedepends=('python-setuptools' 'git')
 provides=('debops')
 conflicts=('debops')
 source=("$_pkgname::git+https://github.com/debops/debops")
@@ -43,5 +43,5 @@ build() {
 
 package() {
     cd "$_pkgname"
-    python2 setup.py install --root="$pkgdir" --optimize=1
+    python setup.py install --root="$pkgdir" --optimize=1
 }


### PR DESCRIPTION
It seems that the main arch ansible package migrated to Python 3. So I had to update this to make debops run on my machine again.

Do you have any issues with me uploading this to the AUR?