### PR TITLE
[ci] Switch syntax test to Python 2.7

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -868,7 +868,7 @@ stages:
 'netbox role':
   <<: *test_role_3rd_deps
   variables:
-    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOK}/service/redis_server.yml ${DEBOPS_PLAYBOOKS}/service/postgresql_server.yml ${DEBOPS_PLAYBOOKS}/service/netbox.yml'
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/redis_server.yml ${DEBOPS_PLAYBOOKS}/service/postgresql_server.yml ${DEBOPS_PLAYBOOKS}/service/netbox.yml'
     JANE_INVENTORY_GROUPS: 'debops_service_redis_server,debops_service_postgresql_server,debops_service_netbox'
     JANE_INVENTORY_HOSTVARS: 'postgresql_server__delegate_to=localhost postgresql__delegate_to=localhost'
     JANE_DIFF_PATTERN: '.*/debops.netbox/.*'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -868,8 +868,8 @@ stages:
 'netbox role':
   <<: *test_role_3rd_deps
   variables:
-    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/postgresql_server.yml ${DEBOPS_PLAYBOOKS}/service/netbox.yml'
-    JANE_INVENTORY_GROUPS: 'debops_service_postgresql_server,debops_service_netbox'
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOK}/service/redis_server.yml ${DEBOPS_PLAYBOOKS}/service/postgresql_server.yml ${DEBOPS_PLAYBOOKS}/service/netbox.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_redis_server,debops_service_postgresql_server,debops_service_netbox'
     JANE_INVENTORY_HOSTVARS: 'postgresql_server__delegate_to=localhost postgresql__delegate_to=localhost'
     JANE_DIFF_PATTERN: '.*/debops.netbox/.*'
     JANE_LOG_PATTERN: '\[debops\.netbox\]'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ variables:
   TEST_PLAYBOOKS: '/vagrant/lib/tests/playbooks'
   DEBOPS_PLAYBOOKS:  '/vagrant/ansible/playbooks'
   VAGRANT_DOTFILE_PATH: '/var/tmp/vagrant-dotfile-${CI_JOB_ID}'
+  JANE_DIFF_BASE_BRANCH: 'origin/stable-1.0'
   GIT_STRATEGY: 'clone'
   TERM: 'xterm'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,10 @@ matrix:
     - python: '3.7'
       env: 'MODE=docs'
 
-    - python: '2.7'
-      env: 'MODE=syntax'
+    # Too many syntax issues in 'stable-1.0' branch to backport from the
+    # 'master' branch
+    #- python: '2.7'
+    #  env: 'MODE=syntax'
 
     - python: '3.7'
       env: 'MODE=docker'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     - python: '3.7'
       env: 'MODE=docs'
 
-    - python: '3.7'
+    - python: '2.7'
       env: 'MODE=syntax'
 
     - python: '3.7'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,13 @@ Changed
 
   .. __: https://pythonclock.org/
 
+- [debops.netbox] The role has been updated to NetBox version ``v2.6.1``. Redis
+  service is now required for NetBox; it can be installed separately via the
+  :ref:`debops.redis_server` Ansible role.
+
+  This change was backported because without it, the NetBox installation using
+  DebOps ``stable-1.0`` branch is broken.
+
 Fixed
 ~~~~~
 

--- a/ansible/roles/debops.netbox/defaults/main.yml
+++ b/ansible/roles/debops.netbox/defaults/main.yml
@@ -256,6 +256,59 @@ netbox__database_password: '{{ lookup("password", secret + "/postgresql/" +
 netbox__load_initial_data: True
                                                                    # ]]]
                                                                    # ]]]
