### PR TITLE
[debops.python] Enable Pyv2 without Ansible facts

### DIFF
--- a/ansible/roles/debops.python/defaults/main.yml
+++ b/ansible/roles/debops.python/defaults/main.yml
@@ -110,7 +110,8 @@ python__dependent_packages3: []
 # :envvar:`python__raw_purge_v2` variable.
 python__v2: '{{ True
                 if ((ansible_python_interpreter|d("")).endswith("python") or
-                    (discovered_interpreter_python|d("")).endswith("python"))
+                    (discovered_interpreter_python|d("")).endswith("python") or
+                    discovered_interpreter_python is undefined)
                 else False }}'
 
                                                                    # ]]]


### PR DESCRIPTION
The 'debops.python' role should now work correctly when Ansible does not
detect Python interpreter correctly, for example in the 'raw' mode.