### PR TITLE
[debops.docker] More robust way to get docker daemon version

### DIFF
--- a/ansible/roles/debops.docker/defaults/main.yml
+++ b/ansible/roles/debops.docker/defaults/main.yml
@@ -66,7 +66,7 @@ docker__upstream_key: '{{ "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
                                                                    # ]]]
 # .. envvar:: docker__upstream_packagename [[[
 #
-# The full docker packagename to be installed.
+# The full docker package name to be installed.
 docker__upstream_packagename: '{{ "docker-" + docker__upstream_edition }}'
 
                                                                    # ]]]
@@ -156,7 +156,7 @@ docker__virtualenv_python_symlink: '/usr/local/bin/docker-python'
                                                                    # ]]]
 # .. envvar:: docker__default_pip_packages [[[
 #
-# List od default Python packages to install in Docker virtualenv. The
+# List of default Python packages to install in Docker virtualenv. The
 # corresponding binaries will be symlinked in the :file:`/usr/local/bin/`
 # directory to allow access from outside of the Python virtualenv.
 # See :ref:`docker__ref_pip_packages` for more details.
@@ -192,8 +192,8 @@ docker__pip_packages: []
 
 # .. envvar:: docker__admins [[[
 #
-# List of UNIX accounts which should be added to :command:`docker` system group which
-# has access to the Docker UNIX socket.
+# List of UNIX accounts which should be added to the ``docker`` system group
+# which giving them access to the Docker UNIX socket.
 docker__admins: '{{ ansible_local.core.admin_users
                     if (ansible_local|d() and ansible_local.core|d() and
                         ansible_local.core.admin_users|d())

--- a/ansible/roles/debops.docker/defaults/main.yml
+++ b/ansible/roles/debops.docker/defaults/main.yml
@@ -66,7 +66,7 @@ docker__upstream_key: '{{ "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
                                                                    # ]]]
 # .. envvar:: docker__upstream_packagename [[[
 #
-# The full docker package name to be installed.
+# The full docker package name to be installed if installing from upstream.
 docker__upstream_packagename: '{{ "docker-" + docker__upstream_edition }}'
 
                                                                    # ]]]
@@ -86,6 +86,12 @@ docker__upstream_repository: '{{ "deb [arch="
         + docker__upstream_arch_map[ansible_architecture]
         + "] https://download.docker.com/linux/" + docker__distribution|lower + " "
         + docker__distribution_release + " " + docker__upstream_channel }}'
+
+                                                                   # ]]]
+# .. envvar:: docker__packagename [[[
+#
+# The full docker package name to be installed.
+docker__packagename: '{{ docker__upstream_packagename if docker__upstream|d() else "docker.io" }}'
 
                                                                    # ]]]
 # .. envvar:: docker__mandatory_packages [[[

--- a/ansible/roles/debops.docker/tasks/main.yml
+++ b/ansible/roles/debops.docker/tasks/main.yml
@@ -32,16 +32,14 @@
 
 - name: Remove other version if upstream is modified
   apt:
-    name: '{{ item }}'
+    name: '{{ ((["docker.io"] if docker__upstream|d()
+                else [docker__upstream_packagename])
+               + (["docker-engine"] if docker__upstream|d()
+                 else [])) | flatten }}'
     state: 'absent'
     install_recommends: False
   register: docker__register_other_version_removed
   until: docker__register_other_version_removed is succeeded
-  with_flattened:
-    - '{{ "docker.io" if docker__upstream|d()
-                else docker__upstream_packagename }}'
-    - '{{ "docker-engine" if docker__upstream|d()
-                else [] }}'
 
 - name: Remove startup file(s) if present
   file:
@@ -58,14 +56,12 @@
 
 - name: Install required packages
   apt:
-    name: '{{ item }}'
+    name: '{{ (docker__mandatory_packages
+               + [ docker__packagename ]
+               + docker__base_packages
+               + docker__packages) | flatten }}'
     state: 'present'
     install_recommends: False
-  with_flattened:
-    - '{{ docker__mandatory_packages }}'
-    - '{{ docker__upstream_packagename if docker__upstream|d() else "docker.io" }}'
-    - '{{ docker__base_packages }}'
-    - '{{ docker__packages }}'
   register: docker__register_packages
   until: docker__register_packages is succeeded
 

--- a/ansible/roles/debops.docker/templates/etc/ansible/facts.d/docker.fact.j2
+++ b/ansible/roles/debops.docker/templates/etc/ansible/facts.d/docker.fact.j2
@@ -3,11 +3,13 @@
 # {{ ansible_managed }}
 
 from __future__ import print_function
-from json import dumps
+from json import loads, dumps
 from sys import exit
 import subprocess
 import os
 import re
+
+docker_pkg = loads('''{{ docker__packagename | to_nice_json }}''')
 
 
 def cmd_exists(cmd):
@@ -21,8 +23,8 @@ output = {'installed': cmd_exists('docker')}
 
 try:
     version_stdout = subprocess.check_output(
-            ["dpkg-query", "-W", "-f=${Version}\n'",
-             "{{ docker__packagename }}"]).split('+')[0]
+        ["dpkg-query", "-W", "-f=${Version}\n'", docker_pkg]
+    ).split('+')[0]
 
     match = re.search(r'^(?:[^:]:)?(?P<docker_version>[^~]+)', version_stdout)
     if match:

--- a/ansible/roles/debops.docker/templates/etc/ansible/facts.d/docker.fact.j2
+++ b/ansible/roles/debops.docker/templates/etc/ansible/facts.d/docker.fact.j2
@@ -22,7 +22,7 @@ output = {'installed': cmd_exists('docker')}
 try:
     version_stdout = subprocess.check_output(
             ["dpkg-query", "-W", "-f=${Version}\n'",
-             "{{ docker__upstream_packagename if docker__upstream|d() else "docker.io" }}"]).split('+')[0]
+             "{{ docker__packagename }}"]).split('+')[0]
 
     match = re.search(r'^(?:[^:]:)?(?P<docker_version>[^~]+)', version_stdout)
     if match:

--- a/ansible/roles/debops.docker/templates/etc/ansible/facts.d/docker.fact.j2
+++ b/ansible/roles/debops.docker/templates/etc/ansible/facts.d/docker.fact.j2
@@ -7,6 +7,7 @@ from json import dumps
 from sys import exit
 import subprocess
 import os
+import re
 
 
 def cmd_exists(cmd):
@@ -19,9 +20,13 @@ def cmd_exists(cmd):
 output = {'installed': cmd_exists('docker')}
 
 try:
-    output['version'] = subprocess.check_output(
-            ['docker', 'version', '--format',
-             '{{ "{{" }}.Server.Version{{ "}}" }}']).strip('\n')
+    version_stdout = subprocess.check_output(
+            ["dpkg-query", "-W", "-f=${Version}\n'",
+             "{{ docker__upstream_packagename if docker__upstream|d() else "docker.io" }}"]).split('+')[0]
+
+    match = re.search(r'^(?:[^:]:)?(?P<docker_version>[^~]+)', version_stdout)
+    if match:
+        output['version'] = match.group('docker_version')
 
 except Exception:
     pass


### PR DESCRIPTION
If the daemon is not running, `docker version` returns:

> Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?

This in turn prevents the task "Configure Docker systemd options" from running which would have fixed the issue in my case.