+# Redis database configuration [[[
+# --------------------------------
+
+# The Redis database configuration is managed by the :ref:`debops.redis_server`
+# Ansible role. See its documentation for details about the default variable
+# values used in the NetBox role.
+
+# .. envvar:: netbox__redis_host [[[
+#
+# Define hostname of the Redis server to use.
+netbox__redis_host: '{{ ansible_local.redis_server.host
+                         if (ansible_local|d() and ansible_local.redis_server|d() and
+                             ansible_local.redis_server.host|d())
+                         else "localhost" }}'
+
+                                                                   # ]]]
+# .. envvar:: netbox__redis_port [[[
+#
+# Define port of Redis server to use.
+netbox__redis_port: '{{ ansible_local.redis_server.port
+                        if (ansible_local|d() and ansible_local.redis_server|d() and
+                            ansible_local.redis_server.port|d())
+                        else "6379" }}'
+
+                                                                   # ]]]
+# .. envvar:: netbox__redis_password [[[
+#
+# Define the Redis authentication password to use.
+netbox__redis_password: '{{ ansible_local.redis_server.password
+                            if (ansible_local|d() and ansible_local.redis_server|d() and
+                                ansible_local.redis_server.password|d())
+                            else "" }}'
+
+                                                                   # ]]]
+# .. envvar:: netbox__redis_database [[[
+#
+# Specify which Redis database to use for NetBox.
+netbox__redis_database: '0'
+
+                                                                   # ]]]
+# .. envvar:: netbox__redis_cache_database [[[
+#
+# Specify which Redis database to use for NetBox chache.
+netbox__redis_cache_database: '{{ (netbox__redis_database|int + 1) }}'
+
+                                                                   # ]]]
+# .. envvar:: netbox__redis_ssl [[[
+#
+# Enable or disable support for encrypted connections to Redis. Currently this
+# option has no support in DebOps.
+netbox__redis_ssl: False
+                                                                   # ]]]
+                                                                   # ]]]
 # NetBox configuration options [[[
 # --------------------------------
 
@@ -282,6 +335,19 @@ netbox__config_secret_key: '{{ lookup("password", secret + "/netbox/" +
 # By default the role uses the list of private admin e-mails from the
 # :ref:`debops.core` Ansible role.
 netbox__config_admins: '{{ lookup("template", "lookup/netbox__config_admins.j2") | from_yaml }}'
+
+                                                                   # ]]]
+# .. envvar:: netbox__config_cache_timeout [[[
+#
+# Cache timeout in seconds. Set to 0 to disable caching.
+netbox__config_cache_timeout: 3600
+
+                                                                   # ]]]
+# .. envvar:: netbox__config_changelog_retention [[[
+#
+# Maximum number of days to retain logged changes. Set to 0 to retain changes
+# indefinitely.
+netbox__config_changelog_retention: 90
 
                                                                    # ]]]
 # .. envvar:: netbox__config_cors_origin_allow_all [[[
@@ -356,6 +422,13 @@ netbox__config_logging: {}
 # ``False``, some information stored in the NetBox database is accessible in
 # the read-only mode for anonymous users.
 netbox__config_login_required: True
+
+                                                                   # ]]]
+# .. envvar:: netbox__config_login_timeout [[[
+#
+# The length of time (in seconds) for which a user will remain logged into the web UI before being prompted to
+# re-authenticate. (Default: 14 days)
+netbox__config_login_timeout: '{{ (60 * 60 * 24 * 14) }}'
 
                                                                    # ]]]
 # .. envvar:: netbox__config_base_path [[[
@@ -486,6 +559,38 @@ netbox__config_prefer_ipv4: False
 # If enabled, NetBox will enforce unique IP space in the "global" table (all
 # prefixes and IP addresses not included in a VRF).
 netbox__config_enforce_global_unique: False
+
+                                                                   # ]]]
+# .. envvar:: netbox__config_exempt_view_permissions [[[
+#
+# Exempt certain models from the enforcement of view permissions. Models listed
+# here will be viewable by all users and by anonymous users. List models in the
+# form `<app>.<model>`. Add '*' to this list to exempt all models.
+netbox__config_exempt_view_permissions: []
+
+                                                                   # ]]]
+# .. envvar:: netbox__config_metrics_enabled [[[
+#
+# When enabled, expose Prometheus monitoring metrics at the HTTP endpoint
+# '/metrics'.
+netbox__config_metrics_enabled: False
+
+                                                                   # ]]]
+# .. envvar:: netbox__config_webhooks_enabled [[[
+#
+# The webhooks backend is disabled by default. Set this to True to enable it. Note that this requires a Redis
+# # database be configured and accessible by NetBox.
+netbox__config_webhooks_enabled: False
+
+                                                                   # ]]]
+# .. envvar:: netbox__config_session_file_path [[[
+#
+# By default, NetBox will store session data in the database. Alternatively,
+# a file path can be specified here to use local file storage instead. (This
+# can be useful for enabling authentication on a standby instance with
+# read-only database access.) Note that the user as which NetBox runs must have
+# read and write permissions to this path.
+netbox__config_session_file_path: False
 
                                                                    # ]]]
 # .. envvar:: netbox__config_media_root [[[

