### PR TITLE
[debops.unattended_upgrades] Ensure valid reboot time generation

### DIFF
--- a/ansible/roles/debops.unattended_upgrades/defaults/main.yml
+++ b/ansible/roles/debops.unattended_upgrades/defaults/main.yml
@@ -277,7 +277,7 @@ unattended_upgrades__auto_reboot: False
 # Specify the time of the automatic reboot instead of ``now``.
 unattended_upgrades__auto_reboot_time: '{{ "02:30"
                                             if (ansible_virtualization_role in [ "host", "NA" ])
-                                            else "02:" + ((55 |random(seed=inventory_hostname, start=40))|string) }}'
+                                            else ("02:%02d"|format(55 |random(seed=inventory_hostname, start=40))) }}'
 
                                                                    # ]]]
 # .. envvar:: unattended_upgrades__bandwidth_limit [[[


### PR DESCRIPTION
Previously, if the user took this as an example and changed the parameters to the `random` Jinja2 filter, a time like "02:3" could have been generated.

With the default settings of the role, such a invalid time was not a concern because only the times from "02:40" to "02:54" (including start and end) where possible.

I have not tested how unattended_upgrades would behave with this invalid time.