### PR TITLE
[debops.php] Install some packages from Sury repo

### DIFF
--- a/ansible/roles/debops.php/defaults/main.yml
+++ b/ansible/roles/debops.php/defaults/main.yml
@@ -745,7 +745,8 @@ php__apt_preferences__dependent_list:
     state: '{{ "present" if php__sury|bool else "absent" }}'
 
   - packages: [ 'php', 'php5', 'php5*', 'php7*', 'dh-php', 'php-*',
-                'libpcre2-8-0', 'libpcre3', 'libzip4' ]
+                'libpcre2-8-0', 'libpcre3', 'libzip4', 'libpcre16-3',
+                'libpcre32-3', 'libpcrecpp0v5', 'libpcre3-dev' ]
     pin: 'origin "packages.sury.org"'
     priority: '500'
     reason: 'Prefer PHP packages from the same repository for consistency'


### PR DESCRIPTION
'libpcre16-3', 'libpcre32-3', 'libpcrecpp0v5' and 'libpcre3-dev' packages are necessary for phpX-dev installation from Sury repo.