### PR TITLE
Check for docker in ansible_virtualization_type

### DIFF
--- a/ansible/roles/debops.sysctl/defaults/main.yml
+++ b/ansible/roles/debops.sysctl/defaults/main.yml
@@ -21,7 +21,7 @@
 # See :ref:`sysctl__ref_writable` for more details.
 sysctl__writable: '{{ [ "net" ]
                       if (ansible_virtualization_role == "guest" and
-                          ansible_virtualization_type in [ "lxc", "openvz" ])
+                          ansible_virtualization_type in [ "docker", "lxc", "openvz" ])
                       else (ansible_local.sysctl.writable
                             if (ansible_local|d() and ansible_local.sysctl|d() and
                                 ansible_local.sysctl.writable|d())


### PR DESCRIPTION
In `sysctl__writable` you are checking against `lxc` and `openvz` as potential container runtimes. Ansible is able to identify `docker` as well. You are able to write `net` parameters inside of a Docker container.
