### PR TITLE
[minor] remove `*__nginx__dependent_servers.*.default`

### DIFF
--- a/ansible/roles/debops.owncloud/defaults/main.yml
+++ b/ansible/roles/debops.owncloud/defaults/main.yml
@@ -1882,7 +1882,6 @@ owncloud__nginx__dependent_servers:
   ## https://docs.nextcloud.com/server/13/admin_manual/installation/nginx.html
   - type: 'default'
     enabled: True
-    default: False
     by_role: 'debops.owncloud'
     filename: 'debops.owncloud'
     name: '{{ owncloud__fqdn }}'

--- a/ansible/roles/debops.rails_deploy/defaults/main.yml
+++ b/ansible/roles/debops.rails_deploy/defaults/main.yml
@@ -442,7 +442,6 @@ rails_deploy_nginx_upstream:
 # Configure the sites-available.
 rails_deploy_nginx_server:
   enabled: '{{ rails_deploy_nginx_server_enabled }}'
-  default: False
   name: '{{ rails_deploy_nginx_domains }}'
   root: '{{ rails_deploy_src }}/public'
 

--- a/ansible/roles/debops.roundcube/defaults/main.yml
+++ b/ansible/roles/debops.roundcube/defaults/main.yml
@@ -366,7 +366,6 @@ roundcube__nginx__dependent_servers:
     filename: 'debops.roundcube'
     by_role: 'debops.roundcube'
     type: 'php'
-    default: False
     root: '{{ roundcube__git_checkout }}'
     access_policy: '{{ roundcube__nginx_access_policy }}'
     index: 'index.php'


### PR DESCRIPTION
I'm using `debops.owncloud` as a template to create a new role based on it. In the `owncloud__nginx__dependent_servers` default variable, I wondered what the `default` variable is for.

* It's not documented (https://docs.debops.org/en/latest/ansible/roles/debops.nginx/defaults-detailed.html#nginx-ref-servers)
* it seems unused. I've checked these files:
  * `ansible/roles/debops.nginx/tasks/nginx_servers.yml`
  * `ansible/roles/debops.nginx/templates/etc/nginx/sites-available/*.conf.j2`

If I'm wrong, simply close this PR.