### PR TITLE
Add debops.secret dependency to debops.gitlab_runner

### DIFF
--- a/ansible/roles/debops.gitlab_runner/meta/main.yml
+++ b/ansible/roles/debops.gitlab_runner/meta/main.yml
@@ -1,6 +1,8 @@
 ---
 
-dependencies: []
+dependencies:
+  - role: debops.secret
+    tags: [ 'role::secret' ]
 
 galaxy_info:
 

--- a/ansible/roles/debops.gitlab_runner/meta/main.yml
+++ b/ansible/roles/debops.gitlab_runner/meta/main.yml
@@ -2,7 +2,6 @@
 
 dependencies:
   - role: debops.secret
-    tags: [ 'role::secret' ]
 
 galaxy_info:
 

--- a/docs/ansible/roles/debops.gitlab_runner/getting-started.rst
+++ b/docs/ansible/roles/debops.gitlab_runner/getting-started.rst
@@ -35,6 +35,14 @@ To change the environment variable that holds the registration token, or save
 the token in Ansible inventory, you can use the :envvar:`gitlab_runner__token`
 variable.
 
+For example storing the token in the ``ansible/secret`` folder:
+
+.. code-block:: console
+
+   gitlab_runner__token: '{{ lookup("password", secret
+                           + "/credentials/" + ansible_fqdn
+                           + "/gitlab/runner/token chars=ascii,numbers") }}'
+
 Initial configuration
 ---------------------
 


### PR DESCRIPTION
Allow to store the Runner Token and Runner API Token in the secret folder.

Example:

```
gitlab_runner__token: '{{ lookup("password", secret
                           + "/credentials/" + ansible_fqdn
                           + "/gitlab/runner/token chars=ascii,numbers") }}'
gitlab_runner__api_token: '{{ lookup("password", secret
                           + "/credentials/" + ansible_fqdn
                           + "/gitlab/runner/api_access_token chars=ascii,numbers") }}'
```