### PR TITLE
[debops.librenms] Adding the ability to modify the config file mode

### DIFF
--- a/ansible/roles/debops.librenms/defaults/main.yml
+++ b/ansible/roles/debops.librenms/defaults/main.yml
@@ -156,6 +156,14 @@ librenms__log_dir: '{{ (ansible_local.root.log
                             ansible_local.root.log|d())
                         else "/var/log") + "/librenms" }}'
                                                                    # ]]]
+
+# .. envvar:: librenms__config_mode [[[
+#
+# LibreNMS config mode. This allows to override the default config mode
+# so that the other system users (i.e. syslog) could execute scripts
+# such as syslog.php.
+librenms__config_mode: '0600'
+                                                                   # ]]]
                                                                    # ]]]
 # LibreNMS sources [[[
 # --------------------

--- a/ansible/roles/debops.librenms/tasks/main.yml
+++ b/ansible/roles/debops.librenms/tasks/main.yml
@@ -103,7 +103,7 @@
     dest: '{{ librenms__install_path + "/config.php" }}'
     owner: '{{ librenms__user }}'
     group: '{{ librenms__group }}'
-    mode: '0600'
+    mode: '{{ librenms__config_mode }}'
   tags: [ 'role::librenms:config', 'role::librenms:database' ]
 
 - name: Download composer.phar if requested


### PR DESCRIPTION
The use case is that I forward syslog to librenms and in **syslog.php** (executed as syslog user) currently fails if it can not read the config file.