### PR TITLE
[debops.netbase] Implement automatic domain config

### DIFF
--- a/ansible/roles/debops.netbase/defaults/main.yml
+++ b/ansible/roles/debops.netbase/defaults/main.yml
@@ -61,14 +61,32 @@ netbase__hostname: '{{ (inventory_hostname_short | d(inventory_hostname.split(".
                                                                    # ]]]
 # .. envvar:: netbase__domain [[[
 #
-# Define a local domain for a given host. This domain will be added in the
-# :file:`/etc/hosts` database and will override any information coming from the
-# DNS service. If it's set to an empty string, the domain will not be
-# configured in the :file:`/etc/hosts` database.
+# Define a local domain for a given host. If this variable is empty, no domain
+# configuration will be added to the :file:`/etc/hosts` database and it's
+# assumed that a DNS service manages the local domain.
 #
-# To configure local domain based on Ansible inventory host configuration, you
-# can set the value to: ``'{{ inventory_hostname.split(".")[1:] | join(".") }}'``
-netbase__domain: ''
+# If the host has been installed with a domain, and its FQDN points to the
+# ``127.0.1.1`` address, the role assumes that a DNS service for the local
+# domain is present, and will not configure a domain in the :file:`/etc/hosts`
+# database. The existing ``127.0.1.1`` entry will be removed to not override
+# the DNS resolution.
+#
+# If the host has been installed without a domain specified, a domain will be
+# generated based on the ``ansible_host`` variable (if it's set to a FQDN
+# address) or ``inventory_hostname`` variable, and saved in the
+# :file:`/etc/hosts` database. The host's FQDN and hostname will point to the
+# default IPv4 and IPv6 addresses of the host.
+netbase__domain: '{{ ""
+                     if (ansible_local|d() and ansible_local.netbase|d() and
+                         (((ansible_local.netbase.self_address|d()) != "127.0.1.1" and
+                           (not ansible_local.netbase.self_local|d())|bool) or
+                          ((ansible_local.netbase.self_address|d()) == "127.0.1.1" and
+                            ansible_local.netbase.self_domain|d())))
+                     else ((ansible_host | d(ansible_ssh_host)).split(".")[1:] | join(".")
+                           if (not (ansible_host | d(ansible_ssh_host)) | ipaddr)
+                           else (inventory_hostname.split(".")[1:] | join(".")
+                                 if (inventory_hostname.split(".") | count > 1)
+                                 else inventory_hostname)) }}'
 
                                                                    # ]]]
 # .. envvar:: netbase__host_ipv4_address [[[

--- a/ansible/roles/debops.netbase/templates/etc/ansible/facts.d/netbase.fact.j2
+++ b/ansible/roles/debops.netbase/templates/etc/ansible/facts.d/netbase.fact.j2
@@ -2,9 +2,55 @@
 
 # {{ ansible_managed }}
 
+"""Return information about host FQDN, domain and IP address
+
+This script checks the FQDN and the IP address of the host and returns it in
+JSON format for consumption by Ansible. The data is gathered from the host's
+perspective, because Ansible facts are not sufficient to determine which FQDN
+and IP address the host recognizes as "itself".
+
+Returned JSON keys:
+
+  - "configured"    If True, the role has been correctly appled on the host.
+
+  - "self_fqdn"     The host's FQDN as seen by its operating system, either
+                    defined locally in '/etc/hosts' or resolved by the DNS.
+
+  - "self_domain"   The host's domain extracted from the FQDN name.
+
+  - "self_address"  IP address resolved by the host from it's FQDN name.
+
+  - "self_local"    If True, the script detected the FQDN and IP address
+                    information in local '/etc/hosts' database.
+
+                    If False, the script did not detect the FQDN and IP address
+                    locally, and assumes that it came from the DNS.
+"""
+
 from __future__ import print_function
 from json import dumps
+import socket
 
-output = {'configured': True}
+
+def get_dns_domain():
+    try:
+        return socket.getfqdn().split('.', 1)[1]
+    except IndexError:
+        return ''
+
+
+output = {'configured': True,
+          'self_address': socket.gethostbyname(socket.getfqdn()),
+          'self_domain': get_dns_domain(),
+          'self_fqdn': socket.getfqdn(),
+          'self_local': False}
+
+# Check if the host address and FQDN are defined locally, to not remove them
+# accidentally
+with open('/etc/hosts', 'r') as hosts:
+    for line in hosts:
+        if (output['self_fqdn'] in line.split()[1:]
+                and output['self_address'] in line.split()[0]):
+            output['self_local'] = True
 
 print(dumps(output, sort_keys=True, indent=4))


### PR DESCRIPTION
The 'debops.netbase' role will check the FQDN and IP address of a given
host from that host's perspective to determine if its current domain and
IP address are defined locally via the '/etc/hosts' database or via
a DNS service. This will be used to update the '/etc/hosts' database.

The existing '127.0.1.1' entry in the local host database will be
removed, and if DNS service is not available, a local FQDN and hostname
will be defined in '/etc/hosts' which will point to the host's default
IPv4 and IPv6 addresses. The domain will be generated automatically
based on the 'ansible_host' value, or if it's an IP address, on the
'inventory_hostname' value.

Fixes #620