### PR TITLE
[debops.prosody] fix typo

### DIFF
--- a/ansible/roles/debops.prosody/defaults/main.yml
+++ b/ansible/roles/debops.prosody/defaults/main.yml
@@ -366,22 +366,29 @@ prosody__combined_config_components: '{{ prosody__default_config_components
 prosody__ferm__dependent_rules:
 
   - type: 'accept'
-    dport: [ '5280', '5281' ]
+    dport: [ '5222' ]
     accept_any: True
     weight: '40'
     by_role: 'prosody'
-    name: 'perosody-xmpp'
+    name: 'prosody-xmpp-client'
     multiport: True
-    rule_state: '{{ "present" if prosody__deploy_state|bool else "absent" }}'
-
+    rule_state: '{{ prosody__deploy_state }}'
+  - type: 'accept'
+    dport: [ '5269' ]
+    accept_any: True
+    weight: '40'
+    by_role: 'prosody'
+    name: 'prosody-xmpp-server'
+    multiport: True
+    rule_state: '{{ prosody__deploy_state }}'
   - type: 'accept'
     dport: [ '5280', '5281' ]
     accept_any: True
     weight: '40'
     by_role: 'prosody'
-    name: 'perosody-http'
+    name: 'prosody-http'
     multiport: True
-    rule_state: '{{ "present" if prosody__deploy_state|bool else "absent" }}'
+    rule_state: '{{ prosody__deploy_state }}'
                                                                    # ]]]
                                                                    # ]]]
                                                                    # ]]]


### PR DESCRIPTION
Fix a few typos.
Ferm rules aren't working because of false usage of the variable `prosody__deploy_state` as bool.
There was also a copy paste issue with the ports