### PR TITLE
[debops.apt] Allow sources to be overridden in inventory.

### DIFF
--- a/ansible/roles/debops.apt/defaults/main.yml
+++ b/ansible/roles/debops.apt/defaults/main.yml
@@ -356,6 +356,19 @@ apt__original_sources:
                          else "absent" }}'
 
                                                                    # ]]]
+# .. envvar:: apt__default_sources_present [[[
+#
+# Define if the default APT package sources for specific distributions should
+# be used or not.
+# If package sources are defined in specific group, host or on all hosts in
+# Ansible inventory, the default sources will be disabled.
+apt__default_sources_present: '{{ "True"
+                                  if ( not apt__group_sources and
+                                       not apt__host_sources and
+                                       not apt__sources )
+                                    else "False" }}'
+
+                                                                   # ]]]
 # .. envvar:: apt__default_sources [[[
 #
 # List of the default APT package sources for specific distributions. These are
@@ -406,6 +419,32 @@ apt__default_sources:
     distribution: 'Devuan'
 
                                                                    # ]]]
+# .. envvar:: apt__security_sources_state [[[
+#
+# Enable (if ``present``) or disable (if ``absent``) the default APT
+# repositories proving security updates.
+# If a local security mirror is defined in Ansible inventory group or host,
+# this will disable the default security repositories.
+apt__security_sources_state: '{{ "present"
+                                  if ( not apt__group_security_sources and
+                                       not apt__host_security_sources )
+                                  else "absent" }}'
+
+                                                                   # ]]]
+# .. envvar:: apt__group_security_sources [[[
+#
+# List of APT repositories that provide security updates for hosts in
+# specific Ansible inventory group.
+apt__group_security_sources: []
+
+                                                                   # ]]]
+# .. envvar:: apt__host_security_sources [[[
+#
+# List of APT repositories that provide security updates for hosts in
+# specific Ansible inventory host.
+apt__host_security_sources: []
+
+                                                                   # ]]]
 # .. envvar:: apt__security_sources [[[
 #
 # List of APT package sources that provide security updates. This list is used
@@ -419,7 +458,7 @@ apt__security_sources:
     suite:      '{{ apt__distribution_release + "/updates" }}'
     components: '{{ apt__distribution_components }}'
     distribution: 'Debian'
-    state:      '{{ "present"
+    state:      '{{ apt__security_sources_state
                     if (apt__distribution_release|d("unknown")
                         in apt__distribution_release_map[apt__distribution]|d([]))
                     else "absent" }}'
@@ -451,7 +490,7 @@ apt__security_sources:
     suite:      '{{ apt__distribution_release + "-security" }}'
     components: '{{ apt__distribution_components }}'
     distribution: 'Ubuntu'
-    state:      '{{ "present"
+    state:      '{{ apt__security_sources_state
                     if (apt__architecture in ["amd64", "i386"])
                     else "absent" }}'
 
@@ -461,7 +500,7 @@ apt__security_sources:
     suite:      '{{ apt__distribution_release + "-security" }}'
     components: '{{ apt__distribution_components }}'
     distribution: 'Ubuntu'
-    state:      '{{ "present"
+    state:      '{{ apt__security_sources_state
                     if (apt__architecture not in ["amd64", "i386"])
                     else "absent" }}'
 
@@ -471,7 +510,7 @@ apt__security_sources:
     suite:      '{{ apt__distribution_release + "-security" }}'
     components: '{{ apt__distribution_components }}'
     distribution: 'Devuan'
-    state:      '{{ "present"
+    state:      '{{ apt__security_sources_state
                     if (apt__distribution_release|d("unknown")
                         in apt__distribution_release_map[apt__distribution]|d([]))
                     else "absent" }}'
@@ -485,8 +524,10 @@ apt__security_sources:
 apt__combined_sources: '{{ apt__sources +
                            apt__group_sources +
                            apt__host_sources +
