### PR TITLE
[debops.unattended_upgrades] Fix Unattended-Upgrade::Origins-Pattern section in unattended-upgrades.j2 template

### DIFF
--- a/ansible/roles/debops.unattended_upgrades/templates/etc/apt/apt.conf.d/50unattended-upgrades.j2
+++ b/ansible/roles/debops.unattended_upgrades/templates/etc/apt/apt.conf.d/50unattended-upgrades.j2
@@ -5,23 +5,22 @@
 // upgraded.
 Unattended-Upgrade::Origins-Pattern {
 {% set unattended_upgrades__tpl_origins = [] %}
-{% set unattended_upgrades__tpl_security_origins_found = False %}
-{% set unattended_upgrades__tpl_release_origins_found = False %}
-{% for element in unattended_upgrades__origins_lookup if not unattended_upgrades__tpl_security_origins_found|bool %}
+{% set ns = namespace(security_origins_found = False, release_origins_found = False) %}
+{% for element in unattended_upgrades__origins_lookup if not ns.security_origins_found|bool %}
 {%   if element in unattended_upgrades__security_origins.keys() %}
 {%     for item in unattended_upgrades__security_origins[element] %}
 {%       set _ = unattended_upgrades__tpl_origins.append(item) %}
 {%     endfor %}
-{%     set unattended_upgrades__tpl_security_origins_found = True %}
+{%     set ns.security_origins_found = True %}
 {%   endif %}
 {% endfor %}
 {% if unattended_upgrades__release | bool %}
-{%   for element in unattended_upgrades__origins_lookup if not unattended_upgrades__tpl_release_origins_found|bool %}
+{%   for element in unattended_upgrades__origins_lookup if not ns.release_origins_found|bool %}
 {%     if element in unattended_upgrades__release_origins.keys() %}
 {%       for item in unattended_upgrades__release_origins[element] %}
 {%         set _ = unattended_upgrades__tpl_origins.append(item) %}
 {%       endfor %}
-{%       set unattended_upgrades__tpl_release_origins_found = True %}
+{%       set ns.release_origins_found = True %}
 {%     endif %}
 {%   endfor %}
 {% endif %}


### PR DESCRIPTION
Template unnattended-upgrades.j2 tries to set outer variables in Jinja
for..in loops in order to track if distribution has been found in
unattended_upgrades__origins_lookup list which is used to map distribution
to list of origin patterns.

However, because assignments inside loops do not outlive loop scope
all matching origins are included whereas only the first match should.

For instance in default configuration this results in

Unattended-Upgrade::Origins-Pattern {
	"o=Debian,n=${distro_codename},l=Debian-Security";
	"o=${distro_id},n=${distro_codename},l=${distro_id}-Security";
};

instead of mere

Unattended-Upgrade::Origins-Pattern {
        "o=Debian,n=${distro_codename},l=Debian-Security";
};

This commit fixes this by using namespaced variables introduced in
Jinja 2.10. which can be modified inside loops.