### PR TITLE
[MariaDB] Change character encoding to 'utf8mb4'

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -174,6 +174,11 @@ Changed
   script. This should allow for multiple administrators to easily coexist and
   run the DebOps playbooks/roles from their own accounts without issues.
 
+- [debops.mariadb_server] [debops.mariadb] The MariaDB/MySQL server and client
+  will now use the ``utf8mb4`` encoding by default instead of the ``utf8``
+  which is an internal MySQL character encoding. This might impact existing
+  databases, see the :ref:`upgrade_notes` for details.
+
 Removed
 ~~~~~~~
 

--- a/ansible/roles/debops.mariadb/defaults/main.yml
+++ b/ansible/roles/debops.mariadb/defaults/main.yml
@@ -174,7 +174,7 @@ mariadb__packages_map:
 #
 # Configuration options related to charset and string encoding on the client.
 mariadb__client_charset_options:
-  'default_character_set': 'utf8'
+  'default_character_set': 'utf8mb4'
 
                                                                    # ]]]
 # .. envvar:: mariadb__client_remote_host_options [[[

--- a/ansible/roles/debops.mariadb_server/defaults/main.yml
+++ b/ansible/roles/debops.mariadb_server/defaults/main.yml
@@ -214,9 +214,9 @@ mariadb_server__mysqld_security_options:
 #
 # Configuration options related to charset and string encoding on the server.
 mariadb_server__mysqld_charset_options:
-  'character_set_server': 'utf8'
-  'collation_server':     'utf8_general_ci'
-  'init_connect':         'SET NAMES utf8'
+  'character_set_server': 'utf8mb4'
+  'collation_server':     'utf8mb4_general_ci'
+  'init_connect':         'SET NAMES utf8mb4'
 
                                                                    # ]]]
 # .. envvar:: mariadb_server__mysqld_network_options [[[
@@ -288,7 +288,7 @@ mariadb_server__mysqld_options:
 mariadb_server__client_options:
   - section: 'client'
     options:
-      'default_character_set': 'utf8'
+      'default_character_set': 'utf8mb4'
 
                                                                    # ]]]
 # .. envvar:: mariadb_server__options [[[

--- a/docs/news/upgrades.rst
+++ b/docs/news/upgrades.rst
@@ -38,6 +38,18 @@ GitLab :command:`gitaly` installation
 
   The above steps shouldn't impact new GitLab installations.
 
+UTF8 encoding in MariaDB
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+- The :ref:`debops.mariadb_server` and :ref:`debops.mariadb` roles will now use
+  the ``utf8mb4`` character encoding by default. This encoding is `the real
+  UTF-8 encoding`__ and not the internal MySQL encoding. This change might
+  impact existing MySQL databases; you can read `an UTF-8 conversion guide`__
+  to check if your database needs to be converted.
+
+  .. __: https://medium.com/@adamhooper/in-mysql-never-use-utf8-use-utf8mb4-11761243e434
+  .. __: https://mathiasbynens.be/notes/mysql-utf8mb4
+
 Inventory variable changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
The default character encoding used in the 'debops.mariadb_server' and
'debops.mariadb' roles is changed to 'utf8mb4' which is the real UTF-8
encoding. More details:

https://medium.com/@adamhooper/in-mysql-never-use-utf8-use-utf8mb4-11761243e434

Fixes #371 