### PR TITLE
[debops.zerotier] - add new role

### DIFF
--- a/ansible/roles/debops.zerotier/defaults/main.yml
+++ b/ansible/roles/debops.zerotier/defaults/main.yml
@@ -1,0 +1,102 @@
+---
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+
+# debops.zerotier default variables [[[
+# =======================================
+
+# .. contents:: Sections
+#    :local:
+#
+# .. include:: ../../../includes/global.rst
+
+
+# zerotier installation, packages [[[
+# -------------------------------------
+
+# .. envvar:: zerotier__upstream [[[
+#
+# Enable zerotier Global Developmet Group APT repository?
+# More information: https://wiki.zerotier.org/wiki/Apt
+zerotier__upstream: True
+
+                                                                   # ]]]
+# .. envvar:: zerotier__upstream_key_id [[[
+#
+# The GPG fingerprint of the upstream APT repository key.
+zerotier__upstream_key_id: '74A5E9C458E1A431F1DA57A71657198823E52A61'
+
+                                                                   # ]]]
+# .. envvar:: zerotier__upstream_apt_repo [[[
+#
+# The upstream APT repository URL in the ``sources.list`` format.
+zerotier__upstream_apt_repo: 'deb http://download.zerotier.com/debian/{{ ansible_distribution_release }} {{ ansible_distribution_release }} main'
+                                                                   # ]]]
+# .. envvar:: zerotier__base_packages [[[
+#
+# List of base zerotier packages to install.
+zerotier__base_packages: [ 'zerotier-one' ]
+
+                                                                   # ]]]
+# .. envvar:: zerotier__packages [[[
+#
+# Install additional packages with zerotier.
+zerotier__packages: []
+
+                                                                   # ]]]
+# .. envvar:: zerotier__api_accesstoken [[[
+#
+# Zerotier api access token.
+zerotier__api_accesstoken: "{{ lookup('env','zerotier_accesstoken') | default() }}"
+
+                                                                   # ]]]
+# .. envvar:: zerotier__api_delegate [[[
+#
+# Zerotier api delegate
+zerotier__api_delegate: localhost
+
+                                                                   # ]]]
+# .. envvar:: zerotier__api_url [[[
+#
+# Zerotier api url
+zerotier__api_url: https://my.zerotier.com
+
+                                                                   # ]]]
+# .. envvar:: zerotier__apt_state [[[
+#
+# Zerotier zerotier__network_ids to join.
+zerotier__network_ids: []
+
+                                                                   # ]]]
+#
+# Zerotier member description.
+zerotier__member_description: ""
+
+                                                                   # ]]]
+# .. envvar:: zerotiezerotier__member_register_short_hostnamer__network [[[
+                                                                   # .. envvar:: zerotier__apt_state [[[
+#
+# Zerotier network id to join.
+zerotier__apt_state: present
+
+                                                                   # ]]]
+# .. envvar:: zerotiezerotier__member_register_short_hostnamer__network [[[
+#
+# Zerotier register to network using short hostname
+zerotier__member_register_short_hostname:  "{{ zerotier_register_short_hostname | default(false) }}"
+
+                                                                   # ]]]
+# .. envvar:: zerotier__network_authorize [[[
+#
+# Zerotier network join status
+zerotier__network_state: present
+
+                                                                   # ]]]
+# .. envvar:: zerotier__network_authorize [[[
+#
+# Zerotier authorize network access
+zerotier__network_authorize: True
+
+                                                                   # ]]]
+                                                                   # ]]]
+                                                                   # ]]]
+

--- a/ansible/roles/debops.zerotier/handlers/main.yml
+++ b/ansible/roles/debops.zerotier/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+# handlers file for unionpos-zerotier
+
+- name: restart zerotier-one.service
+  service:
+    name: zerotier-one.service
+    daemon_reload: true
+    state: 'restarted'

