### PR TITLE
[debops.php] Added support for newer PHP versions

### DIFF
--- a/ansible/roles/debops.php/defaults/main.yml
+++ b/ansible/roles/debops.php/defaults/main.yml
@@ -17,7 +17,7 @@
 #
 # List of APT package names which are scanned to check available PHP versions.
 # The first found package wins.
-php__version_preference: [ 'php7.0', 'php5' ]
+php__version_preference: [ 'php7.2', 'php7.1', 'php7.0', 'php5' ]
 
                                                                    # ]]]
 # .. envvar:: php__sury [[[


### PR DESCRIPTION
Added newer PHP versions `php__version_preference` since `php7.0` isn't actively supported anymore and isn't available on newer Linux distributions like bionic.

Side note: It would be useful to maybe throw an error if `php__version` and `php__long_version` are empty. You get a weird python error otherwise.