### PR TITLE
[lxc_ssh] bugfix binary data copy

### DIFF
--- a/ansible/plugins/connection_plugins/lxc_ssh.py
+++ b/ansible/plugins/connection_plugins/lxc_ssh.py
@@ -1356,7 +1356,7 @@ class Connection(ConnectionBase):
                         ("file or module does not "
                          "exist: {0}").format(to_native(in_path)))
 
-        with open(in_path, 'r') as in_f:
+        with open(in_path, 'rb') as in_f:
             in_data = in_f.read()
             if (len(in_data) == 0):
                 # define a shortcut for empty files - nothing to read so the


### PR DESCRIPTION
This fixes the bug, if you want to copy a binary file over lxc_ssh with ansible.
I haven't tested it with python2, but it should be compatible.