### PR TITLE
[debops.ferm] Handle IPv4/IPv6 addresses in 'dmz'

### DIFF
--- a/ansible/roles/debops.ferm/templates/etc/ferm/rules.d/rule.conf.j2
+++ b/ansible/roles/debops.ferm/templates/etc/ferm/rules.d/rule.conf.j2
@@ -368,6 +368,13 @@
 {%     if ferm__tpl_config['domain_args'] %}{{ ferm__tpl_config['domain_args'] | join(" ") }} {% endif %}{
     @def $PUBLIC_IP  = ( @ipfilter( ({{ ferm__tpl_config['public_ip']  | unique | join(' ') }}) ) );
     @def $PRIVATE_IP = ( @ipfilter( ({{ ferm__tpl_config['private_ip'] | unique | join(' ') }}) ) );
+
+    @def $PUBLIC_IPV4 = "{{ ferm__tpl_config['public_ip'] | unique | ipv4 | first | d('') }}";
+    @def $PUBLIC_IPV6 = "{{ ferm__tpl_config['public_ip'] | unique | ipv6 | first | d('') }}";
+
+    @def $PRIVATE_IPV4 = "{{ ferm__tpl_config['private_ip'] | unique | ipv4 | first | d('') }}";
+    @def $PRIVATE_IPV6 = "{{ ferm__tpl_config['private_ip'] | unique | ipv6 | first | d('') }}";
+
     @if @ne($PUBLIC_IP,"") @if @ne($PRIVATE_IP,"") {
         table filter chain FORWARD {
 {%     if ferm__tpl_config['dmz_ports']|d() %}
@@ -395,7 +402,8 @@
                     dport ({{ ferm__tpl_config['dmz_ports'] | join(" ") }}) {
 {%       endif %}
 {%       if ferm__tpl_config['dport']|d() %}
-                        destination $PUBLIC_IP DNAT to @cat($PRIVATE_IP, ":{{ ferm__tpl_config['dport'][0] }}");
+                        @if @eq($DOMAIN, ip)  @if @ne($PRIVATE_IPV4,"") destination $PUBLIC_IPV4 DNAT to @cat($PRIVATE_IPV4, ":{{ ferm__tpl_config['dport'][0] }}");
+                        @if @eq($DOMAIN, ip6) @if @ne($PRIVATE_IPV6,"") destination $PUBLIC_IPV6 DNAT to @cat($PRIVATE_IPV6, ":{{ ferm__tpl_config['dport'][0] }}");
 {%       else %}
                         destination $PUBLIC_IP DNAT to $PRIVATE_IP;
 {%       endif %}

--- a/ansible/roles/debops.ferm/templates/etc/ferm/rules.d/rule.conf.j2
+++ b/ansible/roles/debops.ferm/templates/etc/ferm/rules.d/rule.conf.j2
@@ -71,6 +71,9 @@
 {%   if config.recent_target|d() %}
 {%     set _ = ferm__tpl_config.update({'recent_target': config.recent_target}) %}
 {%   endif %}
+{%   if config.snat_ip|d() %}
+{%     set _ = ferm__tpl_config.update({'snat_ip': config.snat_ip}) %}
+{%   endif %}
 {%   if config.subchain|d() %}
 {%     set _ = ferm__tpl_config.update({'subchain': (ferm__tpl_config['type'] + "-" + config.name | d((ferm__tpl_config['dport'][0] if ferm__tpl_config['dport']|d() else "rules")))}) %}
 {%   endif %}
@@ -413,9 +416,11 @@
                 destination $PUBLIC_IP DNAT to $PRIVATE_IP;
 {%     endif %}
             }
+{%     if ferm__tpl_config['snat_ip']|d() %}
             chain POSTROUTING {
-                source $PRIVATE_IP SNAT to $PUBLIC_IP;
+                destination $PRIVATE_IP SNAT to {{ ferm__tpl_config['snat_ip'] }};
             }
+{%     endif %}
         }
     }
 }

--- a/docs/ansible/roles/debops.ferm/rules.rst
+++ b/docs/ansible/roles/debops.ferm/rules.rst
@@ -324,10 +324,12 @@ type-specific YAML keys are supported:
   or ``False``. Defaults to ``False``.
 
 ``public_ip``
-  IPv4 address on the public network which accepts connections, required.
+  IPv4 address on the public network which accepts connections, required. Only
+  1 IP address should be used at a time.
 
 ``private_ip``
-  IPv4 address of the host on the internal network, required.
+  IPv4 address of the host on the internal network, required. Only 1 IP address
+  should be used at a time.
 
 ``protocol(s)``
   Optional. List of protocols to forward. Defaults to ``tcp``.


### PR DESCRIPTION
The 'ferm' language does not support iterating over lists or converting
lists to strings, this caused an issue where a list of IP addresses is
concatenated with a string representing a port when the 'dmz' rule type
is used. The result was an error:

    variable 'PRIVATE_IP' must be a string, but it is an array

This patch changes the template for the 'dmz' rule so that the IPv4 and
IPv6 addresses are separated on Ansible level instead of directly in
ferm. Next, only 1 public and private IP address is selected for the
'dmz' rule so that the string concatenation with a port can be performed
correctly. This should solve the issue with the 'dmz' rule type.

Fixes https://github.com/debops/ansible-ferm/issues/55
Fixes https://github.com/debops/ansible-ifupdown/issues/73