### PR TITLE
[debops.icinga_db] Set fact interpreter to python3

### DIFF
--- a/ansible/roles/debops.icinga_db/templates/etc/ansible/facts.d/icinga_db.fact.j2
+++ b/ansible/roles/debops.icinga_db/templates/etc/ansible/facts.d/icinga_db.fact.j2
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!{{ ansible_python['executable'] }}
 
 # {{ ansible_managed }}
 

--- a/ansible/roles/debops.icinga_db/templates/etc/ansible/facts.d/icinga_db.fact.j2
+++ b/ansible/roles/debops.icinga_db/templates/etc/ansible/facts.d/icinga_db.fact.j2
@@ -30,7 +30,7 @@ def get_config(config_file):
             except AttributeError:
                 try:
                     config.read_string(config_string)
-                except:
+                except AttributeError:
                     # Python 2 compatibility
                     sbuffer = StringIO(config_string)
                     config.readfp(sbuffer)

--- a/ansible/roles/debops.icinga_db/templates/etc/ansible/facts.d/icinga_db.fact.j2
+++ b/ansible/roles/debops.icinga_db/templates/etc/ansible/facts.d/icinga_db.fact.j2
@@ -1,4 +1,4 @@
-#!{{ ansible_python['executable'] }}
+#!/usr/bin/env python3
 
 # {{ ansible_managed }}
 

--- a/ansible/roles/debops.icinga_db/templates/etc/ansible/facts.d/icinga_db.fact.j2
+++ b/ansible/roles/debops.icinga_db/templates/etc/ansible/facts.d/icinga_db.fact.j2
@@ -12,6 +12,12 @@ try:
 except ImportError:
     from ConfigParser import ConfigParser
 
+# Python 2 compatibility
+try:
+    from StringIO import StringIO
+except:
+    pass
+
 
 def get_config(config_file):
     config_data = []
@@ -22,7 +28,12 @@ def get_config(config_file):
             try:
                 config.read_string(config_string.decode('utf-8'))
             except AttributeError:
-                config.read_string(config_string)
+                try:
+                    config.read_string(config_string)
+                except:
+                    # Python 2 compatibility
+                    sbuffer = StringIO(config_string)
+                    config.readfp(sbuffer)
 
             for section in config.sections():
 

--- a/ansible/roles/debops.icinga_db/templates/etc/ansible/facts.d/icinga_db.fact.j2
+++ b/ansible/roles/debops.icinga_db/templates/etc/ansible/facts.d/icinga_db.fact.j2
@@ -15,7 +15,7 @@ except ImportError:
 # Python 2 compatibility
 try:
     from StringIO import StringIO
-except:
+except ImportError:
     pass
 
 


### PR DESCRIPTION
The icinga_db fact script fails when run with Python 2. Because of this, the icinga_web role does not set up the database backend correctly, resulting in a broken installation. This commit changes the interpreter to Python 3 which works fine.

This is the error I got when running the fact script with Python 2:
```
Traceback (most recent call last):
  File "/etc/ansible/facts.d/icinga_db.fact", line 50, in <module>
    output.update(get_config(config_file))
  File "/etc/ansible/facts.d/icinga_db.fact", line 25, in get_config
    config.read_string(config_string)
AttributeError: ConfigParser instance has no attribute 'read_string'
```