### PR TITLE
Optional parameters for OpenSSL DH param generator

### DIFF
--- a/ansible/roles/debops.dhparam/defaults/main.yml
+++ b/ansible/roles/debops.dhparam/defaults/main.yml
@@ -156,6 +156,11 @@ dhparam__generate_log: True
 # run at the end of the Diffie-Hellman generator script using ``run-parts``.
 dhparam__hook_path: '{{ dhparam__path + "/hooks.d" }}'
                                                                    # ]]]
+# .. envvar:: dhparam__openssl_options [[[
+#
+# Provide additional options to the openssl dhparam generator (eg. -dsaparam).
+dhparam__openssl_options: ''
+                                                                   # ]]]
                                                                    # ]]]
 # Initial Diffie-Hellman re-generation [[[
 # ----------------------------------------

--- a/ansible/roles/debops.dhparam/tasks/main.yml
+++ b/ansible/roles/debops.dhparam/tasks/main.yml
@@ -43,7 +43,7 @@
              --outfile {{ dhparam__source_path + "/" + dhparam__prefix + item + dhparam__suffix }}
              --bits {{ item }}
     {% elif dhparam__source_library == 'openssl' %}
-    openssl dhparam -out {{ dhparam__source_path + "/" + dhparam__prefix + item + dhparam__suffix }} {{ item }}
+    openssl dhparam {{ dhparam__openssl_options }} -out {{ dhparam__source_path + "/" + dhparam__prefix + item + dhparam__suffix }} {{ item }}
     {% endif %}
   args:
     creates: '{{ dhparam__source_path + "/" + dhparam__prefix + item + dhparam__suffix }}'


### PR DESCRIPTION
Allows passing optional parameters to the openssl dhparam generator.
This is useful for passing in options such as `-dsaparam` for faster
generation of keys.