### PR TITLE
Do not map bad users to guest

### DIFF
--- a/ansible/roles/debops.samba/defaults/main.yml
+++ b/ansible/roles/debops.samba/defaults/main.yml
@@ -132,7 +132,7 @@ samba__default_global:
   unix_password_sync: 'no'
   obey_pam_restrictions: 'yes'
   invalid_users: 'root bin daemon adm sync shutdown halt mail news uucp proxy www-data backup sshd'
-  map_to_guest: 'bad user'
+  map_to_guest: 'never'
   guest_account: 'nobody'
 
   # File system / Directories.


### PR DESCRIPTION
The Samba default is "map to guest = never", which is the more intuitive behaviour compared to the often used "bad user". If a client connects to a Samba server with "map to guest = bad user", the client does not get a hint about a bad user/password and thinks that he did everything fine and remembers this password. The client will then miss some directories which the guest does not have access to and is somehat irritated what is happening.