--- a/ansible/roles/debops.zerotier/tasks/facts.yml
+++ b/ansible/roles/debops.zerotier/tasks/facts.yml
@@ -1,0 +1,22 @@
+---
+
+- name: Make sure that Ansible local facts directory exists
+  file:
+    path: '/etc/ansible/facts.d'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+
+- name: Save ZeroTier local facts
+  template:
+    src: 'etc/ansible/facts.d/zerotier.fact.j2'
+    dest: '/etc/ansible/facts.d/zerotier.fact'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+  register: zerotier__register_facts
+
+- name: Update Ansible facts if they were modified
+  action: setup
+  when: zerotier__register_facts is changed

--- a/ansible/roles/debops.zerotier/tasks/main.yml
+++ b/ansible/roles/debops.zerotier/tasks/main.yml
@@ -1,0 +1,44 @@
+---
+# tasks file for zerotier
+
+- name: Get ZeroTier APT GPG key
+  apt_key:
+    id: '{{ zerotier__upstream_key_id }}'
+    keyserver: '{{ ansible_local.core.keyserver
+                   if (ansible_local|d() and ansible_local.core|d() and
+                       ansible_local.core.keyserver)
+                   else "hkp://pool.sks-keyservers.net" }}'
+    state: 'present'
+  register: zerotier__register_apt_key
+  until: zerotier__register_apt_key is succeeded
+  when: zerotier__upstream|bool
+
+- name: Configure ZeroTier APT repository
+  apt_repository:
+    repo: '{{ zerotier__upstream_apt_repo }}'
+    state: 'present'
+    update_cache: True
+  when: zerotier__upstream|bool
+
+- name: Install ZeroTier packages
+  apt:
+    name: "{{ query('flattened', ['{{ zerotier__base_packages }}', '{{ zerotier__packages }}']) }}"
+    state: "{{ zerotier__apt_state }}"
+    install_recommends: False
+  register: zerotier__register_packages
+  until: zerotier__register_packages is succeeded
+
+- name: zerotier-one.service
+  service:
+    name: zerotier-one.service
+    enabled: yes
+    state: started
+
+- import_tasks: facts.yml
+
+- import_tasks: network.yml
+
+- import_tasks: node.yml
+  when:
+  - zerotier__api_accesstoken | length > 0
+  - ansible_local.zerotier.node_id is defined

--- a/ansible/roles/debops.zerotier/tasks/network.yml
+++ b/ansible/roles/debops.zerotier/tasks/network.yml
@@ -1,0 +1,31 @@
+---
+
+- block:
+
+  - name: Join Zerotier Network
+    command: zerotier-cli join {{ item }}
+    args:
+      creates: /var/lib/zerotier-one/networks.d/{{ item }}.conf
+    # when:
+    #   - ansible_local.zerotier.networks[item] is not defined or ansible_local.zerotier.networks[item].status != 'OK'
+    loop: "{{ lookup('list', zerotier__network_ids) }}"
+
+  when:
+  - not ansible_check_mode
+  - zerotier__network_state == 'present'
+
+- block:
+
+  - name: Leave Zerotier Network
+    command: zerotier-cli leave {{ item }}
+    args:
+      removes: /var/lib/zerotier-one/networks.d/{{ item }}.conf
+    # when:
+    #   - (nsible_local.zerotier.networks[item] is defined and ansible_local.zerotier.networks[item].status == 'OK'
+    loop: "{{ lookup('list', zerotier__network_ids) }}"
+
+  when:
+  - not ansible_check_mode
+  - zerotier__network_state == 'absent'
+
+  become: false

