### PR TITLE
[debops.docker_server] Change TCP listen variable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -129,6 +129,9 @@ Changed
   preparation of adding a role that will provide client functionality like
   network and container management.
 
+- [debops.docker_server] The Docker server no longer listens on a TCP port by
+  default, even if :ref:`debops.pki` is enabled.
+
 - [debops.netbase] Do not try to manage the hostname in LXC, Docker or OpenVZ
   containers by default. We assume that these containers are unprivileged and
   their hostname cannot be changed from the inside of the container.

--- a/ansible/roles/debops.docker_server/defaults/main.yml
+++ b/ansible/roles/debops.docker_server/defaults/main.yml
@@ -260,10 +260,8 @@ docker_server__dns_search: '{{ ansible_local.resolver.search
 
 # .. envvar:: docker_server__tcp [[[
 #
-# Enable or disable listening for TLS connections on the TCP docker port. By
-# default remote connections are enabled if the :ref:`debops.pki` role has been
-# configured on remote host (access is controlled by the firewall).
-docker_server__tcp: '{{ docker_server__pki | bool }}'
+# Enable or disable listening for incoming TCP connections.
+docker_server__tcp: False
 
                                                                    # ]]]
 # .. envvar:: docker_server__tcp_bind [[[
@@ -287,7 +285,7 @@ docker_server__tls_tcp_port: '2376'
                                                                    # ]]]
 # .. envvar:: docker_server__tcp_port [[[
 #
-# Port on which to listen for incoming TLS connections.
+# Port on which to listen for incoming TCP connections.
 docker_server__tcp_port: '{{ docker_server__tls_tcp_port
                              if (docker_server__pki|d() | bool)
                              else docker_server__unencrypted_tcp_port }}'
@@ -296,16 +294,16 @@ docker_server__tcp_port: '{{ docker_server__tls_tcp_port
 # .. envvar:: docker_server__tcp_allow [[[
 #
 # List of IP addresses or subnets in CIDR format which are allowed to connect
-# to the Docker daemon over TLS. If it's not specified, remote connections are
+# to the Docker daemon over TCP. If it's not specified, remote connections are
 # denied by the firewall.
 docker_server__tcp_allow: []
 
                                                                    # ]]]
 # .. envvar:: docker_server__tcp_listen [[[
 #
-# Default connection configured in addition to local socket connection, using
-# TCP over TLS.
-docker_server__tcp_listen: '{{ ("tcp://" + docker_server__tcp_bind + ":" + docker_server__tcp_port)
+# Default TCP connection configured in addition to local socket connection.
+docker_server__tcp_listen: '{{ ("tcp://" + docker_server__tcp_bind + ":" +
+                                docker_server__tcp_port)
                                if (docker_server__tcp|d() | bool) else "" }}'
 
                                                                    # ]]]

--- a/docs/ansible/roles/debops.docker_server/getting-started.rst
+++ b/docs/ansible/roles/debops.docker_server/getting-started.rst
@@ -18,11 +18,12 @@ version of Docker by setting the ``docker_server__upstream: True`` variable in
 Ansible’s inventory. Upstream Docker is installed on Debian Stretch by default,
 since this release does not provide included Docker packages.
 
-If :ref:`debops.pki` was configured on the host, Docker will automatically
-listen on its TCP port for incoming TLS connections, which is by default
-blocked by the :program:`ferm` firewall. If you don't use a firewall or have it
-disabled, you might want to set :envvar:`docker_server__tcp` to ``False`` to
-disable this behavior.
+A Docker server managed by DebOps does not listen on any TCP ports by default.
+You can set :envvar:`docker_server__tcp` to ``True`` if you need remote access
+to the Docker server. You will also need to tweak your firewall in this case,
+which is easily done with :envvar:`docker_server__tcp_allow`. It is recommended
+to use the :ref:`debops.pki` role to secure the connection between the client
+and the Docker server.
 
 Docker manages its own network bridge and :command:`iptables` entries. On hosts
 that don't use upstream Docker packages, the :program:`ferment` Python script
@@ -58,6 +59,9 @@ Useful variables
 
 This is a list of role variables which you most likely want to define in
 Ansible inventory to customize Docker:
+
+:envvar:`docker_server__tcp`
+  Enable or disable listening for TLS connections on the Docker TCP port.
 
 :envvar:`docker_server__tcp_allow`
   List of IP addresses or subnets that can connect to Docker daemon remotely

--- a/docs/news/upgrades.rst
+++ b/docs/news/upgrades.rst
@@ -67,6 +67,12 @@ Inventory variable changes
   inventory group ``[debops_service_docker_server]`` to continue using this
   role.
 
+  Also, the Docker server no longer listens on a TCP port by default, even if
+  :ref:`debops.pki` is enabled. You must set ``docker_server__tcp`` to ``True``
+  and configure an IP address whitelist in ``docker_server__tcp_allow`` if you
+  want to connect to the Docker server over a network. It is recommended to use
+  :ref:`debops.pki` to secure the connection with TLS.
+
 - The :ref:`debops.lxc` role uses different names of the container
   configuration options depending on the LXC version used on the host. The
   ``name`` parameters used in the configuration might change unexpectedly


### PR DESCRIPTION
This change turns listening on a TCP port off by default, even if
`debops.pki` is enabled. This is a security measure, it should prevent
administrators from unknowingly leaving the Docker TCP port open.

Closes #871