### PR TITLE
Clean up leftover 'ansible_local.root' local facts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -166,6 +166,10 @@ Removed
   Support for this mechanism has also been removed from related roles like
   :ref:`debops.libvirtd` and :ref:`debops.lxc`.
 
+- The ``ansible_local.root.flags`` and ``ansible_local.root.uuid`` local facts
+  have been removed. They are replaced by ``ansible_local.tags`` and
+  ``ansible_local.uuid`` local facts, respectively.
+
 
 `debops v0.8.0`_ - 2018-08-06
 -----------------------------

--- a/ansible/roles/debops.console/tasks/main.yml
+++ b/ansible/roles/debops.console/tasks/main.yml
@@ -49,7 +49,7 @@
   tags: [ 'role::console:mount' ]
   when: (
           ansible_local|d() and (
-            (ansible_local.root|d() and 'ignore-cap12s' in ansible_local.root.flags) or (
+            (ansible_local.tags|d() and 'ignore-cap12s' in ansible_local.tags) or (
               ansible_local.cap12s|d() and (
                 not ansible_local.cap12s.enabled|bool or
                 (ansible_local.cap12s.enabled|bool and 'cap_sys_admin' in ansible_local.cap12s.list)

--- a/ansible/roles/debops.core/templates/etc/ansible/facts.d/tags.fact.j2
+++ b/ansible/roles/debops.core/templates/etc/ansible/facts.d/tags.fact.j2
@@ -14,11 +14,6 @@ from sys import exit
 {%     for element in ansible_local.tags %}
 {%       set _ = core__tpl_tags.append(element) %}
 {%     endfor %}
-{%   elif ansible_local|d() and ansible_local.root|d() and
-          ansible_local.root.flags|d() %}
-{%     for element in ansible_local.root.flags %}
-{%       set _ = core__tpl_tags.append(element) %}
-{%     endfor %}
 {%   endif %}
 {% endif %}
 {% set core__tpl_tags_list = (core__tpl_tags + core__tags|d([])

--- a/ansible/roles/debops.iscsi/tasks/main.yml
+++ b/ansible/roles/debops.iscsi/tasks/main.yml
@@ -83,7 +83,7 @@
 
 - name: Manage LVM
   include: manage_lvm.yml
-  when: (ansible_local|d() and ((ansible_local.root and 'ignore-cap12s' in ansible_local.root.flags) or
+  when: (ansible_local|d() and ((ansible_local.tags|d() and 'ignore-cap12s' in ansible_local.tags) or
          (ansible_local.cap12s|d() and (not ansible_local.cap12s.enabled | bool or
           (ansible_local.cap12s.enabled | bool and 'cap_sys_admin' in ansible_local.cap12s.list)))))
 

--- a/ansible/roles/debops.lvm/tasks/main.yml
+++ b/ansible/roles/debops.lvm/tasks/main.yml
@@ -39,6 +39,6 @@
 
 - name: Manage LVM
   include: manage_lvm.yml
-  when: (ansible_local|d() and ((ansible_local.root|d() and 'ignore-cap12s' in ansible_local.root.flags) or
+  when: (ansible_local|d() and ((ansible_local.tags|d() and 'ignore-cap12s' in ansible_local.tags) or
          (ansible_local.cap12s|d() and (not ansible_local.cap12s.enabled | bool or
           (ansible_local.cap12s.enabled | bool and 'cap_sys_admin' in ansible_local.cap12s.list)))))


### PR DESCRIPTION
Some of the local facts in 'ansible_local.root' key have been removed,
and their replacements are available in their own separate local fact
keys.