### PR TITLE
[debops.slapd] Fix regex for deriving base dn

### DIFF
--- a/ansible/roles/debops.slapd/defaults/main.yml
+++ b/ansible/roles/debops.slapd/defaults/main.yml
@@ -185,7 +185,7 @@ slapd__domain: '{{ ansible_local.core.domain
 # BaseDN value of the main OpenLDAP server that contains the LDAP data, defined
 # as a YAML list.
 slapd__base_dn: '{{ slapd__domain.split(".")
-                    | map("regex_replace", "(.*)", "dc=\1")
+                    | map("regex_replace", "^(.*)$", "dc=\1")
                     | list }}'
 
                                                                    # ]]]


### PR DESCRIPTION
For a `slapd__domain` equals to "example.org", the previous regex would
generate `slapd__base_dn` like this:

  ["dc=exampledc=", "dc=orgdc="]

This would result in a final `slapd__basedn` of:

  "dc=exampledc=,dc=orgdc"

Changing the regex to "^(.*)$" fixes the issue for me.