### PR TITLE
[debops.owncloud] Update Redis support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -61,6 +61,9 @@ Changed
   Check the :ref:`upgrade_notes` for issues with upgrading Redis Server support
   on existing GitLab hosts.
 
+- [debops.owncloud] The role will now use Ansible facts managed by the
+  :ref:`debops.redis_server` role to configure Redis support.
+
 Fixed
 ~~~~~
 

--- a/ansible/roles/debops.owncloud/defaults/main.yml
+++ b/ansible/roles/debops.owncloud/defaults/main.yml
@@ -569,35 +569,35 @@ owncloud__apcu_enabled: True
 # requirement is not meet for Ubuntu trusty (neither in the release repos nor
 # in backports) thus Redis will not be enabled automatically by the role.
 # Refer to the `official ownCloud documentation <https://doc.owncloud.org/server/9.0/admin_manual/configuration_server/caching_configuration.html#id4>`__ for details.
-owncloud__redis_enabled: '{{ ansible_local|d() and ansible_local.redis|d() and
-                             ansible_local.redis.enabled|d() | bool and
+owncloud__redis_enabled: '{{ ansible_local|d() and ansible_local.redis_server|d() and
+                             ansible_local.redis_server.installed|d() | bool and
                              (not (ansible_distribution == "Ubuntu" and ansible_distribution_release == "trusty")) }}'
 
 
 # .. envvar:: owncloud__redis_host
 #
 # Redis server to use when :envvar:`owncloud__redis_enabled` is ``True``.
-owncloud__redis_host: '{{ ansible_local.redis.host
-                          if (ansible_local|d() and ansible_local.redis|d() and
-                              ansible_local.redis.host|d())
+owncloud__redis_host: '{{ ansible_local.redis_server.host
+                          if (ansible_local|d() and ansible_local.redis_server|d() and
+                              ansible_local.redis_server.host|d())
                           else "localhost" }}'
 
 
 # .. envvar:: owncloud__redis_port
 #
 # Network port on which the Redis server is listening on.
-owncloud__redis_port: '{{ ansible_local.redis.port
-                          if (ansible_local|d() and ansible_local.redis|d() and
-                              ansible_local.redis.port|d())
+owncloud__redis_port: '{{ ansible_local.redis_server.port
+                          if (ansible_local|d() and ansible_local.redis_server|d() and
+                              ansible_local.redis_server.port|d())
                           else "6379" }}'
 
 
 # .. envvar:: owncloud__redis_password
 #
 # Redis server authentication password.
-owncloud__redis_password: '{{ ansible_local.redis.password
-                              if (ansible_local|d() and ansible_local.redis|d() and
-                                  ansible_local.redis.password|d())
+owncloud__redis_password: '{{ ansible_local.redis_server.password
+                              if (ansible_local|d() and ansible_local.redis_server|d() and
+                                  ansible_local.redis_server.password|d())
                               else omit }}'
 
 # .. Database configuration [[[1

--- a/docs/ansible/roles/debops.owncloud/getting-started.rst
+++ b/docs/ansible/roles/debops.owncloud/getting-started.rst
@@ -43,18 +43,18 @@ on the same host as ownCloud or choose a different host:
 
 .. code-block:: none
 
-    [debops_service_redis]
+    [debops_service_redis_server]
     hostname
 
 This role will use a Redis server automatically when it is managed by
-:ref:`debops.redis`.
+:ref:`debops.redis_server` Ansible role.
 
 In case you chose a different host, you will need to specify which of your
 Redis servers the ownCloud instance should use by setting the Redis
 server host as :envvar:`owncloud__redis_host` and setting
 :envvar:`owncloud__redis_enabled` to ``True``.
 Additionally, you will need to set the :envvar:`owncloud__redis_password`.
-Refer to debops.redis_ for details.
+Refer to :ref:`debops.redis_server` documentation for details.
 
 .. _owncloud__ref_choosing_a_webserver:
 


### PR DESCRIPTION
The 'debops.owncloud' will now use Ansible facts managed by the
'debops.redis_server' to configure Redis support.