### PR TITLE
[debops.nginx] allow `/.well-known/`

### DIFF
--- a/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/default.conf.j2
+++ b/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/default.conf.j2
@@ -340,8 +340,10 @@
 
 {%     endif %}
 {%     if item.deny_hidden|d(True) | bool %}
-        # Disallow access to hidden files and directories
-        location ~ /\. {
+        # Disallow access to hidden files and directories, except `/.well-known/`
+        # https://www.mnot.net/blog/2010/04/07/well-known
+        # https://tools.ietf.org/html/rfc5785
+        location ~ /\.(?!well-known/) {
                 return 404;
         }
 


### PR DESCRIPTION
see RFC 5785: https://tools.ietf.org/html/rfc5785
fixes #428