### PR TITLE
Make sure that pandoc is present before release

### DIFF
--- a/lib/travis/build-sdist/before_install.sh
+++ b/lib/travis/build-sdist/before_install.sh
@@ -5,4 +5,5 @@ set -o nounset -o pipefail -o errexit
 # Prepare environment for building the Python packages
 
 sudo apt-get -qq update
+sudo apt-get -yq install python3-pypandoc
 pip3 install --upgrade pip wheel setuptools

--- a/lib/travis/build-sdist/before_install.sh
+++ b/lib/travis/build-sdist/before_install.sh
@@ -5,5 +5,5 @@ set -o nounset -o pipefail -o errexit
 # Prepare environment for building the Python packages
 
 sudo apt-get -qq update
-sudo apt-get -yq install python3-pypandoc
-pip3 install --upgrade pip wheel setuptools
+sudo apt-get -yq install pandoc
+pip3 install --upgrade pip wheel setuptools pypandoc

--- a/lib/travis/build-wheel/before_install.sh
+++ b/lib/travis/build-wheel/before_install.sh
@@ -5,4 +5,5 @@ set -o nounset -o pipefail -o errexit
 # Prepare environment for building the Python packages
 
 sudo apt-get -qq update
+sudo apt-get -yq install python3-pypandoc
 pip3 install --upgrade pip wheel setuptools

--- a/lib/travis/build-wheel/before_install.sh
+++ b/lib/travis/build-wheel/before_install.sh
@@ -5,5 +5,5 @@ set -o nounset -o pipefail -o errexit
 # Prepare environment for building the Python packages
 
 sudo apt-get -qq update
-sudo apt-get -yq install python3-pypandoc
-pip3 install --upgrade pip wheel setuptools
+sudo apt-get -yq install pandoc
+pip3 install --upgrade pip wheel setuptools pypandoc

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,11 @@ import subprocess
 
 try:
     import pypandoc
-    README = pypandoc.convert('README.md', 'rst')
+    README = pypandoc.convert_file('README.md', 'rst')
 except(IOError, ImportError):
-    README = open('README.md').read()
+    print('Error: The "pandoc" support is required to convert '
+          'the README.md to reStructuredText format')
+    raise
 
 try:
     unicode


### PR DESCRIPTION
The 'pandoc' package is required to convert the 'README.md' file to
reStructuredText for PyPI.