### PR TITLE
Adds TrustedUserCAKeys and HostCertificate options to debops.sshd

### DIFF
--- a/ansible/roles/debops.sshd/defaults/main.yml
+++ b/ansible/roles/debops.sshd/defaults/main.yml
@@ -185,6 +185,26 @@ sshd__listen: []
 sshd__host_keys: [ 'ed25519', 'rsa', 'ecdsa' ]
 
                                                                    # ]]]
+# .. envvar:: sshd__trusted_user_ca_keys [[[
+#
+# List of CA public keys used to assemble a TrustedUserCAKeys file.
+sshd__trusted_user_ca_keys: []
+
+                                                                   # ]]]
+# .. envvar:: sshd__trusted_user_ca_keys_file [[[
+#
+# File name which will contain CA trusted keys
+sshd__trusted_user_ca_keys_file: '/etc/ssh/trusted-user-ca-keys.pem'
+
+                                                                   # ]]]
+# .. envvar:: sshd__scan_for_host_certs [[[
+#
+# Detect, and add, any host certificates found in /etc/ssh/ that match
+# ssh_host_*_key-cert.pub, as long as the key type matches whats in
+# `sshd__host_keys`
+sshd__scan_for_host_certs: False
+
+                                                                   # ]]]
 # .. envvar:: sshd__banner [[[
 #
 # Path to file which should be displayed before user authentication.

--- a/ansible/roles/debops.sshd/tasks/main.yml
+++ b/ansible/roles/debops.sshd/tasks/main.yml
@@ -103,6 +103,25 @@
   check_mode: False
   tags: [ 'role::sshd:config' ]
 
+- name: Get list of available host certs
+  shell: find /etc/ssh -maxdepth 1 -type f -name 'ssh_host_*_key-cert.pub' -exec basename {} .pub \;
+  register: sshd__register_host_certs
+  changed_when: False
+  check_mode: False
+  when: sshd__scan_for_host_certs
+  tags: [ 'role::sshd:config' ]
+
+- name: Setup trusted user CA key file
+  template:
+    src:      '{{ lookup("template_src", "etc/ssh/trusted_user_ca_file.pem.j2") }}'
+    dest:     '{{ sshd__trusted_user_ca_keys_file }}'
+    owner:    'root'
+    group:    'root'
+    mode:     '0644'
+  when: sshd__trusted_user_ca_keys | d() | length > 0  and
+        sshd__trusted_user_ca_keys_file is defined
+  tags: [ 'role::sshd:config' ]
+
 - name: Setup /etc/ssh/sshd_config
   template:
     src:    '{{ lookup("template_src", "etc/ssh/sshd_config.j2") }}'

--- a/ansible/roles/debops.sshd/templates/etc/ssh/sshd_config.j2
+++ b/ansible/roles/debops.sshd/templates/etc/ssh/sshd_config.j2
@@ -26,6 +26,21 @@ HostKey /etc/ssh/ssh_host_{{ hostkey }}_key
 {%   endif %}
 {% endfor %}
 
+{% if sshd__register_host_certs is defined and 'stdout_lines' in sshd__register_host_certs %}
+# List of host key certificates signed by CA
+{%   for cert in sshd__host_key_cert_files.stdout_lines %}
+{%     set sshd__key_matching_cert = cert | regex_replace('-cert', '') %}
+{%     set sshd__key_matching_host_keys = sshd__key_matching_cert | regex_replace('ssh_host_(\w+)_key', '\\1') %}
+{%     if sshd__key_matching_cert in sshd__register_host_keys.stdout_lines and sshd__key_matching_host_keys in sshd__host_keys %}
+HostCertificate /etc/ssh/{{ cert }}.pub
+{%     endif %}
+{%   endfor %}
+{% endif %}
+
+{% if sshd__trusted_user_ca_keys | d() | length > 0 and sshd__trusted_user_ca_keys_file is defined %}
+TrustedUserCAKeys {{ sshd__trusted_user_ca_keys_file }}
+{% endif %}
+
 {% set sshd__tpl_ciphers_max_version =  sshd__ciphers_map.keys() | select('version_compare', sshd__register_version.stdout, '<=') | max %}
 {% set sshd__tpl_ciphers = sshd__ciphers_map[sshd__tpl_ciphers_max_version] %}
 {% set sshd__tpl_ciphers = (sshd__tpl_ciphers + sshd__ciphers_additional) | unique %}

--- a/ansible/roles/debops.sshd/templates/etc/ssh/trusted_user_ca_file.pem.j2
+++ b/ansible/roles/debops.sshd/templates/etc/ssh/trusted_user_ca_file.pem.j2
@@ -1,0 +1,3 @@
+# {{ ansible_managed }}
+
+{{ sshd__trusted_user_ca_keys | join("\n") }}


### PR DESCRIPTION
PR adds the option to use TrustedUserCAKeys and HostCertificate opensshd options via debops.sshd role. 

TrustedUserCAKeys are assembled from a list of public CA keys and deployed to /etc/ssh/trusted-user-ca-keys.pem, which is then added to sshd_config

HostCertificate are added if files with a specific naming format are found in `/etc/ssh/`: `ssh_host_*_key-cert.pub`. If they are, the role checks whether there is a corresponding Host Key file, and whether that key type is enabled via the variable `sshd__host_keys`. If both are true, it's added to sshd_conf.

sshd__trusted_user_ca_keys: A list of strings of CA public keys. If empty, no action is taken.
sshd__trusted_user_ca_keys_file: the name of the where keys will be assembled.

sshd__scan_for_host_certs: Governs whether role looks for host key certs, and
adds them as HostCertificate stanzas in sshd_config. Default is `False`