### PR TITLE
[ci] Test 'nginx + passenger' on Debian Stretch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -917,6 +917,7 @@ stages:
 'nginx/passenger role':
   <<: *test_role_2nd_deps
   variables:
+    BASE_VAGRANT_BOX: 'debian/stretch64'
     JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/nginx.yml'
     JANE_INVENTORY_GROUPS: 'debops_service_nginx'
     JANE_INVENTORY_HOSTVARS: 'nginx_flavor=passenger'


### PR DESCRIPTION
At the moment there's no release of upstream Phusion Passenger for
Debian Buster. The 'debops.nginx' role that uses Passenger from upstream
will be tested using Debian Stretch Vagrant Box for now.