### PR TITLE
[bootstrap] set become to true to avoid using -b on CLI

### DIFF
--- a/ansible/playbooks/bootstrap-ldap.yml
+++ b/ansible/playbooks/bootstrap-ldap.yml
@@ -22,6 +22,7 @@
 - name: Bootstrap Python support on a host
   hosts: [ 'debops_all_hosts', 'debops_service_bootstrap' ]
   gather_facts: False
+  become: True
 
   roles:
 
@@ -34,6 +35,7 @@
 
 - name: Bootstrap host for Ansible management with LDAP
   hosts: [ 'debops_all_hosts', 'debops_service_bootstrap' ]
+  become: True
 
   environment: '{{ inventory__environment | d({})
                    | combine(inventory__group_environment | d({}))

--- a/ansible/playbooks/bootstrap.yml
+++ b/ansible/playbooks/bootstrap.yml
@@ -32,6 +32,7 @@
 - name: Bootstrap Python support on a host
   hosts: [ 'debops_all_hosts', 'debops_service_bootstrap' ]
   gather_facts: False
+  become: True
 
   roles:
 
@@ -44,6 +45,7 @@
 
 - name: Bootstrap host for Ansible management
   hosts: [ 'debops_all_hosts', 'debops_service_bootstrap' ]
+  become: True
 
   environment: '{{ inventory__environment | d({})
                    | combine(inventory__group_environment | d({}))


### PR DESCRIPTION
- `debops.python/raw` use tasks that need privileges escalation
-  `service/core.yml` has `become` set to `False`
- Roles in third play need privilege escalation

I checked docs and there is no usage of bootstrap playbook with `-b` option.