### PR TITLE
Additional templates to rsyslog

### DIFF
--- a/ansible/roles/debops.rsyslog/defaults/main.yml
+++ b/ansible/roles/debops.rsyslog/defaults/main.yml
@@ -687,6 +687,7 @@ rsyslog__conf_filename_templates:
 # .. envvar:: rsyslog__conf_additional_templates [[[
 #
 # List of additional ``rsyslogd`` templates which are used for remote logs.
+# See :ref:`rsyslog__conf_additional_templates`
 rsyslog__conf_additional_templates: []
 
 # ]]]

--- a/ansible/roles/debops.rsyslog/defaults/main.yml
+++ b/ansible/roles/debops.rsyslog/defaults/main.yml
@@ -688,6 +688,7 @@ rsyslog__conf_filename_templates:
 #
 # List of additional ``rsyslogd`` templates which are used for remote logs.
 rsyslog__conf_additional_templates: []
+
 # ]]]
 # .. envvar:: rsyslog__conf_remote_forward [[[
 #

--- a/ansible/roles/debops.rsyslog/defaults/main.yml
+++ b/ansible/roles/debops.rsyslog/defaults/main.yml
@@ -684,6 +684,11 @@ rsyslog__conf_filename_templates:
           $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 
 # ]]]
+# .. envvar:: rsyslog__conf_additional_templates [[[
+#
+# List of additional ``rsyslogd`` templates which are used for remote logs.
+rsyslog__conf_additional_templates: []
+# ]]]
 # .. envvar:: rsyslog__conf_remote_forward [[[
 #
 # Enable log forwardin to another ``rsyslogd`` instance if it's enabled in

--- a/ansible/roles/debops.rsyslog/tasks/main.yml
+++ b/ansible/roles/debops.rsyslog/tasks/main.yml
@@ -160,3 +160,28 @@
           (item.filename|d() and (item.state|d() and item.state == 'absent'))) and
          (item.divert|d() and item.divert|bool))
   notify: [ 'Restart rsyslogd' ]
+
+- name: Remove template files if requested
+  file:
+    dest: '/etc/rsyslog.d/{{ item.name }}.template'
+    state: 'absent'
+  with_flattened:
+    - '{{ rsyslog__conf_additional_templates }}'
+  notify: [ 'Restart rsyslogd' ]
+  when: (item.name|d() and
+         ((item.state|d() and item.state == 'absent') or
+          (item.delete|d() and item.delete|bool)))
+
+- name: Create template files if defined
+  template:
+    src: 'etc/rsyslog.d/template.conf.j2'
+    dest: '/etc/rsyslog.d/{{ item.name }}.template'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  with_flattened:
+    - '{{ rsyslog__conf_additional_templates }}'
+  notify: [ 'Restart rsyslogd' ]
+  when: (item.name|d() and item.state|d('present') != 'absent' and
+         (item.delete is undefined or not item.delete|bool))
+

--- a/ansible/roles/debops.rsyslog/tasks/main.yml
+++ b/ansible/roles/debops.rsyslog/tasks/main.yml
@@ -184,4 +184,3 @@
   notify: [ 'Restart rsyslogd' ]
   when: (item.name|d() and item.state|d('present') != 'absent' and
          (item.delete is undefined or not item.delete|bool))
-

--- a/ansible/roles/debops.rsyslog/tasks/main.yml
+++ b/ansible/roles/debops.rsyslog/tasks/main.yml
@@ -167,10 +167,9 @@
     state: 'absent'
   with_flattened:
     - '{{ rsyslog__conf_additional_templates }}'
+  when: (item.name|d() and item.options|d() and
+         (item.state|d() and item.state == 'absent'))
   notify: [ 'Restart rsyslogd' ]
-  when: (item.name|d() and
-         ((item.state|d() and item.state == 'absent') or
-          (item.delete|d() and item.delete|bool)))
 
 - name: Create template files if defined
   template:
@@ -181,6 +180,6 @@
     mode: '0644'
   with_flattened:
     - '{{ rsyslog__conf_additional_templates }}'
+  when: (item.name|d() and and item.options|d() and
+         item.state|d('present') != 'absent')
   notify: [ 'Restart rsyslogd' ]
-  when: (item.name|d() and item.state|d('present') != 'absent' and
-         (item.delete is undefined or not item.delete|bool))

