### PR TITLE
[debops.redis_server] Disable OOM killer for Redis

### DIFF
--- a/ansible/roles/debops.redis_server/templates/etc/systemd/system/redis-server@.service.j2
+++ b/ansible/roles/debops.redis_server/templates/etc/systemd/system/redis-server@.service.j2
@@ -22,6 +22,9 @@ Group=redis
 RuntimeDirectory=redis-%i
 RuntimeDirectoryMode=2755
 
+# Disable OOM killer for Redis Server process
+OOMScoreAdjust=-1000
+
 UMask=007
 PrivateTmp=yes
 LimitNOFILE=65535


### PR DESCRIPTION
Redis Server usually uses large amount of memory, and in case of the
high memory pressure system OOM killer is more likely to kill the Redis
process because of it. This patch disables OOM killer for Redis Server
processes to avoid this issue.