### PR TITLE
Added option to specify interface in ferm dmz rules

### DIFF
--- a/ansible/roles/debops.ferm/templates/etc/ferm/rules.d/rule.conf.j2
+++ b/ansible/roles/debops.ferm/templates/etc/ferm/rules.d/rule.conf.j2
@@ -369,16 +369,23 @@
 {%     if ferm__tpl_config['domain_args'] %}}{% endif %}
 {%   elif ferm__tpl_config['type'] == 'dmz' %}
 {%     if ferm__tpl_config['domain_args'] %}{{ ferm__tpl_config['domain_args'] | join(" ") }} {% endif %}{
+{%       if ferm__tpl_config['interface']|d() %}
+    @def $PUBLIC_IF  = ({{ ferm__tpl_config['interface']  | unique | join(' ') }});
+{%       endif %}
+{%       if ferm__tpl_config['public_ip']|d() %}
     @def $PUBLIC_IP  = ( @ipfilter( ({{ ferm__tpl_config['public_ip']  | unique | join(' ') }}) ) );
+{%       endif %}
     @def $PRIVATE_IP = ( @ipfilter( ({{ ferm__tpl_config['private_ip'] | unique | join(' ') }}) ) );
 
+{%       if ferm__tpl_config['public_ip']|d() %}
     @def $PUBLIC_IPV4 = "{{ ferm__tpl_config['public_ip'] | unique | ipv4 | first | d('') }}";
     @def $PUBLIC_IPV6 = "{{ ferm__tpl_config['public_ip'] | unique | ipv6 | first | d('') }}";
 
+{%       endif %}
     @def $PRIVATE_IPV4 = "{{ ferm__tpl_config['private_ip'] | unique | ipv4 | first | d('') }}";
     @def $PRIVATE_IPV6 = "{{ ferm__tpl_config['private_ip'] | unique | ipv6 | first | d('') }}";
 
-    @if @ne($PUBLIC_IP,"") @if @ne($PRIVATE_IP,"") {
+    {% if ferm__tpl_config['interface']|d() %}@if @ne($PUBLIC_IF,""){% endif %}{% if ferm__tpl_config['public_ip']|d() %} @if @ne($PUBLIC_IP,""){% endif %} @if @ne($PRIVATE_IP,"") {
         table filter chain FORWARD {
 {%     if ferm__tpl_config['dmz_ports']|d() %}
             protocol ({{ ferm__tpl_config['protocol']|d([ 'tcp' ]) | join(" ") }}) {
@@ -405,15 +412,15 @@
                     dport ({{ ferm__tpl_config['dmz_ports'] | join(" ") }}) {
 {%       endif %}
 {%       if ferm__tpl_config['dport']|d() %}
-                        @if @eq($DOMAIN, ip)  @if @ne($PRIVATE_IPV4,"") destination $PUBLIC_IPV4 DNAT to @cat($PRIVATE_IPV4, ":{{ ferm__tpl_config['dport'][0] }}");
-                        @if @eq($DOMAIN, ip6) @if @ne($PRIVATE_IPV6,"") destination $PUBLIC_IPV6 DNAT to @cat($PRIVATE_IPV6, ":{{ ferm__tpl_config['dport'][0] }}");
+                        @if @eq($DOMAIN, ip)  @if @ne($PRIVATE_IPV4,"") {% if ferm__tpl_config['interface']|d() %}interface $PUBLIC_IF {% endif %}{% if ferm__tpl_config['public_ip']|d() %}destination $PUBLIC_IPV4 {% endif %}DNAT to @cat($PRIVATE_IPV4, ":{{ ferm__tpl_config['dport'][0] }}");
+                        @if @eq($DOMAIN, ip6) @if @ne($PRIVATE_IPV6,"") {% if ferm__tpl_config['interface']|d() %}interface $PUBLIC_IF {% endif %}{% if ferm__tpl_config['public_ip']|d() %}destination $PUBLIC_IPV6 {% endif %}DNAT to @cat($PRIVATE_IPV6, ":{{ ferm__tpl_config['dport'][0] }}");
 {%       else %}
-                        destination $PUBLIC_IP DNAT to $PRIVATE_IP;
+                        {% if ferm__tpl_config['interface']|d() %}interface $PUBLIC_IF {% endif %}{% if ferm__tpl_config['public_ip']|d() %}destination $PUBLIC_IP {% endif %}DNAT to $PRIVATE_IP;
 {%       endif %}
                     }
                 }
 {%     else %}
-                destination $PUBLIC_IP DNAT to $PRIVATE_IP;
+                {% if ferm__tpl_config['interface']|d() %}interface $PUBLIC_IF {% endif %}{% if ferm__tpl_config['public_ip']|d() %}destination $PUBLIC_IP {% endif %}DNAT to $PRIVATE_IP;
 {%     endif %}
             }
 {%     if ferm__tpl_config['snat_ip']|d() %}

--- a/docs/ansible/roles/debops.ferm/rules.rst
+++ b/docs/ansible/roles/debops.ferm/rules.rst
@@ -323,9 +323,14 @@ type-specific YAML keys are supported:
   Optional. Use `iptables multiport`_ extension. Possible values: ``True``
   or ``False``. Defaults to ``False``.
 
+``interface``
+  Optional. List of public network interfaces which accept connections.
+  At least one of ``interface`` or ``public_ip`` is required.
+
 ``public_ip``
-  IPv4 address on the public network which accepts connections, required. Only
-  1 IP address should be used at a time.
+  Optional. IPv4 address on the public network which accepts connections.
+  At least one of ``interface`` or ``public_ip`` is required. Only 1 IP address
+  should be used at a time.
 
 ``private_ip``
   IPv4 address of the host on the internal network, required. Only 1 IP address


### PR DESCRIPTION
 Also made public_ip optional.
This change allows to specify only the interface used for the dmz DNAT rules which is necessary when the public interface has a dynamic address e.g. for a home router.