--- a/ansible/roles/debops.zerotier/tasks/node.yml
+++ b/ansible/roles/debops.zerotier/tasks/node.yml
@@ -1,0 +1,69 @@
+---
+
+- block:
+
+  - name: Authorize member to network
+    uri:
+      url: "{{ zerotier__api_url }}/api/network/{{ item }}/member/{{ ansible_local.zerotier.node_id }}"
+      method: POST
+      headers:
+        Authorization: bearer {{ zerotier__api_accesstoken }}
+      body:
+        hidden: false
+        config:
+          authorized: "{{ zerotier__network_authorize }}"
+      body_format: json
+      register: zerotier__auth_apiresult
+    delegate_to: "{{ zerotier__api_delegate }}"
+    when:
+      - (ansible_local.zerotier.networks[item] is not defined or ansible_local.zerotier.networks[item].status != 'OK')
+    loop: "{{ lookup('list', zerotier__network_ids) }}"
+
+  - name: Configure member in network
+    uri:
+      url: "{{ zerotier__api_url }}/api/network/{{ item }}/member/{{ ansible_local.zerotier.node_id }}"
+      method: POST
+      headers:
+        Authorization: bearer {{ zerotier__api_accesstoken }}
+      body:
+        name: "{{ zerotier__member_register_short_hostname | ternary(inventory_hostname_short, inventory_hostname) }}"
+        description: "{{ zerotier__member_description | default() }}"
+        config:
+          ipAssignments: "{{ zerotier__member_ip_assignments | default([]) | list }}"
+      body_format: json
+      register: zerotier__conf_apiresult
+    delegate_to: "{{ zerotier__api_delegate }}"
+    when:
+      - zerotier__network_state == 'present'
+    #   - ansible_local.zerotier.networks[item] is not defined
+    loop: "{{ lookup('list', zerotier__network_ids) }}"
+
+  when:
+  - not ansible_check_mode
+  - zerotier__network_state == 'present'
+
+- block:
+
+  - name: Remove member from network
+    uri:
+      url: "{{ zerotier__api_url }}/api/network/{{ item }}/member/{{ ansible_local.zerotier.node_id }}"
+      method: DELETE
+      headers:
+        Authorization: bearer {{ zerotier__api_accesstoken }}
+      body:
+        hidden: false
+        config:
+          authorized: false
+      body_format: json
+      register: zerotier__auth_apiresult
+    delegate_to: "{{ zerotier__api_delegate }}"
+    when:
+      - ansible_local.zerotier.networks[item] is defined and ansible_local.zerotier.networks[item].status == 'OK'
+    loop: "{{ lookup('list', zerotier__network_ids) }}"
+
+  when:
+  - not ansible_check_mode
+  - zerotier__network_state == 'absent'
+
+  become: false
+

--- a/ansible/roles/debops.zerotier/templates/etc/ansible/facts.d/zerotier.fact.j2
+++ b/ansible/roles/debops.zerotier/templates/etc/ansible/facts.d/zerotier.fact.j2
@@ -1,0 +1,37 @@
+#!{{ ansible_python['executable'] }}
+
+# {{ ansible_managed }}
+
+from __future__ import print_function
+from json import load, loads, dumps
+from sys import exit
+import subprocess
+
+output = loads('''{{ ({
+    "installed": true,
+    "networks": {}
+}) | to_nice_json }}''')
+
+statusRes = subprocess.check_output(["sudo", "zerotier-cli", "status"])
+
+output['node_id'] = statusRes.split()[2]
+output['node_description'] = "{{ zerotier__member_description }}"
+output['status'] = statusRes
+
+{% if zerotier__network_ids|length %}
+networkRes = subprocess.check_output(["sudo", "zerotier-cli", "listnetworks"]).replace("  ", " unnamed ")
+for network in networkRes.split("\n")[1:-1]:
+  output['networks'][network.split()[2]] = {
+    "nwid": network.split()[2],
+    "name": network.split()[3],
+    "mac": network.split()[4],
+    "status": network.split()[5],
+    "type": network.split()[6],
+    "device": network.split()[7],
+    "ip": network.split()[8],
+  }
+{% endif %}
+
+print(dumps(output, sort_keys=True, indent=2))
+
+print()


### PR DESCRIPTION
this role manages zerotier clients, attaching and removing hosts to existing zerotier networks
it does not take on the task of creating standalone zerotier controller

I imagine there is a bit of work to do here to make this consistent with other debops roles..
I look forward to guidance as to what changes need made
