### PR TITLE
[bsdops.apt] fix: add `when: apt__enabled` to all tasks

### DIFF
--- a/ansible/roles/debops.apt/tasks/main.yml
+++ b/ansible/roles/debops.apt/tasks/main.yml
@@ -20,6 +20,7 @@
     owner: 'root'
     group: 'root'
     mode: '0755'
+  when: apt__enabled|bool
 
 - name: Save APT local facts
   template:
@@ -29,6 +30,7 @@
     group: 'root'
     mode: '0755'
   register: apt__register_facts
+  when: apt__enabled|bool
 
 - name: Update Ansible facts if they were modified
   action: setup


### PR DESCRIPTION
It was missing for two tasks before.

(cherry picked from anotherkamila/debops@12856ca0)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/debops/debops/609)
<!-- Reviewable:end -->