-                           apt__original_sources +
-                           apt__default_sources +
+                           apt__original_sources }} +
+                           {{ apt__default_sources if apt__default_sources_present else [] }} +
+                           {{ apt__host_security_sources +
+                           apt__group_security_sources +
                            apt__security_sources }}'
                                                                    # ]]]
                                                                    # ]]]

--- a/ansible/roles/debops.apt/defaults/main.yml
+++ b/ansible/roles/debops.apt/defaults/main.yml
@@ -356,17 +356,13 @@ apt__original_sources:
                          else "absent" }}'
 
                                                                    # ]]]
-# .. envvar:: apt__default_sources_present [[[
+# .. envvar:: apt__default_sources_state [[[
 #
-# Define if the default APT package sources for specific distributions should
-# be used or not.
+# Enable (if ``present``) or disable (if ``absent``) the default APT
+# package sources for specific distributions.
 # If package sources are defined in specific group, host or on all hosts in
-# Ansible inventory, the default sources will be disabled.
-apt__default_sources_present: '{{ "True"
-                                  if ( not apt__group_sources and
-                                       not apt__host_sources and
-                                       not apt__sources )
-                                    else "False" }}'
+# Ansible inventory, it may be desirable not to include the default sources.
+apt__default_sources_state: 'present'
 
                                                                    # ]]]
 # .. envvar:: apt__default_sources [[[
@@ -382,10 +378,12 @@ apt__default_sources:
   - uri:          'http://deb.debian.org/debian'
     comment:      '{{ "Official " + apt__distribution + " repositories" }}'
     distribution: 'Debian'
+    state:        '{{ apt__default_sources_state }}'
 
   - uri:          'http://mirrordirector.raspbian.org/raspbian/'
     comment:      '{{ "Official " + apt__distribution + " repositories" }}'
     distribution: 'Raspbian'
+    state:        '{{ apt__default_sources_state }}'
 
   - uri:          'http://repos.rcn-ee.com/debian/'
     comment:      'rcn-ee.net repository as used on BeagleBoards for additional hardware support'
@@ -394,7 +392,7 @@ apt__default_sources:
     suite:        '{{ apt__distribution_release }}'
     components:   [ "main" ]
     distribution: 'Debian'
-    state:        '{{ "present"
+    state:        '{{ apt__default_sources_state
                       if (apt__architecture in ["armhf"] and
                           ("cape_universal" in ansible_cmdline) or
                           ("bone_capemgr" in ansible_cmdline))
@@ -403,20 +401,21 @@ apt__default_sources:
   - uri:          'http://archive.ubuntu.com/ubuntu'
     comment:      '{{ "Official " + apt__distribution + " repositories" }}'
     distribution: 'Ubuntu'
-    state:        '{{ "present"
+    state:        '{{ apt__default_sources_state
                       if (apt__architecture in ["amd64", "i386"])
                       else "absent" }}'
 
-  - uri: 'http://ports.ubuntu.com/ubuntu-ports'
-    comment: '{{ "Official " + apt__distribution + " Port repositories" }}'
+  - uri:          'http://ports.ubuntu.com/ubuntu-ports'
+    comment:      '{{ "Official " + apt__distribution + " Port repositories" }}'
     distribution: 'Ubuntu'
-    state:       '{{ "present"
-                     if (apt__architecture not in ["amd64", "i386"])
-                     else "absent" }}'
+    state:        '{{ apt__default_sources_state
+                      if (apt__architecture not in ["amd64", "i386"])
+                      else "absent" }}'
 
   - uri:          'http://auto.mirror.devuan.org/merged'
     comment:      '{{ "Official " + apt__distribution + " repositories" }}'
     distribution: 'Devuan'
+    state:        '{{ apt__default_sources_state }}'
 
                                                                    # ]]]
 # .. envvar:: apt__security_sources_state [[[
@@ -424,11 +423,8 @@ apt__default_sources:
 # Enable (if ``present``) or disable (if ``absent``) the default APT
 # repositories proving security updates.
 # If a local security mirror is defined in Ansible inventory group or host,
