### PR TITLE
[docs] Add pyOpenSSL to required Python packages

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -111,13 +111,21 @@ Ansible:
 
 .. __: https://bitbucket.org/ecollins/passlib/wiki/Home
 
+`pyOpenSSL`__
+  This is a Python wrapper for the OpenSSL library, available in the
+  ``python-openssl`` package. It's a requirement for :ref:`debops.opendkim` and
+  other roles that generate X.509 certificates or private keys on the Ansible
+  Controller.
+
+.. __: https://www.pyopenssl.org/
+
 You can install them using your distribution packages on Debian or
 Ubuntu by running the command:
 
 .. code-block:: console
 
    sudo apt install python-future python-ldap python-netaddr \
-                    python-dnspython python-passlib
+                    python-dnspython python-passlib python-openssl
 
 The missing Python dependencies will be automatically installed with the
 ``ansible`` and ``debops`` Python packages, however some of them, like the

--- a/ansible/playbooks/service/opendkim.yml
+++ b/ansible/playbooks/service/opendkim.yml
@@ -30,12 +30,5 @@
           config: '{{ opendkim__postfix__dependent_maincf }}'
       when: opendkim__postfix_integration|bool
 
-    - role: debops.python
-      tags: [ 'role::python', 'skip::python' ]
-      python__dependent_packages3:
-        - '{{ opendkim__python__dependent_packages3 }}'
-      python__dependent_packages2:
-        - '{{ opendkim__python__dependent_packages2 }}'
-
     - role: debops.opendkim
       tags: [ 'role::opendkim', 'skip::opendkim' ]

--- a/ansible/roles/debops.opendkim/defaults/main.yml
+++ b/ansible/roles/debops.opendkim/defaults/main.yml
@@ -473,23 +473,6 @@ opendkim__postfix__dependent_maincf:
     value:
       - name: 'unix:/opendkim/opendkim.sock'
         weight: -300
-
-                                                                   # ]]]
-# .. envvar:: opendkim__python__dependent_packages3 [[[
-#
-# Configuration for the :ref:`debops.python` Ansible role.
-opendkim__python__dependent_packages3:
-
-  - 'python3-openssl'
-
-                                                                   # ]]]
-# .. envvar:: opendkim__python__dependent_packages2 [[[
-#
-# Configuration for the :ref:`debops.python` Ansible role.
-opendkim__python__dependent_packages2:
-
-  - 'python-openssl'
-
                                                                    # ]]]
                                                                    # ]]]
                                                                    # ]]]


### PR DESCRIPTION
Hey @drybjed, remember #757? I had the exact same problem today. Figured I'd take a closer look at what the `debops.opendkim` role actually does when it needs pyOpenSSL. Turns out it generates the DKIM private key on the Ansible Controller, not on the inventory host. Oops!

These changes revert my changes from #757 and add pyOpenSSL as a Python requirement to the DebOps installation guide. An errata for the errata...