### PR TITLE
[debops.gitlab] Fix usage without LDAP

### DIFF
--- a/ansible/roles/debops.gitlab/defaults/main.yml
+++ b/ansible/roles/debops.gitlab/defaults/main.yml
@@ -832,7 +832,7 @@ gitlab__ldap_label: 'LDAP'
 gitlab__ldap_host: '{{ (ansible_local.ldap.hosts
                         if (ansible_local|d() and ansible_local.ldap|d() and
                             ansible_local.ldap.hosts|d())
-                        else []) | first }}'
+                        else [""]) | first }}'
 
                                                                    # ]]]
 # .. envvar:: gitlab__ldap_port [[[


### PR DESCRIPTION
This patch fixes the error "No first item, sequence was empty" during
configuration file generation.