-# this will disable the default security repositories.
-apt__security_sources_state: '{{ "present"
-                                  if ( not apt__group_security_sources and
-                                       not apt__host_security_sources )
-                                  else "absent" }}'
+# it may be desirable not to include the default security sources.
+apt__security_sources_state: 'present'
 
                                                                    # ]]]
 # .. envvar:: apt__group_security_sources [[[
@@ -452,68 +448,68 @@ apt__host_security_sources: []
 # from normal repositories.
 apt__security_sources:
 
-  - uri:        'http://security.debian.org/'
-    comment:    'Debian Security repository'
-    type:       '{{ apt__source_types }}'
-    suite:      '{{ apt__distribution_release + "/updates" }}'
-    components: '{{ apt__distribution_components }}'
+  - uri:          'http://security.debian.org/'
+    comment:      'Debian Security repository'
+    type:         '{{ apt__source_types }}'
+    suite:        '{{ apt__distribution_release + "/updates" }}'
+    components:   '{{ apt__distribution_components }}'
     distribution: 'Debian'
-    state:      '{{ apt__security_sources_state
-                    if (apt__distribution_release|d("unknown")
-                        in apt__distribution_release_map[apt__distribution]|d([]))
-                    else "absent" }}'
+    state:        '{{ apt__security_sources_state
+                      if (apt__distribution_release|d("unknown")
+                          in apt__distribution_release_map[apt__distribution]|d([]))
+                      else "absent" }}'
 
     # This version may be present on some installations. It's here so that the
     # fact script knows that a given URL is a secuirity source and doesn't
     # create normal entries. This version is not added to the final file.
-  - uri:        'http://security.debian.org'
-    comment:    'Debian Security repository'
-    type:       '{{ apt__source_types }}'
-    suite:      '{{ apt__distribution_release + "/updates" }}'
-    components: '{{ apt__distribution_components }}'
+  - uri:          'http://security.debian.org'
+    comment:      'Debian Security repository'
+    type:         '{{ apt__source_types }}'
+    suite:        '{{ apt__distribution_release + "/updates" }}'
+    components:   '{{ apt__distribution_components }}'
     distribution: 'Debian'
-    state: 'absent'
+    state:        'absent'
 
     # This version shows up in Debian Stretch APT configuration.
     # It's disabled by default to not create duplicate entries.
-  - uri:        'http://security.debian.org/debian-security'
-    comment:    'Debian Security repository'
-    type:       '{{ apt__source_types }}'
-    suite:      '{{ apt__distribution_release + "/updates" }}'
-    components: '{{ apt__distribution_components }}'
+  - uri:          'http://security.debian.org/debian-security'
+    comment:      'Debian Security repository'
+    type:         '{{ apt__source_types }}'
+    suite:        '{{ apt__distribution_release + "/updates" }}'
+    components:   '{{ apt__distribution_components }}'
     distribution: 'Debian'
-    state: 'absent'
+    state:        'absent'
 
-  - uri:        'http://security.ubuntu.com/ubuntu'
-    comment:    'Ubuntu Security repository'
-    type:       '{{ apt__source_types }}'
-    suite:      '{{ apt__distribution_release + "-security" }}'
-    components: '{{ apt__distribution_components }}'
+  - uri:          'http://security.ubuntu.com/ubuntu'
+    comment:      'Ubuntu Security repository'
+    type:         '{{ apt__source_types }}'
+    suite:        '{{ apt__distribution_release + "-security" }}'
+    components:   '{{ apt__distribution_components }}'
     distribution: 'Ubuntu'
-    state:      '{{ apt__security_sources_state
-                    if (apt__architecture in ["amd64", "i386"])
-                    else "absent" }}'
+    state:        '{{ apt__security_sources_state
+                      if (apt__architecture in ["amd64", "i386"])
+                      else "absent" }}'
 
