### PR TITLE
Revert "Allow everyone to access reprepro content"

### DIFF
--- a/ansible/roles/debops.reprepro/tasks/configure_reprepro.yml
+++ b/ansible/roles/debops.reprepro/tasks/configure_reprepro.yml
@@ -55,7 +55,6 @@
     owner: '{{ reprepro_user }}'
     group: '{{ reprepro_group }}'
     mode: '0755'
-    recurse: True
 
 - name: Manage reprepro configuration files
   template:


### PR DESCRIPTION
This reverts commit 41dfe5c5d6c5d7986f8476fc230b1a3ed47dfbb0.

The issue with blocked access to the repository was due to use of 0027
umask. The 'recurse' parameter in the task causes the role to not be
idempotent, eventual solution to usage of reprepro with 0027 umask will
have to be different.