--- a/ansible/roles/debops.netbox/templates/usr/local/lib/netbox/configuration.py.j2
+++ b/ansible/roles/debops.netbox/templates/usr/local/lib/netbox/configuration.py.j2
@@ -27,6 +27,15 @@ DATABASE = {
 # https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-SECRET_KEY
 SECRET_KEY = '{{ netbox__config_secret_key }}'
 
+# Redis database settings. The Redis database is used for caching and background processing such as webhooks
+REDIS = {
+    'HOST': '{{ netbox__redis_host }}',
+    'PORT': {{ netbox__redis_port }},
+    'PASSWORD': '{{ netbox__redis_password }}',
+    'DATABASE': {{ netbox__redis_database }},
+    'CACHE_DATABASE': {{ netbox__redis_cache_database }},
+    'SSL': {{ netbox__redis_ssl }},
+}
 
 #########################
 #                       #
@@ -56,6 +65,12 @@ BANNER_LOGIN = '{{ netbox__config_banner_login }}'
 # Base URL path if accessing NetBox within a directory. For example, if installed at http://example.com/netbox/, set:
 # BASE_PATH = 'netbox/'
 BASE_PATH = '{{ netbox__config_base_path }}'
+
+# Cache timeout in seconds. Set to 0 to disable caching. Defaults to 900 (15 minutes)
+CACHE_TIMEOUT = {{ netbox__config_cache_timeout }}
+
+# Maximum number of days to retain logged changes. Set to 0 to retain changes indefinitely. (Default: 90)
+CHANGELOG_RETENTION = {{ netbox__config_changelog_retention }}
 
 # API Cross-Origin Resource Sharing (CORS) settings. If CORS_ORIGIN_ALLOW_ALL is set to True, all origins will be
 # allowed. Otherwise, define a list of allowed origins using either CORS_ORIGIN_WHITELIST or
@@ -97,6 +112,14 @@ EMAIL = {
 # (all prefixes and IP addresses not assigned to a VRF), set ENFORCE_GLOBAL_UNIQUE to True.
 ENFORCE_GLOBAL_UNIQUE = {{ netbox__config_enforce_global_unique | bool }}
 
+# Exempt certain models from the enforcement of view permissions. Models listed here will be viewable by all users and
+# by anonymous users. List models in the form `<app>.<model>`. Add '*' to this list to exempt all models.
+EXEMPT_VIEW_PERMISSIONS = [
+{% for element in netbox__config_exempt_view_permissions %}
+    '{{ element }}',
+{% endfor %}
+]
+
 # Enable custom logging. Please see the Django documentation for detailed guidance on configuring custom logs:
 #   https://docs.djangoproject.com/en/1.11/topics/logging/
 LOGGING = {{ netbox__config_logging | to_nice_json }}
@@ -104,6 +127,10 @@ LOGGING = {{ netbox__config_logging | to_nice_json }}
 # Setting this to True will permit only authenticated users to access any part of NetBox. By default, anonymous users
 # are permitted to access most data in NetBox (excluding secrets) but not make any changes.
 LOGIN_REQUIRED = {{ netbox__config_login_required | bool }}
+
+# The length of time (in seconds) for which a user will remain logged into the web UI before being prompted to
+# re-authenticate. (Default: 1209600 [14 days])
+LOGIN_TIMEOUT = {{ netbox__config_login_timeout }}
 
 # Setting this to True will display a "maintenance mode" banner at the top of every page.
 MAINTENANCE_MODE = {{ netbox__config_maintenance_mode | bool }}
@@ -116,6 +143,9 @@ MAX_PAGE_SIZE = {{ netbox__config_max_page_size }}
 # The file path where uploaded media such as image attachments are stored. A trailing slash is not needed. Note that
 # the default value of this setting is derived from the installed location.
 MEDIA_ROOT = '{{ netbox__config_media_root }}'
+
+# Expose Prometheus monitoring metrics at the HTTP endpoint '/metrics'
+METRICS_ENABLED = {{ netbox__config_metrics_enabled }}
 
 # Credentials that NetBox will uses to authenticate to devices when connecting via NAPALM.
 NAPALM_USERNAME = '{{ netbox__config_napalm_username }}'
@@ -139,8 +169,17 @@ PREFER_IPV4 = {{ netbox__config_prefer_ipv4 | bool }}
 # this setting is derived from the installed location.
 REPORTS_ROOT = '{{ netbox__config_reports_root }}'
 
+# By default, NetBox will store session data in the database. Alternatively, a file path can be specified here to use
+# local file storage instead. (This can be useful for enabling authentication on a standby instance with read-only
+# database access.) Note that the user as which NetBox runs must have read and write permissions to this path.
+SESSION_FILE_PATH = {{ netbox__config_session_file_path }}
+
 # Time zone (default: UTC)
 TIME_ZONE = '{{ netbox__config_time_zone }}'
+
+# The webhooks backend is disabled by default. Set this to True to enable it. Note that this requires a Redis
+# database be configured and accessible by NetBox.
+WEBHOOKS_ENABLED = {{ netbox__config_webhooks_enabled }}
 
 # Date/time formatting. See the following link for supported formats:
 # https://docs.djangoproject.com/en/dev/ref/templates/builtins/#date

--- a/docs/ansible/roles/debops.netbox/getting-started.rst
+++ b/docs/ansible/roles/debops.netbox/getting-started.rst
@@ -60,6 +60,13 @@ configure one on the same host as NetBox, add that host to the
 :ref:`debops.postgresql_server` role documentation to see how to use the database
 server remotely.
 
+The Redis service is used for caching and is now required by NetBox as well.
+The ``netbox__redis_*`` variables in the :ref:`debops.netbox` role can be used
+to point NetBox to a remote Redis service; by default the role expects Redis to
+be installed locally. You can deploy a Redis Server or cluster using the
+:ref:`debops.redis_server` (and optionally :ref:`debops.redis_sentinel`)
+Ansible roles. See their documentation for more details.
+
 To deploy NetBox on a given host, you need to add that host to the
 ``[debops_service_netbox]`` Ansible inventory group. Complete, example
 inventory:
@@ -67,6 +74,9 @@ inventory:
 .. code-block:: none
 
    [debops_all_hosts]
+   hostname
+
+   [debops_service_redis_server]
    hostname
 
    [debops_service_postgresql_server]

--- a/lib/tests/jane
+++ b/lib/tests/jane
@@ -59,7 +59,7 @@ readonly CI_JOB_NAME="${CI_JOB_NAME:-}"
 readonly CI_JOB_STAGE="${CI_JOB_STAGE:-}"
 readonly VAGRANT_DOTFILE_PATH="${VAGRANT_DOTFILE_PATH:-/var/tmp/vagrant-dotfile-${CI_JOB_ID}}"
 
-readonly JANE_DIFF_BASE_BRANCH="${JANE_DIFF_BASE_BRANCH:-master}"
+readonly JANE_DIFF_BASE_BRANCH="${JANE_DIFF_BASE_BRANCH:-origin/master}"
 readonly JANE_DIFF_PATTERN="${JANE_DIFF_PATTERN:-.*}"
 readonly JANE_LOG_PATTERN="${JANE_LOG_PATTERN:-}"
 readonly JANE_FORCE_TESTS="${JANE_FORCE_TESTS:-}"

--- a/lib/travis/syntax/before_install.sh
+++ b/lib/travis/syntax/before_install.sh
@@ -3,7 +3,7 @@
 set -o nounset -o pipefail -o errexit
 
 sudo apt-get -qq update
-pip3 install --upgrade pip wheel setuptools
-pip3 install \
-     pycodestyle \
-     yamllint
+pip install --upgrade pip wheel setuptools
+pip install \
+    pycodestyle \
+    yamllint


### PR DESCRIPTION
On Python 3.7, there are too many syntax check issues to backport all
of them to the stable-1.0 release.