### PR TITLE
Purge some "with_flattened" for apt module

### DIFF
--- a/ansible/roles/debops.apt/tasks/main.yml
+++ b/ansible/roles/debops.apt/tasks/main.yml
@@ -3,12 +3,10 @@
 
 - name: Install required packages
   apt:
-    name: '{{ item }}'
+    name: '{{ apt__base_packages
+            + apt__packages }}'
     state: 'present'
     install_recommends: False
-  with_flattened:
-    - '{{ apt__base_packages }}'
-    - '{{ apt__packages }}'
   register: apt__register_packages
   until: apt__register_packages
   when: apt__enabled|bool

--- a/ansible/roles/debops.apt_install/tasks/main.yml
+++ b/ansible/roles/debops.apt_install/tasks/main.yml
@@ -5,12 +5,11 @@
 
 - name: Debconf module dependencies
   apt:
-    name: '{{ item }}'
+    name:
+      - 'debconf'
+      - 'debconf-utils'
     state: 'present'
     install_recommends: '{{ apt_install__recommends|bool }}'
-  with_items:
-    - 'debconf'
-    - 'debconf-utils'
   register: apt_install__register_debconf_packages
   until: apt_install__register_debconf_packages
 

--- a/ansible/roles/debops.auth/tasks/main.yml
+++ b/ansible/roles/debops.auth/tasks/main.yml
@@ -5,10 +5,9 @@
 
 - name: Install auth-related packages
   apt:
-    name: '{{ item }}'
+    name: '{{ auth_packages }}'
     state: 'present'
     install_recommends: 'no'
-  with_items: '{{ auth_packages }}'
   register: auth__register_packages
   until: auth__register_packages is succeeded
 

--- a/ansible/roles/debops.auth/tasks/nss_pam_ldap.yml
+++ b/ansible/roles/debops.auth/tasks/nss_pam_ldap.yml
@@ -11,10 +11,13 @@
 
 - name: Install packages require for LDAP authentication
   apt:
-    name: '{{ item }}'
+    name:
+      - 'libnss-ldapd'
+      - 'libpam-ldapd'
+      - 'openssl'
+      - 'ca-certificates'
     state: 'present'
     install_recommends: False
-  with_items: [ 'libnss-ldapd', 'libpam-ldapd', 'openssl', 'ca-certificates' ]
   register: auth__register_pam_ldap_packages
   until: auth__register_pam_ldap_packages is succeeded
 

--- a/ansible/roles/debops.console/tasks/main.yml
+++ b/ansible/roles/debops.console/tasks/main.yml
@@ -2,12 +2,10 @@
 
 - name: Install requested packages
   apt:
-    name: '{{ item }}'
+    name: '{{ console_base_packages
+            + console_conditional_packages }}'
     state: 'present'
     install_recommends: False
-  with_flattened:
-    - '{{ console_base_packages }}'
-    - '{{ console_conditional_packages }}'
   register: console__register_packages
   until: console__register_packages is succeeded
   when: item is defined and item

--- a/ansible/roles/debops.etc_services/tasks/main.yml
+++ b/ansible/roles/debops.etc_services/tasks/main.yml
@@ -2,11 +2,9 @@
 
 - name: Install required packages
   package:
-    name: '{{ item }}'
+    name: '{{ etc_services__base_packages
+            + etc_services__packages }}'
     state: 'present'
-  with_flattened:
-    - '{{ etc_services__base_packages }}'
-    - '{{ etc_services__packages }}'
   register: etc_services__register_packages
   until: etc_services__register_packages is succeeded
 

--- a/ansible/roles/debops.fail2ban/tasks/main.yml
+++ b/ansible/roles/debops.fail2ban/tasks/main.yml
@@ -2,10 +2,11 @@
 
 - name: Install required packages
   apt:
-    name: '{{ item }}'
+    name:
+      - 'fail2ban'
+      - 'whois'
     state: 'present'
     install_recommends: False
-  with_items: [ 'fail2ban', 'whois' ]
   register: fail2ban__register_packages
   until: fail2ban__register_packages is succeeded
 

--- a/ansible/roles/debops.logrotate/tasks/main.yml
+++ b/ansible/roles/debops.logrotate/tasks/main.yml
@@ -2,12 +2,10 @@
 
 - name: Install required packages
   apt:
-    name: '{{ item }}'
+    name: '{{ logrotate__base_packages
+            + logrotate__packages }}'
     state: 'present'
     install_recommends: False
-  with_flattened:
-    - '{{ logrotate__base_packages }}'
-    - '{{ logrotate__packages }}'
   register: logrotate__register_packages
   until: logrotate__register_packages is succeeded
   when: logrotate__enabled|bool

