### PR TITLE
[debops.gitlab_runner] Fix loop variable typo

### DIFF
--- a/ansible/roles/debops.gitlab_runner/templates/etc/gitlab-runner/config.toml.j2
+++ b/ansible/roles/debops.gitlab_runner/templates/etc/gitlab-runner/config.toml.j2
@@ -237,7 +237,7 @@ metrics_server = "{{ gitlab_runner__metrics_server }}"
 {%         if runner.docker_services is string %}
 {%           set _ = gitlab_runner__tpl_docker_services.append(runner.docker_services) %}
 {%         else %}
-{%           for services in runner.docker_services %}
+{%           for service in runner.docker_services %}
 {%             set _ = gitlab_runner__tpl_docker_services.append(service) %}
 {%           endfor %}
 {%         endif %}


### PR DESCRIPTION
Fixes docker_services as a list.