### PR TITLE
[debops.python] Fix raw release version detection

### DIFF
--- a/ansible/roles/debops.python/defaults/main.yml
+++ b/ansible/roles/debops.python/defaults/main.yml
@@ -123,7 +123,7 @@ python__v2: '{{ ansible_local.python.installed2
                       if ((ansible_python_interpreter|d("")).endswith("python") or
                           (discovered_interpreter_python|d("")).endswith("python") or
                            (python__register_raw_release|d() and
-                            python__register_raw_release.stdout|d("") in
+                            (python__register_raw_release.stdout|d("")).strip() in
                             [ "wheezy", "jessie", "stretch",
                               "precise", "trusty", "xenial" ]))
                       else False) }}'

--- a/ansible/roles/debops.python/raw/tasks/main.yml
+++ b/ansible/roles/debops.python/raw/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Detect the OS release manually, no Ansible facts available
-  raw: grep -E '^VERSION=' /etc/os-release | tr -d '(")' | cut -d" " -f2 | tr -d '\n'
+  raw: grep -E '^VERSION=' /etc/os-release | tr -d '(")' | cut -d" " -f2
   register: python__register_raw_release
   changed_when: False
   check_mode: False


### PR DESCRIPTION
Before, I got the following:

```
ok: [gnu.example.net] => {
    "python__register_raw_release": {
        "changed": false,
        "failed": false,
        "rc": 0,
        "stderr": "Connection to gnu.example.net closed.\r\n",
        "stderr_lines": [
            "Connection to gnu.example.net closed."
        ],
        "stdout": "\r\nbuster",
        "stdout_lines": [
            "",
            "buster"
        ]
    }
}
```