### PR TITLE
Fix deprecation warnings in common playbook

### DIFF
--- a/ansible/roles/debops.apt/tasks/main.yml
+++ b/ansible/roles/debops.apt/tasks/main.yml
@@ -7,7 +7,7 @@
     state: 'present'
     install_recommends: False
   register: apt__register_packages
-  until: apt__register_packages
+  until: apt__register_packages is succeeded
   when: apt__enabled|bool
 
 - name: Make sure that Ansible local facts directory exists

--- a/ansible/roles/debops.apt_install/tasks/main.yml
+++ b/ansible/roles/debops.apt_install/tasks/main.yml
@@ -11,7 +11,7 @@
     state: 'present'
     install_recommends: '{{ apt_install__recommends|bool }}'
   register: apt_install__register_debconf_packages
-  until: apt_install__register_debconf_packages
+  until: apt_install__register_debconf_packages is succeeded
 
 - name: Apply requested packages configuration
   debconf:
@@ -40,7 +40,7 @@
                       "lookup/apt_install__all_packages.j2",
                       convert_data=False) | from_json }}'
   register: apt_install__register_packages
-  until: apt_install__register_packages
+  until: apt_install__register_packages is succeeded
   when: apt_install__enabled|bool
 
 - name: Configure alternative symlinks

--- a/ansible/roles/debops.pki/tasks/main.yml
+++ b/ansible/roles/debops.pki/tasks/main.yml
@@ -179,7 +179,7 @@
 # ]]]
 
 # Download files [[[
-- when: pki_download_extra
+- when: pki_download_extra|bool
   block:
     - name: Download custom private files
       copy:
@@ -380,7 +380,7 @@
 # ]]]
 
 # Download files [[[
-- when: pki_download_extra
+- when: pki_download_extra|bool
   block:
     - name: Download public realm contents by host
       copy:

--- a/ansible/roles/debops.sshd/tasks/main.yml
+++ b/ansible/roles/debops.sshd/tasks/main.yml
@@ -113,7 +113,7 @@
   register: sshd__register_host_certs
   changed_when: False
   check_mode: False
-  when: sshd__scan_for_host_certs
+  when: sshd__scan_for_host_certs|bool
   tags: [ 'role::sshd:config' ]
 
 - name: Setup trusted user CA key file


### PR DESCRIPTION
This patch fixes Ansible 2.8 deprecation warnings about using bare
variables in 'when:' conditions in roles included in the common
playbook.