### PR TITLE
[debops.docker_server] reverse condition to support next Debian releases

### DIFF
--- a/ansible/roles/debops.docker_server/templates/etc/systemd/system/docker.service.d/execstart-override.conf.j2
+++ b/ansible/roles/debops.docker_server/templates/etc/systemd/system/docker.service.d/execstart-override.conf.j2
@@ -5,6 +5,8 @@
 # configuration file.
 [Service]
 ExecStart=
-ExecStart={{ "/usr/sbin/dockerd"
-             if ansible_distribution_release == "buster"
-             else "/usr/bin/dockerd" }}
+ExecStart={{ "/usr/bin/dockerd"
+             if (ansible_distribution_release in
+                 ([ "wheezy", "jessie", "stretch",
+                    "trusty", "xenial", "bionic" ]))
+             else "/usr/sbin/dockerd" }}


### PR DESCRIPTION
fixes #911 

I only tested under Buster with distribution packages.