### PR TITLE
[debops.lxc] Add support for container fstab files

### DIFF
--- a/ansible/roles/debops.lxc/tasks/main.yml
+++ b/ansible/roles/debops.lxc/tasks/main.yml
@@ -301,6 +301,34 @@
         item.state|d("started") == "started"
   tags: [ 'role::lxc:containers' ]
 
+- name: Include fstab parameter in LXC container configuration
+  lineinfile:
+    path: '/var/lib/lxc/{{ item.name | d(item) }}/config'
+    regexp: '^lxc\.mount\s+=\s+'
+    line: 'lxc.mount = /var/lib/lxc/{{ item.name | d(item) }}/fstab'
+    insertafter: '^lxc\.rootfs\.backend\s+=\s+'
+    state: 'present'
+  loop: '{{ lxc__containers }}'
+  when: ansible_local|d() and ansible_local.lxc|d() and
+        (item.name | d(item)) not in ansible_local.lxc.containers|d() and
+        item.state|d("started") == "started" and item.fstab|d()
+  tags: [ 'role::lxc:containers' ]
+
+- name: Create custom fstab files for LXC containers
+  copy:
+    content: |
+      # Filesystem table for the '{{ item.name | d(item) }}' LXC container
+      {{ item.fstab | regex_replace('\n$','') }}
+    dest: '/var/lib/lxc/{{ item.name | d(item) }}/fstab'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  loop: '{{ lxc__containers }}'
+  when: ansible_local|d() and ansible_local.lxc|d() and
+        (item.name | d(item)) not in ansible_local.lxc.containers|d() and
+        item.state|d("started") == "started" and item.fstab|d()
+  tags: [ 'role::lxc:containers' ]
+
 - name: Start LXC containers after creation
   systemd:
     name: 'lxc@{{ item.name | d(item) }}.service'

--- a/docs/ansible/roles/debops.lxc/defaults-detailed.rst
+++ b/docs/ansible/roles/debops.lxc/defaults-detailed.rst
@@ -204,6 +204,32 @@ overridden template options:
        template: 'debian'
        template_options: ''
 
+Create custom directory on LXC host and share it between two unprivileged LXC
+containers using the :ref:`debops.resources` and :ref:`debops.lxc` roles,
+mounted at :file:`/opt` directory inside of the containers:
+
+.. code-block:: yaml
+
+   resources__host_paths:
+
+     - name: '/srv/shared/lxc-opt'
+       state: 'directory'
+       owner: '100000'
+       group: '100000'
+       mode: '0755'
+
+   lxc__containers:
+
+     - name: 'container1'
+       fstab: |
+         /srv/shared/lxc-opt opt none bind 0 0
+       state: 'started'
+
+     - name: 'container2'
+       fstab: |
+         /srv/shared/lxc-opt opt none bind 0 0
+       state: 'started'
+
 Syntax
 ~~~~~~
 
@@ -265,6 +291,16 @@ manage LXC containers are:
 
 The parameters below can be used to configure additional aspects of the LXC
 containers when managed by the :ref:`debops.lxc` Ansible role:
+
+``fstab``
+  Optional. YAML text block with :man:`fstab(5)` configuration to mount
+  filesystems inside of the LXC containers. If this parameter is specified, the
+  role will create the :file:`/var/lib/lxc/<container>/fstab` file with the
+  contents of this parameter and configure the container to mount the
+  filesystems specified in this file. Existing LXC containers are not modified.
+
+  See the :man:`lxc.container.conf(5)` ``lxc.mount`` option documentation for
+  more details.
 
 ``ssh``
   Optional, boolean. If ``True``, the role will use the


### PR DESCRIPTION
This patch adds support for mounting directories or filesystems inside
of the LXC containers managed by the 'debops.lxc' role, via external
'fstab' file.