### PR TITLE
[debops.kmod] Fix usage in Ansible --check mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,12 @@ Added
   directories using the ``item.home_acl`` parameter. This can be used for more
   elaborate access restrictions.
 
+Fixed
+~~~~~
+
+- [debops.kmod] The role should now work correctly in Ansible ``--check`` mode
+  before the Ansible local fact script is installed.
+
 
 `debops v0.8.0`_ - 2018-08-06
 -----------------------------

--- a/ansible/roles/debops.kmod/tasks/main.yml
+++ b/ansible/roles/debops.kmod/tasks/main.yml
@@ -65,7 +65,8 @@
   with_items: '{{ kmod__combined_load | parse_kv_items }}'
   register: kmod__register_load
   when: kmod__enabled|bool and item.name|d() and item.state|d('present') not in [ 'config', 'absent', 'ignore' ] and
-        item.modules is undefined and item.name not in ansible_local.kmod.modules
+        item.modules is undefined and ansible_local|d() and ansible_local.kmod|d() and ansible_local.kmod.modules|d() and
+        item.name not in ansible_local.kmod.modules
 
 - name: Update Ansible facts if modules were loaded
   action: setup

--- a/ansible/roles/debops.kmod/tasks/modprobe.yml
+++ b/ansible/roles/debops.kmod/tasks/modprobe.yml
@@ -24,6 +24,7 @@
   when: ((kmod__register_module_config_delete is changed or
           kmod__register_module_config_create is changed) and
          module.blacklist is not defined and
+         ansible_local|d() and ansible_local.kmod|d() and ansible_local.kmod.modules|d() and
          module.name in ansible_local.kmod.modules and
          module.state|d('present') not in [ 'config' ])
 


### PR DESCRIPTION
The role would result in an error when it was run on a host for the
first time in the Ansible '--check' mode due to missing local facts. The
tasks that load/unload the kernel modules will now only be activated
when the 'ansible_local.kmod' local facts are present.