### PR TITLE
Add new role, 'debops.mount'

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -837,6 +837,14 @@ stages:
     JANE_DIFF_PATTERN: '.*/debops.mosquitto/.*'
     JANE_LOG_PATTERN: '\[debops\.mosquitto\]'
 
+'mount role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/mount.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_mount'
+    JANE_DIFF_PATTERN: '.*/debops.mount/.*'
+    JANE_LOG_PATTERN: '\[debops\.mount\]'
+
 
 # --- n --- [[[2
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,11 @@ Added
   - :ref:`debops.dhcp_probe`, can be used to install and configure
     :command:`dhcp_probe` service, which passively detects rogue DHCP servers.
 
+  - :ref:`debops.mount`, the role allows configuration of :file:`/etc/fstab`
+    entries for local devices, bind mounts and can be used to create or modify
+    directories, to permit access to resources by different applications. The
+    role is included by default in the ``common.yml`` playbook.
+
 - [debops.users] The role can now configure ACL entries of the user home
   directories using the ``item.home_acl`` parameter. This can be used for more
   elaborate access restrictions.

--- a/ansible/playbooks/common.yml
+++ b/ansible/playbooks/common.yml
@@ -113,6 +113,9 @@
     - role: debops.users
       tags: [ 'role::users', 'skip::users' ]
 
+    - role: debops.mount
+      tags: [ 'role::mount', 'skip::mount' ]
+
     - role: debops.resources
       tags: [ 'role::resources', 'skip::resources' ]
 

--- a/ansible/playbooks/service/mount.yml
+++ b/ansible/playbooks/service/mount.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Manage local device and bind mounts
+  hosts: [ 'debops_all_hosts', 'debops_service_mount' ]
+  become: True
+
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
+
+  roles:
+
+    - role: debops.mount
+      tags: [ 'role::mount', 'skip::mount' ]

--- a/ansible/playbooks/sys/all.yml
+++ b/ansible/playbooks/sys/all.yml
@@ -1,5 +1,7 @@
 ---
 
+- import_playbook: mount.yml
+
 - import_playbook: netbase.yml
 
 - import_playbook: sysnews.yml

--- a/ansible/playbooks/sys/mount.yml
+++ b/ansible/playbooks/sys/mount.yml
@@ -1,0 +1,1 @@
+../service/mount.yml

--- a/ansible/roles/debops.mount/COPYRIGHT
+++ b/ansible/roles/debops.mount/COPYRIGHT
@@ -1,0 +1,18 @@
+debops.mount - Manage local device and bind mounts using Ansible
+
+Copyright (C) 2018 Maciej Delmanowski <drybjed@gmail.com>
+Copyright (C) 2018 DebOps https://debops.org/
+
+This Ansible role is part of DebOps.
+
+DebOps is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 3, as
+published by the Free Software Foundation.
+
+DebOps is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with DebOps. If not, see https://www.gnu.org/licenses/.

