### PR TITLE
[debops.users] Empty admin accounts set to list

### DIFF
--- a/ansible/roles/debops.users/templates/lookup/users__admin_accounts.j2
+++ b/ansible/roles/debops.users/templates/lookup/users__admin_accounts.j2
@@ -1,5 +1,7 @@
+{% set output = [] %}
 {% if ansible_local|d() and ansible_local.core|d() and ansible_local.core.admin_users|d() %}
 {%   for account in ansible_local.core.admin_users %}
-- name: '{{ account }}'
+{%     set _ = output.append({'name': account}) %}
 {%   endfor %}
 {% endif %}
+{{ output | to_yaml }}


### PR DESCRIPTION
In case that the template lookup for admin accounts results in no admin
accounts detected, ensure that the result is a list instead of a string
to not break the 'flattened' lookup plugin.