### PR TITLE
[debops.redis_s*] Fixed logic on non-systemd.

### DIFF
--- a/ansible/roles/debops.redis_sentinel/tasks/main.yml
+++ b/ansible/roles/debops.redis_sentinel/tasks/main.yml
@@ -151,10 +151,10 @@
 - name: Reload systemd configuration when needed
   systemd:
     daemon_reload: True
-  when: ansible_service_mgr == 'systemd' and
-        redis_sentinel__register_systemd is changed or
-        redis_sentinel__register_systemd_remove is changed or
-        redis_sentinel__register_systemd_override is changed
+  when: (ansible_service_mgr == 'systemd' and (
+          redis_sentinel__register_systemd is changed or
+          redis_sentinel__register_systemd_remove is changed or
+          redis_sentinel__register_systemd_override is changed))
 
 - name: Ensure that Redis Sentinel instances are started
   systemd:

--- a/ansible/roles/debops.redis_server/tasks/main.yml
+++ b/ansible/roles/debops.redis_server/tasks/main.yml
@@ -186,10 +186,10 @@
 - name: Reload systemd configuration when needed
   systemd:
     daemon_reload: True
-  when: ansible_service_mgr == 'systemd' and
-        redis_server__register_systemd is changed or
-        redis_server__register_systemd_remove is changed or
-        redis_server__register_systemd_override is changed
+  when: (ansible_service_mgr == 'systemd' and (
+          redis_server__register_systemd is changed or
+          redis_server__register_systemd_remove is changed or
+          redis_server__register_systemd_override is changed)
 
 - name: Ensure that Redis instances are started
   systemd:


### PR DESCRIPTION
This does not affect functionality on systemd systems and enables
use of the roles on non-systemd ones.