### PR TITLE
[debops.gitlab] Adding support for Ubuntu 18.04 Bionic

### DIFF
--- a/ansible/roles/debops.gitlab/defaults/main.yml
+++ b/ansible/roles/debops.gitlab/defaults/main.yml
@@ -151,6 +151,7 @@ gitlab__release_packages:
   precise: [ 'libssl-dev' ]
   trusty:  [ 'libssl-dev' ]
   xenial:  [ 'libssl-dev', 'libre2-dev' ]
+  bionic:  [ 'libssl-dev', 'libre2-dev' ]
 
                                                                    # ]]]
 # .. envvar:: gitlab__database_packages [[[
@@ -167,6 +168,8 @@ gitlab__database_packages:
   trusty:
     postgresql: [ 'libpq-dev', 'ruby-pg' ]
   xenial:
+    postgresql: [ 'libpq-dev', 'ruby-pg' ]
+  bionic:
     postgresql: [ 'libpq-dev', 'ruby-pg' ]
                                                                    # ]]]
                                                                    # ]]]


### PR DESCRIPTION
Currently both `gitlab__release_packages` and `gitlab__database_packages` have no **bionic** specific packages defined, which cause the following:

```
TASK [debops.gitlab : Install required packages]
********************************
fatal: [hostname]: FAILED! => {"msg": "'dict object' has no attribute u'bionic'"}
```