### PR TITLE
[debops.resources] Support for template generation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,6 +55,10 @@ Added
   daemon will be started once network interfaces are configured and will not
   restart multiple times on each network interface change.
 
+- [debops.resources] The role can now generate custom files using templates,
+  based on a directory structure. See :ref:`resources__ref_templates` for more
+  details.
+
 Changed
 ~~~~~~~
 

--- a/ansible/roles/debops.resources/defaults/main.yml
+++ b/ansible/roles/debops.resources/defaults/main.yml
@@ -86,6 +86,41 @@ resources__parent_dirs_group: '{{ omit }}'
 resources__parent_dirs_mode: '{{ omit }}'
                                                                    # ]]]
                                                                    # ]]]
+# Manage custom templates [[[
+# ---------------------------
+
+# These variables define how the role will manage custom templates on remote
+# hosts. See :ref:`resources__ref_templates` for more details.
+
+# .. envvar:: resources__group_name [[[
+#
+# Name of the directory which contains templates which should be generated on
+# hosts in a specific host group. This variable needs to be set on a group
+# level in the inventory to take effect, only one group is supported at a time.
+resources__group_name: 'nonexistent-host-group'
+
+                                                                   # ]]]
+# .. envvar:: resources__templates [[[
+#
+# Directory which contains templates that should be generated on all hosts in
+# the Ansible inventory.
+resources__templates: '{{ resources__src + "templates/by-group/all" }}'
+
+                                                                   # ]]]
+# .. envvar:: resources__group_templates [[[
+#
+# Directory which contains templates that should be generated on hosts in
+# a specific Ansible inventory group.
+resources__group_templates: '{{ resources__src + "templates/by-group/" + resources__group_name }}'
+
+                                                                   # ]]]
+# .. envvar:: resources__host_templates [[[
+#
+# Directory which contains templates that should be generated on specific hosts
+# in the Ansible inventory.
+resources__host_templates: '{{ resources__src + "templates/by-host/" + inventory_hostname }}'
+                                                                   # ]]]
+                                                                   # ]]]
 # Manage custom paths [[[
 # -----------------------
 
@@ -221,41 +256,6 @@ resources__group_files: []
 #
 # Manage file contents on specific hosts in Ansible inventory.
 resources__host_files: []
-                                                                   # ]]]
-                                                                   # ]]]
-# Manage custom templates [[[
-# ---------------------------
-
-# These variables define how the role will manage custom templates on remote
-# hosts. See :ref:`resources__ref_templates` for more details.
-
-# .. envvar:: resources__group_name [[[
-#
-# Name of the directory which contains templates which should be generated on
-# hosts in a specific host group. This variable needs to be set on a group
-# level in the inventory to take effect, only one group is supported at a time.
-resources__group_name: 'nonexistent-host-group'
-
-                                                                   # ]]]
-# .. envvar:: resources__templates [[[
-#
-# Directory which contains templates that should be generated on all hosts in
-# the Ansible inventory.
-resources__templates: '{{ resources__src + "templates/by-group/all" }}'
-
-                                                                   # ]]]
-# .. envvar:: resources__group_templates [[[
-#
-# Directory which contains templates that should be generated on hosts in
-# a specific Ansible inventory group.
-resources__group_templates: '{{ resources__src + "templates/by-group/" + resources__group_name }}'
-
-                                                                   # ]]]
-# .. envvar:: resources__host_templates [[[
-#
-# Directory which contains templates that should be generated on specific hosts
-# in the Ansible inventory.
-resources__host_templates: '{{ resources__src + "templates/by-host/" + inventory_hostname }}'
                                                                    # ]]]
                                                                    # ]]]
 # Manage custom delayed paths [[[

--- a/ansible/roles/debops.resources/defaults/main.yml
+++ b/ansible/roles/debops.resources/defaults/main.yml
@@ -223,6 +223,41 @@ resources__group_files: []
 resources__host_files: []
                                                                    # ]]]
                                                                    # ]]]
+# Manage custom templates [[[
+# ---------------------------
+
+# These variables define how the role will manage custom templates on remote
+# hosts. See :ref:`resources__ref_templates` for more details.
+
+# .. envvar:: resources__group_name [[[
+#
+# Name of the directory which contains templates which should be generated on
+# hosts in a specific host group. This variable needs to be set on a group
+# level in the inventory to take effect, only one group is supported at a time.
+resources__group_name: 'nonexistent-host-group'
+
+                                                                   # ]]]
+# .. envvar:: resources__templates [[[
+#
+# Directory which contains templates that should be generated on all hosts in
+# the Ansible inventory.
+resources__templates: '{{ resources__src + "templates/by-group/all" }}'
+
+                                                                   # ]]]
+# .. envvar:: resources__group_templates [[[
+#
+# Directory which contains templates that should be generated on hosts in
+# a specific Ansible inventory group.
+resources__group_templates: '{{ resources__src + "templates/by-group/" + resources__group_name }}'
+
+                                                                   # ]]]
+# .. envvar:: resources__host_templates [[[
+#
+# Directory which contains templates that should be generated on specific hosts
+# in the Ansible inventory.
+resources__host_templates: '{{ resources__src + "templates/by-host/" + inventory_hostname }}'
+                                                                   # ]]]
+                                                                   # ]]]
 # Manage custom delayed paths [[[
 # -------------------------------
 

