### PR TITLE
Make dist-upgrade.yaml capable of upgrading /etc/apt/sources.list.d/

### DIFF
--- a/ansible/playbooks/tools/dist-upgrade.yml
+++ b/ansible/playbooks/tools/dist-upgrade.yml
@@ -96,13 +96,22 @@
       stat:
         path: '{{ dist_upgrade_lockfile }}'
       register: dist_upgrade_register_lockfile
+      
+    - name: Find all apt sources.list files
+      find:
+        paths: "/etc/apt/"
+        patterns: "*.list"
+        recurse: yes
+      register: repos
 
     - name: Change current release in APT sources
       replace:
-        dest: '/etc/apt/sources.list'
+        dest: "{{ item.path }}"
         regexp: '{{ dist_upgrade_current_release }}'
         replace: '{{ dist_upgrade_new_release }}'
       register: dist_upgrade_register_replace
+      with_items:
+        - "{{ repos.files }}"
       when: dist_upgrade_current_release in dist_upgrade_version_map.keys() and
             dist_upgrade_new_release is defined and dist_upgrade_new_release
 


### PR DESCRIPTION
As I am only adding repositories in /etc/apt/sources.list.d/, I found it could be useful to detect upgrades in that directory as well