### PR TITLE
[debops.dhcpd] Secure dhcpd configuration

### DIFF
--- a/ansible/roles/debops.dhcpd/tasks/main.yml
+++ b/ansible/roles/debops.dhcpd/tasks/main.yml
@@ -24,7 +24,7 @@
     dest: '/{{ item }}'
     owner: 'root'
     group: 'root'
-    mode: '0644'
+    mode: '0640'
   with_items: "{{ dhcpd_templates }}"
   notify: [ 'Restart dhcp server' ]
   register: dhcpd_register_config


### PR DESCRIPTION
The dhcpd.conf file used to be world-readable, which is a security
issue when nsupdate keys are stored in this file (see dhcpd_keys
variable). This change sets the file mode of the dhcpd configuration
files (/etc/default/isc-dhcp-server and /etc/dhcp/dhcpd.conf under
Debian) to 0640.