### PR TITLE
[debops.owncloud] Fix PHP packages for OwnCloud 10

### DIFF
--- a/ansible/roles/debops.owncloud/defaults/main.yml
+++ b/ansible/roles/debops.owncloud/defaults/main.yml
@@ -64,9 +64,7 @@ owncloud__required_php_packages:
   # - 'SimpleXML'
   # - 'XMLWriter'
 
-  - 'mbstring'
   # - 'posix'
-  - 'zip'
   # - 'zlib'
 
 
@@ -77,7 +75,6 @@ owncloud__required_php_packages:
 owncloud__recommended_php_packages:
   - 'curl'
   - 'bz2'
-  - 'intl'
   - 'mcrypt'
 
   # Recommended/Optional: SFTP storage
@@ -91,6 +88,9 @@ owncloud__base_php_packages:
   - '{{ owncloud__required_php_packages
         if (owncloud__variant == "nextcloud")
         else [] }}'
+
+  - 'mbstring'
+  - 'zip'
 
   - '{{ [ "apcu" ] if (owncloud__apcu_enabled|bool) else [] }}'
   - '{{ [ "mysql" ] if (owncloud__database in [ "mariadb", "mysql" ]) else [] }}'
@@ -119,7 +119,7 @@ owncloud__optional_php_packages:
   - '{{ owncloud__recommended_php_packages
         if (owncloud__variant == "nextcloud")
         else [] }}'
-
+  - 'intl'
   - 'imagick'
 
 


### PR DESCRIPTION
mbstring, intl and zip are required by OwnCloud 10, but were only installed for the NextCloud variant.