### PR TITLE
Locking netbox version on 2.4.9 - the last one to support python2

### DIFF
--- a/ansible/roles/debops.netbox/defaults/main.yml
+++ b/ansible/roles/debops.netbox/defaults/main.yml
@@ -138,7 +138,7 @@ netbox__git_repo: 'https://github.com/digitalocean/netbox.git'
 # .. envvar:: netbox__git_version [[[
 #
 # The :command:`git` branch or tag which will be installed.
-netbox__git_version: 'master'
+netbox__git_version: 'v2.4.9'
 
                                                                    # ]]]
 # .. envvar:: netbox__git_dest [[[


### PR DESCRIPTION
Temporary fix to #580. 