### PR TITLE
[fix] gitlab: add 'git' to gitlab__base_packages; fix #438

### DIFF
--- a/ansible/roles/debops.gitlab/defaults/main.yml
+++ b/ansible/roles/debops.gitlab/defaults/main.yml
@@ -121,10 +121,11 @@ gitlab__distribution_release: '{{ ansible_local.core.distribution_release
 # .. envvar:: gitlab__base_packages [[[
 #
 # List of base APT packages required by GitLab.
-gitlab__base_packages: [ 'build-essential', 'zlib1g-dev', 'libyaml-dev',
+gitlab__base_packages: [ 'build-essential', 'cmake', 'git', 'pkg-config', 'python-docutils',
+                         'unzip',
                          'libgdbm-dev', 'libreadline-dev', 'libncurses5-dev', 'libffi-dev',
                          'libxml2-dev', 'libxslt1-dev', 'libcurl4-openssl-dev', 'libkrb5-dev',
-                         'libicu-dev', 'python-docutils', 'cmake', 'pkg-config', 'unzip' ]
+                         'libicu-dev', 'zlib1g-dev', 'libyaml-dev' ]
 
                                                                    # ]]]
 # .. envvar:: gitlab__release_packages [[[


### PR DESCRIPTION
and group `*-dev` packages in the list