### PR TITLE
[debops.roundcube] Always fetch JS, fixes upgrades

### DIFF
--- a/ansible/roles/debops.roundcube/tasks/deploy_roundcube.yml
+++ b/ansible/roles/debops.roundcube/tasks/deploy_roundcube.yml
@@ -150,7 +150,6 @@
   command: bin/install-jsdeps.sh
   args:
     chdir: '{{ roundcube__git_checkout }}'
-    creates: 'program/js/jquery.min.js'
   become: True
   become_user: '{{ roundcube__user }}'
 


### PR DESCRIPTION
This needs to be run on upgrades.

This can also fix broken installs, which actually was the original issue that got me into debugging this.

Also it doesn't hurt to fetch the JS, should be totally idempotent as long as the previous run was successful also.