### PR TITLE
[debops.python] APT cache: configurable valid time

### DIFF
--- a/ansible/roles/debops.python/defaults/main.yml
+++ b/ansible/roles/debops.python/defaults/main.yml
@@ -17,6 +17,15 @@
 #
 # Enable or disable Python management via the :ref:`debops.python` role.
 python__enabled: True
+
+                                                                   # ]]]
+# .. envvar:: python__raw_apt_cache_valid_time [[[
+#
+# During Python bootstrapping, check if the APT cache was modified X minutes
+# ago (must be a negative number), by default 12h. If the APT cache is older
+# than the specified time in minutes, the role will automatically refresh it.
+# Set to ``0`` to refresh the APT cache on each Ansible run.
+python__raw_apt_cache_valid_time: '-{{ 60 * 60 * 12 }}'
                                                                    # ]]]
                                                                    # ]]]
 # Python 3 management [[[

--- a/ansible/roles/debops.python/raw/tasks/main.yml
+++ b/ansible/roles/debops.python/raw/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Update APT repositories, install core Python packages
   raw: |
-    if [ -z "$(find /var/cache/apt/pkgcache.bin -mmin -43200)" ]; then
+    if [ -z "$(find /var/cache/apt/pkgcache.bin -mmin {{ python__raw_apt_cache_valid_time }})" ]; then
         apt-get -q update
     fi
     if [ "{{ python__raw_purge_v2 | bool | lower }}" = "true" ] && [ ! -f "/etc/ansible/facts.d/python.fact" ] ; then


### PR DESCRIPTION
This patch adds a variable to the 'debops.python' role that allows
control over if/when the APT cache is updated during Python
bootstrapping.