### PR TITLE
[debops.core] Install 'dirmngr' by default

### DIFF
--- a/ansible/roles/debops.core/defaults/main.yml
+++ b/ansible/roles/debops.core/defaults/main.yml
@@ -252,7 +252,7 @@ core__unsafe_writes: False
 # .. envvar:: core__base_packages [[[
 #
 # List of packages required by Ansible local fact scripts.
-core__base_packages: [ 'bash', 'libcap2-bin', 'lsb-release', 'dbus' ]
+core__base_packages: [ 'bash', 'libcap2-bin', 'lsb-release', 'dbus', 'dirmngr' ]
 
                                                                    # ]]]
 # .. envvar:: core__packages [[[


### PR DESCRIPTION
The 'dirmngr' package is required by GnuPG to perform network
operations, like downloading and importing GPG keys from keyservers.
it's not required by default in Debian, and might not be present on
minimal installations, but it might be needed by other DebOps roles to
function properly, therefore the 'debops.core' role will ensure that it
is present by default.

Ref: https://bugs.debian.org/845720
Ref: https://blog.sleeplessbeastie.eu/2017/11/02/how-to-fix-missing-dirmngr/