### PR TITLE
[debops-tools] use ANSIBLE_INVENTORY instead of ANSIBLE_HOSTS variable

### DIFF
--- a/bin/debops-task
+++ b/bin/debops-task
@@ -64,7 +64,7 @@ if module_name not in DEBOPS_RESERVED_NAMES:
 else:
     module = []
 
-os.environ['ANSIBLE_HOSTS'] = os.path.abspath(ansible_inventory)
+os.environ['ANSIBLE_INVENTORY'] = os.path.abspath(ansible_inventory)
 
 # Allow insecure SSH connections if requested
 if INSECURE:


### PR DESCRIPTION
Variable `ANSIBLE_HOSTS` has been deprecated since Ansible 2.8 according to this deprecation warning:
```console
$ debops-task node1 -m ping
[DEPRECATION WARNING]: ANSIBLE_HOSTS option, The variable is misleading as it can be a list of hosts and/or paths to inventory sources , use ANSIBLE_INVENTORY instead. This feature will be removed in 
version 2.8. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

This pull request switch to `ANSIBLE_INVENTORY` as suggested in [Ansible 2.4 porting guide](https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.4.html?highlight=ansible_hosts#specifying-inventory-sources). I found only this occurence of `ANSIBLE_HOSTS` in the whole monorepo.