### PR TITLE
Update default nameConstraints to allow subdomains

### DIFF
--- a/ansible/roles/debops.pki/defaults/main.yml
+++ b/ansible/roles/debops.pki/defaults/main.yml
@@ -530,6 +530,15 @@ pki_default_authority: 'domain'
 pki_ca_name_constraints: True
 
                                                                    # ]]]
+# .. envvar:: pki_ca_name_constraints_critical [[[
+#
+# Specify if the ``nameConstraints`` CA certificate extension should be
+# marked critical by default. Enabling this when using ``nameConstraints`` is
+# recommended by the CA/Browser Forum.
+# Ref: https://cabforum.org/wp-content/uploads/CA-Browser-Forum-BR-1.6.4.pdf
+pki_ca_name_constraints_critical: True
+
+                                                                   # ]]]
 # .. envvar:: pki_ca_domain [[[
 #
 # The DNS domain used by default for an Certificate Authority configuration if

--- a/ansible/roles/debops.pki/files/secret/pki/lib/pki-authority
+++ b/ansible/roles/debops.pki/files/secret/pki/lib/pki-authority
@@ -138,7 +138,7 @@ get_openssl_name_constraints_directive () {
     local name_constraints
     case "${config['name_constraints']}" in
         true|True)
-            name_constraints="nameConstraints         = critical, permitted;DNS:${config_domain}"
+            name_constraints="nameConstraints         = permitted;DNS:${config_domain},permitted;DNS:.${config_domain}"
             ;;
         false|False)
             name_constraints=""

--- a/ansible/roles/debops.pki/files/secret/pki/lib/pki-authority
+++ b/ansible/roles/debops.pki/files/secret/pki/lib/pki-authority
@@ -138,7 +138,14 @@ get_openssl_name_constraints_directive () {
     local name_constraints
     case "${config['name_constraints']}" in
         true|True)
-            name_constraints="nameConstraints         = permitted;DNS:${config_domain},permitted;DNS:.${config_domain}"
+            case "${config['name_constraints_critical']}" in
+                false|False)
+                    name_constraints="nameConstraints         = permitted;DNS:${config_domain},permitted;DNS:.${config_domain}"
+                    ;;
+                *)
+                    name_constraints="nameConstraints         = critical, permitted;DNS:${config_domain},permitted;DNS:.${config_domain}"
+                    ;;
+            esac
             ;;
         false|False)
             name_constraints=""
@@ -1425,6 +1432,12 @@ sub_new-ca () {
                         ;;
                     name-constraints=*)
                         args["name_constraints"]=${OPTARG#*=}
+                        ;;
+                    name-constraints-critical)
+                        args["name_constraints_critical"]="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+                        ;;
+                    name-constraints-critical=*)
+                        args["name_constraints_critical"]=${OPTARG#*=}
                         ;;
                     *)
                         if [ "$OPTERR" = 1 ] && [ "${optspec:0:1}" != ":" ]; then

--- a/ansible/roles/debops.pki/tasks/main.yml
+++ b/ansible/roles/debops.pki/tasks/main.yml
@@ -351,6 +351,7 @@
            --crl "{{ item.crl | d(True) }}"
            --ocsp "{{ item.ocsp | d(True) }}"
            --name-constraints "{{ item.name_constraints | d(pki_ca_name_constraints) }}"
+           --name-constraints-critical "{{ item.name_constraints_critical | d(pki_ca_name_constraints_critical) }}"
   args:
     chdir: '{{ secret + "/pki" }}'
     creates: '{{ secret + "/pki/authorities/" + item.name + "/subject/cert.pem" }}'

--- a/docs/ansible/roles/debops.pki/defaults-detailed.rst
+++ b/docs/ansible/roles/debops.pki/defaults-detailed.rst
@@ -259,9 +259,16 @@ List of supported parameters (incomplete):
   The X.509 Name Constraints certificate extension to include in certificates
   which will be used during certificate verification to ensure that the CA is
   authorized to issue a certificate for the name in question.
