### PR TITLE
[debops.nullmailer] Accept integers in port.

### DIFF
--- a/ansible/roles/debops.nullmailer/templates/lookup/nullmailer__remotes.j2
+++ b/ansible/roles/debops.nullmailer/templates/lookup/nullmailer__remotes.j2
@@ -29,7 +29,7 @@
 {%         set _ = nullmailer__tpl_entry.append('--x509crlfile=' + entry.x509crlfile) %}
 {%       endif %}
 {%       if entry.port|d() %}
-{%         set _ = nullmailer__tpl_entry.append('--port=' + entry.port) %}
+{%         set _ = nullmailer__tpl_entry.append('--port=' + entry.port|string) %}
 {%       endif %}
 {%       if ((entry.auth|d()|bool) or (entry.auth_login|d()|bool)) %}
 {%         set _ = nullmailer__tpl_entry.append('--auth-login') %}


### PR DESCRIPTION
Cast the port in nullmailer__remotes to string, so the user can set
that variable as integer (as he may be tempted to do).