### PR TITLE
[debops.gitlab_runner] use = instead of : when setting the tmpfs

### DIFF
--- a/ansible/roles/debops.gitlab_runner/templates/etc/gitlab-runner/config.toml.j2
+++ b/ansible/roles/debops.gitlab_runner/templates/etc/gitlab-runner/config.toml.j2
@@ -317,13 +317,13 @@ metrics_server = "{{ gitlab_runner__metrics_server }}"
 {%       if runner.docker_tmpfs|d() %}
     [runners.docker_tmpfs]
 {%         for directory, options in runner.docker_tmpfs.items() %}
-      "{{ directory }}": "{{ options }}"
+      "{{ directory }}"= "{{ options }}"
 {%         endfor %}
 {%       endif %}
 {%       if runner.docker_services_tmpfs|d() %}
     [runners.docker.services_tmpfs]
 {%         for directory, options in runner.docker_services_tmpfs.items() %}
-      "{{ directory }}": "{{ options }}"
+      "{{ directory }}"= "{{ options }}"
 {%         endfor %}
 {%       endif %}
 {%    endif %}


### PR DESCRIPTION
There was a typo when we added this feature.
