### PR TITLE
[debops.netbox] Create new Python 3 virtualenv

### DIFF
--- a/ansible/playbooks/service/netbox.yml
+++ b/ansible/playbooks/service/netbox.yml
@@ -39,11 +39,13 @@
         - '{{ netbox__postgresql__dependent_pgpass }}'
 
     - role: debops.python
-      tags: [ 'role::python', 'skip::python', 'role::gunicorn' ]
+      tags: [ 'role::python', 'skip::python', 'role::gunicorn', 'role::netbox' ]
       python__dependent_packages3:
         - '{{ gunicorn__python__dependent_packages3 }}'
+        - '{{ netbox__python__dependent_packages3 }}'
       python__dependent_packages2:
         - '{{ gunicorn__python__dependent_packages2 }}'
+        - '{{ netbox__python__dependent_packages2 }}'
 
     - role: debops.gunicorn
       tags: [ 'role::gunicorn', 'skip::gunicorn' ]

--- a/ansible/roles/debops.netbox/defaults/main.yml
+++ b/ansible/roles/debops.netbox/defaults/main.yml
@@ -40,15 +40,15 @@ netbox__domain: '{{ ansible_local.core.domain
 netbox__base_packages:
   - 'git'
   - 'build-essential'
-  - 'python-dev'
-  - 'python-pip'
+  - 'python{{ netbox__virtualenv_version }}-dev'
+  - 'python{{ netbox__virtualenv_version }}-pip'
   - 'libxml2-dev'
   - 'libxslt1-dev'
   - 'libffi-dev'
   - 'graphviz'
   - 'libpq-dev'
   - 'libssl-dev'
-  - '{{ "python-virtualenv"
+  - '{{ "python{{ netbox__virtualenv_version }}-virtualenv"
         if (ansible_distribution_release in [ "wheezy", "precise" ])
         else "virtualenv" }}'
 

--- a/ansible/roles/debops.netbox/defaults/main.yml
+++ b/ansible/roles/debops.netbox/defaults/main.yml
@@ -170,7 +170,7 @@ netbox__virtualenv_version: '{{ ""
 # .. envvar:: netbox__virtualenv [[[
 #
 # Path where the NetBox ``virtualenv`` directory will be stored.
-netbox__virtualenv: '{{ netbox__lib + "/virtualenv" + netbox__virtualenv_version }}'
+netbox__virtualenv: '{{ netbox__lib + "/virtualenv" }}'
 
                                                                    # ]]]
 # .. envvar:: netbox__virtualenv_env_path [[[

--- a/ansible/roles/debops.netbox/defaults/main.yml
+++ b/ansible/roles/debops.netbox/defaults/main.yml
@@ -40,17 +40,12 @@ netbox__domain: '{{ ansible_local.core.domain
 netbox__base_packages:
   - 'git'
   - 'build-essential'
-  - 'python{{ netbox__virtualenv_version }}-dev'
-  - 'python{{ netbox__virtualenv_version }}-pip'
   - 'libxml2-dev'
   - 'libxslt1-dev'
   - 'libffi-dev'
   - 'graphviz'
   - 'libpq-dev'
   - 'libssl-dev'
-  - '{{ "python{{ netbox__virtualenv_version }}-virtualenv"
-        if (ansible_distribution_release in [ "wheezy", "precise" ])
-        else "virtualenv" }}'
 
                                                                    # ]]]
 # .. envvar:: netbox__packages [[[
@@ -597,6 +592,22 @@ netbox__app_params:
 # Configuration variables for other Ansible roles [[[
 # ---------------------------------------------------
 
+# .. envvar:: netbox__python__dependent_packages3 [[[
+#
+# Configuration for the :ref:`debops.python` Ansible role.
+netbox__python__dependent_packages3:
+
+  - 'python3-dev'
+
+                                                                   # ]]]
+# .. envvar:: netbox__python__dependent_packages2 [[[
+#
+# Configuration for the :ref:`debops.python` Ansible role.
+netbox__python__dependent_packages2:
+
+  - 'python-dev'
+
+                                                                   # ]]]
 # .. envvar:: netbox__gunicorn__dependent_applications [[[
 #
 # Configuration for the :ref:`debops.gunicorn` Ansible role.

--- a/ansible/roles/debops.netbox/defaults/main.yml
+++ b/ansible/roles/debops.netbox/defaults/main.yml
@@ -138,7 +138,7 @@ netbox__git_repo: 'https://github.com/digitalocean/netbox.git'
 # .. envvar:: netbox__git_version [[[
 #
 # The :command:`git` branch or tag which will be installed.
-netbox__git_version: 'v2.4.9'
+netbox__git_version: 'master'
 
                                                                    # ]]]
 # .. envvar:: netbox__git_dest [[[
@@ -156,10 +156,21 @@ netbox__git_checkout: '{{ netbox__virtualenv + "/app" }}'
 # Python virtualenv configuration [[[
 # -----------------------------------
 
+# .. envvar:: netbox__virtualenv_version [[[
+#
+# Beginning with v2.5, NetBox will no longer support Python 2.
+# When this is set to `3` a **new** Python 3 `virtualenv` environment will be
+# created next to the old one.
+# Valid values are `3` or an empty string.
+netbox__virtualenv_version: '{{ ""
+                                 if netbox__git_version|replace("v", "") is version("2.5", "<")
+                                 else "3" }}'
+
+                                                                   # ]]]
 # .. envvar:: netbox__virtualenv [[[
 #
 # Path where the NetBox ``virtualenv`` directory will be stored.
