### PR TITLE
Fix for docker versions that still use docker.socket

### DIFF
--- a/ansible/roles/debops.docker/templates/etc/systemd/system/docker.service.j2
+++ b/ansible/roles/debops.docker/templates/etc/systemd/system/docker.service.j2
@@ -3,7 +3,11 @@
 [Unit]
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
+{% if docker__register_version.stdout is version('18.09', '>=') %}
 BindsTo=containerd.service
+{% else %}
+Requires=docker.socket
+{% endif %}
 After=network-online.target firewalld.service
 Wants=network-online.target
 


### PR DESCRIPTION
Fixes #582.

```
TASK [debops.docker : Install Debian systemd service unit] *******************************************************************************************************************
--- before: /etc/systemd/system/docker.service
+++ after: /home/mike/.ansible/tmp/ansible-local-3512fco9IJ/tmp2oZ2oO/docker.service.j2
@@ -3,7 +3,7 @@
 [Unit]
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
-BindsTo=containerd.service
+Requires=docker.socket
 After=network-online.target firewalld.service
 Wants=network-online.target
``` 