### PR TITLE
[debops.avahi] Add avahi__enabled configuration option

### DIFF
--- a/ansible/roles/debops.avahi/defaults/main.yml
+++ b/ansible/roles/debops.avahi/defaults/main.yml
@@ -13,6 +13,12 @@
 # APT packages [[[
 # ----------------
 
+# .. envvar:: avahi__enabled [[[
+#
+# Should the Avahi service be enabled?
+avahi__enabled: True
+
+                                                                   # ]]]
 # .. envvar:: avahi__base_packages [[[
 #
 # List of APT packages to install for Avahi support.
@@ -414,6 +420,7 @@ avahi__ferm__dependent_rules:
     saddr: '{{ avahi__allow }}'
     protocol: 'udp'
     accept_any: True
+    rule_state: '{{ "present" if (avahi__enabled|bool) else "absent" }}'
                                                                    # ]]]
                                                                    # ]]]
                                                                    # ]]]

--- a/ansible/roles/debops.avahi/handlers/main.yml
+++ b/ansible/roles/debops.avahi/handlers/main.yml
@@ -4,3 +4,4 @@
   service:
     name: 'avahi-daemon'
     state: 'restarted'
+  when: avahi__enabled|bool

--- a/ansible/roles/debops.avahi/tasks/main.yml
+++ b/ansible/roles/debops.avahi/tasks/main.yml
@@ -84,6 +84,12 @@
          (item.value.services|d() or item.value.type|d()))
   tags: [ 'role::avahi:alias', 'role::avahi:services' ]
 
+- name: Ensure that the avahi-daemon service in in the desired state
+  service:
+    name: 'avahi-daemon'
+    enabled: '{{ avahi__enabled|bool }}'
+    state: '{{ "started" if (avahi__enabled|bool) else "stopped" }}'
+
 - name: Make sure that Ansible local facts directory exists
   file:
     path: '/etc/ansible/facts.d'

--- a/ansible/roles/debops.avahi/templates/etc/ansible/facts.d/avahi.fact.j2
+++ b/ansible/roles/debops.avahi/templates/etc/ansible/facts.d/avahi.fact.j2
@@ -1,5 +1,6 @@
 {
 "installed": true,
-"ipv4": {{ avahi__use_ipv4 | bool | lower }},
-"ipv6": {{ avahi__use_ipv6 | bool | lower }}
+"enabled": "{{ avahi__enabled | bool | lower }}",
+"ipv4": {{ avahi__use_ipv4    | bool | lower }},
+"ipv6": {{ avahi__use_ipv6    | bool | lower }}
 }


### PR DESCRIPTION
Some packages like Mandos hard depend on Avahi but can be configured to work without it. Thus disabling the service is the only option if I don’t want to have Avahi running.