### PR TITLE
[debops.slapd] Integrating TLS configuration in one step

### DIFF
--- a/ansible/roles/debops.slapd/tasks/tls.yml
+++ b/ansible/roles/debops.slapd/tasks/tls.yml
@@ -42,4 +42,3 @@
   command: 'ldapmodify -Y EXTERNAL -H ldapi:/// -f {{ slapd_register_tempdir.path|d() + "/configure_tlscerts.ldif" }}'
   when: slapd_pki|d() and slapd_pki | bool and
         not (slapd_register_tls_cert_search.stdout is search("olcTLSCertificateFile:"))
-

--- a/ansible/roles/debops.slapd/tasks/tls.yml
+++ b/ansible/roles/debops.slapd/tasks/tls.yml
@@ -38,21 +38,8 @@
   when: slapd_pki|d() and slapd_pki | bool and
         not (slapd_register_tls_cert_search.stdout is search("olcTLSCertificateFile:"))
 
-- name: Configure TLS certificates (first time only)
+- name: Configure TLS certificates
   command: 'ldapmodify -Y EXTERNAL -H ldapi:/// -f {{ slapd_register_tempdir.path|d() + "/configure_tlscerts.ldif" }}'
   when: slapd_pki|d() and slapd_pki | bool and
         not (slapd_register_tls_cert_search.stdout is search("olcTLSCertificateFile:"))
 
-- name: Configure TLS certificates
-  ldap_attr:
-    dn: 'cn=config'
-    name: '{{ item.key }}'
-    values: '{{ item.value }}'
-    state: 'exact'
-  with_dict:
-    olcTLSCACertificateFile:  '{{ slapd_pki_path + "/" + slapd_pki_realm + "/" + slapd_pki_ca }}'
-    olcTLSCertificateFile:    '{{ slapd_pki_path + "/" + slapd_pki_realm + "/" + slapd_pki_crt }}'
-    olcTLSCertificateKeyFile: '{{ slapd_pki_path + "/" + slapd_pki_realm + "/" + slapd_pki_key }}'
-    olcTLSDHParamFile:        '{{ slapd_dhparam_file }}'
-    olcTLSCipherSuite:        '{{ slapd_pki_ciphers }}'
-  when: slapd_pki|d() and slapd_pki | bool

--- a/ansible/roles/debops.slapd/templates/tmp/configure_tlscerts.ldif.j2
+++ b/ansible/roles/debops.slapd/templates/tmp/configure_tlscerts.ldif.j2
@@ -5,4 +5,9 @@ add: olcTLSCertificateFile
 -
 add: olcTLSCertificateKeyFile
   olcTLSCertificateKeyFile: {{ slapd_pki_path + "/" + slapd_pki_realm + "/" + slapd_pki_key }}
-
+-
+add: olcTLSCACertificateFile
+  olcTLSCACertificateFile: {{ slapd_pki_path + "/" + slapd_pki_realm + "/" + slapd_pki_ca  }}
+-
+add: olcTLSDHParamFile
+  olcTLSDHParamFile: {{ slapd_dhparam_file }}


### PR DESCRIPTION
- future versions of slapd do not allow setting TLS attributes as cn=admin,cn=config
- it is not required anymore to specify a TLS cipher suite