### PR TITLE
Add options to nginx to enable and disable HTTP/2 and SPDY protocol support

### DIFF
--- a/ansible/roles/debops.nginx/defaults/main.yml
+++ b/ansible/roles/debops.nginx/defaults/main.yml
@@ -579,6 +579,23 @@ nginx_hsts_subdomains: True
 nginx_hsts_preload: False
 
                                                                    # ]]]
+# .. envvar:: nginx_enable_http2 [[[
+#
+# Enable HTTP/2 (formerly HTTP QUICK) on nginx.
+# HTTP/2 enables a server to pre‑emptively push resources to a remote client,
+# anticipating that the client may soon request those resource, hence
+# reducing the number of RTTs (Round Trip Times).
+# Available with nginx version >= 1.9.5
+nginx_enable_http2: True
+
+                                                                   # ]]]
+# .. envvar:: nginx_enable_sdpy [[[
+#
+# Enables experimental support for .. _SPDY: https://www.chromium.org/spdy/spdy-protocol HTTP protocol.
+# Available with nginx version >= 1.4 && < 1.9.5
+nginx_enable_sdpy: False
+
+                                                                   # ]]]
 # .. envvar:: nginx__http_csp_append [[[
 #
 # CSP directives to append to all policies. This can be used to set the

--- a/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/default.conf.j2
+++ b/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/default.conf.j2
@@ -535,7 +535,7 @@ server {
 
 {%     endif                                                %}
 {%     for port in nginx_tpl_listen_ssl                     %}
-        listen {{ port }} ssl{% if nginx_version is version_compare('1.9.5','>=') %} http2{% elif nginx_version is version_compare('1.4','>=') %} spdy{% endif %}{% if nginx_tpl_default_server_ssl %} {{ nginx_tpl_default_server_ssl | join(" ") }}{% endif %}{% if (loop.first and nginx_tpl_ipv6only_ssl) %} {{ nginx_tpl_ipv6only_ssl | join(" ") }}{% endif %};
+        listen {{ port }} ssl{% if nginx_version is version_compare('1.9.5','>=') and nginx_enable_http2|bool %} http2{% elif nginx_version is version_compare('1.4','>=') and nginx_enable_sdpy|bool %} spdy{% endif %}{% if nginx_tpl_default_server_ssl %} {{ nginx_tpl_default_server_ssl | join(" ") }}{% endif %}{% if (loop.first and nginx_tpl_ipv6only_ssl) %} {{ nginx_tpl_ipv6only_ssl | join(" ") }}{% endif %};
 {%     endfor                                               %}
 
         ssl_certificate           {{ nginx_tpl_ssl_certificate }};


### PR DESCRIPTION
In some use-cases HTTP/2 support is not desired as the default connection protocol between the client and the nginx server.