### PR TITLE
[debops.dokuwiki] Add 'php-xml' as dependency

### DIFF
--- a/ansible/roles/debops.dokuwiki/defaults/main.yml
+++ b/ansible/roles/debops.dokuwiki/defaults/main.yml
@@ -285,7 +285,7 @@ dokuwiki__max_file_size: '30'
 # List of PHP packages to install using :ref:`debops.php` role.
 dokuwiki__php__dependent_packages:
 
-  - [ 'gmp', 'curl', 'mcrypt', 'ldap' ]
+  - [ 'gmp', 'curl', 'mcrypt', 'ldap', 'xml' ]
 
                                                                    # ]]]
 # .. envvar:: dokuwiki__php__dependent_pools [[[


### PR DESCRIPTION
The 'php-xml' APT package is required by DokuWiki due to the
utf8_encode() and utf8_decode() functions.

Fixes #487 