### PR TITLE
[debops.ldap] Consider DNS NODATA response

### DIFF
--- a/ansible/roles/debops.ldap/defaults/main.yml
+++ b/ansible/roles/debops.ldap/defaults/main.yml
@@ -100,7 +100,8 @@ ldap__servers_srv_rr: '{{ q("dig", "_ldap._tcp." + ldap__domain + "./SRV", "flat
 # Fully Qualified Domain Name.
 ldap__servers: '{{ (ldap__servers_srv_rr | selectattr("target", "defined")
                     | map(attribute="target") | map("regex_replace", "\.$","") | list)
-                   if ("NXDOMAIN" not in ldap__servers_srv_rr)
+                   if ("NXDOMAIN" not in ldap__servers_srv_rr and
+                       ldap__servers_srv_rr[0])
                    else [ "ldap." + ldap__domain ] }}'
 
                                                                    # ]]]


### PR DESCRIPTION
This change makes sure that the `debops.ldap` role falls back to using
'[ "ldap." + ldap__domain ]' as ldap__servers when the Ansible dig
lookup returns an empty (NODATA) response.

Closes: #905