--- a/ansible/roles/debops.mount/defaults/main.yml
+++ b/ansible/roles/debops.mount/defaults/main.yml
@@ -1,0 +1,119 @@
+---
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+
+# debops.mount default variables
+# ==============================
+
+# .. contents:: Sections
+#    :local:
+#
+# .. include:: ../../../includes/global.rst
+
+
+# General configuration [[[
+# -------------------------
+
+# .. envvar:: mount__enabled [[[
+#
+# Enable or disable support for local device mounts, bind mounts and custom
+# directories.
+mount__enabled: '{{ True
+                    if (((ansible_system_capabilities_enforced|d())|bool and
+                         "cap_sys_admin" in ansible_system_capabilities) or
+                        not (ansible_system_capabilities_enforced|d(True))|bool)
+                    else False }}'
+
+                                                                   # ]]]
+# .. envvar:: mount__base_packages [[[
+#
+# List of APT packages to install for correct filesystem management.
+mount__base_packages: '{{ [ "acl" ]
+                          if (((mount__directories
+                                + mount__group_directories
+                                + mount__host_directories)
+                               | flatten) | selectattr("acl", "defined") | list
+                               | subelements("acl"))
+                          else [] }}'
+
+                                                                   # ]]]
+# .. envvar:: mount__packages [[[
+#
+# List of additional APT packages to install for filesystem management.
+mount__packages: []
+                                                                   # ]]]
+                                                                   # ]]]
+# Device mounts [[[
+# -----------------
+
+# These variables control local device mounts, usually external disk drives,
+# LVM block devices or other storage. See :ref:`mount__ref_devices` for
+# more details.
+
+# .. envvar:: mount__devices [[[
+#
+# Define local mounts for all hosts in the Ansible inventory.
+mount__devices: []
+
+                                                                   # ]]]
+# .. envvar:: mount__group_devices [[[
+#
+# Define local mounts for hosts in a specific Ansible inventory group.
+mount__group_devices: []
+
+                                                                   # ]]]
+# .. envvar:: mount__host_devices [[[
+#
+# Define local mounts for specific hosts in the Ansible inventory.
+mount__host_devices: []
+                                                                   # ]]]
+                                                                   # ]]]
+# Custom directories [[[
+# ----------------------
+
+# These variables can be used to create custom directories on mounted
+# filesystems with specific permissions, ACLs, etc.
+# See :ref:`mount__ref_directories` for more details.
+
+# .. envvar:: mount__directories [[[
+#
+# List of directories to manage on all hosts in the Ansible inventory.
+mount__directories: []
+
+                                                                   # ]]]
+# .. envvar:: mount__group_directories [[[
+#
+# List of directories to manage on hosts in a specific Ansible inventory group.
+mount__group_directories: []
+
+                                                                   # ]]]
+# .. envvar:: mount__host_directories [[[
+#
+# List of directories to manage on specific hosts in the Ansible inventory.
+mount__host_directories: []
+                                                                   # ]]]
+                                                                   # ]]]
+# Bind mounts [[[
+# ---------------
+
+# These variables define configuration of bind mounts, separately from normal
+# filesystems to allow bind-mounting of existing directories.
+# See :ref:`mount__ref_binds` for more details.
+
+# .. envvar:: mount__binds [[[
+#
+# Define bind mounts for all hosts in the Ansible inventory.
+mount__binds: []
+
+                                                                   # ]]]
+# .. envvar:: mount__group_binds [[[
+#
+# Define bind mounts for hosts in a specific Ansible inventory group.
+mount__group_binds: []
+
+                                                                   # ]]]
+# .. envvar:: mount__host_binds [[[
+#
+# Define bind mounts for specific hosts in the Ansible inventory.
+mount__host_binds: []
+                                                                   # ]]]
+                                                                   # ]]]

--- a/ansible/roles/debops.mount/meta/main.yml
+++ b/ansible/roles/debops.mount/meta/main.yml
@@ -1,0 +1,32 @@
+---
+
+dependencies: []
+
+galaxy_info:
+
+  role_name: 'mount'
+  author: 'Maciej Delmanowski'
+  description: 'Manage local device and bind mounts'
+  company: 'DebOps'
+  license: 'GPL-3.0'
+  min_ansible_version: '2.6.0'
+  platforms:
+    - name: Ubuntu
+      versions:
+        - precise
+        - quantal
+        - raring
+        - saucy
+        - trusty
+        - xenial
+        - bionic
+    - name: Debian
+      versions:
+        - wheezy
+        - jessie
+        - stretch
+        - buster
+  galaxy_tags:
+    - system
+    - filesystems
+    - mount

