### PR TITLE
[debops.sudo] Enable logind fix on systemd hosts

### DIFF
--- a/ansible/roles/debops.sudo/defaults/main.yml
+++ b/ansible/roles/debops.sudo/defaults/main.yml
@@ -39,7 +39,7 @@ sudo__packages: []
 # Enable or disable a workaround for :command:`sudo` login session not having
 # a ``$XDG_RUNTIME_DIR`` environment variable set. This allows control over
 # another user's :command:`systemd` instance.
-sudo__logind_session: True
+sudo__logind_session: '{{ True if (ansible_service_mgr == "systemd") else False }}'
                                                                    # ]]]
                                                                    # ]]]
 # Sudoers configuration [[[


### PR DESCRIPTION
This change will enable the 'logind' session workaround only on hosts
with 'systemd' as the service manager. On other hosts it might be not
relevant.