### PR TITLE
debops.nslcd role to remove comments from mkhomedir profile

### DIFF
--- a/ansible/roles/debops.nslcd/templates/usr/share/pam-configs/mkhomedir.j2
+++ b/ansible/roles/debops.nslcd/templates/usr/share/pam-configs/mkhomedir.j2
@@ -1,8 +1,4 @@
-# {{ ansible_managed }}
-
-# Enable support for libpam-mkhomedir in PAM
-
-Name: activate mkhomedir
+Name: activate mkhomedir managed by Ansible
 Default: yes
 Priority: 900
 Session-Type: Additional


### PR DESCRIPTION
I've tested this on Ubuntu Xenial and Ubuntu Bionic and they both behave the same
way. As of today, this bug/feature[1] still exist.

When running the mkhomedir profile generated by debops.nslcd tasks, the
following are generated at `/usr/share/pam-config/mkhomedir`

```
# Ansible managed: ansible/roles/debops.debops/debops-master/ansible/roles/debops.nslcd/templates/usr/share/pam-configs/mkhomedir.j2 modified on 2019-06-15 23:38:15 

# Enable support for libpam-mkhomedir in PAM

Name: activate mkhomedir
Default: yes
Priority: 900
Session-Type: Additional
Session:
        required                        pam_mkhomedir.so umask=0027 skel=/etc/skel
```

And running `pam-auth-update --package` to install the default profiles,
`pam-auth-update` will complain [1] with the following:

```
root@delta:~# pam-auth-update --package
Use of uninitialized value $fieldname in hash element at /usr/sbin/pam-auth-update line 691, <PROFILE> line 1.
Use of uninitialized value $fieldname in hash element at /usr/sbin/pam-auth-update line 692, <PROFILE> line 1.
Use of uninitialized value $fieldname in hash element at /usr/sbin/pam-auth-update line 692, <PROFILE> line 2.
Use of uninitialized value $fieldname in hash element at /usr/sbin/pam-auth-update line 691, <PROFILE> line 3.
Use of uninitialized value $fieldname in hash element at /usr/sbin/pam-auth-update line 692, <PROFILE> line 3.
Use of uninitialized value $fieldname in hash element at /usr/sbin/pam-auth-update line 692, <PROFILE> line 4.
```

This seemed to be a limitation in `pam-auth-update` code that it does not support
comments or characters `#`. Removing these comment lines resolved the issue.

```
Name: activate mkhomedir
Default: yes
Priority: 900
Session-Type: Additional
Session:
        required                        pam_mkhomedir.so umask=0027 skel=/etc/skel

root@delta:~# pam-auth-update --package

root@delta:~# grep -rn "mkhome" /etc/pam.d/*
/etc/pam.d/common-session:29:session    required                        pam_mkhomedir.so umask=0027 skel=/etc/skel
/etc/pam.d/common-session-noninteractive:29:session     required                        pam_mkhomedir.so umask=0027 skel=/etc/skel

```

[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=806275