### PR TITLE
[debops.machine] Don't configure tmpfiles @ Wheezy

### DIFF
--- a/ansible/roles/debops.machine/tasks/main.yml
+++ b/ansible/roles/debops.machine/tasks/main.yml
@@ -71,7 +71,7 @@
     group: 'root'
     mode: '0644'
   register: machine__register_tmpfiles
-  when: machine__enabled|bool and ansible_distribution_release in [ 'wheezy', 'jessie' ]
+  when: machine__enabled|bool and ansible_distribution_release in [ 'jessie' ]
 
 - name: Create /run/motd.dynamic symlink
   command: systemd-tmpfiles --create


### PR DESCRIPTION
The Debian Wheezy installation does not have '/etc/tmpfiles.d/'
directory and corresponding service, and because of that the task fails
on Wheezy installs. Therefore, we don't set up this fix on Wheezy.