### PR TITLE
[debops.lxc] Remove host entry in new containers

### DIFF
--- a/ansible/roles/debops.lxc/files/usr/local/bin/lxc-new-unprivileged
+++ b/ansible/roles/debops.lxc/files/usr/local/bin/lxc-new-unprivileged
@@ -73,6 +73,15 @@ main () {
             lxc-start -n "${container}" -d
             lxc-wait -n "${container}" -s RUNNING
 
+            # During container creation, a static hostname is added into
+            # '/etc/hosts' which breaks proper DNS domain resolution of the
+            # container. Because we are using DHCP/DNS server to manage
+            # containers, remove the static host entry to fix the issue.
+            if lxc-attach -n "${container}" -- grep -q '127.0.1.1' /etc/hosts ; then
+                printf "Removing static host entry from /etc/hosts...\n"
+                lxc-attach -n "${container}" -- sed -i "/127\.0\.1\.1/d" /etc/hosts > /dev/null
+            fi
+
             until lxc-prepare-ssh "${container}" ; do
                 ((c++)) && ((c==4)) && break
                 printf "Waiting for network inside container to settle...\n"


### PR DESCRIPTION
The LXC container creation scripts add a static host entry in
'/etc/hosts' file of newly created containers. This breaks name
resolution in DNS-based environments. Because DebOps relies on DNS for
local name resolution, the 'lxc-new-unprivileged' script will remove
that static host entry to fix the issue in new containers.