### PR TITLE
Call the debops.users role before the debops.resources role

### DIFF
--- a/ansible/playbooks/common.yml
+++ b/ansible/playbooks/common.yml
@@ -110,6 +110,9 @@
     - role: debops.machine
       tags: [ 'role::machine', 'skip::machine' ]
 
+    - role: debops.users
+      tags: [ 'role::users', 'skip::users' ]
+
     - role: debops.resources
       tags: [ 'role::resources', 'skip::resources' ]
 
@@ -150,9 +153,6 @@
 
     - role: debops.unattended_upgrades
       tags: [ 'role::unattended_upgrades', 'skip::unattended_upgrades' ]
-
-    - role: debops.users
-      tags: [ 'role::users', 'skip::users' ]
 
     - role: debops.authorized_keys
       tags: [ 'role::authorized_keys', 'skip::authorized_keys' ]


### PR DESCRIPTION
otherwise the resources role may crash if a path/file is created with an owner, who does not exists yet, because the users role has not been executed. Placing the path owner (user) in the bootstrap configuration, if is not an sysadmin, is not always a good idea.