### PR TITLE
[debops.resources] Add 'debops.secret' dependency

### DIFF
--- a/ansible/roles/debops.resources/meta/main.yml
+++ b/ansible/roles/debops.resources/meta/main.yml
@@ -2,6 +2,8 @@
 
 dependencies:
 
+  - role: debops.secret
+
   - role: debops.ansible_plugins
 
 galaxy_info:


### PR DESCRIPTION
This change allows usage of the 'lookup("password")' with the
'debops.secret' role infrastructure in the Ansible inventory. Various
resources managed by the role can contain passwords or other confidental
data stored in the 'secret/' directory.