### PR TITLE
[debops.netbox] Fix version-check in python3

### DIFF
--- a/ansible/roles/debops.netbox/defaults/main.yml
+++ b/ansible/roles/debops.netbox/defaults/main.yml
@@ -158,7 +158,8 @@ netbox__git_checkout: '{{ netbox__virtualenv + "/app" }}'
 # created next to the old one.
 # Valid values are `3` or an empty string.
 netbox__virtualenv_version: '{{ ""
-                                 if netbox__git_version|replace("v", "") is version("2.5", "<")
+                                 if ( netbox__git_version | regex_search("^v?[0-9\.]+")
+                                   and netbox__git_version|replace("v", "") is version("2.5", "<") )
                                  else "3" }}'
 
                                                                    # ]]]


### PR DESCRIPTION
It's not pretty, but seems to work.
Tested with both python 2.7 and 3.7.

'netbox__git_version' should only match the regex_search if it looks
like a version-string. I.e. starts with an optional 'v'-character
following something that resembles a version.

Fixes #597