### PR TITLE
Add support for tagging hosts

### DIFF
--- a/ansible/roles/debops.dnsmasq/templates/etc/dnsmasq.d/00_main.conf.j2
+++ b/ansible/roles/debops.dnsmasq/templates/etc/dnsmasq.d/00_main.conf.j2
@@ -166,7 +166,7 @@ resolv-file = /etc/resolvconf/upstream.conf
 
 {% if dnsmasq__dhcp_hosts is defined %}
 {% for host in dnsmasq__dhcp_hosts %}
-dhcp-host={{ host.mac }},{{ host.ip  }}{% if host.name is defined %},{{ host.name }}{% else %}{% if host.lease_time is defined %},{% endif %}{% endif %}{% if host.lease_time is defined %},{{ host.lease_time }}{% else %},1d{% endif %}
+dhcp-host={{ host.mac }},{% if host.tag is defined %}set:{{ host.tag }},{% endif %}{{ host.ip  }}{% if host.name is defined %},{{ host.name }}{% else %}{% if host.lease_time is defined %},{% endif %}{% endif %}{% if host.lease_time is defined %},{{ host.lease_time }}{% else %},1d{% endif %}
 
 {% endfor %}
 {% endif %}

--- a/docs/ansible/roles/debops.dnsmasq/defaults-detailed.rst
+++ b/docs/ansible/roles/debops.dnsmasq/defaults-detailed.rst
@@ -16,7 +16,7 @@ dnsmasq__dhcp_hosts
 
 :envvar:`dnsmasq__dhcp_hosts` must be a list of hosts. Each host is a dictionary
 consisting of a ``name``, a ``mac`` address, an :command:`ip` address and optionally a
-``lease_time``; by default it's 1 day (``1d``).:
+``tag`` or ``lease_time``; by default it's 1 day (``1d``).:
 
 .. code-block:: yaml
 
@@ -24,5 +24,7 @@ consisting of a ``name``, a ``mac`` address, an :command:`ip` address and option
      - name: client
        mac: '01:23:45:67:89:ab'
        ip: '192.168.0.42'
+       # optional
+       tag: 'R640'
        # optional; default: 1d
        lease_time: 12h


### PR DESCRIPTION
It's useful when you wan't to provide some host specific options. Like different `preseed.cfg` based on hardware:
```
dhcp-boot=tag:debian-installer,tag:R630,http://1.2.3.4/d-i/stretch/preseed-r630.cfg
dhcp-boot=tag:debian-installer,tag:R640,http://1.2.3.4/d-i/stretch/preseed-r640.cfg
```