### PR TITLE
[debops.slapd] Re-introduce slapd__default_services

### DIFF
--- a/ansible/roles/debops.slapd/defaults/main.yml
+++ b/ansible/roles/debops.slapd/defaults/main.yml
@@ -884,3 +884,9 @@ slapd__tcpwrappers__dependent_allow:
     comment: 'Allow connections to OpenLDAP service'
                                                                    # ]]]
                                                                    # ]]]
+# .. envvar:: slapd__default_services [[[
+#
+# List of services which slapd should bind to
+slapd__default_services: '{{ [ "ldap:///", "ldapi:///" ] 
+              + ([ "ldaps:///" ] if slapd__pki else []) }}'
+                                                                   # ]]]

--- a/ansible/roles/debops.slapd/tasks/main.yml
+++ b/ansible/roles/debops.slapd/tasks/main.yml
@@ -128,3 +128,11 @@
                               if ("userPassword" in (item.attributes|d({})).keys() or
                                   "olcRootPW"    in (item.attributes|d({})).keys())
                               else False) }}'
+
+- name: Configure enabled services
+  lineinfile:
+    dest: '/etc/default/slapd'
+    regexp: '^SLAPD_SERVICES='
+    line: 'SLAPD_SERVICES="{{ slapd__default_services | join(" ") }}"'
+    state: 'present'
+  notify: [ 'Restart slapd' ]


### PR DESCRIPTION
It is essential to be able to configure this setting if you set
olcServerId or want to bind to a specific ip address