### PR TITLE
[debops.snmpd] Adding support for per group and per host custom options

### DIFF
--- a/ansible/roles/debops.snmpd/defaults/main.yml
+++ b/ansible/roles/debops.snmpd/defaults/main.yml
@@ -48,9 +48,35 @@ snmpd_logging_options: '-LScd'
                                                                    # ]]]
 # .. envvar:: snmpd_custom_options [[[
 #
-# Custom ``snmpd`` options written in YAML text block format, inserted into
-# ``/etc/snmp/snmpd.conf`` configuration file.
+# Custom ``snmpd`` options written in YAML text block format,
+# inserted into ``/etc/snmp/snmpd.conf`` configuration file on
+# all hosts in the inventory.
 snmpd_custom_options: ''
+
+                                                                   # ]]]
+# .. envvar:: snmpd_group_custom_options [[[
+#
+# Custom ``snmpd`` options written in YAML text block format,
+# inserted into ``/etc/snmp/snmpd.conf`` configuration file on
+# hosts in specific inventory group.
+snmpd_group_custom_options: ''
+
+                                                                   # ]]]
+# .. envvar:: snmpd_host_custom_options [[[
+#
+# Custom ``snmpd`` options written in YAML text block format,
+# inserted into ``/etc/snmp/snmpd.conf`` configuration file on
+# specific hosts in the inventory.
+snmpd_host_custom_options: ''
+
+                                                                   # ]]]
+# .. envvar:: snmpd_combined_custom_options [[[
+#
+# List which combines all of the ``snmp_*_custom_options`` entries
+# together and is used in the role tasks and templates.
+snmpd_combined_custom_options: '{{ snmpd_custom_options
+                                   + snmpd_group_custom_options
+                                   + snmpd_host_custom_options }}'
 
                                                                    # ]]]
 # .. envvar:: snmpd_download_mibs [[[

--- a/ansible/roles/debops.snmpd/templates/etc/snmp/snmpd.conf.j2
+++ b/ansible/roles/debops.snmpd/templates/etc/snmp/snmpd.conf.j2
@@ -32,8 +32,8 @@ master agentx
 load {{ snmpd_load_1min }} {{ snmpd_load_5min }} {{ snmpd_load_15min }}
 
 {% endif %}
-{% if snmpd_custom_options|d() and snmpd_custom_options %}
-{{ snmpd_custom_options }}
+{% if snmpd_combined_custom_options|d() and snmpd_combined_custom_options %}
+{{ snmpd_combined_custom_options }}
 {% endif %}
 
 # Extension scripts


### PR DESCRIPTION
I have a use case where I add some custom options to the whole of the inventory, and now need to define some additional options on per group basis. This PR facilitates this.