### PR TITLE
[debops.pki] Improve portability when getting fqdn

### DIFF
--- a/ansible/roles/debops.pki/files/secret/pki/lib/pki-authority
+++ b/ansible/roles/debops.pki/files/secret/pki/lib/pki-authority
@@ -73,13 +73,21 @@ get_dnsdomainname () {
         dnsdomainname
     else
         local fqdn
-        fqdn="$(hostname -f)"
+        fqdn="$(get_fqdn)"
         if [[ ${fqdn} == *.* ]] ; then
             echo "${fqdn#*.}"
         else
             echo ""
         fi
     fi
+}
+
+get_fqdn () {
+    shopt -s nocasematch
+    case $OSTYPE in
+        *bsd* | dragonfly* ) hostname;;
+        * ) hostname -f;;
+    esac
 }
 
 chmod_idempotent () {
@@ -172,7 +180,7 @@ initialize_environment () {
     config["pki_authorities"]="${config['pki_root']}/authorities"
     config["pki_requests"]="${config['pki_root']}/requests"
 
-    config["pki_default_fqdn"]="$(hostname -f)"
+    config["pki_default_fqdn"]="$(get_fqdn)"
     config["pki_default_domain"]="$(get_dnsdomainname)"
     config["pki_default_domain_dn"]=$(echo "${config['pki_default_domain']}" | cut -d. -f1 | sed 's/.*/\u&/')
 


### PR DESCRIPTION
This PR fixes a portability issue with the pki role when run from certain *BSD systems, in particular, the `-f` argument on `hostname` doesn't exist on OpenBSD, NetBSD and I'm guessing other BSDs as well that use the old `hostname` from 4.2BSD onwards.

The patch works on my Ansible controller which is an OpenBSD 6.4 host, as well as a FreeBSD host I tried it (where `hostname` has the `-f` option). From reading online the man pages of OpenBSD, FreeBSD, NetBSD, DragonFly and 4.3BSD, in all of them, by default `hostname` prints the FQDN, so I'm thinking this is a safe assumption to make for all BSDs.