### PR TITLE
[debops.libvirtd] Reorder roles for idempotency

### DIFF
--- a/ansible/playbooks/service/libvirtd.yml
+++ b/ansible/playbooks/service/libvirtd.yml
@@ -15,6 +15,11 @@
       apt_preferences__dependent_list:
         - '{{ libvirtd__apt_preferences__dependent_list }}'
 
+    - role: debops.nsswitch
+      tags: [ 'role::nsswitch', 'skip::nsswitch' ]
+      nsswitch__dependent_services:
+        - '{{ libvirtd__nsswitch__dependent_services }}'
+
     - role: debops.ferm
       tags: [ 'role::ferm', 'skip::ferm' ]
       ferm__dependent_rules:
@@ -33,8 +38,3 @@
 
     - role: debops.libvirtd_qemu
       tags: [ 'role::libvirtd_qemu', 'skip::libvirtd_qemu', 'role::libvirtd', 'skip::libvirtd' ]
-
-    - role: debops.nsswitch
-      tags: [ 'role::nsswitch', 'skip::nsswitch' ]
-      nsswitch__dependent_services:
-        - '{{ libvirtd__nsswitch__dependent_services }}'


### PR DESCRIPTION
In the 'debops.libvirtd' playbook, the 'debops.nsswitch' role needs to
be applied before the 'debops.ferm' role, so that the 'debops.ferm' role
knows aboout the Avahi service installed prior, without the use of the
'debops.avahi' role. This fixes an issue with idempotent playbook
execution, where on the second run the 'debops.ferm' role "learns" about
Avahi being present via the 'nsswitch' local Ansible fact and configures
access for Avahi service, thus breaking the idempotency.

This is a quirk in the DebOps CI pipeline, but it might have application
in production environments as well.