### PR TITLE
[debops.nginx] Tweak short name generation code

### DIFF
--- a/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/default.conf.j2
+++ b/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/default.conf.j2
@@ -436,21 +436,23 @@
 {%     endif                                                                %}
 
 {% endif                                                                    %}
+{% set nginx__tpl_hostname_domain = item.hostname_domain | d((item.name if item.name is string else item.name[0]).split('.')[1:] | join('.')) %}
 {% if item.hostname is undefined                         %}
 {%   set nginx__tpl_hostnames = []                       %}
 {%   for element in ([ item.name ] if (item.name is string) else item.name) %}
-{%     set element_hostname = element.split('.')[0] %}
-{%     if ('.' not in element_hostname and not element_hostname | ipaddr and
-                 element_hostname not in ([ item.name ] if (item.name is string) else item.name) and
-                 element_hostname is not search('[^a-zA-Z0-9\-\_]+')) %}
+{%     set element_hostname = element | regex_replace(('\.' + (nginx__tpl_hostname_domain | replace('.', '\.')) + '$'), '') %}
+{%     if (not element_hostname | ipaddr and
+           element_hostname not in ([ item.name ] if (item.name is string) else item.name) and
+           not element_hostname.startswith('www') and
+           element_hostname is not search('[^a-zA-Z0-9\-\_\.]+')) and
+           (element_hostname + '.' + nginx__tpl_hostname_domain) in ([ item.name ] if item.name is string else item.name) %}
 {%       set _ = nginx__tpl_hostnames.append(element_hostname) %}
 {%     endif %}
 {%   endfor %}
 {% else %}
 {%   set nginx__tpl_hostnames = ([ item.hostname ] if (item.hostname is string) else item.hostname) %}
 {% endif %}
-{% set nginx__tpl_hostname_domain = (item.name if item.name is string else item.name[0]).split('.')[1:] | join('.') %}
-{% if nginx__tpl_hostnames|d()                           %}
+{% if nginx__tpl_hostnames|d() and item.listen|d(True)                  %}
 # Support for redirection via DNS suffixes in /etc/resolv.conf
 server {
 {%   if item.listen|d(True)                            %}
@@ -458,7 +460,7 @@ server {
         listen {{ port }};
 {%       endfor                                        %}
 
-{%       for address in nginx__tpl_hostnames %}
+{%       for address in nginx__tpl_hostnames | unique %}
         server_name {{ address }};
 {%       endfor                                        %}
 
@@ -473,7 +475,7 @@ server {
         listen {{ port }};
 {%       endfor                                        %}
 
-{%       for address in nginx__tpl_hostnames %}
+{%       for address in nginx__tpl_hostnames | unique %}
         server_name {{ address }}.local;
 {%       endfor                                        %}
 

--- a/docs/ansible/roles/debops.nginx/defaults-detailed.rst
+++ b/docs/ansible/roles/debops.nginx/defaults-detailed.rst
@@ -54,10 +54,10 @@ Common role options
   - ``host/`` -> ``host.example.com``
   - ``host.local`` -> ``host.example.com``
 
-  The ``example.com`` domain will be based on the first value of the ``name``
-  parameter. Users can use the short hostnames in browsers by appending ``/``
-  character after the short name. Specifying directories or arguments is also
-  supported.
+  The ``example.com`` domain will be based on the ``hostname_domain``
+  parameter, or if not specified on the first value of the ``name`` parameter.
+  Users can use the short hostnames in browsers by appending ``/`` character
+  after the short name. Specifying directories or arguments is also supported.
 
   This allows the :command:`nginx` webserver to correctly handle short
   subdomains passed to it via DNS suffixes defined in :file:`/etc/resolv.conf`,
@@ -68,6 +68,18 @@ Common role options
   alphanumeric subdomains with optional dashes and underscores are supported in
   this mode. To tell the role to not autogenerate the redirection, set the
   ``hostname`` parameter to ``False``.
+
+``hostname_domain``
+  Optional. Specify the base DNS domain to use for short hostnames and
+  subdomains. You can use this to set the base domain in multi-subdomain
+  environments. For example, setting it to ``example.com`` will result in
+  redirects:
+
+  - ``host/`` -> ``host.example.com``
+  - ``sub.host/`` -> ``sub.host.example.com``
+
+  Supporting more than one level of subdomains with DNS suffixes on the clients
+  depends on the :man:`resolv.conf(5)` configuration, the ``ndots`` parameter.
 
 ``enabled``
   Optional, boolean. Defaults to ``True``.


### PR DESCRIPTION
The short hostname generation code used by the 'debops.nginx' role is
tweaked to work better with large number of subdomains and multiple
subdomain levels:

- Add 'hostname_domain' parameter which can be used to set base domain
  for short hostnames. Short hostnames can contain dots, 'hostname_domain'
  parameter can be used to select the base level of subdomains to use.

- Short hostnames will not be added if support for HTTP connections in
  a given server is turned off via the 'listen' parameter.

- Short hostnames beginning with the 'www' string are ignored because
  this subdomain too common to be used properly.

- The role checks if autogenerated short hostname + autodetected domain
  actually is in the list of server_names configured for a given server,
  to avoid wrongly detected FQDNs.