### PR TITLE
Fix nameConstraints to allow subdomains.

### DIFF
--- a/ansible/roles/debops.pki/files/secret/pki/lib/pki-authority
+++ b/ansible/roles/debops.pki/files/secret/pki/lib/pki-authority
@@ -130,7 +130,7 @@ get_openssl_name_constraints_directive () {
     local name_constraints
     case "${config['name_constraints']}" in
         true|True)
-            name_constraints="nameConstraints         = critical, permitted;DNS:${config_domain}"
+            name_constraints="nameConstraints         = critical, permitted;DNS:.${config_domain}"
             ;;
         false|False)
             name_constraints=""


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc5280#section-4.2.1.10 the
DNS name should be prefixed with a leading "." to allow hosts and
subdomains based on that name.