### PR TITLE
[debops.ferm] Fix forced rule "filter_icmp_flood"

### DIFF
--- a/ansible/roles/debops.ferm/defaults/main.yml
+++ b/ansible/roles/debops.ferm/defaults/main.yml
@@ -452,7 +452,7 @@ ferm__default_rules:
     type: 'hashlimit'
     weight_class: 'filter-icmp'
     protocol: 'icmp'
-    enabled: '{{ ferm__filter_icmp | bool }}'
+    rule_state: '{{ "present" if (ferm__filter_icmp | bool) else "absent" }}'
     hashlimit: '{{ ferm__filter_icmp_limit }}'
     hashlimit_burst: '{{ ferm__filter_icmp_burst }}'
     hashlimit_expire: '{{ ferm__filter_icmp_expire }}'


### PR DESCRIPTION
~~Will close https://github.com/debops/debops/issues/734.~~
Replaces the unused `enabled` attribute with a correct `rule_state` in the default rule "filter_icmp_flood". Now it's possible to remove the rule using:

    ferm__filter_icmp: False