### PR TITLE
[debops.root_account] fix: The "Configure authorized SSH keys for roo…

### DIFF
--- a/ansible/roles/debops.root_account/defaults/main.yml
+++ b/ansible/roles/debops.root_account/defaults/main.yml
@@ -190,6 +190,15 @@ root_account__group_authorized_keys: []
 root_account__host_authorized_keys: []
 
                                                                    # ]]]
+# .. envvar:: root_account__combined_authorized_keys [[[
+#
+# This variable combines all root_account__*authorized_keys variables 
+# together and is used in the role tasks and templates.
+root_account__combined_authorized_keys: '{{ root_account__authorized_keys
+                                            + root_account__group_authorized_keys
+                                            + root_account__host_authorized_keys }}'
+
+                                                                   # ]]]
 # .. envvar:: root_account__authorized_keys_exclusive [[[
 #
 # If ``True``, only the public SSH keys defined in the above variable will be

--- a/ansible/roles/debops.root_account/defaults/main.yml
+++ b/ansible/roles/debops.root_account/defaults/main.yml
@@ -192,7 +192,7 @@ root_account__host_authorized_keys: []
                                                                    # ]]]
 # .. envvar:: root_account__combined_authorized_keys [[[
 #
-# This variable combines all root_account__*authorized_keys variables 
+# This variable combines all root_account__*authorized_keys variables
 # together and is used in the role tasks and templates.
 root_account__combined_authorized_keys: '{{ root_account__authorized_keys
                                             + root_account__group_authorized_keys

--- a/ansible/roles/debops.root_account/tasks/main.yml
+++ b/ansible/roles/debops.root_account/tasks/main.yml
@@ -66,14 +66,12 @@
 
 - name: Configure authorized SSH keys for root account
   authorized_key:
-    key: "{{ q('flattened', root_account__authorized_keys
-                            + root_account__group_authorized_keys
-                            + root_account__host_authorized_keys)
+    key: "{{ q('flattened', root_account__combined_authorized_keys)
               | join('\n') }}"
     exclusive: '{{ root_account__authorized_keys_exclusive|bool }}'
     state: 'present'
     user: 'root'
-  when: root_account__enabled|bool and root_account__authorized_keys|d() and
+  when: root_account__enabled|bool and root_account__combined_authorized_keys|d() and
         root_account__authorized_keys_state != 'absent'
 
 - name: Remove /root/.ssh/authorized_keys file if requested


### PR DESCRIPTION
…t account" tasks when condition ignores all ssh keys specified in root_account__group_authorized_keys and root_account__host_authorized_keys.