### PR TITLE
 Fix docker.service-j2 systemd template

### DIFF
--- a/ansible/roles/debops.docker/defaults/main.yml
+++ b/ansible/roles/debops.docker/defaults/main.yml
@@ -318,7 +318,7 @@ docker__env_no_proxy: '{{ ansible_env.no_proxy | d() }}'
 #
 # List of host connections configured in the Docker daemon (``--host`` parameter).
 docker__listen:
-  - '{{ "fd://" if ansible_service_mgr == "systemd" else "unix:///var/run/docker.sock" }}'
+  - '{{ "unix:///var/run/docker.sock" }}'
   - '{{ docker__tcp_listen }}'
 
                                                                    # ]]]

--- a/ansible/roles/debops.docker/templates/etc/systemd/system/docker.service.j2
+++ b/ansible/roles/debops.docker/templates/etc/systemd/system/docker.service.j2
@@ -3,9 +3,9 @@
 [Unit]
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
-After=network-online.target docker.socket firewalld.service
+BindsTo=containerd.service
+After=network-online.target firewalld.service
 Wants=network-online.target
-Requires=docker.socket
 
 [Service]
 Type=notify
@@ -21,23 +21,38 @@ EnvironmentFile=-/etc/default/docker
 ExecStart=/usr/bin/docker -d -H fd:// $DOCKER_OPTS
 {% endif %}
 ExecReload=/bin/kill -s HUP $MAINPID
-LimitNOFILE=1048576
+TimeoutSec=0
+RestartSec=2
+Restart=always
+
+# Note that StartLimit* options were moved from "Service" to "Unit" in systemd 229.
+# Both the old, and new location are accepted by systemd 229 and up, so using the old location
+# to make them work for either version of systemd.
+StartLimitBurst=3
+
+# Note that StartLimitInterval was renamed to StartLimitIntervalSec in systemd 230.
+# Both the old, and new name are accepted by systemd 230 and up, so using the old name to make
+# this option work for either version of systemd.
+StartLimitInterval=60s
+
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNOFILE=infinity
 LimitNPROC=infinity
 LimitCORE=infinity
-# Uncomment TasksMax if your systemd version supports it.
-# Only systemd 226 and above support this version.
+
+# Comment TasksMax if your systemd version does not supports it.
+# Only systemd 226 and above support this option.
 TasksMax=infinity
-TimeoutStartSec=0
+
 # set delegate yes so that systemd does not reset the cgroups of docker containers
 Delegate=yes
+
 # kill only the docker process, not all processes in the cgroup
 KillMode=process
-# restart the docker process if it exits prematurely
-Restart=on-failure
-StartLimitBurst=3
-StartLimitInterval=60s
 
 [Install]
 WantedBy=multi-user.target
+
+
+

--- a/ansible/roles/debops.docker/templates/etc/systemd/system/docker.service.j2
+++ b/ansible/roles/debops.docker/templates/etc/systemd/system/docker.service.j2
@@ -53,6 +53,3 @@ KillMode=process
 
 [Install]
 WantedBy=multi-user.target
-
-
-

--- a/ansible/roles/debops.docker/templates/etc/systemd/system/docker.service.j2
+++ b/ansible/roles/debops.docker/templates/etc/systemd/system/docker.service.j2
@@ -12,9 +12,9 @@ Type=notify
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
-{% if docker__register_version.stdout is version_compare('1.12', '>=') %}
+{% if docker__register_version.stdout is version('1.12', '>=') %}
 ExecStart=/usr/bin/dockerd {{ docker__options | join(" ") }}
-{% elif docker__register_version.stdout is version_compare('1.10', '>=') %}
+{% elif docker__register_version.stdout is version('1.10', '>=') %}
 ExecStart=/usr/bin/docker daemon {{ docker__options | join(" ") }}
 {% else %}
 EnvironmentFile=-/etc/default/docker


### PR DESCRIPTION
 Fix docker.service-j2 systemd template. Between docker docker version 18.06.1-ce and 18.09.0 the systemd unit is not more dependent on 'docer.sock' unit. Therefore update the template with the latest example systemd unit from docker-ce debian deb pkg.

Use the unix socket and not the file descriptor. Otherwise the systemd unit won't work...