### PR TITLE
[debops.icinga_web] Prefer packages from backports

### DIFF
--- a/ansible/playbooks/service/icinga_web.yml
+++ b/ansible/playbooks/service/icinga_web.yml
@@ -16,6 +16,7 @@
     - role: debops.apt_preferences
       tags: [ 'role::apt_preferences', 'skip::apt_preferences' ]
       apt_preferences__dependent_list:
+        - '{{ icinga_web__apt_preferences__dependent_list }}'
         - '{{ php__apt_preferences__dependent_list }}'
         - '{{ nginx__apt_preferences__dependent_list }}'
         - '{{ postgresql__apt_preferences__dependent_list | d([]) }}'

--- a/ansible/roles/debops.icinga_web/defaults/main.yml
+++ b/ansible/roles/debops.icinga_web/defaults/main.yml
@@ -1116,6 +1116,17 @@ icinga_web__combined_director_kickstart_cfg: '{{ icinga_web__current_director_ki
 # Configuration for other Ansible roles [[[
 # -----------------------------------------
 
+# .. envvar:: icinga_web__apt_preferences__dependent_list [[[
+#
+# Configuration for the :ref:`debops.apt_preferences` Ansible role.
+icinga_web__apt_preferences__dependent_list:
+
+  - package: [ 'icingaweb2', 'icingaweb2-*', 'icingacli', 'php-icinga' ]
+    backports: [ 'stretch' ]
+    by_role: 'debops.icinga_web'
+    reason: 'Incompatibility with PHP 7.3'
+
+                                                                   # ]]]
 # .. envvar:: icinga_web__postgresql__dependent_roles [[[
 #
 # Configuration of PostgreSQL roles for :ref:`debops.postgresql` Ansible role.


### PR DESCRIPTION
The 'icingaweb2*' APT packages in Debian Stretch are broken on systems
with PHP 7.3. The packages in the 'stretch-backports' repository have
been fixed and work fine in this environment.