### PR TITLE
[debops.postgresql_server] Fix check mode in role

### DIFF
--- a/ansible/roles/debops.postgresql_server/tasks/main.yml
+++ b/ansible/roles/debops.postgresql_server/tasks/main.yml
@@ -30,6 +30,7 @@
     executable: 'bash'
   register: postgresql_server__register_version
   changed_when: False
+  check_mode: False
   tags: [ 'role::postgresql_server:packages', 'role::postgresql_server:config',
           'role::postgresql_server:auto_backup' ]
 
@@ -72,6 +73,7 @@
   command: cat /proc/sys/kernel/shmmax
   register: postgresql_server__register_sysctl_shmmax
   changed_when: False
+  check_mode: False
   tags: [ 'role::postgresql_server:config' ]
 
 - include: manage_clusters.yml

--- a/ansible/roles/debops.postgresql_server/tasks/manage_clusters.yml
+++ b/ansible/roles/debops.postgresql_server/tasks/manage_clusters.yml
@@ -7,6 +7,7 @@
     warn: False
   register: postgresql_server__register_shm
   changed_when: False
+  check_mode: False
   tags: [ 'role::postgresql_server:config' ]
 
 - name: Create PostgreSQL clusters


### PR DESCRIPTION
This patch fixes usage of the Ansible '--check' mode with the
'role::postgresql_server:config' tag, allowing to check PostgreSQL
Server configuration changes before applying them.

Fixes #584