### PR TITLE
[debops.system_users] Custom local getent script

### DIFF
--- a/ansible/roles/debops.system_users/files/script/getent_passwd.py
+++ b/ansible/roles/debops.system_users/files/script/getent_passwd.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+# Get the specified user information from the system password database.
+# This solution should work on all platforms; Ansible 'getent' module does not
+# work correctly on Apple macOS.
+# Ref: https://github.com/ansible/ansible/issues/38339
+#
+# Usage: getent_passwd.py <username>
+
+import sys
+import os
+import pwd
+import operator
+from json import dumps
+
+
+def getent(user):
+    all = pwd.getpwall()
+    user = sorted(
+        (u for u in all if u.pw_name == user),
+        key=operator.attrgetter("pw_name"),
+    )[0]
+    return ({user.pw_name: ["x", user.pw_uid, user.pw_gid, user.pw_gecos,
+                            user.pw_dir, user.pw_shell]})
+
+
+if __name__ == "__main__":
+    try:
+        user = sys.argv[1]
+        try:
+            print(dumps(getent(user), sort_keys=True, indent=4))
+        except IndexError:
+            sys.exit(2)
+
+    except Exception:
+        print("Usage: %s <user>" % os.path.basename(sys.argv[0]))
+        sys.exit(1)

--- a/ansible/roles/debops.system_users/tasks/main.yml
+++ b/ansible/roles/debops.system_users/tasks/main.yml
@@ -1,17 +1,18 @@
 ---
 
 - name: Gather local Ansible user details
-  getent:
-    database: 'passwd'
-    key: '{{ system_users__self_name }}'
+  script: 'script/getent_passwd.py {{ system_users__self_name }}'
+  register: system_users__register_passwd
   delegate_to: 'localhost'
   become: False
+  changed_when: False
   check_mode: False
+  run_once: True
 
 - name: Remember local Ansible user details
   set_fact:
-    system_users__fact_self_comment: '{{ getent_passwd[system_users__self_name][3] }}'
-    system_users__fact_self_shell: '{{ getent_passwd[system_users__self_name][5] }}'
+    system_users__fact_self_comment: '{{ (system_users__register_passwd.stdout|from_json)[system_users__self_name][3] }}'
+    system_users__fact_self_shell: '{{ (system_users__register_passwd.stdout|from_json)[system_users__self_name][5] }}'
 
 - name: Ensure that reqired packages are installed
   package:


### PR DESCRIPTION
The 'getent' Ansible module does not work correctly on Apple macOS,
therefore the 'debops.system_users' role will use a custom Python script
to get the current Ansible user information from the Ansible Controller.

Ref: https://github.com/ansible/ansible/issues/38339