### PR TITLE
debops.lvm: Create file system when mount parameter is defined

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -121,6 +121,9 @@ Fixed
   certificate was not performed at all, without any actual changes in the
   service, with subsequent task exiting with an error due to misconfiguration.
 
+- [debops.lvm] Make sure a file system is created by default when the ``mount``
+  parameter is defined in the :envvar:`lvm__logical_volumes`.
+
 
 `debops v0.8.1`_ - 2019-02-02
 -----------------------------

--- a/ansible/roles/debops.lvm/tasks/manage_lvm.yml
+++ b/ansible/roles/debops.lvm/tasks/manage_lvm.yml
@@ -63,7 +63,7 @@
   when: lvm__logical_volumes|d(False) and
         item.vg|d() and item.lv|d() and item.size|d() and
         item.state|d('present') != 'absent' and
-        ((item.mount|d() and item.fs|d()) or item.fs|d())
+        ((item.mount|d() and item.fs|d(True)) or item.fs|d())
 
 - name: Manage mount points
   mount:


### PR DESCRIPTION
According to the documentation:
> By default, a filesystem specified in `lvm_default_fs_type` variable is created in all new Logical Volumes if `item.mount` is specified.

Unfortunately this doesn't work because in this case the default value for `fs` is empty which means `false`. This fix makes sure that a file system is created when a mount point is defined.