### PR TITLE
[debops.ansible_plugins] Fix Py3 support in module

### DIFF
--- a/ansible/roles/debops.ansible_plugins/library/ldap_attrs.py
+++ b/ansible/roles/debops.ansible_plugins/library/ldap_attrs.py
@@ -11,7 +11,7 @@
 from __future__ import absolute_import, division, print_function
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_native, to_bytes
 
 import traceback
 import re
@@ -254,9 +254,9 @@ class LdapAttr(object):
 
         if isinstance(values, list):
             if self.ordered:
-                norm_values = self._order_values(list(map(str, values)))
+                norm_values = self._order_values(list(map(to_bytes, values)))
             else:
-                norm_values = list(map(str, values))
+                norm_values = list(map(to_bytes, values))
         elif values != "":
             norm_values = [str(values)]
 


### PR DESCRIPTION
The 'ldap_attrs' Ansible module should now work correctly on Python
3 environment.

Ref: https://github.com/ansible/ansible/issues/39569