--- a/ansible/roles/debops.ntp/tasks/install.yml
+++ b/ansible/roles/debops.ntp/tasks/install.yml
@@ -2,14 +2,12 @@
 
 - name: Install required packages
   apt:
-    name: '{{ item }}'
+    name: '{{ "chrony" if (ntp__daemon == "chrony") else ""
+            + "ntpdate" if (ntp__daemon == "ntpdate") else ""
+            + "ntp" if (ntp__daemon == "ntpd") else ""
+            + "openntpd" if (ntp__daemon == "openntpd") else "" }}'
     state: 'present'
     install_recommends: False
-  with_flattened:
-    - [ '{{ "chrony" if (ntp__daemon == "chrony") else [] }}' ]
-    - [ '{{ "ntpdate" if (ntp__daemon == "ntpdate") else [] }}' ]
-    - [ '{{ "ntp" if (ntp__daemon == "ntpd") else [] }}' ]
-    - [ '{{ "openntpd" if (ntp__daemon == "openntpd") else [] }}' ]
   register: ntp__register_apt_install
   until: ntp__register_apt_install is succeeded
 

--- a/ansible/roles/debops.ntp/tasks/main.yml
+++ b/ansible/roles/debops.ntp/tasks/main.yml
@@ -6,23 +6,20 @@
 
 - name: Install required packages
   apt:
-    name: '{{ item }}'
+    name: [ 'tzdata' ]
     state: '{{ "present" if (ansible_local|d() and ansible_local.ntp|d()) else "latest" }}'
     install_recommends: False
-  with_items: [ 'tzdata' ]
   register: ntp__register_apt_tzdata
   until: ntp__register_apt_tzdata is succeeded
 
 - name: Ensure that alternative daemons/programs are not installed
   apt:
-    name: '{{ item }}'
+    name: '{{ "chrony" if (ntp__daemon != "chrony") else ""
+            + "ntpdate" if (ntp__daemon != "ntpdate" and not ntp__ignore_ntpdate|bool) else ""
+            + "ntp" if (ntp__daemon not in [ "ntpd", "openntpd"]) else ""
+            + "openntpd" if (ntp__daemon != "openntpd") else "" }}'
     state: 'absent'
     purge: True
-  with_flattened:
-    - [ '{{ "chrony" if (ntp__daemon != "chrony") else [] }}' ]
-    - [ '{{ "ntpdate" if (ntp__daemon != "ntpdate" and not ntp__ignore_ntpdate|bool) else [] }}' ]
-    - [ '{{ "ntp" if (ntp__daemon not in [ "ntpd", "openntpd"]) else [] }}' ]
-    - [ '{{ "openntpd" if (ntp__daemon != "openntpd") else [] }}' ]
   register: ntp__register_apt_purge
   until: ntp__register_apt_purge is succeeded
 

--- a/ansible/roles/debops.nullmailer/tasks/main.yml
+++ b/ansible/roles/debops.nullmailer/tasks/main.yml
@@ -2,23 +2,19 @@
 
 - name: Install required packages
   package:
-    name: '{{ item }}'
+    name: '{{ nullmailer__base_packages
+            + nullmailer__smtpd_packages
+            + nullmailer__packages }}'
     state: 'present'
-  with_flattened:
-    - '{{ nullmailer__base_packages }}'
-    - '{{ nullmailer__smtpd_packages }}'
-    - '{{ nullmailer__packages }}'
   register: nullmailer__register_packages
   until: nullmailer__register_packages is succeeded
   when: nullmailer__deploy_state|d('present') != 'absent'
 
 - name: Purge other SMTP servers
   apt:
-    name: '{{ item }}'
+    name: '{{ nullmailer__purge_mta_packages }}'
     state: 'absent'
     purge: True
-  with_flattened:
-    - '{{ nullmailer__purge_mta_packages }}'
   when: (nullmailer__deploy_state|d('present') != 'absent' and
          nullmailer__purge_mta_packages)
 

--- a/ansible/roles/debops.pki/tasks/main.yml
+++ b/ansible/roles/debops.pki/tasks/main.yml
@@ -22,19 +22,16 @@
 # Install PKI packages [[[
 - name: Install PKI packages
   apt:
-    name: '{{ item }}'
+    name: '{{ pki_base_packages
+            + pki_acme_packages
+                if (pki_acme|bool or pki_acme_install|bool) else []
+            +  pki_packages }}'
     state: 'present'
     install_recommends: False
     cache_valid_time: '{{ ansible_local.core.cache_valid_time
                           if (ansible_local|d() and ansible_local.core|d() and
                               ansible_local.core.cache_valid_time|d())
                           else "86400" }}'