-netbox__virtualenv: '{{ netbox__lib + "/virtualenv" }}'
+netbox__virtualenv: '{{ netbox__lib + "/virtualenv" + netbox__virtualenv_version }}'
 
                                                                    # ]]]
 # .. envvar:: netbox__virtualenv_env_path [[[

--- a/ansible/roles/debops.netbox/handlers/main.yml
+++ b/ansible/roles/debops.netbox/handlers/main.yml
@@ -2,9 +2,8 @@
 
 - name: Restart gunicorn for netbox
   service:
-    name: 'gunicorn'
+    name: 'gunicorn@netbox'
     state: 'restarted'
-    args: 'netbox'
   when: (not netbox__app_internal_appserver|bool and
          ansible_local|d() and ansible_local.gunicorn|d() and
          ansible_local.gunicorn.installed|bool)

--- a/ansible/roles/debops.netbox/handlers/main.yml
+++ b/ansible/roles/debops.netbox/handlers/main.yml
@@ -4,6 +4,7 @@
   service:
     name: 'gunicorn'
     state: 'restarted'
+    args: 'netbox'
   when: (not netbox__app_internal_appserver|bool and
          ansible_local|d() and ansible_local.gunicorn|d() and
          ansible_local.gunicorn.installed|bool)

--- a/ansible/roles/debops.netbox/tasks/main.yml
+++ b/ansible/roles/debops.netbox/tasks/main.yml
@@ -54,6 +54,19 @@
     path: '{{ netbox__git_checkout }}'
   register: netbox__register_installed
 
+- name: Check current virtualenv version
+  stat:
+    path: '{{ netbox__virtualenv + "/bin/python" }}'
+  register: netbox__register_virtualenv_version
+
+- name: Remove old python2 based virtualenv
+  file:
+    path: '{{ netbox__virtualenv }}'
+    state: 'absent'
+  register: netbox__register_virtalenv_deleted
+  when: ( netbox__virtualenv_version == '3' and
+          netbox__register_virtualenv_version.stat.lnk_target|d() == 'python2' )
+
 - name: Create NetBox checkout directory
   file:
     path: '{{ netbox__git_checkout }}'
@@ -98,7 +111,8 @@
   when: (netbox__register_source.before is undefined or
          (netbox__register_source.before|d() and netbox__register_target_branch.stdout|d() and
           netbox__register_source.before != netbox__register_target_branch.stdout) or
-          not netbox__register_installed.stat.exists|bool)
+          not netbox__register_installed.stat.exists|bool or
+          netbox__register_virtalenv_deleted.changed|bool)
 
 - name: Create Python virtualenv for NetBox
   pip:

--- a/ansible/roles/debops.netbox/tasks/main.yml
+++ b/ansible/roles/debops.netbox/tasks/main.yml
@@ -38,16 +38,6 @@
     - '{{ netbox__config_media_root }}'
     - '{{ netbox__config_reports_root }}'
 
-- name: Create Python virtualenv for NetBox
-  pip:
-    name: 'wsgiref'
-    virtualenv: '{{ netbox__virtualenv }}'
-  become: True
-  become_user: '{{ netbox__user }}'
-  register: netbox__register_virtualenv
-  changed_when: (netbox__register_virtualenv is success and
-                 netbox__register_virtualenv.stdout is search('New python executable in'))
-
 - name: Clone NetBox source code
   git:
     repo: '{{ netbox__git_repo }}'
@@ -110,19 +100,19 @@
           netbox__register_source.before != netbox__register_target_branch.stdout) or
           not netbox__register_installed.stat.exists|bool)
 
-# This is required due to an issue with setuptools
-# https://github.com/digitalocean/netbox/issues/864
-- name: Upgrade pip and setuptools in the virtualenv
-  environment:
-    VIRTUAL_ENV: '{{ netbox__virtualenv }}'
-    PATH: '{{ netbox__virtualenv_env_path }}'
-  shell: pip install --upgrade --force-reinstall pip setuptools
-  args:
-    chdir: '{{ netbox__git_checkout + "/netbox" }}'
-    executable: '/bin/sh'
+- name: Create Python virtualenv for NetBox
+  pip:
+    name: [ 'pip', 'setuptools' ]
+    virtualenv: '{{ netbox__virtualenv }}'
+    virtualenv_python: '{{ "python" + netbox__virtualenv_version }}'
+    # This is required due to an issue with setuptools
+    # https://github.com/digitalocean/netbox/issues/864
+    state: 'forcereinstall'
   become: True
   become_user: '{{ netbox__user }}'
-  when: netbox__register_checkout is changed
+  register: netbox__register_virtualenv
+  changed_when: (netbox__register_virtualenv is success and
+                 netbox__register_virtualenv.stdout is search('New python executable in'))
 
 - name: Clean up stale Python bytecode
   shell: find . -name '*.pyc' -delete


### PR DESCRIPTION
Netbox v2.5 and newer no longer supports Python 2.
This creates a new vituealenv directory based on Python 3 when
`netbox__git_version` is v2.5+ or master/develop.
This *should* make a clean upgrade of existing Netbox installations.

I'm not sure this is the best way to handle this kind of situation. I'm not that 'at home' with python virtualenvs, and couldn't find a way to upgrade the existing virtualenv to python 3.
This also most likely needs a bit more testing.