### PR TITLE
[debops.rsyslog] Ensure that the rsyslog__user can access the ssl certs

### DIFF
--- a/ansible/roles/debops.rsyslog/defaults/main.yml
+++ b/ansible/roles/debops.rsyslog/defaults/main.yml
@@ -81,6 +81,14 @@ rsyslog__user: '{{ "syslog" if rsyslog__unprivileged|bool else "root" }}'
 rsyslog__group: '{{ "syslog" if rsyslog__unprivileged|bool else "root" }}'
 
                                                                    # ]]]
+# .. envvar:: rsyslog__append_groups [[[
+#
+# List of additional UNIX groups to add the rsyslog user into. The
+# ``ssl-cert`` UNIX group is used for the X.509 private key access.
+rsyslog__append_groups: '{{ ["ssl-cert"] if (rsyslog__unprivileged|bool
+				and rsyslog__pki|bool) else [] }}'
+
+                                                                   # ]]]
 # .. envvar:: rsyslog__home [[[
 #
 # The home directory of the :envvar:`rsyslog__user` user, dependent on the OS

--- a/ansible/roles/debops.rsyslog/tasks/main.yml
+++ b/ansible/roles/debops.rsyslog/tasks/main.yml
@@ -22,6 +22,8 @@
   user:
     name: '{{ rsyslog__user }}'
     group: '{{ rsyslog__group }}'
+    groups: '{{ rsyslog__append_groups | join(",") | default(omit) }}'
+    append: True
     home: '{{ rsyslog__home }}'
     shell: '/bin/false'
     state: 'present'


### PR DESCRIPTION
I hit an issue today with the following setup

```
rsyslog__capabilities: [ 'tls' ]
rsyslog__forward: [ '*.* @@loghost1.{{ ansible_domain }}:6514' ]
```

It turns out that rsyslog refuses to start as it can not access the certificates.

