### PR TITLE
 [debops.owncloud] Install PHP modules required for the twofactor app

### DIFF
--- a/ansible/roles/debops-contrib.x2go_server/docs/getting-started.rst
+++ b/ansible/roles/debops-contrib.x2go_server/docs/getting-started.rst
@@ -21,7 +21,7 @@ To setup and manage the X2Go server, add the hosts to the
 If you are using debops.sshd_ for configuring your OpenSSH server, you will
 need to adopt some of the defaults of this role to allow X2Go clients to
 connect to the X2Go server via SSH.
-The recommended way to do those adoptions is to symlink the
+The recommended way to do this adaption is to symlink the
 :file:`docs/inventory/debops_service_x2go_server_global_role_vars` file shipped
 with this role into your inventory under
 :file:`ansible/inventory/group_vars/debops_service_x2go_server_global_role_vars`

--- a/ansible/roles/debops.owncloud/defaults/main.yml
+++ b/ansible/roles/debops.owncloud/defaults/main.yml
@@ -92,11 +92,14 @@ owncloud__base_php_packages:
   - 'mbstring'
   - 'zip'
 
+  ## Required for the "OpenOTP Two Factor Authentication" (twofactor_rcdevsopenotp) as of NC 14.
+  - 'ldap'
+  - 'soap'
+
   - '{{ [ "apcu" ] if (owncloud__apcu_enabled|bool) else [] }}'
   - '{{ [ "mysql" ] if (owncloud__database in [ "mariadb", "mysql" ]) else [] }}'
   - '{{ [ "pgsql" ] if (owncloud__database in [ "postgresql" ]) else [] }}'
   - '{{ [ "redis" ] if (owncloud__redis_enabled | bool) else [] }}'
-  - '{{ [ "ldap" ] if (owncloud__ldap_enabled | bool) else [] }}'
 
   ## Seems to be required at least for PHP7.0 to fix:
   ## PHP Warning: PHP Startup: Unable to load dynamic library '/usr/lib/php/20151012/redis.so'

--- a/docs/ansible/roles/debops.netbase/defaults-detailed.rst
+++ b/docs/ansible/roles/debops.netbase/defaults-detailed.rst
@@ -81,7 +81,7 @@ with specific parameters:
   If the value is empty, the host record will be removed from the database.
 
 ``separator``
-  Optional, boolean. If set and ``True``, the generated templae will contain an
+  Optional, boolean. If set and ``True``, the generated template will contain an
   empty line before a given entry, to allow for better readability. This
   parameter is ignored when the ``lineinfile`` mode is used to manage the
   database.


### PR DESCRIPTION
twofactor_rcdevsopenotp requires the ldap and soap PHP modules as of NC 14. Further versions of NC will require MFA/2FA. Allowing the twofactor_rcdevsopenotp app to be installed in a default DebOps setup seems like a sensible way to go.