-  with_flattened:
-    - '{{ pki_base_packages }}'
-    - '{{ pki_acme_packages
-          if (pki_acme|bool or pki_acme_install|bool)
-          else [] }}'
-    - '{{ pki_packages }}'
   register: pki__register_packages
   until: pki__register_packages is succeeded
   when: pki_enabled | bool

--- a/ansible/roles/debops.postfix/tasks/main.yml
+++ b/ansible/roles/debops.postfix/tasks/main.yml
@@ -2,13 +2,11 @@
 
 - name: Install Postfix APT packages
   apt:
-    name: '{{ item }}'
+    name: '{{ postfix__base_packages
+            + postfix__dependent_packages
+            + postfix__packages }}'
     state: 'present'
     install_recommends: False
-  with_flattened:
-    - '{{ postfix__base_packages }}'
-    - '{{ postfix__dependent_packages }}'
-    - '{{ postfix__packages }}'
   register: postfix__register_packages
   until: postfix__register_packages is succeeded
   when: ansible_pkg_mgr == 'apt'
@@ -16,10 +14,9 @@
 
 - name: Purge other SMTP servers
   apt:
-    name: '{{ item }}'
+    name: '{{ postfix__purge_packages }}'
     state: 'absent'
     purge: True
-  with_flattened: '{{ postfix__purge_packages }}'
   when: postfix__purge_packages|d() and ansible_pkg_mgr == 'apt'
   tags: [ 'meta::provision' ]
 

--- a/ansible/roles/debops.python/tasks/main.yml
+++ b/ansible/roles/debops.python/tasks/main.yml
@@ -2,10 +2,9 @@
 
 - name: Install requested APT packages
   apt:
-    name: '{{ item }}'
+    name: '{{ python__combined_packages }}'
     state: 'present'
     install_recommends: False
-  with_flattened: '{{ python__combined_packages }}'
   register: python__register_apt_packages
   until: python__register_apt_packages is succeeded
   when: python__enabled|bool and ansible_pkg_mgr == 'apt'

--- a/ansible/roles/debops.rsyslog/tasks/main.yml
+++ b/ansible/roles/debops.rsyslog/tasks/main.yml
@@ -2,13 +2,12 @@
 
 - name: Install required packages
   apt:
-    name: '{{ item }}'
+    name: '{{ rsyslog__base_packages
+            + rsyslog__tls_packages
+                if (rsyslog__pki|bool) else []
+            + rsyslog__packages }}'
     state: 'present'
     install_recommends: False
-  with_flattened:
-    - '{{ rsyslog__base_packages }}'
-    - '{{ rsyslog__tls_packages if rsyslog__pki|bool else [] }}'
-    - '{{ rsyslog__packages }}'
   register: rsyslog__register_packages
   until: rsyslog__register_packages is succeeded
   when: rsyslog__enabled|bool

--- a/ansible/roles/debops.sshd/tasks/main.yml
+++ b/ansible/roles/debops.sshd/tasks/main.yml
@@ -60,17 +60,15 @@
 
 - name: Ensure OpenSSH support is installed
   apt:
-    name: '{{ item }}'
+    name: '{{ sshd__base_packages
+            + sshd__recommended_packages
+            + sshd__optional_packages
+            + sshd__ldap_packages
+            + sshd__packages }}'
     state: '{{ "present"
                if (ansible_local|d() and ansible_local.sshd|d())
                else "latest" }}'
     install_recommends: False
-  with_flattened:
-    - '{{ sshd__base_packages }}'
-    - '{{ sshd__recommended_packages }}'
-    - '{{ sshd__optional_packages }}'
-    - '{{ sshd__ldap_packages }}'
-    - '{{ sshd__packages }}'
   register: sshd__register_packages
   until: sshd__register_packages is succeeded
 

--- a/ansible/roles/debops.unattended_upgrades/tasks/main.yml
+++ b/ansible/roles/debops.unattended_upgrades/tasks/main.yml
@@ -2,12 +2,10 @@
 
 - name: Install required packages
   apt:
-    name: '{{ item }}'
+    name: '{{ unattended_upgrades__base_packages
+            + unattended_upgrades__packages }}'
     state: 'present'
     install_recommends: False
-  with_flattened:
-    - '{{ unattended_upgrades__base_packages }}'
-    - '{{ unattended_upgrades__packages }}'
   register: unattended_upgrades__register_packages
   until: unattended_upgrades__register_packages is succeeded
   when: unattended_upgrades__enabled | bool


### PR DESCRIPTION
In order to fix some deprecation warning like : 
```
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply 
multiple items and specifying `name: {{ item }}`, please use `name: [u'{{ apt__base_packages }}', u'{{ apt__packages }}']` and remove 
the loop. This feature will be removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
```