### PR TITLE
Fix `yadm pull`-output to match on buster

### DIFF
--- a/ansible/roles/debops.root_account/tasks/main.yml
+++ b/ansible/roles/debops.root_account/tasks/main.yml
@@ -114,7 +114,7 @@
         yadm pull
     fi
   register: root_account__register_dotfiles
-  changed_when: ('Already up-to-date.' not in root_account__register_dotfiles.stdout_lines)
+  changed_when: ('Already up to date.' not in root_account__register_dotfiles.stdout_lines|regex_replace('-', ' '))
   when: root_account__dotfiles_enabled|bool
   check_mode: False
 

--- a/ansible/roles/debops.system_users/tasks/main.yml
+++ b/ansible/roles/debops.system_users/tasks/main.yml
@@ -270,7 +270,7 @@
   become_user: '{{ (item.prefix | d(system_users__prefix)) + item.name }}'
   check_mode: False
   register: system_users__register_dotfiles
-  changed_when: ('Already up-to-date.' not in system_users__register_dotfiles.stdout_lines)
+  changed_when: ('Already up to date.' not in system_users__register_dotfiles.stdout_lines|regex_replace('-', ' '))
   when: (system_users__enabled|bool and item.name|d() and item.name != 'root' and
          item.state|d('present') not in [ 'absent', 'ignore' ] and (item.create_home|d(True))|bool and
          (item.dotfiles | d(item.dotfiles_enabled | d(system_users__dotfiles_enabled))) | bool and

--- a/ansible/roles/debops.users/tasks/main.yml
+++ b/ansible/roles/debops.users/tasks/main.yml
@@ -260,7 +260,7 @@
   become_user: '{{ item.name }}'
   check_mode: False
   register: users__register_dotfiles
-  changed_when: ('Already up-to-date.' not in users__register_dotfiles.stdout_lines)
+  changed_when: ('Already up to date.' not in users__register_dotfiles.stdout_lines|regex_replace('-', ' '))
   when: (users__enabled|bool and item.name|d() and item.name != 'root' and
          item.state|d('present') not in [ 'absent', 'ignore' ] and item.create_home|d(True) and
          (item.dotfiles | d(item.dotfiles_enabled | d(users__dotfiles_enabled))) | bool and


### PR DESCRIPTION
Using a newer git-package from stretch-backports or buster
and performing `git pull` in an already up-to-date git-repository,
returns no dashes;
'Already up to date.'