### PR TITLE
[debops.nginx] Add tags for maps and upstreams

### DIFF
--- a/ansible/roles/debops.nginx/tasks/main.yml
+++ b/ansible/roles/debops.nginx/tasks/main.yml
@@ -233,6 +233,7 @@
   when: (nginx__deploy_state in [ 'present' ])
 
 - include: 'nginx_configs.yml'
+  tags: [ 'role::nginx:servers' ]
   when: (nginx__deploy_state in [ 'present' ])
 
 - include: 'nginx_servers.yml'


### PR DESCRIPTION
The 'role::nginx:servers' Ansible tag will also include generation of
maps and upstreams configuration files, for completion.

Fixes #410 