### PR TITLE
Change ifupdown forward configuration per documentation

### DIFF
--- a/ansible/roles/debops.ifupdown/templates/lookup/ifupdown__ferm__dependent_rules.j2
+++ b/ansible/roles/debops.ifupdown/templates/lookup/ifupdown__ferm__dependent_rules.j2
@@ -8,7 +8,7 @@
 {%       if params.forward|d()|bool %}
 {%         set ifupdown__tpl_forward_rules = (['domain $domains table filter chain FORWARD {']
              + (['    interface ' + interface_name + ' ' + params.forward_interface_ferm_rule|d("ACCEPT") + ";"]
-                if params.forward_interface_ferm_rule|d() != omit
+                if params.forward_interface_ferm_rule_enabled|d(True)|bool
                 else [])
              + (['    outerface ' + interface_name + ' ' + params.forward_outerface_ferm_rule|d("ACCEPT") + ";"]
                 if params.forward_outerface_ferm_rule_enabled|d(True)|bool


### PR DESCRIPTION
Discovered that the Ferm forward configuration from the ifupdown role didn't use the forward_interface_ferm_rule_enabled option like the documentation specified so I fixed it.