--- a/ansible/roles/debops.mount/tasks/main.yml
+++ b/ansible/roles/debops.mount/tasks/main.yml
@@ -1,0 +1,131 @@
+---
+
+- name: Install required packages
+  package:
+    name: '{{ (mount__base_packages + mount__packages) | flatten }}'
+    state: 'present'
+  when: mount__enabled|bool
+
+  # This task allows configuration of the outer mount point attributes, but
+  # will not change them while the device is mounted.
+- name: Ensure that the mount points exist
+  file:
+    path:    '{{ item.path    | d(item.dest | d(item.name)) }}'
+    owner:   '{{ item.owner   | d("root") }}'
+    group:   '{{ item.group   | d(item.owner | d("root")) }}'
+    mode:    '{{ item.mode    | d("0755") }}'
+    state:   'directory'
+  loop: '{{ (mount__devices
+             + mount__group_devices
+             + mount__host_devices)
+            | flatten }}'
+  when: (mount__enabled|bool and item.state|d('mounted') in [ 'mounted', 'present', 'unmounted' ] and
+         (item.device | d(item.src)) not in (ansible_mounts | map(attribute='device') | list))
+
+- name: Stop devices automounted by systemd if requested
+  systemd:
+    name: '{{ item.name | regex_replace("^/","") | regex_replace("/","-") + ".automount" }}'
+    state: 'stopped'
+  loop: '{{ (mount__devices
+             + mount__group_devices
+             + mount__host_devices)
+            | flatten }}'
+  when: (mount__enabled|bool and ansible_service_mgr == 'systemd' and item.state|d('mounted') in [ 'unmounted', 'absent' ] and
+         (((item.opts if (item.opts is string) else item.opts | join(',')) if item.opts|d() else 'defaults') is match(".*x-systemd.automount.*")))
+
+- name: Manage device mounts
+  mount:
+    src:    '{{ item.src }}'
+    path:   '{{ item.path   | d(item.dest | d(item.name)) }}'
+    fstype: '{{ item.fstype | d("auto") }}'
+    opts:   '{{ ((item.opts if (item.opts is string) else (item.opts | join(","))) if item.opts|d() else "defaults") }}'
+    dump:   '{{ item.dump   | d(omit) }}'
+    passno: '{{ item.passno | d(omit) }}'
+    state:  '{{ item.state  | d("mounted") }}'
+    fstab:  '{{ item.fstab  | d(omit) }}'
+  loop: '{{ (mount__devices
+             + mount__group_devices
+             + mount__host_devices)
+            | flatten }}'
+  register: mount__register_devices
+  when: (mount__enabled|bool and
+         (item.name|d() or item.dest|d() or item.path|d()) and
+         item.src|d() and item.fstype|d())
+
+- name: Restart 'local-fs.target' systemd unit
+  systemd:
+    name: 'local-fs.target'
+    state: 'restarted'
+    daemon_reload: True
+  loop: '{{ mount__register_devices.results }}'
+  when: (mount__enabled|bool and ansible_service_mgr == 'systemd' and item is changed and
+         (((item.opts if (item.opts is string) else item.opts | join(',')) if item.opts|d() else 'defaults') is match(".*x-systemd.automount.*")))
+
+- name: Manage directories
+  file:
+    path:    '{{ item.path    | d(item.dest | d(item.name)) }}'
+    owner:   '{{ item.owner   | d("root") }}'
+    group:   '{{ item.group   | d(item.owner | d("root")) }}'
+    mode:    '{{ item.mode    | d("0755") }}'
+    recurse: '{{ item.recurse | d(omit) }}'
+    state:   '{{ item.state   | d("directory") }}'
+  loop: '{{ (mount__directories
+             + mount__group_directories
+             + mount__host_directories)
+            | flatten }}'
+  when: mount__enabled|bool and (item.path|d() or item.dest|d() or item.name|d()) and
+        item.state|d('directory') in [ 'directory', 'absent' ]
+
+- name: Manage directory ACLs
+  acl:
+    path:        '{{ item.0.path        | d(item.0.dest | d(item.0.name)) }}'
+    default:     '{{ item.1.default     | d(omit) }}'
+    entity:      '{{ item.1.entity      | d(omit) }}'
+    etype:       '{{ item.1.etype       | d(omit) }}'
+    permissions: '{{ item.1.permissions | d(omit) }}'
+    follow:      '{{ item.1.follow      | d(omit) }}'
+    recursive:   '{{ item.1.recursive   | d(omit) }}'
+    state:       '{{ item.1.state       | d("present") }}'
+  loop: '{{ ((mount__directories
+             + mount__group_directories
+             + mount__host_directories)
+             | flatten) | selectattr("acl", "defined") | list
+             | subelements("acl") }}'
+  loop_control:
+    label: '{{ {"name": item.0.name, "acl": item.1} }}'
+  when: mount__enabled|bool and (item.0.path|d() or item.0.dest|d() or item.0.name|d()) and
+        item.0.state|d('directory') == 'directory' and item.0.acl|d()
+
+- name: Manage bind mounts
+  mount:
+    src:    '{{ item.src }}'
+    path:   '{{ item.path   | d(item.dest | d(item.name)) }}'
+    fstype: '{{ item.fstype | d("none") }}'
+    opts:   '{{ ((item.opts if (item.opts is string) else (item.opts | join(","))) if item.opts|d() else "bind") }}'
+    dump:   '{{ item.dump   | d(omit) }}'
+    passno: '{{ item.passno | d(omit) }}'
+    state:  '{{ item.state  | d("mounted") }}'
+    fstab:  '{{ item.fstab  | d(omit) }}'
+  loop: '{{ (mount__binds
+             + mount__group_binds
+             + mount__host_binds)
+            | flatten }}'
+  when: (mount__enabled|bool and
+         (item.name|d() or item.dest|d() or item.path|d()) and
+         item.src|d())
+
+- name: Make sure that Ansible local facts directory exists
+  file:
+    path: '/etc/ansible/facts.d'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+
+- name: Save mount local facts
+  template:
+    src: 'etc/ansible/facts.d/mount.fact.j2'
+    dest: '/etc/ansible/facts.d/mount.fact'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'

