### PR TITLE
[debops.php] Support PHP Composer from upstream

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -221,6 +221,15 @@ Changed
   non-security related upgrades, such as timezone changes, antivirus database
   changes, and similar.
 
+- [debops.php] The role will install the :command:`composer` command from the
+  upstream GitHub repository on older OS releases, including Debian Stretch
+  (current Stable release). This is due to incompatibility of the ``composer``
+  APT package included in Debian Stretch and PHP 7.3.
+
+  The custom ``composer`` command installation tasks have been removed from the
+  :ref:`debops.roundcube` and :ref:`debops.librenms` roles, since
+  :ref:`debops.php` will take care of the installation.
+
 Removed
 ~~~~~~~
 

--- a/ansible/roles/debops.librenms/defaults/main.yml
+++ b/ansible/roles/debops.librenms/defaults/main.yml
@@ -23,7 +23,6 @@ librenms__base_packages:
         if (ansible_local|d() and ansible_local.apt|d() and
             (ansible_local.apt.nonfree|d())|bool)
         else [] }}'
-  - '{{ "composer" if not librenms__composer_phar|bool else [] }}'
 
                                                                    # ]]]
 # .. envvar:: librenms__monitoring_packages [[[
@@ -184,33 +183,6 @@ librenms__install_version: 'master'
 #
 # Enable or disable daily upgrades pulled from LibreNMS ``git`` repository.
 librenms__update: True
-                                                                   # ]]]
-                                                                   # ]]]
-# PHP Composer support [[[
-# ------------------------
-
-# .. envvar:: librenms__composer_phar [[[
-#
-# If this is set to ``True`` the ``composer.phar`` script will be downloaded
-# from the :envvar:`librenms__composer_phar_url` and used to install the
-# missing PHP packages. If this is set to ``False`` the system-wide
-# :command:`composer` is used.
-# WARNING: Setting this variable to ``True`` has some security implications as
-# the download is not cryptographically verified. This is only meant to be a
-# work-around for old distribution releases not supporting the downstream
-# packaged :command:`composer`.
-librenms__composer_phar: '{{ True
-                             if ansible_distribution_release in [ "jessie", "trusty" ]
-                             else False }}'
-
-                                                                   # ]]]
-# .. envvar:: librenms__composer_phar_url [[[
-#
-# URL to the file:`composer.phar` script which will be used to install PHP
-# packages not available in the APT repository on distribution releases which
-# don't package PHP composer. If this is set to ``False``, :command:`composer`
-# will be installed via APT package manager.
-librenms__composer_phar_url: 'https://getcomposer.org/composer.phar'
                                                                    # ]]]
                                                                    # ]]]
 # Database configuration [[[

--- a/ansible/roles/debops.librenms/tasks/main.yml
+++ b/ansible/roles/debops.librenms/tasks/main.yml
@@ -117,34 +117,14 @@
     mode: '{{ librenms__config_mode }}'
   tags: [ 'role::librenms:config', 'role::librenms:database' ]
 
-- name: Download composer.phar if requested
-  get_url:
-    url: '{{ librenms__composer_phar_url }}'
-    dest: '{{ librenms__install_path }}'
-    mode: '0640'
-  become: True
-  become_user: '{{ librenms__user }}'
-  when: librenms__composer_phar|bool
-
-- name: Install missing PHP packages via composer.phar
-  command: php composer.phar install
-  args:
-    chdir: '{{ librenms__install_path }}'
-  become: True
-  become_user: '{{ librenms__user }}'
-  when: librenms__composer_phar|bool
-  register: librenms__register_composer_phar
-  changed_when: not "Nothing to install or update" in librenms__register_composer_phar.stderr|d('')
-
-- name: Install missing PHP packages via system-wide composer
+- name: Install missing PHP packages via Composer
   composer:
-    command: install
+    command: 'install'
     working_dir: '{{ librenms__install_path }}'
   register: librenms__register_composer
   until: librenms__register_composer is succeeded
   become: True
   become_user: '{{ librenms__user }}'
-  when: not librenms__composer_phar|bool
 
 - name: Initialize database
   command: php build-base.php

--- a/ansible/roles/debops.php/COPYRIGHT
+++ b/ansible/roles/debops.php/COPYRIGHT
@@ -1,8 +1,8 @@
 debops.php - Manage PHP5/PHP7 environment using Ansible
 
 Copyright (C) 2016 Mariano Barcia <mariano.barcia@gmail.com>
