### PR TITLE
[debops.nullmailer] Add 'debops.secret' dependency

### DIFF
--- a/ansible/roles/debops.nullmailer/meta/main.yml
+++ b/ansible/roles/debops.nullmailer/meta/main.yml
@@ -1,6 +1,8 @@
 ---
 
-dependencies: []
+dependencies:
+
+  - role: debops.secret
 
 galaxy_info:
 


### PR DESCRIPTION
Some of the 'nullmailer' configuration options like 'remotes' can
contain passwords. Because of that, 'debops.secret' was added to the
role hard dependencies; with it, you can store confidential information
in the project 'secret/' directory and access it through the
'lookup("password")' Ansible lookup from the inventory.

Closes #494 