### PR TITLE
[Vagrant] use ifup@ method to restart network for Virtualbox boxes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -156,8 +156,10 @@ if [ -d /run/systemd/system ] ; then
         printf "%s\n" "Restarting systemd-networkd.service"
         systemctl restart systemd-networkd.service
     else
-        printf "%s\n" "Restarting networking.service"
-        systemctl restart networking.service
+        printf "%s\n" "Detecting primary network interface"
+        primary_interface="$(/sbin/ip -o -0 addr | grep -v LOOPBACK | awk '{print $2}' | sed 's/://')"
+        printf "%s\n" "Restarting ifup@$primary_interface.service"
+        systemctl stop ifup@$primary_interface.service ; systemctl start ifup@$primary_interface.service
     fi
 else
     printf "%s\n" "Restarting networking init script"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -158,8 +158,8 @@ if [ -d /run/systemd/system ] ; then
     else
         printf "%s\n" "Detecting primary network interface"
         primary_interface="$(/sbin/ip -o -0 addr | grep -v LOOPBACK | awk '{print $2}' | sed 's/://')"
-        printf "%s\n" "Restarting ifup@$primary_interface.service"
-        systemctl stop ifup@$primary_interface.service ; systemctl start ifup@$primary_interface.service
+        printf "%s\n" "Restarting ifup@${primary_interface}.service"
+        systemctl stop "ifup@${primary_interface}.service" ; systemctl start "ifup@${primary_interface}.service"
     fi
 else
     printf "%s\n" "Restarting networking init script"


### PR DESCRIPTION
This patch will fix #629.

I'm just trying to make `master` working by using the same commands ` vagrant` use to restart networking in VM.

Current Vagrant config doesn't permit to have a `master` and a `node` be able to speak to each other. I will open a  dedicated issue for this problem (see #848).