### PR TITLE
Fix exception thrown by debops-default for Py2/3.

### DIFF
--- a/bin/debops-defaults
+++ b/bin/debops-defaults
@@ -56,7 +56,7 @@ def cat(filename, outstream):
         return
     try:
         # Read input file as Unicode object and pass it to outstream.
-        outstream.write(fh.read())
+        outstream.write(fh.read().encode('utf-8'))
     finally:
         fh.close()
 


### PR DESCRIPTION
Without the encoding debops-defaults throws exceptions with Py2 and Py3.