-  - uri:        'http://ports.ubuntu.com/ubuntu-ports'
-    comment:    'Ubuntu Ports Security repository'
-    type:       '{{ apt__source_types }}'
-    suite:      '{{ apt__distribution_release + "-security" }}'
-    components: '{{ apt__distribution_components }}'
+  - uri:          'http://ports.ubuntu.com/ubuntu-ports'
+    comment:      'Ubuntu Ports Security repository'
+    type:         '{{ apt__source_types }}'
+    suite:        '{{ apt__distribution_release + "-security" }}'
+    components:   '{{ apt__distribution_components }}'
     distribution: 'Ubuntu'
-    state:      '{{ apt__security_sources_state
-                    if (apt__architecture not in ["amd64", "i386"])
-                    else "absent" }}'
+    state:        '{{ apt__security_sources_state
+                      if (apt__architecture not in ["amd64", "i386"])
+                      else "absent" }}'
 
-  - uri:        'http://auto.mirror.devuan.org/merged'
-    comment:    'Devuan Security repository'
-    type:       '{{ apt__source_types }}'
-    suite:      '{{ apt__distribution_release + "-security" }}'
-    components: '{{ apt__distribution_components }}'
+  - uri:          'http://auto.mirror.devuan.org/merged'
+    comment:      'Devuan Security repository'
+    type:         '{{ apt__source_types }}'
+    suite:        '{{ apt__distribution_release + "-security" }}'
+    components:   '{{ apt__distribution_components }}'
     distribution: 'Devuan'
-    state:      '{{ apt__security_sources_state
-                    if (apt__distribution_release|d("unknown")
-                        in apt__distribution_release_map[apt__distribution]|d([]))
-                    else "absent" }}'
+    state:        '{{ apt__security_sources_state
+                      if (apt__distribution_release|d("unknown")
+                          in apt__distribution_release_map[apt__distribution]|d([]))
+                      else "absent" }}'
 
                                                                    # ]]]
 # .. envvar:: apt__combined_sources [[[
@@ -524,9 +520,9 @@ apt__security_sources:
 apt__combined_sources: '{{ apt__sources +
                            apt__group_sources +
                            apt__host_sources +
-                           apt__original_sources }} +
-                           {{ apt__default_sources if apt__default_sources_present else [] }} +
-                           {{ apt__host_security_sources +
+                           apt__original_sources +
+                           apt__default_sources +
+                           apt__host_security_sources +
                            apt__group_security_sources +
                            apt__security_sources }}'
                                                                    # ]]]

--- a/ansible/roles/debops.apt/templates/etc/ansible/facts.d/apt.fact.j2
+++ b/ansible/roles/debops.apt/templates/etc/ansible/facts.d/apt.fact.j2
@@ -15,7 +15,7 @@ import os
 {% set apt__tpl_default_sources = [] %}
 {% set apt__tpl_default_sources_map = {} %}
 {% set apt__tpl_source_distributions = {} %}
-{% for repo in apt__security_sources %}
+{% for repo in ( apt__host_security_sources, apt__group_security_sources, apt__security_sources ) %}
 {%   set _ = apt__tpl_security_sources.extend(
                  debops__tpl_macros.flattened(
                      repo.uri, repo.uris) | from_json) %}

--- a/ansible/roles/debops.apt/templates/etc/ansible/facts.d/apt.fact.j2
+++ b/ansible/roles/debops.apt/templates/etc/ansible/facts.d/apt.fact.j2
@@ -15,7 +15,9 @@ import os
 {% set apt__tpl_default_sources = [] %}
 {% set apt__tpl_default_sources_map = {} %}
 {% set apt__tpl_source_distributions = {} %}
-{% for repo in ( apt__host_security_sources, apt__group_security_sources, apt__security_sources ) %}
+{% for repo in ( apt__host_security_sources,
+                 apt__group_security_sources,
+                 apt__security_sources ) %}
 {%   set _ = apt__tpl_security_sources.extend(
                  debops__tpl_macros.flattened(
                      repo.uri, repo.uris) | from_json) %}

