### PR TITLE
Fix problem while cloning over ssh. 

### DIFF
--- a/ansible/roles/debops.gitlab/tasks/main.yml
+++ b/ansible/roles/debops.gitlab/tasks/main.yml
@@ -45,6 +45,14 @@
     state: 'present'
   when: gitlab_support_filesystem_acl|bool
 
+- name: Allow GitLab user to the ~/.ssh directory
+  file:
+    path: '{{ gitlab_home + "/.ssh" }}'
+    owner: '{{ gitlab_user }}'
+    group: '{{ gitlab_group }}'
+    mode: 0644
+    recurse: true
+
 - name: Configure ~/.gitconfig
   template:
     src: 'var/local/git/gitconfig.j2'

--- a/ansible/roles/debops.gitlab/tasks/main.yml
+++ b/ansible/roles/debops.gitlab/tasks/main.yml
@@ -50,7 +50,7 @@
     path: '{{ gitlab_home + "/.ssh" }}'
     owner: '{{ gitlab_user }}'
     group: '{{ gitlab_group }}'
-    mode: 0700
+    mode: '0700'
 
 - name: Configure ~/.gitconfig
   template:

--- a/ansible/roles/debops.gitlab/tasks/main.yml
+++ b/ansible/roles/debops.gitlab/tasks/main.yml
@@ -50,8 +50,7 @@
     path: '{{ gitlab_home + "/.ssh" }}'
     owner: '{{ gitlab_user }}'
     group: '{{ gitlab_group }}'
-    mode: 0644
-    recurse: true
+    mode: 0700
 
 - name: Configure ~/.gitconfig
   template:

--- a/ansible/roles/debops.gitlab/tasks/main.yml
+++ b/ansible/roles/debops.gitlab/tasks/main.yml
@@ -48,6 +48,7 @@
 - name: Allow GitLab user to the ~/.ssh directory
   file:
     path: '{{ gitlab_home + "/.ssh" }}'
+    state: 'directory'
     owner: '{{ gitlab_user }}'
     group: '{{ gitlab_group }}'
     mode: '0700'


### PR DESCRIPTION
Gitlab was not able to add the ssh keys of the users in the ~/.ssh directory.
Therefore add task to set the correct directory permission for ~/.ssh.