### PR TITLE
Support for iPXE on EFI systems

### DIFF
--- a/ansible/roles/debops.dhcpd/defaults/main.yml
+++ b/ansible/roles/debops.dhcpd/defaults/main.yml
@@ -162,6 +162,13 @@ dhcpd_ipxe_dhcp_space: True
 dhcpd_ipxe_chain_filename: 'undionly.kpxe'
 
                                                                    # ]]]
+# .. envvar:: dhcpd_ipxe_efi_chain_filename [[[
+#
+# Initial file sent to hosts using EFI which requested a PXE boot, used to
+# chain-load iPXE boot loader.
+dhcpd_ipxe_efi_chain_filename: 'ipxe.efi'
+
+                                                                   # ]]]
 # .. envvar:: dhcpd_ipxe_filename [[[
 #
 # File sent to hosts booted with iPXE, by default load the standard menu file.

--- a/ansible/roles/debops.dhcpd/templates/etc/dhcp/ipxe.j2
+++ b/ansible/roles/debops.dhcpd/templates/etc/dhcp/ipxe.j2
@@ -44,12 +44,17 @@ option ipxe.sdi code 40 = unsigned integer 8;
 option ipxe.nfs code 41 = unsigned integer 8;
 
 {% endif %}
+# Client architecture detection
+option client-arch code 93 = unsigned integer 16;
+
 # iPXE chain-loading configuration
 if exists user-class and option user-class = "iPXE" {
         filename "{{ dhcpd_ipxe_filename }}";
 {% if dhcpd_ipxe_options is defined and dhcpd_ipxe_options %}
 {{ dhcpd_ipxe_options | indent(8, true) }}
 {% endif %}
+} elsif option client-arch != 00:00 {
+        filename "{{ dhcpd_ipxe_efi_chain_filename }}";
 } else {
         filename "{{ dhcpd_ipxe_chain_filename }}";
 }


### PR DESCRIPTION
EFI systems configured to do EFI PXE booting can't use the iPXE binary
compiled for legacy BIOS PXE. They need the ipxe.efi variant compiled
for EFI.