--- a/ansible/roles/debops.mount/templates/etc/ansible/facts.d/mount.fact.j2
+++ b/ansible/roles/debops.mount/templates/etc/ansible/facts.d/mount.fact.j2
@@ -1,0 +1,13 @@
+#!/usr/bin/python{{ '2' if (ansible_python_version is version_compare('3.5', '<')) else '3' }}
+
+# {{ ansible_managed }}
+
+from __future__ import print_function
+from json import loads, dumps
+from sys import exit
+
+output = loads('''{{ {'configured': True,
+                      'enabled': mount__enabled|bool
+                      } | to_nice_json }}''')
+
+print(dumps(output, sort_keys=True, indent=4))

--- a/docs/ansible/role-index.rst
+++ b/docs/ansible/role-index.rst
@@ -127,6 +127,7 @@ other hosts.
 - :ref:`debops.cryptsetup`
 - :ref:`debops.iscsi`
 - :ref:`debops.lvm`
+- :ref:`debops.mount`
 - :ref:`debops.nfs`
 - :ref:`debops.nfs_server`
 - :ref:`debops.persistent_paths`
@@ -262,6 +263,7 @@ System configuration
 - :ref:`debops.locales`
 - :ref:`debops.logrotate`
 - :ref:`debops.machine`
+- :ref:`debops.mount`
 - :ref:`debops.netbase`
 - :ref:`debops.nsswitch`
 - :ref:`debops.ntp`

