### PR TITLE
[debops.gitlab] Avoid OOM during asset compilation

### DIFF
--- a/ansible/roles/debops.gitlab/tasks/configure_gitlab_ce.yml
+++ b/ansible/roles/debops.gitlab/tasks/configure_gitlab_ce.yml
@@ -273,6 +273,7 @@
 
 - name: Precompile GitLab assets
   command: bundle exec rake {{ gitlab_assets_compile }} RAILS_ENV=production NODE_ENV=production
+           NODE_OPTIONS='--max_old_space_size=4096'
   args:
     chdir: '{{ gitlab_ce_git_checkout }}'
   become: True


### PR DESCRIPTION
During 'debops.gitlab' asset compilation, Node scripts can crash with
Out of Memory message. This change should ensure that this doesn't
happen.

Ref: https://gitlab.com/gitlab-org/gitlab-ce/issues/50937