### PR TITLE
[fix] don't create sudoers file if `debops.sudo` is not used

### DIFF
--- a/ansible/roles/debops.gitlab_runner/tasks/main.yml
+++ b/ansible/roles/debops.gitlab_runner/tasks/main.yml
@@ -210,7 +210,9 @@
     owner: 'root'
     group: 'root'
     mode: '0440'
-  when: gitlab_runner__vagrant_libvirt|bool
+  when: (ansible_local|d() and ansible_local.sudo|d() and
+         (ansible_local.sudo.installed|d()|bool)) and
+         (gitlab_runner__vagrant_libvirt|bool))
 
 - name: Find 'vagrant-libvirt' source code
   command: find /usr/share/rubygems-integration/all/gems -maxdepth 1 -type d -name 'vagrant-libvirt-*'
@@ -233,7 +235,9 @@
     owner: 'root'
     group: 'root'
     mode: '0440'
-  when: gitlab_runner__vagrant_lxc|bool
+  when: (ansible_local|d() and ansible_local.sudo|d() and
+         (ansible_local.sudo.installed|d()|bool) and
+         gitlab_runner__vagrant_lxc|bool)
 
 - name: Make sure that Ansible fact directory exists
   file:

--- a/ansible/roles/debops.nginx/tasks/main.yml
+++ b/ansible/roles/debops.nginx/tasks/main.yml
@@ -130,7 +130,9 @@
     owner: 'root'
     group: 'root'
     mode: '0440'
-  when: (nginx__deploy_state in [ 'present' ])
+  when: (ansible_local|d() and ansible_local.sudo|d() and
+         (ansible_local.sudo.installed|d()|bool) and
+         (nginx__deploy_state in [ 'present' ]))
 
 - name: Divert original /etc/nginx/nginx.conf
   command: dpkg-divert --quiet --local --divert /etc/nginx/nginx.conf.dpkg-divert

--- a/ansible/roles/debops.php/tasks/main.yml
+++ b/ansible/roles/debops.php/tasks/main.yml
@@ -55,6 +55,8 @@
     owner: 'root'
     group: 'root'
     mode: '0440'
+  when: (ansible_local|d() and ansible_local.sudo|d() and
+         (ansible_local.sudo.installed|d()|bool))
 
                                                                    # ]]]
 # php.ini management [[[

--- a/ansible/roles/debops.smstools/tasks/main.yml
+++ b/ansible/roles/debops.smstools/tasks/main.yml
@@ -61,6 +61,8 @@
 - name: Configure access to sendsms via sudo
   template: src=etc/sudoers.d/smstools.j2 dest=/etc/sudoers.d/smstools
             owner=root group=root mode=0440
+  when: (ansible_local|d() and ansible_local.sudo|d() and
+         (ansible_local.sudo.installed|d()|bool))
 
 - name: Configure xinetd SMS service
   template: src=etc/xinetd.d/sms.j2 dest=/etc/xinetd.d/sms


### PR DESCRIPTION
fix #516