### PR TITLE
[debops.reprepro] Default to no Component for update rules

### DIFF
--- a/ansible/roles/debops.reprepro/templates/var/lib/reprepro/conf/updates.j2
+++ b/ansible/roles/debops.reprepro/templates/var/lib/reprepro/conf/updates.j2
@@ -7,13 +7,9 @@
 {% endfor %}
 {% if item.Components is defined and item.Components %}
 Components: {{ item.Components }}
-{% else %}
-Components: {{ reprepro_repository_components[reprepro_distribution | lower] | join(" ") }}
 {% endif %}
 {% if item.UDebComponents is defined and item.UDebComponents %}
 UDebComponents: {{ item.UDebComponents }}
-{% else %}
-UDebComponents: {{ reprepro_repository_components[reprepro_distribution | lower] | join(" ") }}
 {% endif %}
 {% if item.Architectures is undefined %}
 Architectures: {{ reprepro_architectures | join(" ") }}


### PR DESCRIPTION
Don't set Component or UDebComponent for update rules if no component is
set in the configuration. Reprepro will then use the components from the
Distribution being updated. This is a saner default than using
reprepro_repository_components. The same logic is already used for pull
rules.

With the current code it's also not possible to not set Component or
UDebComponent on an update rule which makes updates from a repository
which does not have any udeb components hard.