### PR TITLE
[debops.netbase] Add 'dbus' as a required package.

### DIFF
--- a/ansible/roles/debops.netbase/defaults/main.yml
+++ b/ansible/roles/debops.netbase/defaults/main.yml
@@ -22,7 +22,7 @@ netbase__enabled: True
 # .. envvar:: netbase__base_packages [[[
 #
 # List of base APT packages to linstall for netbase support.
-netbase__base_packages: [ 'netbase', 'libcap2-bin' ]
+netbase__base_packages: [ 'netbase', 'libcap2-bin', 'dbus' ]
 
                                                                    # ]]]
 # .. envvar:: netbase__packages [[[


### PR DESCRIPTION
The 'hostname' ansible module seem to be using hostnamectl for setting
the hostname. This requires dbus to be installed.
Fixes #702