### PR TITLE
[debops.stunnel] Make options parameter for services configured via inventory

### DIFF
--- a/ansible/roles/debops.stunnel/defaults/main.yml
+++ b/ansible/roles/debops.stunnel/defaults/main.yml
@@ -54,6 +54,13 @@ stunnel_ssl_ciphers: 'ALL:ECDHE:!SSLv3:!SSLv2:!kEDH:!aNULL:!ADH:!eNULL:!MEDIUM:!
 stunnel_ssl_curve: 'prime256v1'
 
                                                                    # ]]]
+# .. envvar:: stunnel_ssl_opts [[[
+#
+# List of SSL options passed to the OpenSSL library
+# See stunnel4(8) for more details.
+stunnel_ssl_opts: [ 'NO_SSLv3' ]
+
+                                                                   # ]]]
 # .. envvar:: stunnel_ssl_verify [[[
 #
 # What level of scrutiny should stunnel use to check validity of

--- a/ansible/roles/debops.stunnel/templates/etc/stunnel/service.conf.j2
+++ b/ansible/roles/debops.stunnel/templates/etc/stunnel/service.conf.j2
@@ -37,8 +37,15 @@ ciphers		= {{ item.ssl_ciphers | default(stunnel_ssl_ciphers) }}
 curve		= {{ item.ssl_curve   | default(stunnel_ssl_curve) }}
 
 sslVersion	= all
-options		= NO_SSLv2
-options		= NO_SSLv3
+{% if item.ssl_opts is defined and item.ssl_opts %}
+{%   for opt in item.ssl_opts %}
+options         = {{ opt }}
+{%   endfor %}
+{% else %}
+{%   for opt in stunnel_ssl_opts %}
+options         = {{ opt }}
+{%   endfor %}
+{% endif %}
 verify		= {{ item.ssl_verify | default(stunnel_ssl_verify) }}
 
 {% if stunnel_pki is defined and stunnel_pki %}

--- a/docs/ansible/roles/debops.stunnel/defaults-detailed.rst
+++ b/docs/ansible/roles/debops.stunnel/defaults-detailed.rst
@@ -123,6 +123,10 @@ These parameters are related to ``stunnel`` itself.
   Text block, optional. Add other options on the server side of the ``stunnel``
   configuration, in the form of a YAML text block.
 
+``ssl_opts``
+  List, optional. SSL options for ``stunnel`` configuration. Will override the
+  defaults.
+
 /etc/services parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Changed the SSL options parameter to be configured via inventory instead of hard-coded in the template. The default setting drops the "NO_SSLv2" option. This addresses #684.