### PR TITLE
[debops.nullmailer] use allmailfrom to force envelope sender

### DIFF
--- a/ansible/roles/debops.nullmailer/defaults/main.yml
+++ b/ansible/roles/debops.nullmailer/defaults/main.yml
@@ -122,7 +122,6 @@ nullmailer__defaultdomain: '{{ nullmailer__domain }}'
 # they don't allow arbitrary envelope sender addresses. (Needs nullmailer >= 1.4)
 nullmailer__allmailfrom: ''
                                                                    # ]]]
- 
                                                                    # ]]]
 # SMTP relay configuration [[[
 # ----------------------------
@@ -243,7 +242,7 @@ nullmailer__configuration_files:
     state: '{{ "present" if nullmailer__sendtimeout else "absent" }}'
 
   - dest: '/etc/nullmailer/allmailfrom'
-    content: '{{ nullmailer__allmailfrom}}'
+    content: '{{ nullmailer__allmailfrom }}'
     state: '{{ "present" if nullmailer__allmailfrom else "absent" }}'
 
                                                                    # ]]]

--- a/ansible/roles/debops.nullmailer/defaults/main.yml
+++ b/ansible/roles/debops.nullmailer/defaults/main.yml
@@ -115,6 +115,14 @@ nullmailer__defaulthost: '{{ nullmailer__mailname }}'
 # The string appended to the host part of the e-mail addresses without a dot.
 nullmailer__defaultdomain: '{{ nullmailer__domain }}'
                                                                    # ]]]
+
+# .. envvar:: nullmailer__allmailfrom [[[
+#
+# Force envelope sender. Needed for some mail relays with authentication if
+# they don't allow arbitrary envelope sender addresses. (Needs nullmailer >= 1.4)
+nullmailer__allmailfrom: ''
+                                                                   # ]]]
+ 
                                                                    # ]]]
 # SMTP relay configuration [[[
 # ----------------------------
@@ -233,6 +241,10 @@ nullmailer__configuration_files:
   - dest: '/etc/nullmailer/sendtimeout'
     content: '{{ nullmailer__sendtimeout }}'
     state: '{{ "present" if nullmailer__sendtimeout else "absent" }}'
+
+  - dest: '/etc/nullmailer/allmailfrom'
+    content: '{{ nullmailer__allmailfrom}}'
+    state: '{{ "present" if nullmailer__allmailfrom else "absent" }}'
 
                                                                    # ]]]
 # .. envvar:: nullmailer__private_configuration_files [[[


### PR DESCRIPTION
available  for nullmailer >= 1.4 (debian stretch-backports)