### PR TITLE
Fail2ban: group and host management for ignoreip

### DIFF
--- a/ansible/roles/debops.fail2ban/defaults/main.yml
+++ b/ansible/roles/debops.fail2ban/defaults/main.yml
@@ -39,6 +39,20 @@ fail2ban_dbpurgeage: '{{ (60 * 60 * 24) }}'
 fail2ban_ignoreip: []
 
                                                                    # ]]]
+# .. envvar:: fail2ban_group_ignoreip [[[
+#
+# List of IP addresses or CIDR networks which should be ignored by fail2ban in
+# a specific Ansible inventory group.
+fail2ban_group_ignoreip: []
+
+                                                                   # ]]]
+# .. envvar:: fail2ban_host_ignoreip [[[
+#
+# List of IP addresses or CIDR networks which should be ignored by fail2ban on
+# a specific hosts in the Ansible inventory.
+fail2ban_host_ignoreip: []
+
+                                                                   # ]]]
 # .. envvar:: fail2ban_ignoreip_default [[[
 #
 # List of default IP addresses or CIDR networks which should be ignored by

--- a/ansible/roles/debops.fail2ban/templates/etc/fail2ban/jail.local.d/default.local.j2
+++ b/ansible/roles/debops.fail2ban/templates/etc/fail2ban/jail.local.d/default.local.j2
@@ -6,7 +6,7 @@
 
 [DEFAULT]
 
-ignoreip       = {{ (fail2ban_ignoreip_default|d([]) + fail2ban_ignoreip|d([])) | join(" ") }}
+ignoreip       = {{ (fail2ban_ignoreip_default|d([]) + fail2ban_ignoreip|d([]) + fail2ban_group_ignoreip|d([]) + fail2ban_host_ignoreip|d([])) | join(" ") }}
 
 findtime       = {{ fail2ban_findtime }}
 maxretry       = {{ fail2ban_maxretry }}


### PR DESCRIPTION
In order to add IP to whitelist from a group or a host.