### PR TITLE
Add nginx http extra options.

### DIFF
--- a/ansible/roles/debops.nginx/defaults/main.yml
+++ b/ansible/roles/debops.nginx/defaults/main.yml
@@ -277,6 +277,13 @@ nginx_http_options: |
     text/x-cross-domain-policy;
 
 # ]]]
+# .. envvar:: nginx_http_extra_options [[[
+#
+# A string or YAML text block with additional nginx options placed in the
+# :file:`/etc/nginx/nginx.conf` inside of the "http" block.
+nginx_http_extra_options: ''
+
+                                                                   # ]]]
 # .. envvar:: nginx_extra_options [[[
 #
 # A string or YAML text block with additional nginx options placed in the

--- a/ansible/roles/debops.nginx/templates/etc/nginx/nginx.conf.j2
+++ b/ansible/roles/debops.nginx/templates/etc/nginx/nginx.conf.j2
@@ -43,6 +43,10 @@ http {
 {{ nginx_http_options | indent(8, true) | regex_replace("(?m)^\s*$", "") }}
 
 {% endif %}
+{% if nginx_http_extra_options|d() and nginx_http_extra_options %}
+{{ nginx_http_extra_options | indent(8, true) | regex_replace("(?m)^\s*$", "") }}
+
+{% endif %}
 {% block nginx_tpl_block_log %}
 {%      set nginx_tpl_access_log_format = '' %}
 {%      if nginx_access_log_format is defined %}


### PR DESCRIPTION
Add nginx_http_extra_options variable to nginx.conf template in order to allow more options in HTTP section without changing the default nginx_http_options config.

Usage:
``` yaml
    nginx_http_extra_options: |
      proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=mattermost_cache:10m max_size=3g inactive=120m use_temp_path=off;
```

See nginx docs (http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_path).