-  The extension is set to critical which REQUIRES X.509 libraries to support it or to return an error.
-  This is done following common recommendations
-  (ref: `Which properties of a X.509 certificate should be critical and which not? <https://security.stackexchange.com/questions/30974/which-properties-of-a-x-509-certificate-should-be-critical-and-which-not>`_).
-  The default is ``True`` which will result in ``critical, permitted;DNS:${config_domain}``.
-  It can be set to ``False`` to not include X.509 Name Constraints in certificates.
-  Any other value (not matching :regexp:`^(?:[Tt]rue|[Ff]alse)$`) will be included as is as X.509 Name Constraint.
+  The default is ``True`` which will result in ``critical, permitted;DNS:${config_domain}``
+  (the 'critical, ' part is omitted when ``item.name_constraints_critical`` is
+  set to ``False``). It can be set to ``False`` to not include X.509 Name
+  Constraints in certificates. Any other value (not matching :regexp:`^(?:[Tt]rue|[Ff]alse)$`)
+  will be included as is as X.509 Name Constraint.
+
+``name_constraints_critical``
+  Boolean, for specifying whether to mark the default Name Constraints
+  extension as critical or not. The default is ``True``. The CA/Browser forum
+  recommends this to be enabled (REQUIRING X.509 libraries to support it or to
+  return an error), but mentions that the extension may be disabled for
+  compatibility reasons
+  (ref: `Baseline Requirements for the Issuance and Management of Publicly-Trusted Certificates (v1.6.4)<https://cabforum.org/wp-content/uploads/CA-Browser-Forum-BR-1.6.4.pdf>`_).

--- a/docs/ansible/roles/debops.pki/defaults-detailed.rst
+++ b/docs/ansible/roles/debops.pki/defaults-detailed.rst
@@ -271,4 +271,4 @@ List of supported parameters (incomplete):
   recommends this to be enabled (REQUIRING X.509 libraries to support it or to
   return an error), but mentions that the extension may be disabled for
   compatibility reasons
-  (ref: `Baseline Requirements for the Issuance and Management of Publicly-Trusted Certificates (v1.6.4)<https://cabforum.org/wp-content/uploads/CA-Browser-Forum-BR-1.6.4.pdf>`_).
+  (ref: `Baseline Requirements for the Issuance and Management of Publicly-Trusted Certificates (v1.6.4) <https://cabforum.org/wp-content/uploads/CA-Browser-Forum-BR-1.6.4.pdf>`_).

--- a/docs/ansible/roles/debops.pki/getting-started.rst
+++ b/docs/ansible/roles/debops.pki/getting-started.rst
@@ -72,8 +72,8 @@ ones you will likely want to change are:
 
   ``debops.pki`` now supports the X.509 Name Constraints certificate extension by
   default. This may break software using old version of OpenSSL and multi-domain
-  environments. Please see ``name_constraints`` under :ref:`pki__ref_authorities`
-  for more information.
+  environments. Please see ``name_constraints`` and ``name_constraints_critical``
+  under :ref:`pki__ref_authorities` for more information.
 
 Example inventory
 -----------------


### PR DESCRIPTION
'permitted;DNS:${config_domain}' only allows names which exactly match
${config_domain}. 'permitted;DNS:.${config_domain}' (notice the extra ".") only
allows expanded labels, but not ${config_domain} itself. Let's have the best of
both worlds by combining the two name constraints together, which allows both
${config_domain} and expanded labels.

OpenSSL throws `error 47 at 0 depth lookup: permitted subtree violation; error
hcert.pem: verification failed` when using this role with critical
nameConstraints. That's why I removed the 'critical' property. This might be
better for backwards compatibility as well. Modern software will still refuse
to accept the certificate when the name is outside the nameConstraints space.
For example, Mozilla Firefox 60.6.1esr-1~deb9u1 will fail to connect with
'SEC_ERROR_CERT_NOT_IN_NAME_SPACE', and curl 7.52.1-5+deb9u9 fails with '(60)
SSL certificate problem: permitted subtree violation'.