### PR TITLE
[debops.redis_server] Make `redis_server__auth_password` optional

### DIFF
--- a/ansible/roles/debops.redis_server/defaults/main.yml
+++ b/ansible/roles/debops.redis_server/defaults/main.yml
@@ -193,9 +193,11 @@ redis_server__default_base_options:
 
   - name: 'masterauth'
     value: '{{ redis_server__auth_password }}'
+    state: '{{ "present" if redis_server__auth_password|d() else "ignore" }}'
 
   - name: 'requirepass'
     value: '{{ redis_server__auth_password }}'
+    state: '{{ "present" if redis_server__auth_password|d() else "ignore" }}'
 
   - name: 'always-show-logo'
     value: False


### PR DESCRIPTION
This is an issue that encountered trying to update my DebOps project. Previously, leaving `redis_server__auth_password` as an empty string would configure the Redis server without a password. Redis doesn't seem to like this anymore and the server won't start.

I added a check for `redis_server__auth_password` when generating `redis_server__default_base_options`. If `redis_server__auth_password` is `False`, it ignores the option which lets you configure the Redis server without a password. Not sure if that's the ideal fix, but it seems to fit the role structure.