### PR TITLE
[debops.nginx] php*.conf.j2 : use item.try_files instead of hardcoded values

### DIFF
--- a/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/php.conf.j2
+++ b/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/php.conf.j2
@@ -11,7 +11,7 @@
 
 {% endblock %}
 {% block nginx_tpl_block_location_root %}
-                try_files $uri $uri/ $uri.php;
+                try_files {{ item.try_files|default("$uri $uri/ $uri.php") | join(' ') }};
 {% endblock %}
 {% block nginx_tpl_block_custom_status_locations %}
 {%   if item.php_status|d()|bool %}

--- a/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/php5.conf.j2
+++ b/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/php5.conf.j2
@@ -63,7 +63,7 @@
 
 {% endblock %}
 {% block nginx_tpl_block_location_root %}
-                try_files $uri $uri/ $uri.php;
+                try_files {{ item.try_files|default("$uri $uri/ $uri.php") | join(' ') }};
 {% endblock %}
 {% block nginx_tpl_block_custom_status_locations %}
 {% if item.php5_status|d(nginx_php5_status) and (nginx_status or nginx_status_localhost) %}


### PR DESCRIPTION
In `php.conf.j2` and `php5.conf.j2`, hardcoded values of `try_files` were used, instead of the user definable `item.try_files` variable. 

This was no suitable for all cases : for example, can't use index.php for all URL for custom handling with many frameworks.