### PR TITLE
[debops.apt_install] Control kernel hints better

### DIFF
--- a/ansible/roles/debops.apt_install/defaults/main.yml
+++ b/ansible/roles/debops.apt_install/defaults/main.yml
@@ -93,6 +93,17 @@ apt_install__state: '{{ "present"
                         else "latest" }}'
 
                                                                    # ]]]
+# .. envvar:: apt_install__no_kernel_hints [[[
+#
+# Enable or disable configuration of the hints about upgraded kernel requiring
+# a reboot of the host, created by the :command:`needrestart` package.  By
+# default these hints will be disabled, which helps with non-interactive APT
+# package installation done by Ansible.
+apt_install__no_kernel_hints: '{{ True
+                                  if ("needrestart" in apt_install__conditional_whitelist_packages)
+                                  else False }}'
+
+                                                                   # ]]]
 # .. envvar:: apt_install__recommends [[[
 #
 # Boolean variable that controls installation of recommended packages.

--- a/ansible/roles/debops.apt_install/tasks/main.yml
+++ b/ansible/roles/debops.apt_install/tasks/main.yml
@@ -71,7 +71,7 @@
     src: 'etc/needrestart/conf.d/no-kernel-hints.conf.j2'
     dest: '/etc/needrestart/conf.d/no-kernel-hints.conf'
     mode: '0644'
-  when: apt_install__enabled|bool
+  when: apt_install__enabled|bool and apt_install__no_kernel_hints|bool
 
 - name: Make sure that Ansible fact directory exists
   file:


### PR DESCRIPTION
The 'debops.apt_install' role can disable the 'needrestart' hints about
kernel upgrades requiring restart. This patch makes this functionality
conditional; the configuration will not be performed if the
'needrestart' package will not be installed by the role.

Fixes #814 
Fixes #772 