### PR TITLE
Chrony support

### DIFF
--- a/ansible/roles/debops.ntp/defaults/main.yml
+++ b/ansible/roles/debops.ntp/defaults/main.yml
@@ -100,6 +100,18 @@ ntp__servers_map:
 # Fudge local clock if time servers is not available.
 ntp__fudge: True
                                                                    # ]]]
+
+# .. envvar:: ntp__servers_as_pool [[[
+#
+# Treat NTP server addresses as pool addresses. The server name is expected
+# to resolve to multiple IP addresses which might change over time. This is
+# currently only supported by :program:`chrony`. Other NTP servers will
+# ignore this setting.
+ntp__servers_as_pool: '{{ False if ansible_distribution == "Debian"
+                                   and ansible_distribution_release == "jessie"
+                          else True }}'
+
+                                                                   # ]]]
                                                                    # ]]]
 # Timezone configuration [[[
 # --------------------------

--- a/ansible/roles/debops.ntp/defaults/main.yml
+++ b/ansible/roles/debops.ntp/defaults/main.yml
@@ -214,7 +214,7 @@ ntp__ferm__dependent_rules:
     name: 'jump-filter-ntp'
     target: '{{ ntp__ferm_chain }}'
     rule_state: '{{ "present" if (
-                      ntp__daemon in [ "openntpd", "ntpd" ] and
+                      ntp__daemon in [ "openntpd", "ntpd", "chrony" ] and
                       ntp__firewall_access|bool)
                     else "absent" }}'
 
@@ -231,7 +231,7 @@ ntp__ferm__dependent_rules:
     recent_set_name: 'ntp-new'
     recent_log: False
     rule_state: '{{ "present" if (
-                      ntp__daemon in [ "openntpd", "ntpd" ] and
+                      ntp__daemon in [ "openntpd", "ntpd", "chrony" ] and
                       ntp__firewall_access|bool)
                     else "absent" }}'
 
@@ -251,7 +251,7 @@ ntp__ferm__dependent_rules:
     recent_target: '{{ ntp__ferm_recent_target }}'
     recent_log_prefix: 'ipt-recent-ntp: '
     rule_state: '{{ "present" if (
-                      ntp__daemon in [ "openntpd", "ntpd" ] and
+                      ntp__daemon in [ "openntpd", "ntpd", "chrony" ] and
                       ntp__firewall_access|bool)
                     else "absent" }}'
 
@@ -265,7 +265,7 @@ ntp__ferm__dependent_rules:
     role: 'ntp'
     role_weight: '40'
     rule_state: '{{ "present" if (
-                      ntp__daemon in [ "openntpd", "ntpd" ] and
+                      ntp__daemon in [ "openntpd", "ntpd", "chrony" ] and
                       ntp__firewall_access|bool)
                     else "absent" }}'
                                                                    # ]]]

--- a/ansible/roles/debops.ntp/templates/etc/chrony/chrony.conf.j2
+++ b/ansible/roles/debops.ntp/templates/etc/chrony/chrony.conf.j2
@@ -30,10 +30,10 @@ allow all
 deny all
 
 {%   if ntp__allow is string %}
-allow ntp__allow
+allow {{ ntp__allow }}
 {%   else %}
 {%     for address in ntp__allow %}
-allow address
+allow {{ address }}
 {%     endfor %}
 {%   endif %}
 

--- a/ansible/roles/debops.ntp/templates/etc/chrony/chrony.conf.j2
+++ b/ansible/roles/debops.ntp/templates/etc/chrony/chrony.conf.j2
@@ -6,7 +6,7 @@
 pool {{ ntp__servers }} iburst
 {% else %}
 {% for address in ntp__servers %}
-pool {{ address }} iburst
+{{ ntp__servers_as_pool | ternary('pool', 'server') }} {{ address }} iburst
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
Three fixes for chrony support. The first is primarily relevant to support Debian Jessie, the two others are relevant if you want to run chrony as an NTP server. If you prefer individual pull requests I can also create two or even three.