### PR TITLE
[debops.gitlab_runner] Use new docker_server facts

### DIFF
--- a/ansible/roles/debops.gitlab_runner/defaults/main.yml
+++ b/ansible/roles/debops.gitlab_runner/defaults/main.yml
@@ -117,8 +117,9 @@ gitlab_runner__shell: '/bin/bash'
 #
 # Global number of jobs that can run concurrently on all configured runners.
 gitlab_runner__concurrent: '{{ ansible_processor_vcpus
-                               if (ansible_local|d() and ansible_local.docker|d() and
-                                   (ansible_local.docker.installed|d()) | bool)
+                               if (ansible_local|d() and
+                                   ansible_local.docker_server|d() and
+                                   (ansible_local.docker_server.installed|d()) | bool)
                                else "1" }}'
 
                                                                    # ]]]
@@ -251,8 +252,8 @@ gitlab_runner__default_instances:
     executor: 'shell'
     run_untagged: False
     state: '{{ "absent"
-               if (ansible_local|d() and ansible_local.docker|d() and
-                   (ansible_local.docker.installed|d()) | bool)
+               if (ansible_local|d() and ansible_local.docker_server|d() and
+                   (ansible_local.docker_server.installed|d()) | bool)
                else "present" }}'
 
   - name: '{{ ansible_hostname + "-docker" }}'
@@ -260,7 +261,7 @@ gitlab_runner__default_instances:
     tags: [ 'docker' ]
     state: '{{ "present"
                if (ansible_local|d() and ansible_local.docker|d() and
-                   (ansible_local.docker.installed|d()) | bool)
+                   (ansible_local.docker_server.installed|d()) | bool)
                else "absent" }}'
 
   - name: '{{ ansible_hostname + "-docker-root" }}'
@@ -270,8 +271,8 @@ gitlab_runner__default_instances:
     run_untagged: False
     tags: [ 'docker-privileged' ]
     state: '{{ "present"
-               if (ansible_local|d() and ansible_local.docker|d() and
-                   (ansible_local.docker.installed|d()) | bool)
+               if (ansible_local|d() and ansible_local.docker_server|d() and
+                   (ansible_local.docker_server.installed|d()) | bool)
                else "absent" }}'
 
                                                                    # ]]]

--- a/ansible/roles/debops.gitlab_runner/tasks/main.yml
+++ b/ansible/roles/debops.gitlab_runner/tasks/main.yml
@@ -28,8 +28,8 @@
     name: '{{ gitlab_runner__user }}'
     groups: 'docker'
     append: True
-  when: (ansible_local|d() and ansible_local.docker|d() and
-         (ansible_local.docker.installed|d()) | bool)
+  when: (ansible_local|d() and ansible_local.docker_server|d() and
+         (ansible_local.docker_server.installed|d()) | bool)
 
 - name: Copy custom files to GitLab Runner host
   copy:

--- a/ansible/roles/debops.gitlab_runner/templates/lookup/gitlab_runner__shell_tags.j2
+++ b/ansible/roles/debops.gitlab_runner/templates/lookup/gitlab_runner__shell_tags.j2
@@ -5,8 +5,8 @@
 {% if (ansible_local|d() and ansible_local.tags|d()) %}
 {%   set _ = output.extend(ansible_local.tags) %}
 {% endif %}
-{% if (ansible_local|d() and ansible_local.docker|d() and
-       (ansible_local.docker.installed|d()) | bool) %}
+{% if (ansible_local|d() and ansible_local.docker_server|d() and
+       (ansible_local.docker_server.installed|d()) | bool) %}
 {%   set _ = output.append('docker-host') %}
 {% endif %}
 {% if (ansible_local|d() and ansible_local.lxc|d() and


### PR DESCRIPTION
`debops.gitlab_runner` used to use the `debops.docker` local facts to
determine if the Docker daemon was installed. The `debops.docker` role
has been renamed to `debops.docker_server`. These changes make sure
that `debops.gitlab_runner` uses the new local facts.

A quick `grep` shows that this is the only other role where Docker local facts are used.