### PR TITLE
[debops.owncloud] Small fixes

### DIFF
--- a/ansible/roles/debops.owncloud/defaults/main.yml
+++ b/ansible/roles/debops.owncloud/defaults/main.yml
@@ -417,7 +417,6 @@ owncloud__variant_name_map:
 #
 # * ownCloud ``10.0``
 #
-# * Nextcloud ``13.0``
 # * Nextcloud ``14.0``
 # * Nextcloud ``15.0``
 #

--- a/ansible/roles/debops.owncloud/tasks/setup_owncloud.yml
+++ b/ansible/roles/debops.owncloud/tasks/setup_owncloud.yml
@@ -161,7 +161,6 @@
     - '{{ owncloud__group_occ_cmd_list }}'
     - '{{ owncloud__host_occ_cmd_list }}'
     - '{{ owncloud__dependent_occ_cmd_list }}'
-  when: owncloud__do_autosetup|bool
 # .. ]]]
 
 # Configure cron job for background tasks [[[

--- a/ansible/roles/debops.owncloud/tasks/setup_owncloud.yml
+++ b/ansible/roles/debops.owncloud/tasks/setup_owncloud.yml
@@ -104,9 +104,7 @@
            '--admin-pass={{ owncloud__admin_password }}'
            {% endif %}
   register: owncloud__register_occ_install
-  when: owncloud__do_autosetup|bool and owncloud__release not in [ '8.0' ]
-  ## Did not work with 8.1.6-2.1 because of https://github.com/owncloud/core/issues/17583
-  ## Falling back to URL auto install method.
+  when: owncloud__do_autosetup|bool
 
 # .. ]]]
 
@@ -204,6 +202,6 @@
   failed_when: (owncloud__register_occ_integrity_check_core.rc != 0 or
                 owncloud__register_occ_integrity_check_core.stdout_lines|length != 0)
   changed_when: False
-  when: (owncloud__do_autosetup|bool and owncloud__release is version_compare("9.0.8", ">="))
+  when: owncloud__do_autosetup|bool
 
 # ]]]


### PR DESCRIPTION
I don’t fully understand the error to be honest. `owncloud__do_autosetup` is defined. ansible 2.7.5

```
fatal: [host.example.org]: FAILED! => {"msg": "The conditional check 'owncloud__do_autosetup|bool' failed. The error was: error while evaluating conditional (owncloud__do_autosetup|bool): 'owncloud__do_autosetup
' is undefined\n\nThe error appears to have been in '/home/user/.ansible/ypid-ansible-common/submodules/debops/ansible/roles/debops.owncloud/tasks/setup_owncloud.yml': line 153, column 3, but may\nbe elsewhere i
n the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n# Run occ commands as specified in the inventory [[[\n- name: Run occ commands as specified in the inventory\n  ^ here\n"
}
```