### PR TITLE
Use secrets with the nullmailer role

### DIFF
--- a/ansible/playbooks/service/nullmailer.yml
+++ b/ansible/playbooks/service/nullmailer.yml
@@ -10,9 +10,6 @@
 
   roles:
 
-    - role: debops.etc_aliases/env
-      tags: [ 'role::etc_aliases', 'role::secret', 'role::nullmailer' ]
-
     - role: debops.nullmailer/env
       tags: [ 'role::nullmailer', 'role::ferm', 'role::tcpwrappers' ]
 
@@ -31,9 +28,6 @@
       tags: [ 'role::tcpwrappers', 'skip::tcpwrappers' ]
       tcpwrappers__dependent_allow:
         - '{{ nullmailer__tcpwrappers__dependent_allow }}'
-
-    - role: debops.etc_aliases
-      tags: [ 'role::etc_aliases', 'skip::etc_aliases' ]
 
     - role: debops.nullmailer
       tags: [ 'role::nullmailer', 'skip::nullmailer' ]

--- a/ansible/playbooks/service/nullmailer.yml
+++ b/ansible/playbooks/service/nullmailer.yml
@@ -10,8 +10,17 @@
 
   roles:
 
+    - role: debops.etc_aliases/env
+      tags: [ 'role::etc_aliases', 'role::secret', 'role::nullmailer' ]
+
     - role: debops.nullmailer/env
       tags: [ 'role::nullmailer', 'role::ferm', 'role::tcpwrappers' ]
+
+    - role: debops.secret
+      tags: [ 'role::secret', 'role::nullmailer' ]
+      secret__directories:
+        - '{{ etc_aliases__secret__directories }}'
+        - '{{ postfix__secret__directories }}'
 
     - role: debops.ferm
       tags: [ 'role::ferm', 'skip::ferm' ]
@@ -22,6 +31,9 @@
       tags: [ 'role::tcpwrappers', 'skip::tcpwrappers' ]
       tcpwrappers__dependent_allow:
         - '{{ nullmailer__tcpwrappers__dependent_allow }}'
+
+    - role: debops.etc_aliases
+      tags: [ 'role::etc_aliases', 'skip::etc_aliases' ]
 
     - role: debops.nullmailer
       tags: [ 'role::nullmailer', 'skip::nullmailer' ]

--- a/ansible/roles/debops.nullmailer/meta/main.yml
+++ b/ansible/roles/debops.nullmailer/meta/main.yml
@@ -1,6 +1,8 @@
 ---
 
-dependencies: []
+dependencies:
+
+  - role: debops.secret
 
 galaxy_info:
 


### PR DESCRIPTION
Just like the postfix role.

1. Use aliases to send notification to the correct email address/alias
2. Sometimes is necessary to use a SMTP transport server from which nullmailer needs credentials, thus use the secret role to store and retrieve this credentials