### PR TITLE
Ensure that "users" roles work without yadm

### DIFF
--- a/ansible/roles/debops.root_account/tasks/main.yml
+++ b/ansible/roles/debops.root_account/tasks/main.yml
@@ -115,7 +115,8 @@
     fi
   register: root_account__register_dotfiles
   changed_when: ('Already up to date.' not in root_account__register_dotfiles.stdout_lines|regex_replace('-', ' '))
-  when: root_account__dotfiles_enabled|bool
+  when: ((ansible_local|d() and ansible_local.yadm|d() and (ansible_local.yadm.installed|d())|bool) and
+         root_account__dotfiles_enabled|bool)
   check_mode: False
 
 - name: Make sure Ansible fact directory exists

--- a/ansible/roles/debops.system_users/tasks/main.yml
+++ b/ansible/roles/debops.system_users/tasks/main.yml
@@ -273,6 +273,7 @@
   changed_when: ('Already up to date.' not in system_users__register_dotfiles.stdout_lines|regex_replace('-', ' '))
   when: (system_users__enabled|bool and item.name|d() and item.name != 'root' and
          item.state|d('present') not in [ 'absent', 'ignore' ] and (item.create_home|d(True))|bool and
+         (ansible_local|d() and ansible_local.yadm|d() and (ansible_local.yadm.installed|d())|bool) and
          (item.dotfiles | d(item.dotfiles_enabled | d(system_users__dotfiles_enabled))) | bool and
          (item.dotfiles_repo | d(system_users__dotfiles_repo)) and (item.user|d(True))|bool)
   no_log: '{{ item.no_log | d(True if item.password|d() else False) }}'

--- a/ansible/roles/debops.users/tasks/main.yml
+++ b/ansible/roles/debops.users/tasks/main.yml
@@ -263,6 +263,7 @@
   changed_when: ('Already up to date.' not in users__register_dotfiles.stdout_lines|regex_replace('-', ' '))
   when: (users__enabled|bool and item.name|d() and item.name != 'root' and
          item.state|d('present') not in [ 'absent', 'ignore' ] and item.create_home|d(True) and
+         (ansible_local|d() and ansible_local.yadm|d() and (ansible_local.yadm.installed|d())|bool) and
          (item.dotfiles | d(item.dotfiles_enabled | d(users__dotfiles_enabled))) | bool and
          (item.dotfiles_repo | d(users__dotfiles_repo)) and (item.user|d(True))|bool and not (item.chroot|d())|bool)
   no_log: '{{ item.no_log | d(True if item.password|d() else False) }}'


### PR DESCRIPTION
The 'debops.root_account', 'debops.system_users' and 'debops.users'
Ansible roles will now work correctly when the 'yadm' command is not
available and user accounts have the support for dotfiles enabled.

Fixes #811 