-Copyright (C) 2016-2017 Maciej Delmanowski <drybjed@gmail.com>
-Copyright (C) 2016-2017 DebOps https://debops.org/
+Copyright (C) 2016-2019 Maciej Delmanowski <drybjed@gmail.com>
+Copyright (C) 2016-2019 DebOps https://debops.org/
 
 This Ansible role is part of DebOps.
 

--- a/ansible/roles/debops.php/defaults/main.yml
+++ b/ansible/roles/debops.php/defaults/main.yml
@@ -100,10 +100,7 @@ php__base_packages:
   - '{{ "php" + php__version }}'
   - 'curl'
   - 'gd'
-  - '{{ []
-        if (ansible_distribution_release in
-            [ "wheezy", "jessie", "precise", "trusty"])
-        else "composer" }}'
+  - '{{ [] if php__composer_upstream_enabled|bool else "composer" }}'
   - '{{ "mcrypt"
         if (php__version is version_compare("7.2","<"))
         else [] }}'
@@ -230,6 +227,48 @@ php__common_included_packages:
   - 'sysvmsg'
   - 'tokenizer'
   - 'zlib'
+                                                                   # ]]]
+                                                                   # ]]]
+# PHP Composer support [[[
+# ------------------------
+
+# .. envvar:: php__composer_upstream_enabled [[[
+#
+# Enable or disable installation of the :command:`composer` command from
+# upstream. The ``composer`` package in older OS releases might not work as
+# expected. If upstream installation is disabled, the ``composer`` APT package
+# will be installed instead.
+php__composer_upstream_enabled: '{{ True
+                                    if (ansible_distribution_release in
+                                        [ "wheezy", "jessie", "stretch",
+                                          "precise", "trusty", "xenial", "bionic" ])
+                                    else False }}'
+
+                                                                   # ]]]
+# .. envvar:: php__composer_upstream_version [[[
+#
+# The version of the PHP Composer release to install from upstream.
+# Remember to update the watch file and the SHA256 checksum on changes.
+php__composer_upstream_version: '1.8.5'
+
+                                                                   # ]]]
+# .. envvar:: php__composer_upstream_checksum [[[
+#
+# The SHA256 checksum of the PHP Composer release selected for installation.
+php__composer_upstream_checksum: 'sha256:23b29b1a921b56db3c12ba531752dffcfaa3de0fcece3e54974e06990e46bbf9'
+
+                                                                   # ]]]
+# .. envvar:: php__composer_upstream_url [[[
+#
+# The URL to the PHP Composer binary which should be installed.
+php__composer_upstream_url: '{{ "https://github.com/composer/composer/releases/download/"
+                                + php__composer_upstream_version + "/composer.phar" }}'
+
+                                                                   # ]]]
+# .. envvar:: php__composer_upstream_dest [[[
+#
+# The absolute path of the PHP Composer binary destination file.
+php__composer_upstream_dest: '/usr/local/bin/composer'
                                                                    # ]]]
                                                                    # ]]]
 # Global php.ini configuration [[[

--- a/ansible/roles/debops.php/meta/watch-composer
+++ b/ansible/roles/debops.php/meta/watch-composer
@@ -1,0 +1,8 @@
+# Role: debops.php
+# Package: composer
+# Version: 1.8.5
+
+version=3
+options=uversionmangle=s/-?([^\d.]+)/~$1/i;tr/A-Z/a-z/,dversionmangle=s/\+dfsg$//,repacksuffix=+dfsg \
+https://github.com/composer/composer/releases \
+.*/v?(\d.+)\.tar\.gz

--- a/ansible/roles/debops.php/tasks/main.yml
+++ b/ansible/roles/debops.php/tasks/main.yml
@@ -23,6 +23,14 @@
   until: php__register_packages is succeeded
   notify: [ 'Restart php-fpm' ]
 
+- name: Install PHP Composer from upstream
+  get_url:
+    url: '{{ php__composer_upstream_url }}'
+    dest: '{{ php__composer_upstream_dest }}'
+    checksum: '{{ php__composer_upstream_checksum }}'
+    mode: '0755'
+  when: php__composer_upstream_enabled|bool
+
 - name: Ensure older PHP packages are absent on reset
   include: 'packages_absent_for_version.yml'
   loop_control:

--- a/ansible/roles/debops.roundcube/defaults/main.yml
+++ b/ansible/roles/debops.roundcube/defaults/main.yml
@@ -79,37 +79,6 @@ roundcube__packages: []
 #
 # APT packages required for the Roundcube installation.
 roundcube__base_packages: [ 'curl', 'file', 'unzip' ]
