### PR TITLE
Fix for python3 compatibility on list keys

### DIFF
--- a/ansible/roles/debops.postfix/templates/lookup/postfix__init_maincf.j2
+++ b/ansible/roles/debops.postfix/templates/lookup/postfix__init_maincf.j2
@@ -1,7 +1,7 @@
 {% set postfix__tpl_init_maincf = [] %}
 {% for entry in postfix__combined_maincf %}
 {%   if 'section' not in entry.keys() %}
-{%     set entry_name = (entry.name | d(entry.keys()[0])) %}
+{%     set entry_name = (entry.name | d(entry | list | first)) %}
 {%     if entry_name is search('_sasl_') %}
 {%       set _ = postfix__tpl_init_maincf.append({'name': entry_name, 'state': 'init', 'section': 'auth'}) %}
 {%     elif entry_name.startswith('smtpd_tls_') %}


### PR DESCRIPTION
Fixes an issue on templating with python3 and jinja2.

Came up on this with my archlinux machine.

Please have a look into https://github.com/debops/debops/issues/376 for more details