### PR TITLE
[docker] In Docker, check if 'src/' dir exists

### DIFF
--- a/lib/docker/docker-entrypoint
+++ b/lib/docker/docker-entrypoint
@@ -12,7 +12,7 @@ set -o nounset -o pipefail -o errexit
 # "Missing privilege separation directory: /run/sshd"
 sudo mkdir -p /run/sshd
 
-if ! [ -d "src/controller" ] ; then
+if ! [ -d "src" ] ; then
 
     debops-init src/controller
     mkdir -p src/controller/ansible/inventory/host_vars/localhost


### PR DESCRIPTION
This change should avoid issues with DebOps used as a Docker image and
the Docker entrypoint script causing errors when a Docker volume is
mounted at '~/src/' directory. The custom Ansible Controller directory
will be created only when the '~/src' directory is not found.