### PR TITLE
[debops.rsyslog] Don't rely on SysV init script

### DIFF
--- a/ansible/roles/debops.rsyslog/defaults/main.yml
+++ b/ansible/roles/debops.rsyslog/defaults/main.yml
@@ -1006,7 +1006,11 @@ rsyslog__logrotate__dependent_config:
           delaycompress
           compress
         postrotate: |
-          invoke-rc.d rsyslog rotate > /dev/null
+          {{ "invoke-rc.d rsyslog rotate > /dev/null"
+            if (ansible_distribution_release in
+                 ([ "wheezy", "jessie", "stretch",
+                    "precise", "trusty" ]))
+            else "/usr/lib/rsyslog/rsyslog-rotate" }}
 
       - logs: '{{ rsyslog__default_logfiles | difference(["/var/log/syslog"]) }}'
         options: |
@@ -1018,7 +1022,11 @@ rsyslog__logrotate__dependent_config:
           delaycompress
           sharedscripts
         postrotate: |
-          invoke-rc.d rsyslog rotate > /dev/null
+          {{ "invoke-rc.d rsyslog rotate > /dev/null"
+            if (ansible_distribution_release in
+                 ([ "wheezy", "jessie", "stretch",
+                    "precise", "trusty" ]))
+            else "/usr/lib/rsyslog/rsyslog-rotate" }}
 
   - filename: 'rsyslog-remote'
     logs: [ '/var/log/remote/*/*/syslog', '/var/log/remote/*/*/*.log' ]
@@ -1031,7 +1039,11 @@ rsyslog__logrotate__dependent_config:
       delaycompress
       sharedscripts
     postrotate: |
-      invoke-rc.d rsyslog rotate > /dev/null
+      {{ "invoke-rc.d rsyslog rotate > /dev/null"
+        if (ansible_distribution_release in
+             ([ "wheezy", "jessie", "stretch",
+                "precise", "trusty" ]))
+        else "/usr/lib/rsyslog/rsyslog-rotate" }}
 # ]]]
 # ]]]
 # ]]]


### PR DESCRIPTION
Since Buster, rsyslog has a new helper script to close open log files.
Same for Ubuntu since at least 16.04.