### PR TITLE
[debops.lxc] Use user's own ~/.ssh/authorized_keys

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -64,6 +64,12 @@ Changed
 - [debops.owncloud] The role will now use Ansible facts managed by the
   :ref:`debops.redis_server` role to configure Redis support.
 
+- [debops.lxc] The :command:`lxc-prepare-ssh` script will now install SSH
+  public keys from the user account that is running the script via
+  :command:`sudo` instead of the system's ``root`` account, which is usually
+  what you want to do if other people manage their own LXC containers on
+  a host.
+
 Fixed
 ~~~~~
 

--- a/ansible/roles/debops.lxc/files/usr/local/bin/lxc-prepare-ssh
+++ b/ansible/roles/debops.lxc/files/usr/local/bin/lxc-prepare-ssh
@@ -8,7 +8,14 @@ set -o nounset -o pipefail -o errexit
 
 readonly SCRIPT="$(basename "${0}")"
 readonly CONTAINER="${1:-}"
-readonly AUTHORIZED_KEYS="${2:-"${HOME}/.ssh/authorized_keys"}"
+
+if [ -n "${SUDO_USER}" ] ; then
+    readonly USER_HOME="$(getent passwd "${SUDO_USER}" | cut -d: -f6)"
+else
+    readonly USER_HOME="${HOME}"
+fi
+
+readonly AUTHORIZED_KEYS="${2:-"${USER_HOME}/.ssh/authorized_keys"}"
 
 container_exists () {
     local container

--- a/docs/ansible/roles/debops.lxc/getting-started.rst
+++ b/docs/ansible/roles/debops.lxc/getting-started.rst
@@ -96,11 +96,9 @@ The :command:`lxc-prepare-ssh` is a custom script installed by the
 :ref:`debops.lxc` role. It will start the specified container, make sure that
 OpenSSH service is installed inside, and add the current user's
 :file:`~/.ssh/authorized_keys` contents on the ``root`` account inside of the
-container.
-
-Since these commands are executed using ``root`` account on the LXC host, that
-account should have a set of SSH authorized keys which are the same as the
-Ansible administrator. Alternatively, you can specify a custom file with
+container. The script will check if the ``${SUDO_USER}`` variable is defined in
+the environment and use that user's :file:`~/.ssh/authorized_keys` file as
+source of SSH public keys. Alternatively, you can specify a custom file with
 authorized SSH keys to add in the container's
 :file:`/root/.ssh/authorized_keys` file.
 


### PR DESCRIPTION
The 'lxc-prepare-ssh' script is now aware of the '${SUDO_USER}' variable
and will use the user's own ~/.ssh/authorized_keys instead of the
/root/.ssh/authorized_keys of the LXC host system.