### PR TITLE
[ci] Add base Python 3 environment in Vagrant box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -377,6 +377,10 @@ EOF
         python-unittest2 \
         python-wheel \
         python-yaml \
+        python3 \
+        python3-apt \
+        python3-pip \
+        python3-setuptools \
         rsync \
         shellcheck \
         yamllint ${ansible_from_debian}


### PR DESCRIPTION
This is needed for the 'debops' Python package to be successfully built
in GitLab CI tests. Full switch to Python 3 will happen when Vagrant
Boxes are switchted to Debian Buster base.