### PR TITLE
Revert "[debops.users] Add support for home dir ACLs"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,10 +49,6 @@ Added
   to maintain long-running services when not logged in via their own private
   :command:`systemd` instances.
 
-- [debops.users] The role can now configure ACL entries of the user home
-  directories using the ``item.home_acl`` parameter. This can be used for more
-  elaborate access restrictions.
-
 - [debops.sudo] You can now manage configuration files located in the
   :file:`/etc/sudoers.d/` directory using :ref:`sudo__*_sudoers <sudo__ref_sudoers>`
   inventory variables, with multiple level of conditional options.

--- a/ansible/roles/debops.users/defaults/main.yml
+++ b/ansible/roles/debops.users/defaults/main.yml
@@ -25,12 +25,6 @@ users__enabled: True
 users__no_log: True
 
                                                                    # ]]]
-# .. envvar:: users__acl_enabled [[[
-#
-# Enable or disable support for filesystem ACL management.
-users__acl_enabled: True
-
-                                                                   # ]]]
 # .. envvar:: users__default_system [[[
 #
 # If enabled, user groups and accounts will be considered "system" accounts by

--- a/ansible/roles/debops.users/tasks/users.yml
+++ b/ansible/roles/debops.users/tasks/users.yml
@@ -79,34 +79,6 @@
          (item.home_owner|d() or item.home_group|d() or item.home_mode|d()))
   no_log: '{{ users__no_log | bool }}'
 
-- name: Manage home directory ACLs
-  acl:
-    path:        '{{ item.0.home | d("~" + item.0.name) }}'
-    default:     '{{ item.1.default     | d(omit) }}'
-    entity:      '{{ item.1.entity      | d(omit) }}'
-    entry:       '{{ item.1.entry       | d(omit) }}'
-    etype:       '{{ item.1.etype       | d(omit) }}'
-    permissions: '{{ item.1.permissions | d(omit) }}'
-    follow:      '{{ item.1.follow      | d(omit) }}'
-    recursive:   '{{ item.1.recursive   | d(omit) }}'
-    state:       '{{ item.1.state       | d("present") }}'
-  loop: '{{ (lookup("flattened",
-                    users__default_accounts
-                    + users__admin_accounts
-                    + users__accounts
-                    + users__group_accounts
-                    + users__host_accounts
-                    + users__dependent_accounts,
-                    wantlist=True))
-             | selectattr("home_acl", "defined") | list
-             | subelements("home_acl") }}'
-  loop_control:
-    label: '{{ {"name": item.0.name, "home_acl": item.1} }}'
-  when: (users__acl_enabled|bool and
-         item.0.name|d() and item.0.name != 'root' and item.0.state|d('present') != 'absent' and
-         item.0.createhome|d(True) and item.0.home_acl|d())
-  no_log: '{{ users__no_log | bool }}'
-
 - name: Allow specified UNIX accounts to linger when not logged in
   command: loginctl enable-linger {{ item.name }}
   args:

--- a/docs/ansible/roles/debops.users/defaults-detailed.rst
+++ b/docs/ansible/roles/debops.users/defaults-detailed.rst
@@ -173,37 +173,6 @@ Parameters related to home directories
   Optional. Specify path to the directory, contents of which will be copied to
   the newly created home directory.
 
-``home_acl``
-  Optional. Configure filesystem ACL entries of the home directory of a given
-  UNIX user account. This parameter is a list of YAML dictionaries, each
-  element uses a specific set of parameters derived from the ``acl`` Ansible
-  module, see its documentation for details, as well as the :man:`acl(5)`,
-  :man:`setfacl(1)` and :man:`getfacl` manual pages. Some useful parameters:
-
-  ``default``
-    Optional, boolean. If ``True``, set a given ACL entry as the default for
-    new files and directories inside a given directory. Only works with
-    directories.
-
-  ``entity``
-    Name of the UNIX user account or group that a given ACL entry applies to.
-
-  ``etype``
-    Specify the ACL entry type to configure. Valid choices: ``user``,
-    ``group``, ``mask``, ``other``.
-
-  ``permissions``
-    Specify the permission to apply for a given ACL entry. This parameter
-    cannot be specified when the state of an ACL entry is set to ``absent``.
-
-  ``recursive``
-    Apply a given ACL entry recursively to all entities in a given path.
-
-  ``state``
-    Optional. If not specified or ``present``, the ACL entry will be created.
-    If ``absent``, the ACL entry will be removed. The ``query`` state doesn't
-    make sense in this context and shouldn't be used.
-
 Parameters related to the account's private SSH key
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/ansible/roles/debops.users/examples/manage-accounts.yml
+++ b/docs/ansible/roles/debops.users/examples/manage-accounts.yml
@@ -4,17 +4,14 @@ users__accounts:
 
   # A basic account
   - name: 'user1'
-    group: 'user1'
 
   # More elaborate account with SSH access and dotfiles
   - name: 'user2'
-    group: 'user2'
     groups: [ 'sshusers' ]
     shell: '/bin/zsh'
     dotfiles_enabled: True
 
-  # An user account with a random password, stored in 'secret/'. This user
-  # account will be added in the 'users' UNIX group instead of its own group.
+  # An user account with a random password, stored in 'secret/'
   - name: 'user3'
     update_password: 'on_create'
     password: '{{ lookup("password", secret + "/credentials/" + ansible_fqdn
@@ -23,24 +20,3 @@ users__accounts:
   # Remove an user account if it exists
   - name: 'user_removed'
     state: 'absent'
-
-  # An example SFTPonly application account with custom ACL entries for the web
-  # server access. SFTPonly configuration is managed in the 'debops.sshd' role,
-  # SSH keys need to be set up with 'debops.authorized_keys', home directory is
-  # owned by the 'root' account and users don't have write permissions there,
-  # only in subdirectories.
-  - name: 'application'
-    group: 'application'
-    groups: 'sftopnly'
-    comment: 'SFTPonly application account'
-    shell: '/usr/sbin/nologin'
-    dotfiles_enabled: False
-    home: '/home/application'
-    home_owner: 'root'
-    home_group: 'application'
-    home_mode: '0750'
-    home_acl:
-
-      - entity: 'www-data'
-        etype: 'group'
-        permissions: 'x'


### PR DESCRIPTION
This reverts commit ed3ba34653a1c3f8acdc6e09a6572a794876a133.

The 'subelements' Ansible filter plugin is available since Ansible 2.6,
which is too early for it to be widely used. Therefore I'm reverting the
commit that introduced the home directory ACL management, this feature
will be brought back after some time to allow for 'subelements' filter
plugin to be widely available.

More details: https://github.com/ansible/ansible/commit/a5f05c6f