### PR TITLE
[debops.ifupdown] Adding support for purging netplan in favour of ifupdown

### DIFF
--- a/ansible/roles/debops.ifupdown/defaults/main.yml
+++ b/ansible/roles/debops.ifupdown/defaults/main.yml
@@ -16,7 +16,7 @@
 # .. envvar:: ifupdown__base_packages [[[
 #
 # List of base APT packages to install.
-ifupdown__base_packages: [ 'resolvconf', 'rdnssd', 'bsdutils', 'rsync' ]
+ifupdown__base_packages: [ 'ifupdown', 'resolvconf', 'rdnssd', 'bsdutils', 'rsync' ]
 
                                                                    # ]]]
 # .. envvar:: ifupdown__dynamic_packages [[[
@@ -31,6 +31,12 @@ ifupdown__dynamic_packages: '{{ lookup("template", "lookup/ifupdown__dynamic_pac
 #
 # List of additional APT packages to install with the role.
 ifupdown__packages: []
+                                                                   # ]]]
+# .. envvar:: ifupdown__purge_packages [[[
+#
+# List of APT packages which will be purged when this role is
+# enabled, to stop them from interfering with ``ifupdown``.
+ifupdown__purge_packages: [ 'netplan.io', 'nplan' ]
                                                                    # ]]]
                                                                    # ]]]
 # General role configuration [[[

--- a/ansible/roles/debops.ifupdown/tasks/main.yml
+++ b/ansible/roles/debops.ifupdown/tasks/main.yml
@@ -11,6 +11,14 @@
   register: ifupdown__register_packages
   until: ifupdown__register_packages is succeeded
 
+- name: Purge conflicting packages
+  apt:
+    name: '{{ item }}'
+    state: 'absent'
+    purge: True
+  with_flattened:
+    - '{{ ifupdown__purge_packages }}'
+
 - name: Create custom ifupdown systemd services
   include: ifup_systemd.yml
 


### PR DESCRIPTION
Netplan is a default network manager on Ubuntu Bionic (18.04), so these of us who would rather use  ifupdown for whatever reason, need to purge `netplan.io` and `nplan` packages manually, so that they would not conflict with ifupdown. This PR adds support for this.