### PR TITLE
[debops.netbase] Ensure POSIX capabilities support

### DIFF
--- a/ansible/roles/debops.netbase/defaults/main.yml
+++ b/ansible/roles/debops.netbase/defaults/main.yml
@@ -22,7 +22,7 @@ netbase__enabled: True
 # .. envvar:: netbase__base_packages [[[
 #
 # List of base APT packages to linstall for netbase support.
-netbase__base_packages: [ 'netbase' ]
+netbase__base_packages: [ 'netbase', 'libcap2-bin' ]
 
                                                                    # ]]]
 # .. envvar:: netbase__packages [[[

--- a/ansible/roles/debops.netbase/tasks/main.yml
+++ b/ansible/roles/debops.netbase/tasks/main.yml
@@ -9,6 +9,27 @@
     - '{{ netbase__packages }}'
   when: netbase__enabled|bool
 
+- name: Make sure that Ansible local facts directory exists
+  file:
+    path: '/etc/ansible/facts.d'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+
+- name: Save netbase local facts
+  template:
+    src: 'etc/ansible/facts.d/netbase.fact.j2'
+    dest: '/etc/ansible/facts.d/netbase.fact'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+  register: netbase__register_facts
+
+- name: Update Ansible facts if they were modified
+  action: setup
+  when: netbase__register_facts is changed
+
 - name: Manage the hostname
   hostname:
     name: '{{ netbase__hostname }}'
@@ -40,24 +61,3 @@
     state:   '{{ "present" if item.value|d() else "absent" }}'
   with_dict: '{{ netbase__networks | combine(netbase__group_networks, netbase__host_networks) }}'
   when: netbase__enabled|bool
-
-- name: Make sure that Ansible local facts directory exists
-  file:
-    path: '/etc/ansible/facts.d'
-    state: 'directory'
-    owner: 'root'
-    group: 'root'
-    mode: '0755'
-
-- name: Save netbase local facts
-  template:
-    src: 'etc/ansible/facts.d/netbase.fact.j2'
-    dest: '/etc/ansible/facts.d/netbase.fact'
-    owner: 'root'
-    group: 'root'
-    mode: '0755'
-  register: netbase__register_facts
-
-- name: Update Ansible facts if they were modified
-  action: setup
-  when: netbase__register_facts is changed


### PR DESCRIPTION
The 'debops.netbase' role depends on checking for 'cap_sys_admin'
POSIX capability to change the hostname. Ansible requires the
'libcap2-bin' package to be present on the remote host before exposing
list of POSIX capabilities in host facts.

This patch ensures that the 'libcap2-bin' package is installed before
being used by the role.