### PR TITLE
Added debops.apt to start of bootstrap playbook

### DIFF
--- a/ansible/playbooks/bootstrap.yml
+++ b/ansible/playbooks/bootstrap.yml
@@ -47,6 +47,9 @@
 
   roles:
 
+    - role: debops.apt
+      tags: [ 'role::apt', 'skip::apt' ]
+
     - role: debops.python
       tags: [ 'role::python', 'skip::python' ]
 


### PR DESCRIPTION
Solves issue with ubuntu bionic and python3-pip moved to another apt repository.