### PR TITLE
[debops.docker_registry] Ignore errors during GC

### DIFF
--- a/ansible/roles/debops.docker_registry/templates/usr/local/bin/docker-registry-gc.j2
+++ b/ansible/roles/debops.docker_registry/templates/usr/local/bin/docker-registry-gc.j2
@@ -15,7 +15,7 @@ readonly DELETE_UNTAGGED="{{ '--delete-untagged' if (docker_registry__version is
 readonly REDIS_ENABLED="{{ docker_registry__redis_enabled | bool | lower }}"
 readonly REDIS_DATABASE="{{ docker_registry__redis_db }}"
 
-if "${REGISTRY_BIN}" garbage-collect "${CONFIG_FILE}" --dry-run \
+if "${REGISTRY_BIN}" garbage-collect "${CONFIG_FILE}" --dry-run 2>/dev/null \
    | grep --extended-regexp "^blob eligible for deletion" > /dev/null ; then
     sudo systemctl stop docker-registry.service
     "${REGISTRY_BIN}" garbage-collect "${CONFIG_FILE}" "${DELETE_UNTAGGED}" > /dev/null 2>&1


### PR DESCRIPTION
In a case where Docker Registry has not received any uploads, the
garbage collector script can emit an error message about Registry path
not being found. This is not a fatal error, therefore it should be safe
to be sent to /dev/null to avoid e-mails to the administrator.