### PR TITLE
[debops.logrotate] Fix generated logrotate configuration

### DIFF
--- a/ansible/roles/debops.logrotate/templates/etc/logrotate.conf.j2
+++ b/ansible/roles/debops.logrotate/templates/etc/logrotate.conf.j2
@@ -60,7 +60,7 @@
 {%     endif %}
 {%     if section.postrotate|d() %}
     postrotate
-{{ section.postrotate | indent(8, true) -}}
+{{ section.postrotate | indent(8, true) }}
 {{ '    endscript' }}
 {%     endif %}
 {%     if section.preremove|d() %}
@@ -73,6 +73,7 @@
 {{ section.lastaction | indent(8, true) -}}
 {{ '    endscript' }}
 {%     endif %}
+
 }
 {%   endif %}
 {% endmacro %}

--- a/ansible/roles/debops.logrotate/templates/etc/logrotate.d/config.j2
+++ b/ansible/roles/debops.logrotate/templates/etc/logrotate.d/config.j2
@@ -54,7 +54,7 @@
 {%       if section.postrotate|d() %}
 
     postrotate
-{{ section.postrotate | indent(8, true) -}}
+{{ section.postrotate | indent(8, true) }}
 {{ '    endscript' }}
 {%       endif %}
 {%       if section.preremove|d() %}
@@ -67,6 +67,7 @@
 {{ section.lastaction | indent(8, true) -}}
 {{ '    endscript' }}
 {%       endif %}
+
 }
 {%     endif %}
 {%   endif %}


### PR DESCRIPTION
@drybjed I noticed that on my systems, invalid logrotate configuration was generated because the ending `}` was on the same line as the last directive. Can you reproduce this or do you think it is an issue with my setup?

This patch was not comprehensibly tested because I am not sure if I made a mistake.