### PR TITLE
[debops.docker_gen] Update docker_gen to 0.7.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -143,6 +143,10 @@ Changed
     the default Stretch environment. The downloaded ``.deb`` package will be
     verified using the RStudio Inc. GPG signing key before installation.
 
+  - [debops.docker_gen] The docker-gen version that this role installs by
+    default has been updated to version 0.7.4. This release notably adds IPv6
+    and docker network support.
+
 - [debops.lxc] The :command:`lxc-prepare-ssh` script will read the public SSH
   keys from specific files (``root`` key file, and the ``$SUDO_USER`` key file)
   and will not accept any custom files to read from, to avoid possible security

--- a/ansible/roles/debops.docker_gen/defaults/main.yml
+++ b/ansible/roles/debops.docker_gen/defaults/main.yml
@@ -27,7 +27,7 @@ docker_gen__os_arch: 'linux-amd64'
 # .. envvar:: docker_gen__version [[[
 #
 # Version of :command:`docker-gen` to install.
-docker_gen__version: '0.4.1'
+docker_gen__version: '0.7.4'
 
                                                                    # ]]]
 # .. envvar:: docker_gen__release [[[

--- a/ansible/roles/debops.docker_gen/files/usr/local/lib/templates/nginx-upstreams.conf.tmpl
+++ b/ansible/roles/debops.docker_gen/files/usr/local/lib/templates/nginx-upstreams.conf.tmpl
@@ -4,20 +4,22 @@ upstream {{ $host }} {
 {{ range $index, $value := $containers }}
 
 	{{ $addrLen := len $value.Addresses }}
+	{{ $network := index $value.Networks 0 }}
+
 	{{/* If only 1 port exposed, use that */}}
 	{{ if eq $addrLen 1 }}
 		{{ with $address := index $value.Addresses 0 }}
-		   # {{$value.Name}}
-		   server {{ $address.IP }}:{{ $address.Port }};
+			# {{$value.Name}}
+			server {{ $network.IP }}:{{ $address.Port }};
 		{{ end }}
 
 	{{/* If more than one port exposed, use the one matching VIRTUAL_PORT env var */}}
 	{{ else if $value.Env.VIRTUAL_PORT }}
 		{{ range $i, $address := $value.Addresses }}
-		   {{ if eq $address.Port $value.Env.VIRTUAL_PORT }}
-		   # {{$value.Name}}
-		   server {{ $address.IP }}:{{ $address.Port }};
-		   {{ end }}
+			{{ if eq $address.Port $value.Env.VIRTUAL_PORT }}
+			# {{$value.Name}}
+			server {{ $network.IP }}:{{ $address.Port }};
+			{{ end }}
 		{{ end }}
 
 	{{/* Else default to standard web port 80 */}}
@@ -25,7 +27,7 @@ upstream {{ $host }} {
 		{{ range $i, $address := $value.Addresses }}
 			{{ if eq $address.Port "80" }}
 			# {{$value.Name}}
-			server {{ $address.IP }}:{{ $address.Port }};
+			server {{ $network.IP }}:{{ $address.Port }};
 			{{ end }}
 		{{ end }}
 	{{ end }}

--- a/ansible/roles/debops.docker_gen/meta/watch-docker-gen
+++ b/ansible/roles/debops.docker_gen/meta/watch-docker-gen
@@ -1,6 +1,6 @@
 # Role: debops.docker_gen
 # Package: docker-gen
-# Version: 0.4.1
+# Version: 0.7.4
 
 version=4
 https://github.com/jwilder/docker-gen/tags .*/v?(\d\S+)\.tar\.gz


### PR DESCRIPTION
0.7.4 is the latest docker-gen release, supporting IPv6 and docker networks. These changes also update the nginx template in order to support docker networks.