### PR TITLE
Evilham improve devuan support

### DIFF
--- a/ansible/roles/debops.apt/defaults/main.yml
+++ b/ansible/roles/debops.apt/defaults/main.yml
@@ -458,7 +458,7 @@ apt__default_sources:
                       if (apt__architecture not in ["amd64", "i386"])
                       else "absent" }}'
 
-  - uri:          'http://auto.mirror.devuan.org/merged'
+  - uri:          'http://deb.devuan.org/merged'
     comment:      '{{ "Official " + apt__distribution + " repositories" }}'
     distribution: 'Devuan'
     state:        '{{ apt__default_sources_state }}'
@@ -555,7 +555,7 @@ apt__security_sources:
                       if (apt__architecture not in ["amd64", "i386"])
                       else "absent" }}'
 
-  - uri:          'http://auto.mirror.devuan.org/merged'
+  - uri:          'http://deb.devuan.org/merged'
     comment:      'Devuan Security repository'
     type:         '{{ apt__source_types }}'
     suite:        '{{ apt__distribution_release + "-security" }}'

--- a/ansible/roles/debops.unattended_upgrades/defaults/main.yml
+++ b/ansible/roles/debops.unattended_upgrades/defaults/main.yml
@@ -113,6 +113,11 @@ unattended_upgrades__security_origins:
     - 'o=Debian,n=${distro_codename},l=Debian-Security'
     - 'o=${distro_id},n=${distro_codename}-updates'
 
+  # https://www.devuan.org/
+  'Devuan':
+    - 'o=Devuan,n=${distro_codename}-security,l=Devuan-security'
+    - 'o=Devuan,n=${distro_codename}-updates'
+
   # http://www.ubuntu.com/usn/
   'Ubuntu':
     - 'o=Ubuntu,n=${distro_codename},a=${distro_codename}-security'
@@ -134,6 +139,10 @@ unattended_upgrades__release_origins:
     - 'o=Debian Backports'
 
   'Debian':
+    - 'o=${distro_id},n=${distro_codename}'
+    - 'o=${distro_id} Backports,n=${distro_codename}-backports'
+
+  'Devuan':
     - 'o=${distro_id},n=${distro_codename}'
     - 'o=${distro_id} Backports,n=${distro_codename}-backports'
 

--- a/ansible/roles/debops.unattended_upgrades/defaults/main.yml
+++ b/ansible/roles/debops.unattended_upgrades/defaults/main.yml
@@ -115,7 +115,7 @@ unattended_upgrades__security_origins:
 
   # https://www.devuan.org/
   'Devuan':
-    - 'o=Devuan,n=${distro_codename}-security,l=Devuan-security'
+    - 'o=Devuan,n=${distro_codename}-security,l=Devuan-Security'
     - 'o=Devuan,n=${distro_codename}-updates'
 
   # http://www.ubuntu.com/usn/


### PR DESCRIPTION
There is currently an issue with Devuan Beowulf/testing (it's based on Debian Buster/stable), and it's related to lsb_release in there, so right now unattended-upgrades won't work in that release.

That requires more investigation and there's still at least some weeks until it becomes stable officially, so maybe it'll "fix itself" from debops' perspective.