### PR TITLE
[debops.logrotate] keep newlines in config

### DIFF
--- a/ansible/roles/debops.logrotate/templates/etc/logrotate.conf.j2
+++ b/ansible/roles/debops.logrotate/templates/etc/logrotate.conf.j2
@@ -1,16 +1,16 @@
 # {{ ansible_managed }}
 
 {% if logrotate__options %}
-{{ logrotate__options -}}
+{{ logrotate__options }}
 {% endif %}
 {% if logrotate__group_options %}
-{{ logrotate__group_options -}}
+{{ logrotate__group_options }}
 {% endif %}
 {% if logrotate__host_options %}
-{{ logrotate__host_options -}}
+{{ logrotate__host_options }}
 {% endif %}
 {% if logrotate__default_options %}
-{{ logrotate__default_options -}}
+{{ logrotate__default_options }}
 {% endif %}
 {% macro print_config(section) %}
 {%   if section.state is undefined or section.state != 'absent' %}
@@ -46,31 +46,31 @@
 {%       endif %}
 {%     endif %}
 {%     if section.options|d() %}
-{{ section.options | indent(4, true) -}}
+{{ section.options | indent(4, true) }}
 {%     endif %}
 {%     if section.firstaction|d() %}
     firstaction
-{{ section.firstaction | indent(8, true) -}}
+{{ section.firstaction | indent(8, true) }}
 {{ '    endscript' }}
 {%     endif %}
 {%     if section.prerotate|d() %}
     prerotate
-{{ section.prerotate | indent(8, true) -}}
+{{ section.prerotate | indent(8, true) }}
 {{ '    endscript' }}
 {%     endif %}
 {%     if section.postrotate|d() %}
     postrotate
-{{ section.postrotate | indent(8, true) -}}
+{{ section.postrotate | indent(8, true) }}
 {{ '    endscript' }}
 {%     endif %}
 {%     if section.preremove|d() %}
     preremove
-{{ section.preremove | indent(8, true) -}}
+{{ section.preremove | indent(8, true) }}
 {{ '    endscript' }}
 {%     endif %}
 {%     if section.lastaction|d() %}
     lastaction
-{{ section.lastaction | indent(8, true) -}}
+{{ section.lastaction | indent(8, true) }}
 {{ '    endscript' }}
 {%     endif %}
 }
@@ -80,7 +80,7 @@
 {%   if item.sections|d() %}
 {%     for section in item.sections %}
 {%       if (section.log|d() or section.logs|d() or section.filename|d()) and section.state|d('present') != 'absent' %}
-{{ print_config(section) -}}
+{{ print_config(section) }}
 {%         if not loop.last %}
 
 {%         endif %}
@@ -88,7 +88,7 @@
 {%     endfor %}
 {%   else %}
 {%     if (item.log|d() or item.logs|d() or item.filename|d()) and item.state|d('present') != 'absent' %}
-{{ print_config(item) -}}
+{{ print_config(item) }}
 {%       if not loop.last %}
 
 {%       endif %}

--- a/ansible/roles/debops.logrotate/templates/etc/logrotate.d/config.j2
+++ b/ansible/roles/debops.logrotate/templates/etc/logrotate.d/config.j2
@@ -4,7 +4,7 @@
 {%   if section.state is undefined or section.state != 'absent' %}
 {%     if section.comment|d() %}
 
-{{ section.comment | regex_replace('\n$','') | comment(prefix='', postfix='') -}}
+{{ section.comment | regex_replace('\n$','') | comment(prefix='', postfix='') }}
 {%     endif %}
 {%     if section.log|d() %}
 {%       if section.log is string %}
@@ -35,9 +35,9 @@
 {%     endif %}
 {%     if section.options|d() %}
 {%       if section.log|d() or section.logs|d() %}
-{{ section.options | indent(4, true) -}}
+{{ section.options | indent(4, true) }}
 {%       else %}
-{{ section.options -}}
+{{ section.options }}
 {%       endif %}
 {%     endif %}
 {%     if section.log|d() or section.logs|d() %}
@@ -48,23 +48,23 @@
 {%       endif %}
 {%       if section.prerotate|d() %}
     prerotate
-{{ section.prerotate | indent(8, true) -}}
+{{ section.prerotate | indent(8, true) }}
 {{ '    endscript' }}
 {%       endif %}
 {%       if section.postrotate|d() %}
 
     postrotate
-{{ section.postrotate | indent(8, true) -}}
+{{ section.postrotate | indent(8, true) }}
 {{ '    endscript' }}
 {%       endif %}
 {%       if section.preremove|d() %}
     preremove
-{{ section.preremove | indent(8, true) -}}
+{{ section.preremove | indent(8, true) }}
 {{ '    endscript' }}
 {%       endif %}
 {%       if section.lastaction|d() %}
     lastaction
-{{ section.lastaction | indent(8, true) -}}
+{{ section.lastaction | indent(8, true) }}
 {{ '    endscript' }}
 {%       endif %}
 }
@@ -74,7 +74,7 @@
 {% if item.sections|d() %}
 {%   for section in item.sections %}
 {%     if (section.log|d() or section.logs|d() or section.filename|d()) and section.state|d('present') != 'absent' %}
-{{ print_config(section) -}}
+{{ print_config(section) }}
 {%       if not loop.last %}
 
 {%       endif %}
@@ -82,6 +82,6 @@
 {%   endfor %}
 {% else %}
 {%   if (item.log|d() or item.logs|d() or item.filename|d()) and item.state|d('present') != 'absent' %}
-{{ print_config(item) -}}
+{{ print_config(item) }}
 {%   endif %}
 {% endif %}


### PR DESCRIPTION
These changes remove the Jinja 'strip' operations from the logrotate templates. Logrotate does not like missing newlines and presented us with errors like these:

```
/etc/cron.daily/logrotate:
error: php7.0-fpm:prerotate, postrotate or preremove without endscript
error: found error in file php7.0-fpm, skipping
error: rsyslog:prerotate, postrotate or preremove without endscript
error: found error in file rsyslog, skipping
error: rsyslog-remote:prerotate, postrotate or preremove without endscript
error: found error in file rsyslog-remote, skipping
error: /etc/logrotate.conf:14 bad rotation count '1}'
error: found error in /var/log/wtmp , skipping
```

These errors were all caused by missing newlines. For example, 'endscript' and the curly bracket after the '1' must be on new lines.
I'm not sure why the 'strip' operation was in the templates in the first place. Maybe I'm overlooking something, but this seems to work for us.