### PR TITLE
[debops.gitlab] Allow excluding parts of backup

### DIFF
--- a/ansible/roles/debops.gitlab/defaults/main.yml
+++ b/ansible/roles/debops.gitlab/defaults/main.yml
@@ -338,6 +338,14 @@ gitlab_backup_frequency: 'daily'
 # How long to store backups for, in seconds
 gitlab_backup_keep_time: '{{ (60 * 60 * 24 * 7) }}'
                                                                    # ]]]
+# .. envvar:: gitlab_backup_exclude [[[
+#
+# Choose what should be excluded from the backup. An empty list means that
+# nothing will be excluded from the backup.
+# Valid options can be found at;
+# https://docs.gitlab.com/ee/raketasks/backup_restore.html#excluding-specific-directories-from-the-backup
+gitlab_backup_exclude: []
+                                                                   # ]]]
                                                                    # ]]]
 # Redis configuration [[[
 # -----------------------

--- a/ansible/roles/debops.gitlab/tasks/configure_gitlab_ce.yml
+++ b/ansible/roles/debops.gitlab/tasks/configure_gitlab_ce.yml
@@ -272,5 +272,9 @@
     state: 'present'
     user: '{{ gitlab_user }}'
     job: 'cd {{ gitlab_ce_git_checkout }} \
-          ; PATH=/usr/local/bin:/usr/bin:/bin bundle exec rake gitlab:backup:create RAILS_ENV=production CRON=1'
+          ; PATH=/usr/local/bin:/usr/bin:/bin bundle exec rake gitlab:backup:create
+          RAILS_ENV=production CRON=1
+          {{ "SKIP=" + ([ gitlab_backup_exclude ]
+            if (gitlab_backup_exclude is string) else gitlab_backup_exclude) | join(",")
+              if gitlab_backup_exclude | length > 0 else "" }}'
     cron_file: 'gitlab-backup'

--- a/ansible/roles/debops.gitlab/tasks/gitlab_ce_pre_upgrade.yml
+++ b/ansible/roles/debops.gitlab/tasks/gitlab_ce_pre_upgrade.yml
@@ -20,7 +20,11 @@
   when: gitlab_use_systemd | bool
 
 - name: Create backup of GitLab instance
-  command: bundle exec rake gitlab:backup:create RAILS_ENV=production
+  command: |
+    bundle exec rake gitlab:backup:create RAILS_ENV=production
+    {{ "SKIP=" + ([ gitlab_backup_exclude ]
+            if (gitlab_backup_exclude is string) else gitlab_backup_exclude) | join(",")
+              if gitlab_backup_exclude | length > 0 else "" }}
   args:
     chdir: '{{ gitlab_ce_git_checkout }}'
   register: gitlab__register_backup


### PR DESCRIPTION
Make it possible to add the SKIP-variable to the GitLab backup cronjob
and the pre-upgrade backup of GitLab.

I have however not tested the changes in `gitlab_ce_pre_upgrade.yml` to any great extent.