### PR TITLE
Check that shells exist before changing them.

### DIFF
--- a/ansible/roles/debops.root_account/tasks/main.yml
+++ b/ansible/roles/debops.root_account/tasks/main.yml
@@ -15,6 +15,16 @@
   changed_when: False
   check_mode: False
 
+- name: Check if preferred shell exists
+  stat: path="{{ root_account__shell }}"
+  register: root_account__register_shell
+  when: root_account__enabled|bool and root_account__shell|d(False)
+
+- name: Fail if setting a shell that does not exist
+  fail:
+    msg: "Trying to set a shell that does not exist, this can lock you out!"
+  when: root_account__enabled|bool and root_account__shell|d(False) and not root_account__register_shell.stat.exists
+
 - name: Enforce root system group
   group:
     name: 'root'

--- a/ansible/roles/debops.users/tasks/users.yml
+++ b/ansible/roles/debops.users/tasks/users.yml
@@ -24,38 +24,20 @@
   getent:
     database: 'group'
 
-- name: Get preferred shells
-  set_fact:
-    users__register_shell_path: '{{ item.shell|d() }}'
-  with_flattened:
-    - '{{ users__default_accounts }}'
-    - '{{ users__admin_accounts }}'
-    - '{{ users__accounts }}'
-    - '{{ users__group_accounts }}'
-    - '{{ users__host_accounts }}'
-    - '{{ users__dependent_accounts }}'
-  register: users__register_shell_paths
-  no_log: '{{ users__no_log | bool }}'
-
-- name: Get preferred shells as set
-  set_fact:
-    users__register_shell_paths_set: |
-      {{ users__register_shell_paths.results |
-         map(attribute='ansible_facts.users__register_shell_path') |
-         unique | list
-      }}
-
-- name: Check if preferred shell exists
-  stat: path="{{ item }}"
-  with_flattened:
-    - '{{ users__register_shell_paths_set }}'
-    - '{{ [ users__default_shell ] if users__default_shell|d() else [] }}'
+- name: Check if defined shells exist
+  stat:
+    path: "{{ item }}"
+  loop: '{{ ((users__default_accounts + users__admin_accounts + users__root_accounts
+              + users__accounts + users__group_accounts + users__host_accounts
+              + users__dependent_accounts) | selectattr("shell", "defined")
+              | map(attribute="shell") | unique | list)
+            + ([ users__default_shell ] if users__default_shell|d() else []) }}'
   register: users__register_shell_stats
 
-- name: Fail if setting a shell that does not exist
+- name: Fail if a defined shell does not exist
   fail:
     msg: "Trying to set a shell that does not exist, this can lock you out!"
-  with_items: '{{ users__register_shell_stats.results }}'
+  loop: '{{ users__register_shell_stats.results }}'
   when: not item.stat.exists
 
 - name: Manage user accounts

--- a/ansible/roles/debops.users/tasks/users.yml
+++ b/ansible/roles/debops.users/tasks/users.yml
@@ -24,6 +24,40 @@
   getent:
     database: 'group'
 
+- name: Get preferred shells
+  set_fact:
+    users__register_shell_path: '{{ item.shell|d() }}'
+  with_flattened:
+    - '{{ users__default_accounts }}'
+    - '{{ users__admin_accounts }}'
+    - '{{ users__accounts }}'
+    - '{{ users__group_accounts }}'
+    - '{{ users__host_accounts }}'
+    - '{{ users__dependent_accounts }}'
+  register: users__register_shell_paths
+  no_log: '{{ users__no_log | bool }}'
+
+- name: Get preferred shells as set
+  set_fact:
+    users__register_shell_paths_set: |
+      {{ users__register_shell_paths.results |
+         map(attribute='ansible_facts.users__register_shell_path') |
+         unique | list
+      }}
+
+- name: Check if preferred shell exists
+  stat: path="{{ item }}"
+  with_flattened:
+    - '{{ users__register_shell_paths_set }}'
+    - '{{ [ users__default_shell ] if users__default_shell|d() else [] }}'
+  register: users__register_shell_stats
+
+- name: Fail if setting a shell that does not exist
+  fail:
+    msg: "Trying to set a shell that does not exist, this can lock you out!"
+  with_items: '{{ users__register_shell_stats.results }}'
+  when: not item.stat.exists
+
 - name: Manage user accounts
   user:
     name:               '{{ item.name }}'


### PR DESCRIPTION
If *someone* wants to, say, change the default shell to [fish](https://fish.sh) and forgets computers are computers and will do what you tell them instead of what you want, saying something like:

    users__accounts:
      - name: *someone*
        shell: 'fish'

Will result in that entry in `/etc/passwd` and that means that no login is possible.

This PR checks shell existence for both `debops.root_account` and `debops.users` roles.