### PR TITLE
[debops.postgresql] Fix duplication in ~/.pgpass

### DIFF
--- a/ansible/roles/debops.postgresql/tasks/main.yml
+++ b/ansible/roles/debops.postgresql/tasks/main.yml
@@ -207,7 +207,7 @@
                         ((item.server  | d(postgresql__server if postgresql__server else "localhost")) | replace(".","\.")),
                         (item.port     | d(postgresql__port)),
                         (item.database | d("\*")),
-                        (item.role     | d("\*"))
+                        (item.name     | d(item.role | d(item.owner | d("\*"))))
                        ] | join(":")
                       ) + ":" }}'
     line: '{{ [


### PR DESCRIPTION
If the 'postgresql__pgpass' entries only specify the 'owner' of the
~/.pgpass file, the role would add duplicate entries and the playbook
wouldn't be idempotent. This commit fixes this by including alternative
names of the file owner into account.