--- a/docs/ansible/roles/debops.mount/defaults-detailed.rst
+++ b/docs/ansible/roles/debops.mount/defaults-detailed.rst
@@ -1,0 +1,345 @@
+Default variable details
+========================
+
+Some of ``debops.mount`` default variables have more extensive configuration
+than simple strings or lists, here you can find documentation and examples for
+them.
+
+.. contents::
+   :local:
+   :depth: 1
+
+.. _mount__ref_devices:
+
+mount__devices
+--------------
+
+The ``mount__*_devices`` variables define a list of YAML dictionaires that
+configure local device mounts. They can be used to configure any mount type,
+however remote devices should be avoided (the role is executed early in the
+DebOps ``common.yml`` playbook, when network configuration might not be
+finished), and bind mounts have their own set of variables and a separate task
+to allow creation of source directories.
+
+The role does not create new filesystems, the devices configured by it should
+have their own filesystems configured and formatted beforehand.
+
+Examples
+~~~~~~~~
+
+Create an :file:`/etc/fstab` entry for a disk drive that's not mounted on boot,
+with specific filesystem type:
+
+.. code-block:: yaml
+
+   mount__devices:
+
+     - name: '/media/backups'
+       src: '/dev/sdb1'
+       fstype: 'ext4'
+       opts: 'defaults,noauto,nofail'
+
+Create an automount entry for an USB drive using :command:`systemd` automount
+functionality (you can find its UUID with :command:`lsblk -f` command):
+
+.. code-block:: yaml
+
+   mount__devices:
+
+     - name: '/media/USB_Stick'
+       src: 'UUID=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+       opts: [ 'defaults', 'noauto', 'nofail', 'x-systemd.automount',
+               'x-systemd.idle-timeout=2', 'x-systemd.device-timeout=2',
+               'x-systemd.mount-timeout=2' ]
+
+       # Without this, Ansible tries to mount the drive right away which
+       # results in an error
+       state: 'present'
+
+Syntax
+~~~~~~
+
+Each ``mount__*_devices`` list entry is a YAML dictionary with specific
+parameters. Most of the parameters are the same as the Ansible ``mount``
+module:
+
+``src``
+  Required. A device name which will be mounted at a given path. It can be
+  a block device file in :file:`/dev` directory, or a label, or device UUID.
+  See :man:`fstab(5)` manual page, first field description for more details.
+
+``path`` / ``dest`` / ``name``
+  Required. Absolute path in the filesystem where a given device will be
+  mounted.
+
+``fstype``
+  Optional. Specify the filesystem type to use with a given device. If not
+  specified, ``auto`` will be used to perform autodetection.
+
+``opts``
+  Optional. String (comma-delimited) or YAML list of options for a given mount
+  point. If not specified, ``defaults`` will be used instead.
+
+``dump``
+  Optional. This field determines which filesystems should be backeed up by the
+  :man:`dump(8)` command. If not specified, ``0`` is set by default.
+
+``passno``
+  Optional. This field determines the order of the filesystem checks on boot
+  done by the :man:`fsck(8)` command. The root filesystem should be it set to
+  ``1``, other filesystems should be set to ``2``. If not specified, it
+  defaults to ``0``, which disables filesystem checks on boot.
+
+``state``
+  Optional. If not specified or ``mounted``, the device entry will be added to
+  the :file:`/etc/fstab` database and it will be automatically mounted.
+  Unmounted devices will be mounted again. If the mount point directory is not
+  present, it will be automatically created.
+
+  If ``present``, the device entry will be added to :file:`/etc/fstab`, but
+  Ansible will not try to mount it right away (preferable for automounted
+  devices). Already mounted devices will not be changed.
+
+  If ``unmounted``, Ansible will try and unmount the already mounted device.
+  The :file:`/etc/fstab` database will not be changed, however missing entries
+  will be added.
+
+  If ``absent``, the mounted device will be unmounted, and the
+  :file:`/etc/fstab` database entry, along with the mount point directory, will
+  be removed.
+
+``fstab``
+  Optional. Absolute path of the alternative :man:`fstab(5)` database to use
+  instead of the default :file:`/etc/fstab` database.
+
+Additional parameters control functions outside of the Ansible ``mount``
+module:
+
+``device``
+  Optional. The role creates the required mount points by itself instead of
+  letting the Ansible ``mount`` module do it; this allows for fine-grained
+  control over initial mount point attributes. The task that creates the mount
+  points is not executed when they are actually mounted - the role checks if
+  the ``src`` parameter is present in the ``ansible_mounts`` fact entries as
+  the ``device`` dictionary key.
+
+  In case that the ``src`` parameter and the expected ``device`` dictionary key
+  are different, you can set the ``device`` parameter to override the check.
+
+``owner``
+  Optional. Specify the UNIX account that will be the owner of the initial
+  mount point, before the device is mounted. If not specified, ``root`` will be
+  the owner.
+
+``group``
+  Optional. Specify the UNIX group that will be the group of the initial mount
+  point, before the device is mounted. If not specified, the value of ``owner``
+  is used, otherwise ``root`` will be the group.
+
+``mode``
+  Optional. Specify the UNIX permissions that will be applied to the initial
+  mount point, before the device is mounted. If not specified, ``0755`` will be
+  set by default.
+
+
+.. _mount__ref_directories:
+
+mount__directories
+------------------
+
+The ``mount__*_directories`` variables are list of YAML dictionaries, each
+entry difining a directory in the filesystem, with optional attributes.  These
+variables can be used to create, modify or remove directories in the
+filesystems after they are mounted.
+
+Examples
+~~~~~~~~
+
+Create a directory owned by root on the mounted filesystem:
+
+.. code-block:: yaml
+
+   mount__directories:
+
+     - path: '/media/USB_Stick/Private'
+
+Create directory for data sharing btween unprivileged LXC containers. This
+assumes that the unprivileged LXC containers are started by ``root`` and use
+subUID/subGID range defined by the :ref:`debops.root_account` Ansible role:
+
+.. code-block:: yaml
+
+   mount__directories:
+
+     - path: '/srv/shared/lxc-opt'
+       owner: '100000'
+       group: '100000'
+       mode: '0751'
+
+Create directory with custom ACL permissions that allows the ``www-data``
+UNIX group to write files:
+
+.. code-block:: yaml
+
+   mount__directories:
+
+     - path: '/srv/www'
+
+     - path: '/srv/www/data'
+       owner: 'root'
+       group: 'root'
+       mode: '0750'
+       acl:
+         - entity: 'www-data'
+           etype: 'group'
+           permissions: 'rwx'
+
+Syntax
+~~~~~~
+
+The ``mount__*_directories`` lists contain YAML dictionaries, each dictionary
+can have spcific parameters, that reflect the Ansible ``file`` module
+parameters:
+
+``path`` / ``dest`` / ``name``
+  Required. Absolute path of the directory that is managed by the role.
+
+``owner``
+  Optional. Specify the UNIX account that should be the owner of the directory.
+  If not specified, ``root`` is used by default.
+
+``group``
+  Optional. Specify the UNIX group that should be the main group of the given
+  directory. If not specified, the value of ``owner`` is used by default,
+  otherwise ``root`` is set.
+
+``mode``
+  Optional. Set the permissions of the managed directory. If not specified,
+  ``0755`` will be used by default.
+
+``recurse``
+  Optional, boolean. If defined and ``True``, the role will set the specified
+  permissions and ownership recursively to all subdirectories of the given
+  directory as well as to the directory itself.
+
+``state``
+  Optional. If not specified or ``directory``, the given directory will be
+  created or updated with the specified permissions and ownership. If
+  ``absent``, the given directory will be removed. Other values of the
+  ``state`` parameter are ignored in this role.
+
+``acl``
+  Optional. This parameter defines Access Control List entries for a given
+  directory, each entry is a YAML dictionary with specific parameters:
+
+  ``entity``
+    Name of the ACL entity to manage, either UNIX account or UNIX group.
+
+  ``etype``
+    The entity type of a given ACL, check the :man:`setfacl(1)` manual page for
+    more details. Choices: ``user``, ``group``, ``other``, ``mask``.
+
+  ``permissions``
+    Specify the permissions to set for a given ACL entry, they can be
+    a combination of ``r`` (read), ``w`` (write) and ``x`` (execute).
+
+  ``default``
+    Optional, boolean. If defined and ``True``, a given ACL entry will be the
+    default for all entities created inside of a given directory.
+
+  ``follow``
+    Optional, boolean. If set and ``True``, the Ansible module will follow the
+    symlinked directory to the symlink target and change its attributes instead
+    of the symlink attributes.
+
+  ``recursive``
+    Optional, boolean. If set and ``True``, the Ansible module will apply the
+    specified ACL to all objects in a given path.
+
+  ``state``
+    Optional. If not set or ``present``, the ACL entry will be added to the
+    current object. If ``absent``, the ACL entry will be removed from the
+    current path.
+
+
+.. _mount__ref_binds:
+
+mount__binds
+------------
+
+The ``mount__*_binds`` variables can be used to create bind mounted directories
+in the filesystem. Bind mounts are similar to symlinks, where a given directory
+is mounted at a different place in the filesystem. This can be used to give
+access to parts of the filesystem in a different namespace, for example in
+a LXC container.
+
+The task tha manages the bind mounts are separate from the "normal" mounts to
+allow the system to mount devices that could have parts of their filesystem
+bind-mounted later on.
+
+Examples
+~~~~~~~~
+
+Bind mount the USB drive at a different point in the filesystem:
+
+.. code-block:: yaml
+
+   mount__binds:
+
+     - src: '/media/USB_Stick'
+       dest: '/srv/removable/data'
+
+Syntax
+~~~~~~
+
+Each ``mount__*_binds`` list entry is a YAML dictionary with specific
+parameters. The parameters are the same as the Ansible ``mount`` module:
+
+``src``
+  Required. A directory name which will be bind mounted at a given path. The
+  directory should already exist. You can use the :ref:`mount__ref_directories`
+  variables to create the directories beforehand.
+
+``path`` / ``dest`` / ``name``
+  Required. Absolute path in the filesystem where a given directory will be
+  bind mounted.
+
+``fstype``
+  Optional. Specify the filesystem type to use with a given device. If not
+  specified, ``none`` will be used, which is required for bind mounts.
+
+``opts``
+  Optional. String (comma-delimited) or YAML list of options for a given mount
+  point. If not specified, ``bind`` will be used instead.
+
+``dump``
+  Optional. This field determines which filesystems should be backeed up by the
+  :man:`dump(8)` command. If not specified, ``0`` is set by default.
+
+``passno``
+  Optional. This field determines the order of the filesystem checks on boot
+  done by the :man:`fsck(8)` command. The root filesystem should be it set to
+  ``1``, other filesystems should be set to ``2``. If not specified, it
+  defaults to ``0``, which disables filesystem checks on boot.
+
+``state``
+  Optional. If not specified or ``mounted``, the bind mount entry will be added
+  to the :file:`/etc/fstab` database and it will be automatically mounted.
+  Unmounted bind directories will be mounted again. If the mount point
+  directory is not present, it will be automatically created.
+
+  If ``present``, the bind mount entry will be added to :file:`/etc/fstab`, but
+  Ansible will not try to mount it right away (preferable for automounted
+  devices). Already mounted bind directories will not be changed.
+
+  If ``unmounted``, Ansible will try and unmount the already bind mounted
+  directories.  The :file:`/etc/fstab` database will not be changed, however
+  missing entries will be added.
+
+  If ``absent``, the bind mounted directory will be unmounted, and the
+  :file:`/etc/fstab` database entry, along with the mount point directory, will
+  be removed.
+
+``fstab``
+  Optional. Absolute path of the alternative :man:`fstab(5)` database to use
+  instead of the default :file:`/etc/fstab` database.