--- a/ansible/roles/debops.resources/tasks/main.yml
+++ b/ansible/roles/debops.resources/tasks/main.yml
@@ -5,6 +5,42 @@
 - name: Pre hooks
   include: '{{ lookup("task_src", "resources/pre_main.yml") }}'
 
+# Manage custom templates [[[1
+- name: Ensure that template directories exist
+  file:
+    path: '/{{ item.path }}'
+    mode: '{{ item.mode }}'
+    state: 'directory'
+  with_filetree:
+    - '{{ resources__host_templates }}'
+    - '{{ resources__group_templates }}'
+    - '{{ resources__templates }}'
+  when: item.state == 'directory'
+
+- name: Generate custom templates
+  template:
+    src: '{{ item.src }}'
+    dest: '/{{ item.path }}'
+    mode: '{{ item.mode }}'
+  with_filetree:
+    - '{{ resources__host_templates }}'
+    - '{{ resources__group_templates }}'
+    - '{{ resources__templates }}'
+  when: item.state == 'file'
+
+- name: Recreate custom symlinks
+  file:
+    src: '{{ item.src }}'
+    dest: '/{{ item.path }}'
+    mode: '{{ item.mode }}'
+    state: 'link'
+    force: True
+  with_filetree:
+    - '{{ resources__host_templates }}'
+    - '{{ resources__group_templates }}'
+    - '{{ resources__templates }}'
+  when: item.state == 'link'
+
 # Manage custom paths [[[1
 - name: Manage paths on remote hosts
   file:
@@ -180,42 +216,6 @@
          (item.dest|d() or item.path|d() or item.name|d()) and
          (item.state|d('present') == 'absent'))
   tags: [ 'role::resources:files' ]
-
-# Manage custom templates [[[1
-- name: Ensure that template directories exist
-  file:
-    path: '/{{ item.path }}'
-    mode: '{{ item.mode }}'
-    state: 'directory'
-  with_filetree:
-    - '{{ resources__host_templates }}'
-    - '{{ resources__group_templates }}'
-    - '{{ resources__templates }}'
-  when: item.state == 'directory'
-
-- name: Generate custom templates
-  template:
-    src: '{{ item.src }}'
-    dest: '/{{ item.path }}'
-    mode: '{{ item.mode }}'
-  with_filetree:
-    - '{{ resources__host_templates }}'
-    - '{{ resources__group_templates }}'
-    - '{{ resources__templates }}'
-  when: item.state == 'file'
-
-- name: Recreate custom symlinks
-  file:
-    src: '{{ item.src }}'
-    dest: '/{{ item.path }}'
-    mode: '{{ item.mode }}'
-    state: 'link'
-    force: True
-  with_filetree:
-    - '{{ resources__host_templates }}'
-    - '{{ resources__group_templates }}'
-    - '{{ resources__templates }}'
-  when: item.state == 'link'
 
 # Manage custom delayed paths [[[1
 - name: Manage delayed paths on remote hosts

--- a/ansible/roles/debops.resources/tasks/main.yml
+++ b/ansible/roles/debops.resources/tasks/main.yml
@@ -181,6 +181,42 @@
          (item.state|d('present') == 'absent'))
   tags: [ 'role::resources:files' ]
 
+# Manage custom templates [[[1
+- name: Ensure that template directories exist
+  file:
+    path: '/{{ item.path }}'
+    mode: '{{ item.mode }}'
+    state: 'directory'
+  with_filetree:
+    - '{{ resources__host_templates }}'
+    - '{{ resources__group_templates }}'
+    - '{{ resources__templates }}'
+  when: item.state == 'directory'
+
+- name: Generate custom templates
+  template:
+    src: '{{ item.src }}'
+    dest: '/{{ item.path }}'
+    mode: '{{ item.mode }}'
+  with_filetree:
+    - '{{ resources__host_templates }}'
+    - '{{ resources__group_templates }}'
+    - '{{ resources__templates }}'
+  when: item.state == 'file'
+
+- name: Recreate custom symlinks
+  file:
+    src: '{{ item.src }}'
+    dest: '/{{ item.path }}'
+    mode: '{{ item.mode }}'
+    state: 'link'
+    force: True
+  with_filetree:
+    - '{{ resources__host_templates }}'
+    - '{{ resources__group_templates }}'
+    - '{{ resources__templates }}'
+  when: item.state == 'link'
+
 # Manage custom delayed paths [[[1
 - name: Manage delayed paths on remote hosts
   file:

--- a/docs/ansible/roles/debops.resources/defaults-detailed.rst
+++ b/docs/ansible/roles/debops.resources/defaults-detailed.rst
@@ -11,6 +11,72 @@ examples for them.
    :local:
    :depth: 1
 
