### PR TITLE
Add tags to task

### DIFF
--- a/ansible/roles/debops.php/tasks/main.yml
+++ b/ansible/roles/debops.php/tasks/main.yml
@@ -109,6 +109,7 @@
   register: php__register_diversions
   check_mode: False
   changed_when: False
+  tags: [ 'role::php:pools', 'role::php:config' ]
 
 - name: Divert default PHP-FPM configuration and pool
   command: dpkg-divert --quiet --local --divert {{ item + ".dpkg-divert" }}


### PR DESCRIPTION
Solve this error:

`debops service/php -t role::php:pools` 

```
fatal: [app01]: FAILED! =>
  msg: |-
    The conditional check '"fpm" in php__server_api_packages and item + ".dpkg-divert" not in php__register_diversions.stdout_lines' failed. The error was: error while evaluating conditional ("fpm" in php__server_api_packages and item + ".dpkg-divert" not in php__register_diversions.stdout_lines): 'php__register_diversions' is undefined

    The error appears to have been in '/opt/talma/.local/share/virtualenvs/debops-gUYggkol/lib/python3.6/site-packages/debops/ansible/roles/debops.php/tasks/main.yml': line 113, column 3, but may
    be elsewhere in the file depending on the exact syntax problem.

    The offending line appears to be:


    - name: Divert default PHP-FPM configuration and pool
      ^ here

```