### PR TITLE
PostgreSQL Replica servers are readonly.

### DIFF
--- a/ansible/roles/debops.postgresql_server/tasks/secure_installation.yml
+++ b/ansible/roles/debops.postgresql_server/tasks/secure_installation.yml
@@ -12,6 +12,8 @@
   become_user: '{{ item.user | d(postgresql_server__user) }}'
   when: item.name|d()
   no_log: True
+  register: postgresql_server__register_postgresql_user
+  failed_when: "'cannot execute ALTER ROLE in a read-only transaction' not in postgresql_server__register_postgresql_user.msg"
 
 - name: Grant connect on postgres to PUBLIC
   postgresql_privs:
@@ -25,6 +27,8 @@
     - '{{ postgresql_server__clusters }}'
   become_user: '{{ item.user | d(postgresql_server__user) }}'
   when: item.name|d()
+  register: postgresql_server__register_postgresql_privs
+  failed_when: "'cannot execute GRANT in a read-only transaction' not in postgresql_server__register_postgresql_privs.msg"
 
 - name: Revoke temporary on postgres from PUBLIC
   postgresql_privs:
@@ -38,3 +42,5 @@
     - '{{ postgresql_server__clusters }}'
   become_user: '{{ item.user | d(postgresql_server__user) }}'
   when: item.name|d()
+  register: postgresql_server__register_postgresql_revoke
+  failed_when: "'cannot execute REVOKE in a read-only transaction' not in postgresql_server__register_postgresql_revoke.msg"


### PR DESCRIPTION
This handles error checking on READ-ONLY states only, providing
a fix when it tries to do these write operations on a slave.