### PR TITLE
[debops.nginx] No longer limit HTTP methods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -245,6 +245,9 @@ Changed
   be removed to allow the DNS to take over. If it doesn't, the configuration
   will be left intact with assumtion that the domain is configured locally.
 
+- [debops.nginx] The role will no longer default to limiting the allowed HTTP
+  request methods to GET, HEAD and POST on PHP-enabled websites.
+
 Removed
 ~~~~~~~
 

--- a/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/php.conf.j2
+++ b/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/php.conf.j2
@@ -49,10 +49,7 @@
 {%   if item.php_upstream|d() %}
 
         location ~ ^(?!.+\.php/)(?<script_name>.+\.php)$ {
-{%     if item.php_limit_except is undefined %}
-                limit_except GET HEAD POST { deny all; }
-
-{%     elif item.php_limit_except|d() %}
+{%      if item.php_limit_except|d() %}
                 limit_except {{ item.php_limit_except if item.php_limit_except is string else item.php_limit_except | join(' ') }} { deny all; }
 
 {%     endif %}
@@ -83,10 +80,7 @@
         }
 
         location ~ ^(?<script_name>.+\.php)(?<path_info>/.*)$ {
-{%     if item.php_limit_except is undefined %}
-                limit_except GET HEAD POST { deny all; }
-
-{%     elif item.php_limit_except|d() %}
+{%     if item.php_limit_except|d() %}
                 limit_except {{ item.php_limit_except if item.php_limit_except is string else item.php_limit_except | join(' ') }} { deny all; }
 
 {%     endif %}

--- a/docs/ansible/roles/debops.nginx/defaults-detailed.rst
+++ b/docs/ansible/roles/debops.nginx/defaults-detailed.rst
@@ -750,12 +750,9 @@ Available when ``item.type`` is set to ``php`` for a server.
 
 ``php_limit_except`` or False
   Optional, string or list of strings or boolean (``False``).
-  Methods to allow for all hosts.
+  Whitelist of allowed HTTP request methods.
 
-  If undefined, default limits will be applied (block all requests except GET,
-  HEAD and POST).
-
-  If set to ``False``, limits are disabled.
+  If absent or ``False``, limits are disabled.
 
   Refer to the `Nginx limit_except directive documentation`_ for details.
 

--- a/docs/news/upgrades.rst
+++ b/docs/news/upgrades.rst
@@ -85,6 +85,11 @@ Inventory variable changes
 - The ``core__keyserver`` variable and its corresponding local fact have been
   replaced by the :envvar:`keyring__keyserver` with a corresponding local fact.
 
+- The :ref:`debops.nginx` role no longer defaults to limiting the allowed HTTP
+  request methods to GET, HEAD and POST on PHP-enabled websites. Use the
+  ``item.php_limit_except`` parameter if you want to keep limiting the request
+  methods.
+
 
 v1.0.0 (2019-05-22)
 -------------------


### PR DESCRIPTION
HTTP request methods used to be limited to GET, HEAD and POST by
default on PHP-enabled websites. This caused REST API calls to break.
This commit changes that behaviour so that there are no limits applied
by default. The user can set their own request method whitelist in the
``item.php_limit_except`` parameter.

Closes #935