### PR TITLE
[debops.ifupdown] Run ifup_systemd conditionally.

### DIFF
--- a/ansible/roles/debops.ifupdown/tasks/ifup_systemd.yml
+++ b/ansible/roles/debops.ifupdown/tasks/ifup_systemd.yml
@@ -24,7 +24,7 @@
 - name: Reload systemd services
   systemd:
     daemon_reload: True
-  when: ansible_service_mgr == 'systemd' and ifupdown__register_systemd_services is changed
+  when: ifupdown__register_systemd_services is changed
 
   ## https://stackoverflow.com/a/28888474
 - name: Test if Ansible is running in check mode
@@ -37,4 +37,4 @@
     name: '{{ item }}'
     enabled: True
   with_items: [ 'ifup-wait-all-auto', 'ifup-allow-boot' ]
-  when: (ansible_service_mgr == 'systemd' and ifupdown__register_check_mode is not skipped)
+  when: ifupdown__register_check_mode is not skipped

--- a/ansible/roles/debops.ifupdown/tasks/main.yml
+++ b/ansible/roles/debops.ifupdown/tasks/main.yml
@@ -21,6 +21,7 @@
 
 - name: Create custom ifupdown systemd services
   include: ifup_systemd.yml
+  when: ansible_service_mgr == 'systemd'
 
 - name: Reset network configuration on role upgrade
   file:


### PR DESCRIPTION
Fixes #718.

No changes in behaviour on a systemd setup.
Allows usage of the role on non-systemd setups.