### PR TITLE
Added local stratum fudge for chronyd

### DIFF
--- a/ansible/roles/debops.ntp/templates/etc/chrony/chrony.conf.j2
+++ b/ansible/roles/debops.ntp/templates/etc/chrony/chrony.conf.j2
@@ -39,6 +39,11 @@ allow {{ address }}
 
 {% endif %}
 
+{% if ntp__fudge is defined and ntp__fudge %}
+# Fudge local clock if time servers is not available
+local stratum 10
+{% endif %}
+
 # This directive specify the location of the file containing ID/key pairs for
 # NTP authentication.
 keyfile /etc/chrony/chrony.keys


### PR DESCRIPTION
This uses the ntp__fudge attribute to enable/disable the
local stratum option in chronyd's configuration. Set
to True, and it adds the `local stratum 10` line for
servers as per suggestions when running multiple time sync
servers.