### PR TITLE
[debops.mosquitto] Fix version check RC error

### DIFF
--- a/ansible/roles/debops.mosquitto/tasks/main.yml
+++ b/ansible/roles/debops.mosquitto/tasks/main.yml
@@ -46,7 +46,8 @@
   when: mosquitto__pip_packages|d()
 
 - name: Check the installed Mosquitto version
-  shell: set -o nounset -o pipefail -o errexit && mosquitto -h | head -n 1 | awk '{print $3}'
+  shell: set -o nounset -o pipefail -o errexit &&
+         mosquitto -h | head -n 1 | awk '{print $3}' || true
   args:
     executable: '/bin/bash'
   register: mosquitto__register_version


### PR DESCRIPTION
The 'mosquitto -h' command returns with non-zero exit code which results
in an error with pipefail option enabled. Let's avoid that.