--- a/ansible/roles/debops.rsyslog/templates/etc/rsyslog.d/template.conf.j2
+++ b/ansible/roles/debops.rsyslog/templates/etc/rsyslog.d/template.conf.j2
@@ -1,16 +1,34 @@
-{#
-    ==== template for rsyslog created via debops.rsyslog role ====
-#}
 # {{ ansible_managed }}
 
-{% if item.name is defined and item.name %}
-{% if item.comment is defined and item.comment %}
+{#
+#    ==== template for rsyslog created via debops.rsyslog role ====
+#
+# List of parameters supported by this template:
+#
+#   - item.name: ''
+#       Name of the template. Required.
+#
+#   - item.comment: ''
+#       Comment to the template, which you want to see on the top of the
+#       template file. Optional.
+#
+#   - item.options: |
+#       Text block with value mapping specified in the template format, check
+#       rsyslog documentation or examples if not sure about syntax. Required.
+#
+#   - item.delete: False
+#       If this parameter is defined and True, template file will be removed
+#       from the rsyslog configuration. Optional.
+#}
+
+{% if item.name is defined and item.name                                    %}
+{% if item.comment is defined and item.comment                              %}
 # {{ item.comment }}
-{% endif %}
+{% endif                                                                    %}
 template(
         name="{{ item.name }}"
-        {% if item.options is defined and item.options %}
-        {{ item.options | indent(8) | regex_replace("(?m)^\s*$", "") }}
-        {% endif %}
+        {% if item.options is defined and item.options                      %}
+{{ item.options | indent(8) | regex_replace("(?m)^\s*$", "") }}
+        {% endif                                                            %}
 )
-{% endif %}
+{% endif                                                                    %}

--- a/ansible/roles/debops.rsyslog/templates/etc/rsyslog.d/template.conf.j2
+++ b/ansible/roles/debops.rsyslog/templates/etc/rsyslog.d/template.conf.j2
@@ -16,8 +16,8 @@
 #       Text block with value mapping specified in the template format, check
 #       rsyslog documentation or examples if not sure about syntax. Required.
 #
-#   - item.delete: False
-#       If this parameter is defined and True, template file will be removed
+#   - item.state: 'present'
+#       If this parameter is defined and 'absent', template file will be removed
 #       from the rsyslog configuration. Optional.
 #}
 

--- a/ansible/roles/debops.rsyslog/templates/etc/rsyslog.d/template.conf.j2
+++ b/ansible/roles/debops.rsyslog/templates/etc/rsyslog.d/template.conf.j2
@@ -1,0 +1,16 @@
+{#
+    ==== template for rsyslog created via debops.rsyslog role ====
+#}
+# {{ ansible_managed }}
+
+{% if item.name is defined and item.name %}
+{% if item.comment is defined and item.comment %}
+# {{ item.comment }}
+{% endif %}
+template(
+        name="{{ item.name }}"
+        {% if item.options is defined and item.options %}
+        {{ item.options | indent(8) | regex_replace("(?m)^\s*$", "") }}
+        {% endif %}
+)
+{% endif %}

--- a/docs/ansible/roles/debops.rsyslog/defaults-detailed.rst
+++ b/docs/ansible/roles/debops.rsyslog/defaults-detailed.rst
@@ -163,3 +163,28 @@ The parameters below can be used in the main list or in the ``sections`` list:
 
 You can see many examples of the rules in :file:`defaults/main.yml` file of the
 ``debops.rsyslog`` role.
+
+.. _rsyslog__conf_additional_templates:
+
+rsyslog__conf_additional_templates
+----------------------------------
+
+This list defines additional rsyslog templates. 
+
+Each additional template can have following parameters, some of them are
+mandatory.
+
+``name```
+  Name of the template. Required.
+
+``comment``
+  Comment to the template, which you want to see on the top of the
+  template file. Optional.
+
+``options``
+  Text block with value mapping specified in the template format, check
+  rsyslog documentation or examples if not sure about syntax. Required.
+
+``delete``
+  If this parameter is defined and ``True``, template file will be removed
+  from the rsyslog configuration. Optional.

--- a/docs/ansible/roles/debops.rsyslog/defaults-detailed.rst
+++ b/docs/ansible/roles/debops.rsyslog/defaults-detailed.rst
@@ -194,8 +194,7 @@ Example of a template definition:
 .. code-block:: yaml
 
    rsyslog__conf_additional_templates:
-     - rsyslog_template_news:
-       name: "RemoteServiceNewsLog"
+     - name: "RemoteServiceNewsLog"
        comment: "Very interesting news!"
        options: |
          type="string"

--- a/docs/ansible/roles/debops.rsyslog/defaults-detailed.rst
+++ b/docs/ansible/roles/debops.rsyslog/defaults-detailed.rst
@@ -189,15 +189,14 @@ mandatory.
   If this parameter is defined and ``absent``, template file will be removed
   from the rsyslog configuration. Optional.
 
-Example of template definition:
+Example of a template definition:
 
 .. code-block:: yaml
 
-rsyslog__conf_additional_templates:
-  - '{{ rsyslog_template_news }}'
-rsyslog_template_news:
-  name: "RemoteServiceNewsLog"
-  comment: "Very interesting news!"
-  options: |
-    type="string"
-    string="/var/log/remote/services/news/news.log"
+   rsyslog__conf_additional_templates:
+     - rsyslog_template_news:
+       name: "RemoteServiceNewsLog"
+       comment: "Very interesting news!"
+       options: |
+         type="string"
+         string="/var/log/remote/services/news/news.log"

--- a/docs/ansible/roles/debops.rsyslog/defaults-detailed.rst
+++ b/docs/ansible/roles/debops.rsyslog/defaults-detailed.rst
@@ -185,6 +185,19 @@ mandatory.
   Text block with value mapping specified in the template format, check
   rsyslog documentation or examples if not sure about syntax. Required.
 
-``delete``
-  If this parameter is defined and ``True``, template file will be removed
+``state``
+  If this parameter is defined and ``absent``, template file will be removed
   from the rsyslog configuration. Optional.
+
+Example of template definition:
+
+.. code-block:: yaml
+
+rsyslog__conf_additional_templates:
+  - '{{ rsyslog_template_news }}'
+rsyslog_template_news:
+  name: "RemoteServiceNewsLog"
+  comment: "Very interesting news!"
+  options: |
+    type="string"
+    string="/var/log/remote/services/news/news.log"


### PR DESCRIPTION
Rsyslog default templates are very basic and in real world situations you need to set more of them. This pull request allows additional templates definitions in DebOps.