--- a/ansible/roles/debops.apt/templates/etc/ansible/facts.d/apt.fact.j2
+++ b/ansible/roles/debops.apt/templates/etc/ansible/facts.d/apt.fact.j2
@@ -15,8 +15,8 @@ import os
 {% set apt__tpl_default_sources = [] %}
 {% set apt__tpl_default_sources_map = {} %}
 {% set apt__tpl_source_distributions = {} %}
-{% for repo in ( apt__host_security_sources,
-                 apt__group_security_sources,
+{% for repo in ( apt__host_security_sources +
+                 apt__group_security_sources +
                  apt__security_sources ) %}
 {%   set _ = apt__tpl_security_sources.extend(
                  debops__tpl_macros.flattened(

--- a/docs/ansible/roles/debops.apt/getting-started.rst
+++ b/docs/ansible/roles/debops.apt/getting-started.rst
@@ -11,7 +11,9 @@ Default configuration
 Role tries to detect the original APT repositories configured on the system and
 use them in the generated :file:`/etc/apt/sources.list` configuration file. They
 will be placed before the default repositories, with assumption that the
-original repositories pointed to the closest mirror.
+original repositories pointed to the closest mirror. The original APT
+repositories can be completely disabled by setting ``apt__original_sources: []``
+in your inventory.
 
 The ``non-free`` repositories will be enabled automatically on hardware-based
 hosts in case any non-free firmware is required. Otherwise, only the ``main``
@@ -31,6 +33,34 @@ following setting in your inventory:
 .. code-block:: yaml
 
    apt__enabled: False
+
+
+If you have a local APT mirror that you want a group of hosts to use
+exclusively, you could compose your inventory like this:
+
+.. code-block:: yaml
+
+   # Don't use the default mirrors
+   apt__default_sources_state: 'absent'
+   
+   # Don't use the default security mirrors
+   apt__security_sources_state: 'absent'
+   
+   # Replace the original APT mirror
+   apt__original_sources: []
+   
+   # Define local APT mirror
+   apt__group_sources:
+     - uri:          'http://mirrors.domain.fqdn/debian'
+       comment:      '{{ "Local " + apt__distribution + " repositories" }}'
+       distribution: 'Debian'
+
+   # Define local APT security mirrors
+   apt__group_security_sources:
+     - uri:          'http://mirrors.domain.fqdn/debian-security'
+       comment:      '{{ "Local " + apt__distribution + " Security repository" }}'
+       suite:        '{{ apt__distribution_release + "/updates" }}'
+       distribution: 'Debian'
 
 
 Example playbook


### PR DESCRIPTION
Before this, there was no good way to override apt__security_sources
and apt__default_sources, without copying the entire variables to your
inventory.
This may be beneficial when you want to use a local mirror instead
of the public mirrors.

Example inventory configuration;
```yaml
apt__original_sources: []

apt__group_security_sources:
  - uri:          'http://deb.domain.fqdn/debian-security'
    comment:      '{{ "Local " + apt__distribution + " Security repository" }}'
    type:         '{{ apt__source_types }}'
    suite:        '{{ apt__distribution_release + "/updates" }}'
    components:   '{{ apt__distribution_components }}'
    distribution: 'Debian'
    state:        'present'
  - uri:          'http://deb.domain.fqdn/ubuntu-security'
    comment:      '{{ "Local " + apt__distribution + " Security repository" }}'
    type:         '{{ apt__source_types }}'
    suite:        '{{ apt__distribution_release + "-security" }}'
    components:   '{{ apt__distribution_components }}'
    distribution: 'Ubuntu'
    state:        'present'

  - uris:
      - 'https://deb.domain.fqdn/debian-security'
      - 'http://deb.domain.fqdn/debian-security/'
      - 'https://deb.domain.fqdn/debian-security/'
    state: "absent"

apt__group_sources:
  - uri:          'http://deb.domain.fqdn/debian'
    comment:      '{{ "Local " + apt__distribution + " repositories" }}'
    distribution: 'Debian'
  - uri:          'http://deb.domain.fqdn/ubuntu'
    comment:      '{{ "not-so-Official " + apt__distribution + " repositories" }}'
    distribution: 'Ubuntu'
```