### PR TITLE
[debops.rsyslog] Add more weight entries

### DIFF
--- a/ansible/roles/debops.rsyslog/defaults/main.yml
+++ b/ansible/roles/debops.rsyslog/defaults/main.yml
@@ -335,16 +335,21 @@ rsyslog__host_forward: []
 # See :ref:`rsyslog__rules` for more details.
 rsyslog__weight_map:
   'global':    '05'
+  'globals':   '05'
   'module':    '10'
   'modules':   '10'
   'template':  '20'
   'templates': '20'
   'output':    '30'
+  'outputs':   '30'
   'service':   '30'
+  'services':  '30'
   'rule':      '50'
   'rules':     '50'
   'ruleset':   '50'
+  'rulesets':  '50'
   'input':     '90'
+  'inputs':    '90'
 
                                                                    # ]]]
 # .. envvar:: rsyslog__rules [[[


### PR DESCRIPTION
This patch makes names of "weights" used in rsyslog configuration
consistent (singular, plural).

Based on: https://github.com/linux-system-roles/logging/pull/2