### PR TITLE
fix missing unicode in python 3

### DIFF
--- a/ansible/roles/debops.ansible_plugins/filter_plugins/debops_filter_plugins.py
+++ b/ansible/roles/debops.ansible_plugins/filter_plugins/debops_filter_plugins.py
@@ -24,6 +24,12 @@ from __future__ import (absolute_import, division, print_function)
 from past.builtins import basestring
 from operator import itemgetter
 
+try:
+    unicode = unicode
+except NameError:
+    # py3
+    unicode = str
+
 __metaclass__ = type
 
 


### PR DESCRIPTION
Fixes a issue for unicode class in python 3.

Found it elsewhere in the code of debops and adapted for this file.