### PR TITLE
[debops.nginx] Only reference named location when we will generate it

### DIFF
--- a/ansible/roles/debops.nginx/templates/etc/nginx/snippets/acme-challenge.conf.j2
+++ b/ansible/roles/debops.nginx/templates/etc/nginx/snippets/acme-challenge.conf.j2
@@ -17,7 +17,9 @@ location ^~ /.well-known/acme-challenge/ {
 location @well-known-acme-challenge {
         root {{ nginx_acme_root }};
         default_type "text/plain";
+{% if nginx_acme_domain %}
         try_files $uri @redirect-acme-challenge;
+{% endif %}
 }
 
 {% if nginx_acme_domain %}


### PR DESCRIPTION
Prevents error: could not find named location "@redirect-acme-challenge"