### PR TITLE
[debops-init] add missing "plugins" path for searching callbacks

### DIFF
--- a/bin/debops
+++ b/bin/debops
@@ -95,7 +95,7 @@ def gen_ansible_cfg(filename, config, project_root, playbooks_path,
             yield os.path.join(monorepo_path, "ansible", "playbooks", type)
             yield os.path.join(monorepo_path, "ansible", "plugins", type)
             yield os.path.join(monorepo_path, "ansible", type)
-        yield os.path.join(DEBOPS_PY_PACKAGE, type)
+        yield os.path.join(DEBOPS_PY_PACKAGE, "plugins", type)
         yield os.path.join(DEBOPS_PY_PACKAGE, "playbooks", type)
         yield os.path.join(playbooks_path, type)
         yield os.path.join("/usr/share/ansible/", type)


### PR DESCRIPTION
Fix #845 