### PR TITLE
[debops.lvm] Don't manage lvmetad service anymore

### DIFF
--- a/ansible/roles/debops.lvm/tasks/main.yml
+++ b/ansible/roles/debops.lvm/tasks/main.yml
@@ -45,6 +45,9 @@
     name: 'lvm2-lvmetad.socket'
     state: '{{ "started" if lvm__global_use_lvmetad else "stopped" }}'
     enabled: '{{ lvm__global_use_lvmetad }}'
+  when: (ansible_distribution_release in [ 'wheezy', 'jessie', 'stretch',
+                                           'precise', 'trusty', 'xenial',
+                                           'bionic' ])
 
 - name: Manage LVM
   include: manage_lvm.yml


### PR DESCRIPTION
The 'lvm2-lvmetad' service and init script have been removed from LVM
upstream and are no longer present in Debian Buster.