### PR TITLE
[debops.docker_server] update path to docker daemon for buster

### DIFF
--- a/ansible/roles/debops.docker_server/templates/etc/systemd/system/docker.service.d/execstart-override.conf.j2
+++ b/ansible/roles/debops.docker_server/templates/etc/systemd/system/docker.service.d/execstart-override.conf.j2
@@ -5,4 +5,6 @@
 # configuration file.
 [Service]
 ExecStart=
-ExecStart=/usr/bin/dockerd
+ExecStart={{ "/usr/sbin/dockerd"
+             if ansible_distribution_release == "buster"
+             else "/usr/bin/dockerd" }}


### PR DESCRIPTION
Hello,

Tested against:
- Debian Stretch with upstream packages: `docker-ce` and `docker-ce-cli`
- Debian Buster with distribution packages: `docker.io`

fixes #820