### PR TITLE
[debops.docker_server] Find 'dockerd' binary

### DIFF
--- a/ansible/roles/debops.docker_server/templates/etc/ansible/facts.d/docker_server.fact.j2
+++ b/ansible/roles/debops.docker_server/templates/etc/ansible/facts.d/docker_server.fact.j2
@@ -19,6 +19,14 @@ def cmd_exists(cmd):
     )
 
 
+def cmd_abspath(cmd):
+    binaries = (os.path.abspath(os.path.join(path, cmd))
+                for path in os.environ["PATH"].split(os.pathsep))
+    for binary in binaries:
+        if os.access(binary, os.X_OK):
+            return binary
+
+
 output = {'installed': cmd_exists('docker')}
 
 try:
@@ -30,6 +38,11 @@ try:
     if match:
         output['version'] = match.group('docker_version')
 
+except Exception:
+    pass
+
+try:
+    output['dockerd_binary'] = cmd_abspath('dockerd')
 except Exception:
     pass
 

--- a/ansible/roles/debops.docker_server/templates/etc/systemd/system/docker.service.d/execstart-override.conf.j2
+++ b/ansible/roles/debops.docker_server/templates/etc/systemd/system/docker.service.d/execstart-override.conf.j2
@@ -5,6 +5,7 @@
 # configuration file.
 [Service]
 ExecStart=
-ExecStart={{ "/usr/sbin/dockerd"
-             if ansible_distribution_release == "buster"
-             else "/usr/bin/dockerd" }}
+ExecStart={{ ansible_local.docker_server.dockerd_binary
+             if (ansible_local|d() and ansible_local.docker_server|d() and
+                 ansible_local.docker_server.dockerd_binary|d())
+             else "/usr/sbin/dockerd" }}


### PR DESCRIPTION
Different versions of the Docker service (Debian, Ubuntu, upstream) put
the 'dockerd' binary in different places. This patch ensures that the
'debops.docker_server' role knows where the 'dockerd' binary can be
found so that the correct path can be used in the 'systemd' unit
override.

Fixes #911 
Fixes #912 