### PR TITLE
[debops.mariadb_server] Don't drop root@localhost

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -94,6 +94,11 @@ Changed
   ``php5`` packages, but the ``php5.6`` packages from Ondřej Surý APT
   repository work fine.
 
+- [debops.mariadb_server] The mysql user 'root' is no longer dropped.
+  This user is used for database maintenance and authenticates using the
+  unix_auth plugin. However, debops still maintains and sets a password for
+  'root'.
+
 Fixed
 ~~~~~
 

--- a/ansible/roles/debops.mariadb_server/tasks/secure_installation.yml
+++ b/ansible/roles/debops.mariadb_server/tasks/secure_installation.yml
@@ -1,15 +1,5 @@
 ---
 
-- name: Drop unnecessary root accounts
-  mysql_user:
-    name: 'root'
-    host: '{{ item }}'
-    state: 'absent'
-  with_flattened:
-    - [ '127.0.0.1', '::1' ]
-    - [ '{{ ansible_hostname if (ansible_hostname != "localhost") else [] }}' ]
-  when: item|d()
-
 - name: Update database root password
   mysql_user:
     name: 'root'


### PR DESCRIPTION
Since Debian Jessie the maintenance scripts that is included in debian
mariadb-server package relies on the 'root'@'localhost' identified via
a unix_socket.
Dropping this root account will make these maintenance scripts no longer
working.
Instead it should be sufficient to just append a password to the
existing root account. This will allow the maintenacne scripts to
conntinue to work password-less via the unix_socket, and you can still
use the password to connect without using the unix_socket.

[More info](https://sources.debian.org/src/mariadb-10.1/10.1.26-0+deb9u1/debian/mariadb-server-10.1.README.Debian/)