### PR TITLE
Fix empty file support in 'lxc_ssh.py' plugin

### DIFF
--- a/ansible/plugins/connection_plugins/lxc_ssh.py
+++ b/ansible/plugins/connection_plugins/lxc_ssh.py
@@ -1358,7 +1358,13 @@ class Connection(ConnectionBase):
 
         with open(in_path, 'r') as in_f:
             in_data = in_f.read()
-            cmd = ('cat > %s; echo -n done' % pipes.quote(out_path))
+            if (len(in_data) == 0):
+                # define a shortcut for empty files - nothing to read so the
+                # ssh pipe will hang
+                cmd = ('touch %s; echo -n done' % pipes.quote(out_path))
+            else:
+                # regular command
+                cmd = ('cat > %s; echo -n done' % pipes.quote(out_path))
             h = self.container_name
             if (self.lxc_version == 2):
                 lxc_cmd = ('lxc exec %s --mode=non-interactive -- '


### PR DESCRIPTION
This commit includes the fix for creation of empty files using the
'lxc_ssh.py' connection plugin.

Issue: https://github.com/andreasscherbaum/ansible-lxc-ssh/issues/17
Fix: https://github.com/andreasscherbaum/ansible-lxc-ssh/pull/18