### PR TITLE
[debops.nginx] Update 'try_files' to support lists

### DIFF
--- a/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/default.conf.j2
+++ b/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/default.conf.j2
@@ -394,7 +394,7 @@
 {%         else                                            %}
         location / {
 {%             block nginx_tpl_block_location_root         %}
-                try_files {{ item.try_files|default(nginx_default_try_files) | join(' ') }} =404;
+                try_files {{ (([ item.try_files ] if item.try_files is string else item.try_files) if item.try_files|d() else nginx_default_try_files) | join(' ') }} =404;
 {%             endblock                                    %}
         }
 {%         endif                                           %}

--- a/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/php.conf.j2
+++ b/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/php.conf.j2
@@ -11,7 +11,7 @@
 
 {% endblock %}
 {% block nginx_tpl_block_location_root %}
-                try_files {{ item.try_files|default("$uri $uri/ $uri.php") | join(' ') }};
+                try_files {{ (([ item.try_files ] if item.try_files is string else item.try_files) if item.try_files|d() else ["$uri $uri/ $uri.php"]) | join(' ') }};
 {% endblock %}
 {% block nginx_tpl_block_custom_status_locations %}
 {%   if item.php_status|d()|bool %}

--- a/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/php5.conf.j2
+++ b/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/php5.conf.j2
@@ -63,7 +63,7 @@
 
 {% endblock %}
 {% block nginx_tpl_block_location_root %}
-                try_files {{ item.try_files|default("$uri $uri/ $uri.php") | join(' ') }};
+                try_files {{ (([ item.try_files ] if item.try_files is string else item.try_files) if item.try_files|d() else ["$uri $uri/ $uri.php"]) | join(' ') }};
 {% endblock %}
 {% block nginx_tpl_block_custom_status_locations %}
 {% if item.php5_status|d(nginx_php5_status) and (nginx_status or nginx_status_localhost) %}

--- a/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/rails.conf.j2
+++ b/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/rails.conf.j2
@@ -11,7 +11,7 @@
 {%   else %}
         location / {
 {%     block nginx_tpl_block_location_root %}
-                try_files {{ item.try_files|default(nginx_default_try_files) | join(' ') }} =404;
+                try_files {{ (([ item.try_files ] if item.try_files is string else item.try_files) if item.try_files|d() else nginx_default_try_files) | join(' ') }} =404;
 {%     endblock %}
         }
 {%   endif %}


### PR DESCRIPTION
The 'item.try_files' directive used in the 'debops.nginx' server
configuration can be specified either as a string or as a list. The
templates that generate the configuration will now check which version
is used and correctly format the result. This avoids an issue where
a string is treated as a list and formatted incorrectly with a space
between each letter.