### PR TITLE
[debops.icinga] Don't use 'repository.d/' dir

### DIFF
--- a/ansible/roles/debops.icinga/defaults/main.yml
+++ b/ansible/roles/debops.icinga/defaults/main.yml
@@ -590,7 +590,8 @@ icinga__default_configuration:
         value: |
           include_recursive "repository.d"
         state: '{{ "absent"
-                   if (ansible_distribution_release == "wheezy")
+                   if (ansible_distribution_release == "wheezy" or
+                       icinga__version | version("2.8.0", "<"))
                    else "present" }}'
 
       - name: 'conf.d'


### PR DESCRIPTION
The '/etc/icinga2/repository.d/' directory is not used since Icinga
2.8.0 release.