### PR TITLE
[debops.etherpad] Don't add '\n' in user passwords

### DIFF
--- a/ansible/roles/debops.etherpad/templates/var/local/etherpad-lite/etherpad-lite/settings.json.j2
+++ b/ansible/roles/debops.etherpad/templates/var/local/etherpad-lite/etherpad-lite/settings.json.j2
@@ -145,7 +145,7 @@ See also: https://github.com/debops/ansible-etherpad/pull/16/files#r41485963
 {% for name in etherpad_users %}
     "{{ name }}": {
 {% if 'ep_hash_auth' in (etherpad__default_plugins + etherpad_plugins) %}
-      "hash": "{{ lookup('pipe', 'printf "%s\n" "' + lookup('password', secret + '/credentials/' + inventory_hostname + '/etherpad/users/' + name) + '" | sha512sum | cut -f1 -d" "') }}",
+      "hash": "{{ lookup('pipe', 'printf "%s" "' + lookup('password', secret + '/credentials/' + inventory_hostname + '/etherpad/users/' + name) + '" | sha512sum | cut -f1 -d" "') }}",
 {% else %}
       "password": "{{ lookup('password', secret + '/credentials/' + inventory_hostname + '/etherpad/users/' + name) }}",
 {% endif %}


### PR DESCRIPTION
Fixes #373