### PR TITLE
[debops.postgresql] Delegate to inventory_hostname

### DIFF
--- a/ansible/roles/debops.postgresql/defaults/main.yml
+++ b/ansible/roles/debops.postgresql/defaults/main.yml
@@ -91,8 +91,8 @@ postgresql__port: '5432'
 # locally, host will delegate the tasks to itself automatically.
 postgresql__delegate_to: '{{ postgresql__server
                              if (postgresql__server|d() and
-                                 (postgresql__server != "localhost" or not postgresql__server))
-                             else omit }}'
+                                 postgresql__server != "localhost")
+                             else inventory_hostname }}'
 
                                                                    # ]]]
 # .. envvar:: postgresql__password_hostname [[[


### PR DESCRIPTION
Currently the value of the 'postgresql__delegate_to' variable is used in
Ansible facts; using 'omit' can result in the wrong facts beging saved
on the remote host.

This patch changes the value to use 'inventory_hostname' instead, which
should correctly delegate the task to the host.

Fixes #510 