### PR TITLE
fix `php__register_version`

### DIFF
--- a/ansible/roles/debops.php/env/tasks/main.yml
+++ b/ansible/roles/debops.php/env/tasks/main.yml
@@ -37,7 +37,7 @@
 - name: Detect PHP version from available packages
   environment:
     LC_ALL: 'C'
-  shell: apt-cache show {{ php__version_preference | join(' ') }} | grep -E '^Package:\s+php' | head -n 1 | awk '{print $2}' | sed -e 's/^php//'
+  shell: apt-cache show {{ php__version_preference | join(' ') }} | grep -E '^Package:\s+php[0-9.]+$' | head -n 1 | awk '{print $2}' | sed -e 's/^php//'
   register: php__register_version
   check_mode: False
   changed_when: False


### PR DESCRIPTION
environment:

- Debian 9.3 (stretch)
- `php__sury: True`
- `php__version_preference: ['7.2', '7.1', '7.0']`

output of `apt-cache show {{ php__version_preference | join(' ') }} | grep -E '^Package:\s+php' | head` right before the _Detect PHP version from available packages_ task:

```
Package: php7.2-cli
Package: php7.2-common
Package: php7.2-json
Package: php7.2-opcache
Package: php7.2
Package: php7.2-dev
Package: php7.2-bcmath
Package: php7.2-bz2
Package: php7.2-cgi
Package: php7.2-curl
```

We want `7.2` to be the result (`php__register_version.stdout`), but currently I get `7.2-cli`.