### PR TITLE
change deprecated patchpanel dokuwiki to switchpanel

### DIFF
--- a/ansible/roles/debops.dokuwiki/defaults/main.yml
+++ b/ansible/roles/debops.dokuwiki/defaults/main.yml
@@ -179,8 +179,8 @@ dokuwiki__plugins_syntax:
   - repo: 'https://github.com/cosmocode/dig.git'
     dest: 'dig'
 
-  - repo: 'https://github.com/grantemsley/dokuwiki-plugin-patchpanel.git'
-    dest: 'patchpanel'
+  - repo: 'https://github.com/GreenItSolutions/dokuwiki-plugin-switchpanel.git'
+    dest: 'switchpanel'
 
   - repo: 'https://github.com/ashrafhasson/dokuwiki-plugin-advrack.git'
     dest: 'advrack'


### PR DESCRIPTION
Patchpanel dokuwiki plugin is deprecated; Switchpanel is the successor.