-
-                                                                   # ]]]
-# .. envvar:: roundcube__composer_packages [[[
-#
-# APT packages required to install PHP composer.
-roundcube__composer_packages: [ 'composer ']
-
-                                                                   # ]]]
-# .. envvar:: roundcube__composer_phar [[[
-#
-# If this is set to ``True`` the ``composer.phar`` script will be downloaded
-# from the :envvar:`roundcube__composer_phar_url` and used to install the
-# missing PHP packages. If this is set to ``False`` the system-wide
-# :command:`composer` is used.
-# WARNING: Setting this variable to ``True`` has some security implications as
-# the download is not cryptographically verified. This is only meant to be a
-# work-around for old distribution releases not supporting the downstream
-# packaged :command:`composer`.
-roundcube__composer_phar: '{{ True
-                              if (ansible_distribution_release in
-                                  [ "jessie", "stretch", "trusty", "xenial", "bionic" ])
-                              else False }}'
-
-                                                                   # ]]]
-# .. envvar:: roundcube__composer_phar_url [[[
-#
-# URL to the file:`composer.phar` script which will be used to install PHP
-# packages not available in the APT repository on distribution releases which
-# don't package PHP composer. If this is set to ``False``, :command:`composer`
-# will be installed via APT package manager.
-roundcube__composer_phar_url: 'https://getcomposer.org/composer.phar'
                                                                    # ]]]
                                                                    # ]]]
 # Roundcube user account [[[

--- a/ansible/roles/debops.roundcube/tasks/deploy_roundcube.yml
+++ b/ansible/roles/debops.roundcube/tasks/deploy_roundcube.yml
@@ -137,34 +137,14 @@
     group: '{{ roundcube__group }}'
     mode: '0640'
 
-- name: Download composer.phar if requested
-  get_url:
-    url: '{{ roundcube__composer_phar_url }}'
-    dest: '{{ roundcube__git_checkout }}'
-    mode: '0640'
-  become: True
-  become_user: '{{ roundcube__user }}'
-  when: roundcube__composer_phar|bool
-
-- name: Install missing PHP packages via composer.phar
-  command: php composer.phar install
-  args:
-    chdir: '{{ roundcube__git_checkout }}'
-  become: True
-  become_user: '{{ roundcube__user }}'
-  when: roundcube__composer_phar|bool
-  register: roundcube__register_composer_phar
-  changed_when: not "Nothing to install or update" in roundcube__register_composer_phar.stderr|d('')
-
-- name: Install missing PHP packages via system-wide composer
+- name: Install missing PHP packages via Composer
   composer:
-    command: install
+    command: 'install'
     working_dir: '{{ roundcube__git_checkout }}'
   become: True
   become_user: '{{ roundcube__user }}'
   register: roundcube__register_composer
   until: roundcube__register_composer is succeeded
-  when: not roundcube__composer_phar|bool
 
 - name: Install Javascript packages
   command: bin/install-jsdeps.sh

--- a/ansible/roles/debops.roundcube/tasks/main.yml
+++ b/ansible/roles/debops.roundcube/tasks/main.yml
@@ -46,8 +46,6 @@
   with_flattened:
     - '{{ roundcube__base_packages }}'
     - '{{ roundcube__packages }}'
-    - '{{ roundcube__composer_packages
-          if not roundcube__composer_phar|bool else [] }}'
   register: roundcube__register_packages
   until: roundcube__register_packages is succeeded
   tags: [ 'role::roundcube:pkg' ]

--- a/docs/ansible/roles/debops.php/getting-started.rst
+++ b/docs/ansible/roles/debops.php/getting-started.rst
@@ -61,6 +61,17 @@ to function correctly. See the :ref:`provided playbook <php__ref_example_playboo
 to see an example usage.
 
 
+PHP Composer installation
+-------------------------
+
+The :ref:`debops.php` role wil install the `PHP Composer`__, a dependency
+manager for PHP. The version from the OS repositories will be preferred. On
+older OS releases (including Debian Stretch), a known upstream binary will be
+downloaded and installed instead.
+
+.. __: https://getcomposer.org/
+
+
 Layout of the php.ini configuration
 -----------------------------------
 


### PR DESCRIPTION
The 'debops.php' role can now conditionally install PHP Composer using
the upstream package, via checksumed GitHub releases. Composer from
upstream will be installed on older OS releases, including Debian
Stretch, because older versions break with PHP 7.3.

Custom Composer installation tasks from other DebOps roles have been
removed, installation is now centralized in the 'debops.php' role.