### PR TITLE
[debops.system_groups] Track the connection type

### DIFF
--- a/ansible/roles/debops.system_groups/defaults/main.yml
+++ b/ansible/roles/debops.system_groups/defaults/main.yml
@@ -46,7 +46,7 @@ system_groups__sudo_enabled: '{{ True
 # host so that local users can still control access to ``root`` account using
 # a password.
 system_groups__admins_sudo_nopasswd: '{{ False
-                                         if (ansible_connection == "local")
+                                         if (system_groups__fact_ansible_connection == "local")
                                          else True }}'
 
                                                                    # ]]]

--- a/ansible/roles/debops.system_groups/tasks/main.yml
+++ b/ansible/roles/debops.system_groups/tasks/main.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: Create a fact that knows the Ansible connection type
+  set_fact:
+    system_groups__fact_ansible_connection: '{{ ansible_connection }}'
+
 - name: Ensure that requested UNIX system groups exist
   group:
     name: '{{ item.name }}'


### PR DESCRIPTION
The 'ansible_connection' variable is not correctly resolved inside of
Jinja templates - it turns into a 'ansible.utils.sentinel.Sentinel'
Python object instead. Because of that, if we want to use it directly or
indirectly inside of Jinja templates, it needs to be resolved
beforehand, for example as a runtime fact.