### PR TITLE
[debops.opendkim] Add pyOpenSSL

### DIFF
--- a/ansible/playbooks/service/opendkim.yml
+++ b/ansible/playbooks/service/opendkim.yml
@@ -30,5 +30,12 @@
           config: '{{ opendkim__postfix__dependent_maincf }}'
       when: opendkim__postfix_integration|bool
 
+    - role: debops.python
+      tags: [ 'role::python', 'skip::python' ]
+      python__dependent_packages3:
+        - '{{ opendkim__python__dependent_packages3 }}'
+      python__dependent_packages2:
+        - '{{ opendkim__python__dependent_packages2 }}'
+
     - role: debops.opendkim
       tags: [ 'role::opendkim', 'skip::opendkim' ]

--- a/ansible/roles/debops.opendkim/defaults/main.yml
+++ b/ansible/roles/debops.opendkim/defaults/main.yml
@@ -473,6 +473,23 @@ opendkim__postfix__dependent_maincf:
     value:
       - name: 'unix:/opendkim/opendkim.sock'
         weight: -300
+
+                                                                   # ]]]
+# .. envvar:: opendkim__python__dependent_packages3 [[[
+#
+# Configuration for the :ref:`debops.python` Ansible role.
+opendkim__python__dependent_packages3:
+
+  - 'python3-openssl'
+
+                                                                   # ]]]
+# .. envvar:: opendkim__python__dependent_packages2 [[[
+#
+# Configuration for the :ref:`debops.python` Ansible role.
+opendkim__python__dependent_packages2:
+
+  - 'python-openssl'
+
                                                                    # ]]]
                                                                    # ]]]
                                                                    # ]]]

--- a/ansible/roles/debops.opendkim/defaults/main.yml
+++ b/ansible/roles/debops.opendkim/defaults/main.yml
@@ -16,7 +16,7 @@
 # .. envvar:: opendkim__base_packages [[[
 #
 # List of APT packages to install for OpenDKIM support.
-opendkim__base_packages: [ 'opendkim', 'opendkim-tools', 'python-openssl' ]
+opendkim__base_packages: [ 'opendkim', 'opendkim-tools' ]
 
                                                                    # ]]]
 # .. envvar:: opendkim__packages [[[

--- a/ansible/roles/debops.opendkim/defaults/main.yml
+++ b/ansible/roles/debops.opendkim/defaults/main.yml
@@ -16,7 +16,7 @@
 # .. envvar:: opendkim__base_packages [[[
 #
 # List of APT packages to install for OpenDKIM support.
-opendkim__base_packages: [ 'opendkim', 'opendkim-tools' ]
+opendkim__base_packages: [ 'opendkim', 'opendkim-tools', 'python-openssl' ]
 
                                                                    # ]]]
 # .. envvar:: opendkim__packages [[[


### PR DESCRIPTION
I was greeted with an error when I tried out the debops.opendkim role on a Debian 9 box (with Ansible 2.7.5) this morning:

```
failed: [myhostname -> localhost] (item={u'name': u'mail'}) => {"changed": false, "item": {"name": "mail"}, "msg": "the python pyOpenSSL module is required"}
```

Turns out the 'python-openssl' package was missing. This package contains the pyOpenSSL module needed to generate the DKIM keys. These changes add this package to the `opendkim__base_packages` variable.