### PR TITLE
[docs] Add git-crypt to additional software list

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,9 @@ General
     development; production code should be put in the :file:`ansible/roles/`
     and the :file:`ansible/playbooks/` directories respectively.
 
+- The :command:`debops-init` script now also creates the .gitattributes file
+  for use with :command:`git-crypt`. It is commented out by default.
+
 :ref:`debops.apt_install` role
 ''''''''''''''''''''''''''''''
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -226,6 +226,16 @@ Additional, useful software
 
 .. __: https://en.wikipedia.org/wiki/EncFS
 
+`git-crypt`__
+  You can use :command:`git-crypt` to transparently encrypt files in the
+  :file:`secret/` directory when committing to a Git repository. Unlike
+  ``EncFS``, the files are not encrypted on your local hard disk, and the path
+  names are not encrypted at all. The excellent 'Using git-crypt' section on
+  the website or in the `man page`__ will get you started.
+
+.. __: https://www.agwa.name/projects/git-crypt/
+.. __: https://manpages.debian.org/git-crypt.1
+
 ``uuidgen``
   This command is used to generate unique UUID strings for hosts which are then
   stored as Ansible facts. On Debian, it's available in the ``uuid-runtime``

--- a/bin/debops-init
+++ b/bin/debops-init
@@ -70,6 +70,11 @@ retry_files_enabled = False
 ;ssh_args = -o ControlMaster=auto -o ControlPersist=60s
 """
 
+DEFAULT_GITATTRIBUTES = """# Uncomment the lines below to encrypt your secrets with git-crypt
+#ansible/{SECRET_NAME}/** filter=git-crypt diff=git-crypt
+#{SECRET_NAME}/** filter=git-crypt diff=git-crypt
+"""
+
 DEFAULT_GITIGNORE = r"""\
 debops
 ansible.cfg
@@ -162,6 +167,9 @@ def write_config_files(project_root):
     # Create .debops.cfg
     write_file(os.path.join(project_root, DEBOPS_CONFIG),
                DEFAULT_DEBOPS_CONFIG)
+    # Create .gitattributes
+    write_file(os.path.join(project_root, '.gitattributes'),
+               DEFAULT_GITATTRIBUTES.format(SECRET_NAME=SECRET_NAME))
     # Create .gitignore
     write_file(os.path.join(project_root, '.gitignore'),
                DEFAULT_GITIGNORE.format(SECRET_NAME=SECRET_NAME,

--- a/bin/debops-init
+++ b/bin/debops-init
@@ -70,7 +70,8 @@ retry_files_enabled = False
 ;ssh_args = -o ControlMaster=auto -o ControlPersist=60s
 """
 
-DEFAULT_GITATTRIBUTES = """# Uncomment the lines below to encrypt your secrets with git-crypt
+DEFAULT_GITATTRIBUTES = """
+# Uncomment the lines below to encrypt your secrets with git-crypt
 #ansible/{SECRET_NAME}/** filter=git-crypt diff=git-crypt
 #{SECRET_NAME}/** filter=git-crypt diff=git-crypt
 """


### PR DESCRIPTION
Hey @drybjed, thanks for the suggestion to use git-crypt instead of EncFS! It's been working flawlessly for us. It's is a piece of cake to setup thanks to the 'Using git-crypt' section in the documentation. I suggest we add git-crypt to the 'Additional, useful software' section in the installation guide.