+.. _resources__ref_templates:
+
+resources__templates
+--------------------
+
+The :ref:`debops.resources` role supports dynamic generation of directories,
+templated files and symlinks using the `with_filetree`__ Ansible lookup plugin.
+
+.. __: https://docs.ansible.com/ansible/2.5/plugins/lookup/filetree.html
+
+The file, directory and symlink management is limited - the managed resources
+will be owned by ``root`` UNIX account and will be placed in the ``root`` UNIX
+group, however the specific file mode will be preserved; for example if you
+create a file with ``0600`` permissions, the same permissions will be set by
+the role on the remote host. You can use the :ref:`resources__ref_paths`
+functionality to modify file/directory ownership afterwards.
+
+.. warning::
+
+   The task ensures that each directory in the path exists, including
+   permissions. You have to set specific permissions for certain directories
+   like :file:`/root` (``0700``) or :file:`/tmp` (``1777``)  in order to not
+   modify them in unexpected manner.
+
+For this functionality to work, the role expects a specific directory structure
+located in the :file:`ansible/resources/` directory (or wherever the
+:envvar:`resources__src` variable points to):
+
+.. code-block:: none
+
+   ansible/resources/
+   └── templates/
+       ├── by-group/
+       │   ├── all/
+       │   ├── group-name1/
+       │   └── group-name2/
+       └── by-host/
+           ├── hostname1/
+           └── hostname2/
+
+The ``with_filetree`` Ansible lookup plugin will look for resources to manage
+in specific hostname directory, then a specific group name directory defined by
+the :envvar:`resources__group_name` variable, then in the :file:`by-group/all/`
+directory. The resource found first in this order wins and no further checks
+are performed; this means that you can put a file in the :file:`by-group/all/`
+directory and then override it using a host-specific directory.
+
+Each directory structure starts at the root of the filesystem (:file:`/`), so
+to create a file in a subdirectory you need to recreate the entire path. For
+example, to create the :file:`/var/lib/application/custom.txt` file, it needs
+to be placed in:
+
+.. code-block:: none
+
+   ansible/resources/templates/by-group/all/var/lib/application/custom.txt
+
+In the templates, you can reference variables from the Ansible facts (including
+local facts managed by other roles) and Ansible inventory. Referencing
+variables from other roles might work only if these roles are included in the
+playbook, however that is not idempotent and should be avoided.
+
+To manage resources on a group level, you need to define the
+:envvar:`resources__group_name` variable in the inventory group that contains
+the directory name in the :file:`ansible/resources/template/by-group/`
+directory. Only one group level is supported.
+
 .. _resources__ref_paths:
 
 resources__paths
@@ -235,61 +301,3 @@ Create a custom :program:`cron` task that restarts a service daily:
          #!/bin/sh
          # {{ ansible_managed }}
          test -x /usr/bin/service && systemctl restart service
-
-.. _resources__ref_templates:
-
-resources__templates
---------------------
-
-The :ref:`debops.resources` role supports dynamic generation of directories,
-templated files and symlinks using the `with_filetree`__ Ansible lookup plugin.
-
-.. __: https://docs.ansible.com/ansible/2.5/plugins/lookup/filetree.html
-
-The file, directory and symlink management is limited - the managed resources
-will be owned by ``root`` UNIX account and will be placed in the ``root`` UNIX
-group, however the specific file mode will be preserved; for example if you
-create a file with ``0600`` permissions, the same permissions will be set by
-the role on the remote host.
-
-For this functionality to work, the role expects a specific directory structure
-located in the :file:`ansible/resources/` directory (or wherever the
-:envvar:`resources__src` variable points to):
-
-.. code-block:: none
-
-   ansible/resources/
-   └── templates/
-       ├── by-group/
-       │   ├── all/
-       │   ├── group-name1/
-       │   └── group-name2/
-       └── by-host/
-           ├── hostname1/
-           └── hostname2/
-
-The ``with_filetree`` Ansible lookup plugin will look for resources to manage
-in specific hostname directory, then a specific group name directory defined by
-the :envvar:`resources__group_name` variable, then in the :file:`by-group/all/`
-directory. The resource found first in this order wins and no further checks
-are performed; this means that you can put a file in the :file:`by-group/all/`
-directory and then override it using a host-specific directory.
-
-Each directory structure starts at the root of the filesystem (:file:`/`), so
-to create a file in a subdirectory you need to recreate the entire path. For
-example, to create the :file:`/var/lib/application/custom.txt` file, it needs
-to be placed in:
-
-.. code-block:: none
-
-   ansible/resources/templates/by-group/all/var/lib/application/custom.txt
-
-In the templates, you can reference variables from the Ansible facts (including
-local facts managed by other roles) and Ansible inventory. Referencing
-variables from other roles might work only if these roles are included in the
-playbook, however that is not idempotent and should be avoided.
-
-To manage resources on a group level, you need to define the
-:envvar:`resources__group_name` variable in the inventory group that contains
-the directory name in the :file:`ansible/resources/template/by-group/`
-directory. Only one group level is supported.


### PR DESCRIPTION
This patch adds support for template generation in the
'debops.resources' Ansible role, using the 'with_filetree' Ansible
lookup plugin.

Fixes #349 