--- a/docs/ansible/roles/debops.mount/getting-started.rst
+++ b/docs/ansible/roles/debops.mount/getting-started.rst
@@ -1,0 +1,64 @@
+Getting started
+===============
+
+.. contents::
+   :local:
+
+
+Example inventory
+-----------------
+
+The ``debops.mount`` role is included by default in the DebOps ``common.yml``
+playbook and does not need to be explicitly enabled. It can be disabled if
+needed, by setting the :envvar:`mount__enabled` boolean variable to ``False``
+in the Ansible inventory.
+
+
+Example playbook
+----------------
+
+If you are using this role without DebOps, here's an example Ansible playbook
+that uses the ``debops.mount`` role:
+
+.. literalinclude:: ../../../../ansible/playbooks/service/mount.yml
+   :language: yaml
+
+
+Ansible tags
+------------
+
+You can use Ansible ``--tags`` or ``--skip-tags`` parameters to limit what
+tasks are performed during Ansible run. This can be used after a host was first
+configured to speed up playbook execution, when you are sure that most of the
+configuration is already in the desired state.
+
+Available role tags:
+
+``role::mount``
+  Main role tag, should be used in the playbook to execute all of the role
+  tasks as well as role dependencies.
+
+
+Other resources
+---------------
+
+List of other useful resources related to the ``debops.mount`` Ansible role:
+
+- Manual pages: :man:`fstab(5)`, :man:`systemd.mount(5)`,
+  :man:`systemd.automount(5)`
+
+- `Ansible 'mount' module documentation`__
+
+  .. __: https://docs.ansible.com/ansible/latest/modules/mount_module.html
+
+- `Debian Wiki: fstab`__
+
+  .. __: https://wiki.debian.org/fstab
+
+- `Arch Linux Wiki: fstab`__
+
+  .. __: https://wiki.archlinux.org/index.php/Fstab
+
+- `StackExchange: What is a bind mount?`__
+
+  .. __: https://unix.stackexchange.com/a/198591

--- a/docs/ansible/roles/debops.mount/index.rst
+++ b/docs/ansible/roles/debops.mount/index.rst
@@ -1,0 +1,31 @@
+.. _debops.mount:
+
+debops.mount
+============
+
+The ``debops.mount`` Ansible role can be used to manage local filesystem mounts
+as well as bind mounts in the :file:`/etc/fstab` database. Custom directories
+can also be created by this role, with support for normal as well as ACL
+attributes.
+
+This role is meant to be used to configure local filesystems, for remote
+filesystems, you can use the :ref:`debops.nfs` role instead, which will
+configure the NFS client service.
+
+.. toctree::
+   :maxdepth: 2
+
+   getting-started
+   defaults
+   defaults-detailed
+
+Copyright
+---------
+
+.. literalinclude:: ../../../../ansible/roles/debops.mount/COPYRIGHT
+
+..
+ Local Variables:
+ mode: rst
+ ispell-local-dictionary: "american"
+ End:


### PR DESCRIPTION
The role 'debops.mount' allows configuration of local device and bind
mounts. It's included in the 'common.yml' playbook by default.