### PR TITLE
Fix DMZ ferm rule type with dport set

### DIFF
--- a/ansible/roles/debops.ferm/templates/etc/ferm/rules.d/rule.conf.j2
+++ b/ansible/roles/debops.ferm/templates/etc/ferm/rules.d/rule.conf.j2
@@ -97,6 +97,9 @@
 {%     endif %}
 {%     if config.port|d() or config.ports|d() %}
 {%       set _ = ferm__tpl_config.update({'dmz_ports': (debops__tpl_macros.flattened(config.port|d(config.ports))) | from_json }) %}
+{%       if ferm__tpl_config['dport'] == [] %}
+{%          set _ = ferm__tpl_config['dport'].extend(ferm__tpl_config['dmz_ports']) %}
+{%       endif %}
 {%     endif %}
 {%   endif %}
 {%   for interface in (debops__tpl_macros.flattened(config.interface_present|d(config.interfaces_present)) | from_json) %}
@@ -389,10 +392,10 @@
         table filter chain FORWARD {
 {%     if ferm__tpl_config['dmz_ports']|d() %}
             protocol ({{ ferm__tpl_config['protocol']|d([ 'tcp' ]) | join(" ") }}) {
-{%       if ferm__tpl_config['dmz_ports'] | length > 1 %}
-                mod multiport destination-ports ({{ ferm__tpl_config['dmz_ports'] | join(" ") }}) {
+{%       if ferm__tpl_config['dport'] | length > 1 %}
+                mod multiport destination-ports ({{ ferm__tpl_config['dport'] | join(" ") }}) {
 {%       else %}
-                dport ({{ ferm__tpl_config['dmz_ports'] | join(" ") }}) {
+                dport ({{ ferm__tpl_config['dport'] | join(" ") }}) {
 {%       endif %}
                     destination $PRIVATE_IP ACCEPT;
                 }


### PR DESCRIPTION
The filter rule in the FORWARD chain is traversed after the DNAT rule
in the PREROUTING chain. Thus the filter rule has to match on the
dport value instead of the port value.

This issue was already fixed in commit 7e247611ccb56476a86766c2707d198da1346c32
for the old dmz rule template.