### PR TITLE
Make sure that needrestart directory exists

### DIFF
--- a/ansible/roles/debops.apt_install/tasks/main.yml
+++ b/ansible/roles/debops.apt_install/tasks/main.yml
@@ -66,6 +66,15 @@
   when: item.name|d() and not item.path|d()
   changed_when: apt_install__register_alternatives.stdout|d()
 
+- name: Make sure that needrestart directory exists
+  file:
+    path: '/etc/needrestart/conf.d'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+  when: apt_install__enabled|bool
+
 - name: Disable kernel hints about pending upgrades
   template:
     src: 'etc/needrestart/conf.d/no-kernel-hints.conf.j2'


### PR DESCRIPTION
When using role 'apt_install' and with package 'needrestart' removed from 'apt_install__conditional_whitelist_packages' (via playlist vars), the role will fail because of the missing directory '/etc/needrestart/conf.d'.

~~~
fatal: [hostname.example.com]: FAILED! => {"changed": false, "checksum": "b93b52748afef755a3a909215bb594a18e04495a", "msg": "Destination directory /etc/needrestart/conf.d does not exist"}
~~~

Two fixes were possible, I currently chose the lazy one of just creating the directory. The other fix would be to check if needrestart is present before creating the directory. If the latter fix is preferred, then I'll do that one.


