### PR TITLE
[debops.logrotate] Add 'filename' as valid trigger

### DIFF
--- a/ansible/roles/debops.logrotate/templates/etc/logrotate.conf.j2
+++ b/ansible/roles/debops.logrotate/templates/etc/logrotate.conf.j2
@@ -79,7 +79,7 @@
 {% for item in logrotate__default_config %}
 {%   if item.sections|d() %}
 {%     for section in item.sections %}
-{%       if (section.log|d() or section.logs|d()) and section.state|d('present') != 'absent' %}
+{%       if (section.log|d() or section.logs|d() or section.filename|d()) and section.state|d('present') != 'absent' %}
 {{ print_config(section) -}}
 {%         if not loop.last %}
 
@@ -87,7 +87,7 @@
 {%       endif %}
 {%     endfor %}
 {%   else %}
-{%     if (item.log|d() or item.logs|d()) and item.state|d('present') != 'absent' %}
+{%     if (item.log|d() or item.logs|d() or item.filename|d()) and item.state|d('present') != 'absent' %}
 {{ print_config(item) -}}
 {%       if not loop.last %}
 

--- a/ansible/roles/debops.logrotate/templates/etc/logrotate.d/config.j2
+++ b/ansible/roles/debops.logrotate/templates/etc/logrotate.d/config.j2
@@ -73,7 +73,7 @@
 {% endmacro %}
 {% if item.sections|d() %}
 {%   for section in item.sections %}
-{%     if (section.log|d() or section.logs|d()) and section.state|d('present') != 'absent' %}
+{%     if (section.log|d() or section.logs|d() or section.filename|d()) and section.state|d('present') != 'absent' %}
 {{ print_config(section) -}}
 {%       if not loop.last %}
 
@@ -81,7 +81,7 @@
 {%     endif %}
 {%   endfor %}
 {% else %}
-{%   if (item.log|d() or item.logs|d()) and item.state|d('present') != 'absent' %}
+{%   if (item.log|d() or item.logs|d() or item.filename|d()) and item.state|d('present') != 'absent' %}
 {{ print_config(item) -}}
 {%   endif %}
 {% endif %}


### PR DESCRIPTION
Ensure that the configuration entries without 'log' or 'logs' parameters
still work as expected when the 'filename' parameter is specified.