### PR TITLE
fix bad link for getting started guide

### DIFF
--- a/bin/debops-init
+++ b/bin/debops-init
@@ -115,7 +115,7 @@ HOSTS_FILE_HEADER = """\
 # https://github.com/debops/debops-playbooks/blob/master/playbooks/common.yml
 #
 # You should check Getting Started guide for useful suggestions:
-# https://docs.debops.org/en/latest/debops-playbooks/docs/guides/getting-started.html
+# https://docs.debops.org/en/latest/debops-playbooks/guides/getting-started.html
 """
 
 HOSTS_FILE_CONTENT_CONTROLER = """


### PR DESCRIPTION
fix debops-init inventory/hosts file link to the getting started guide
(previous reference was invalid likely due to doc reorg)