### PR TITLE
[debops.postgresql_server] Don't change template1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -205,6 +205,12 @@ Removed
   created by the normal templates provided by the ``lxc`` package, and then
   configured using DebOps roles as usual.
 
+- [debops.postgresql_server] The tasks that modified the default ``template1``
+  database and its schema have been removed to make the PostgreSQL installation
+  more compatible with applications packaged in Debian that rely on the
+  PostgreSQL service. See the relevant commit for more details. Existing
+  installations shouldn't be affected.
+
 
 `debops v0.7.2`_ - 2018-03-28
 -----------------------------

--- a/ansible/roles/debops.postgresql_server/tasks/secure_installation.yml
+++ b/ansible/roles/debops.postgresql_server/tasks/secure_installation.yml
@@ -13,33 +13,6 @@
   when: item.name|d()
   no_log: True
 
-- name: Revoke all privileges on template1 from PUBLIC
-  postgresql_privs:
-    database: 'template1'
-    port: '{{ item.port }}'
-    role: 'PUBLIC'
-    type: 'database'
-    privs: 'ALL'
-    state: 'absent'
-  with_flattened:
-    - '{{ postgresql_server__clusters }}'
-  become_user: '{{ item.user | d(postgresql_server__user) }}'
-  when: item.name|d()
-
-- name: Revoke all privileges on schema public from PUBLIC
-  postgresql_privs:
-    database: 'template1'
-    port: '{{ item.port }}'
-    role: 'PUBLIC'
-    type: 'schema'
-    obj: 'public'
-    privs: 'ALL'
-    state: 'absent'
-  with_flattened:
-    - '{{ postgresql_server__clusters }}'
-  become_user: '{{ item.user | d(postgresql_server__user) }}'
-  when: item.name|d()
-
 - name: Grant connect on postgres to PUBLIC
   postgresql_privs:
     database: 'postgres'


### PR DESCRIPTION
The 'template1' PostgreSQL database is used as a template for newly
created databases. The 'debops.postgresql_server' role contained a set
of tasks that modified the 'template1' database to allow better support
for multi-tenancy in the PostgreSQL service, based on documentation from

  https://wiki.postgresql.org/wiki/Shared_Database_Hosting

Unfortunately it seems that the changes made by the role affect
installation of packaged database schemas which are not designed with
these modifications in mind. In some cases this results in broken usage
of 'dbconfig' functionality in Debian. Due to that, the 'template1'
modifications are removed from the base 'debops.postgresql_server' role.
They might be re-introduced in DebOps in a separate Ansible role that
will support PostgreSQL multi-tenancy in the future.