### PR TITLE
[debops.icinga_web] Allow DELETE method in HTTP requests

### DIFF
--- a/ansible/roles/debops.icinga_web/defaults/main.yml
+++ b/ansible/roles/debops.icinga_web/defaults/main.yml
@@ -1250,6 +1250,7 @@ icinga_web__nginx__dependent_servers:
     root: '/usr/share/icingaweb2/public'
     filename: 'debops.icinga_web'
     php_upstream: 'php_icingaweb'
+    php_limit_except: [ 'GET', 'HEAD', 'POST', 'DELETE' ]
 
     options: |
       if (!-d $request_filename) {


### PR DESCRIPTION
Icinga Director REST API includes HTTP DELETE method for some
operations, and thus this method needs to be allowed by Icinga Web Nginx
server configuration:

https://github.com/Icinga/icingaweb2-module-director/blob/master/doc/70-REST-API.md