### PR TITLE
[debops.sysctl] Support nested dependent variables

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,10 @@ Fixed
 - [debops.kmod] The role should now work correctly in Ansible ``--check`` mode
   before the Ansible local fact script is installed.
 
+- [debops.sysctl] The role should correctly handle nested lists in role
+  dependent variables, which are now flattened before being passed to the
+  configuration filter.
+
 
 `debops v0.8.0`_ - 2018-08-06
 -----------------------------

--- a/ansible/roles/debops.sysctl/defaults/main.yml
+++ b/ansible/roles/debops.sysctl/defaults/main.yml
@@ -263,7 +263,7 @@ sysctl__dependent_parameters: []
 # Sysctl configuration file path where all kernel parameters will be configured
 # by ``debops.sysctl``.
 sysctl__combined_parameters: '{{ sysctl__default_parameters
-                                 + sysctl__dependent_parameters
+                                 + lookup("flattened", sysctl__dependent_parameters, wantlist=True)
                                  + sysctl__parameters
                                  + sysctl__group_parameters
                                  + sysctl__host_parameters }}'


### PR DESCRIPTION
The role should now correctly handle nested lists specified as dependent
variables. This allows usage of 'sysctl' configuration from multiple
roles in the same playbook.