### PR TITLE
[debops.unattended_upgrades] Change upgrade policy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -187,6 +187,12 @@ Changed
   which is an internal MySQL character encoding. This might impact existing
   databases, see the :ref:`upgrade_notes` for details.
 
+- [debops.unattended_upgrades] On hosts without a domain set, the role enabled
+  all upgrades, not just security updates. This will not happen anymore, the
+  security updates are enabled everywhere by default, you need to enable all
+  upgrades specifically via the :envvar:`unattended_upgrades__release`
+  variable.
+
 Removed
 ~~~~~~~
 

--- a/ansible/roles/debops.unattended_upgrades/defaults/main.yml
+++ b/ansible/roles/debops.unattended_upgrades/defaults/main.yml
@@ -24,11 +24,7 @@ unattended_upgrades__enabled: True
 # By default, :program:`unattended-upgrade` performs only upgrades of packages
 # from security repositories. This variable allows you to enable upgrades from
 # all repositories (main, updates, backports).
-#
-# If a host does not have a domain set, it will be considered a workstation or
-# a laptop and :program:`unattended-upgrade` will perform upgrades of packages
-# from all repositories.
-unattended_upgrades__release: '{{ False if ansible_domain else True }}'
+unattended_upgrades__release: False
 
                                                                    # ]]]
 # .. envvar:: unattended_upgrades__base_packages [[[


### PR DESCRIPTION
The role enabled unattended upgrades for all packages on hosts without
a domain, however this was deemed too risky as a default. Now, only
security updates will be automatically upgraded, administrators can
enable upgrades for all packages via Ansible inventory.

Fixes #387