### PR TITLE
Add nginx_multi_accept option

### DIFF
--- a/ansible/roles/debops.nginx/defaults/main.yml
+++ b/ansible/roles/debops.nginx/defaults/main.yml
@@ -392,6 +392,15 @@ nginx_real_ip_recursive: False
 nginx_default_keepalive_timeout: 60
 
                                                                    # ]]]
+
+# .. envvar:: nginx_multi_accept [[[
+#
+# If enabled a worker proccess will accept all new connections at a time,
+# instead of a new connection at a time.
+nginx_multi_accept: 'off'
+
+                                                                   # ]]]
+
 # .. envvar:: nginx_pki [[[
 #
 # Enable or disable support for PKI/SSL/TLS in nginx.

--- a/ansible/roles/debops.nginx/templates/etc/nginx/nginx.conf.j2
+++ b/ansible/roles/debops.nginx/templates/etc/nginx/nginx.conf.j2
@@ -27,6 +27,7 @@ env PATH;
 {% endif %}
 events {
         worker_connections {{ nginx_worker_connections | default('1024') }};
+        multi_accept {{ nginx_multi_accept | default('off') }};
 }
 
 http {


### PR DESCRIPTION
Enable a worker proccess accept all new connections at a time.

This PR solves an issue with nginx under low load with long polling HTTP connections, waiting for a response from the backend.

Setting ```multi_accept``` to ```on``` reduces the CPU load of the nginx processes.