### PR TITLE
[debops.users] Readd users__default_shell which was removed in v1.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,9 @@ Added
   listens for connections. The ``ldaps:///`` service is enabled by default when
   support for the :ref:`debops.pki` role is enabled on the OpenLDAP host.
 
+- [debops.users] Readd :envvar:`users__default_shell` which was removed in
+  `debops v1.0.0`_.
+
 Changed
 ~~~~~~~
 

--- a/ansible/roles/debops.users/defaults/main.yml
+++ b/ansible/roles/debops.users/defaults/main.yml
@@ -23,6 +23,15 @@ users__enabled: True
 #
 # Enable or disable support for filesystem ACL management.
 users__acl_enabled: '{{ True if ("acl" in users__base_packages) else False }}'
+
+                                                                   # ]]]
+# .. envvar:: users__default_shell [[[
+#
+# Specify absolute path of the shell which should be configured on all user
+# accounts managed by this role, if not overriden by the user configuration. If
+# not specified, the shell won't be changed, but new accounts will not have
+# a defined shell either.
+users__default_shell: ''
                                                                    # ]]]
                                                                    # ]]]
 # APT packages [[[

--- a/ansible/roles/debops.users/tasks/main.yml
+++ b/ansible/roles/debops.users/tasks/main.yml
@@ -49,7 +49,9 @@
     system:             '{{ item.system             | d(omit) }}'
     shell:              '{{ item.shell              | d(users__chroot_shell
                                                         if (item.chroot|d())|bool
-                                                        else omit) }}'
+                                                        else (users__default_shell
+                                                              if users__default_shell|d()
+                                                              else omit)) }}'
     create_home:        '{{ item.create_home        | d(omit) }}'
     move_home:          '{{ item.move_home          | d(omit) }}'
     skeleton:           '{{ item.skeleton           | d(omit) }}'

--- a/ansible/roles/debops.users/templates/lookup/users__shell_packages.j2
+++ b/ansible/roles/debops.users/templates/lookup/users__shell_packages.j2
@@ -1,8 +1,8 @@
 {% set users__tpl_shells = [] %}
-{% for shell in (users__combined_accounts | parse_kv_items
-                 | selectattr("state", "equalto", "present")
-                 | selectattr("shell", "defined")
-                 | map(attribute="shell") | unique | list) %}
+{% for shell in ((users__combined_accounts | parse_kv_items
+                  | selectattr("state", "equalto", "present")
+                  | selectattr("shell", "defined")
+                  | map(attribute="shell")|list) + [ users__default_shell ] | unique | list) %}
 {%   if shell in users__shell_package_map.keys() %}
 {%     set _ = users__tpl_shells.append(users__shell_package_map[shell]) %}
 {%   endif %}


### PR DESCRIPTION
@drybjed Am I missing something? I think this option is still useful.