### PR TITLE
[multiple roles] add NCSC-NL cipher suite

### DIFF
--- a/ansible/roles/debops.apache/defaults/main.yml
+++ b/ansible/roles/debops.apache/defaults/main.yml
@@ -589,6 +589,11 @@ apache__tls_cipher_suite_sets:
   # https://cipherli.st/
   cipherli_st: 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH'
 
+  # https://www.ncsc.nl/
+  # https://www.ncsc.nl/english/current-topics/factsheets/it-security-guidelines-for-transport-layer-security-tls.html
+  # This is the 'good' cipher suite from version 2.0 of the document.
+  ncsc_nl: 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES128-GCM-SHA256'
+
                                                                    # ]]]
 # .. envvar:: apache__tls_honor_cipher_order [[[
 #

--- a/ansible/roles/debops.dovecot/defaults/main.yml
+++ b/ansible/roles/debops.dovecot/defaults/main.yml
@@ -264,7 +264,12 @@ dovecot_ssl_cipher_list_default: 'TLSv1+HIGH:!SSLv2:!EXPORT:!RC4:!aNULL:!eNULL:!
 #
 # https://bettercrypto.org/
 dovecot_ssl_cipher_list_better_cypto: 'EDH+CAMELLIA:EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA256:EECDH:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!IDEA:!ECDSA:kEDH:CAMELLIA128-SHA:AES128-SHA'
+
                                                                    # ]]]
+# .. envvar:: dovecot_ssl_cipher_list_ncsc_nl [[[
+#
+# https://www.ncsc.nl/english/current-topics/factsheets/it-security-guidelines-for-transport-layer-security-tls.html
+dovecot_ssl_cipher_list_ncsc_nl: 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES128-GCM-SHA256'
                                                                    # ]]]
 # Dovecot custom configuration [[[
 # --------------------------------

--- a/ansible/roles/debops.nginx/defaults/main.yml
+++ b/ansible/roles/debops.nginx/defaults/main.yml
@@ -1153,6 +1153,10 @@ nginx_ssl_ciphers:
   # https://community.qualys.com/thread/12182
   fips: 'FIPS@STRENGTH:!aNULL:!eNULL'
 
+  # NCSC-NL 'good' cipher suite from IT Security Guidelines for Transport Layer Security v2.0
+  # https://www.ncsc.nl/english/current-topics/factsheets/it-security-guidelines-for-transport-layer-security-tls.html
+  ncsc_nl: 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES128-GCM-SHA256'
+
   # This cipher set disables the 'ssl_ciphers' option in 'nginx' and the
   # default set of SSL ciphers for a given platform will be used.
   default: ''


### PR DESCRIPTION
The Dutch National Cyber Security Centre published updated TLS
guidelines last month. This version was created in collaboration with
the national communication security agency, with contributions from
numerous organizations and individuals.

One of the changes in this version is the cipher suite selection. This
commit adds the 'good' cipher suite from the document to debops.apache,
debops.dovecot and debops.nginx.

I'm not sure if this is the best way to add new ciphers, especially since they have to be added in multiple places. Can't we do this with Ansible facts or something?