### PR TITLE
[debops.nginx] Support to disable logging per Nginx server

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,8 @@ Added
 
   .. __: https://www.flamingspork.com/projects/libeatmydata/
 
+- [debops.nginx] Support to disable logging per Nginx server.
+
 Changed
 ~~~~~~~
 

--- a/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/default.conf.j2
+++ b/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/default.conf.j2
@@ -213,8 +213,16 @@
 {%             elif nginx_access_log_format is defined                              %}
 {%                 set nginx_tpl_access_log_format = ' ' +  nginx_access_log_format %}
 {%             endif                                                                %}
+{%             if item.access_log_enabled|d(True) | bool %}
         access_log {{ (item.log_path | d(nginx_log_path)) + '/' + item.access_log | d(item.filename | d(item.name if item.name is string else item.name[0]) + '_access') }}.log{{ nginx_tpl_access_log_format }};
+{%             else %}
+        access_log off;
+{%             endif %}
+{%             if item.error_log_enabled|d(True) | bool %}
         error_log {{ (item.log_path | d(nginx_log_path)) + '/' + item.error_log | d(item.filename | d(item.name if item.name is string else item.name[0]) + '_error') }}.log;
+{%             else %}
+        error_log off;
+{%             endif %}
 {%         endif                                                                    %}
 {%     endblock                                                                     %}
 {%     block nginx_tpl_block_index                                                  %}

--- a/docs/ansible/roles/debops.nginx/defaults-detailed.rst
+++ b/docs/ansible/roles/debops.nginx/defaults-detailed.rst
@@ -590,10 +590,18 @@ Logging and monitoring
   Name of the access log file.
   The suffix ``.log`` will be added automatically.
 
+``access_log_enabled``
+  Optional, boolean. Defaults to ``True``.
+  If access logging should be enabled.
+
 ``error_log``
   Optional, string. Defaults to ``<``name[0]>_error``.
   Name of the error log file.
   The suffix ``.log`` will be added automatically.
+
+``error_log_enabled``
+  Optional, boolean. Defaults to ``True``.
+  If error logging should be enabled.
 
 ``access_log_format``
   Optional. Name of the access log format.


### PR DESCRIPTION
I was surprised to find that the role does not actually support to disable logging yet.