### PR TITLE
[debops.resolvconf] Get upstream nameservers when using systemd-resolved

### DIFF
--- a/ansible/roles/debops.resolvconf/templates/etc/ansible/facts.d/resolvconf.fact.j2
+++ b/ansible/roles/debops.resolvconf/templates/etc/ansible/facts.d/resolvconf.fact.j2
@@ -13,6 +13,26 @@ def cmd_exists(cmd):
         for path in os.environ["PATH"].split(os.pathsep)
     )
 
+def read_resolv_file(file):
+    try:
+        with open(file, 'r') as f:
+            nameservers = []
+            domain = ''
+            search = []
+            for line in f:
+                if line.startswith('nameserver'):
+                    nameservers.append(line.strip().split()[1])
+                elif line.startswith('domain'):
+                    domain = line.strip().split()[1]
+                elif line.startswith('search'):
+                    for element in line.strip().split()[1:]:
+                        search.append(element.rstrip('.'))
+
+            return nameservers, domain, search
+
+    except Exception:
+        pass
+
 
 output = loads('''{{ {"configured": True,
                       "deploy_state": resolvconf__deploy_state
@@ -24,37 +44,21 @@ if not output['installed']:
     output['deploy_state'] = 'absent'
 
 # Get the primary resolver configuration
-try:
-    with open('/etc/resolv.conf', 'r') as f:
-        nameservers = []
-        domain = ''
-        search = []
-        for line in f:
-            if line.startswith('nameserver'):
-                nameservers.append(line.strip().split()[1])
-            elif line.startswith('domain'):
-                domain = line.strip().split()[1]
-            elif line.startswith('search'):
-                for element in line.strip().split()[1:]:
-                    search.append(element.rstrip('.'))
+nameservers, domain, search = read_resolv_file('/etc/resolv.conf')
 
-        if nameservers:
-            output['nameservers'] = nameservers
-        if domain:
-            output['domain'] = domain
-        if search:
-            output['search'] = search
-
-except Exception:
-    pass
+if nameservers:
+    output['nameservers'] = nameservers
+if domain:
+    output['domain'] = domain
+if search:
+    output['search'] = search
 
 # Get the upstream resolver configuration
+upstream_nameservers = []
 resolvconf_path = '/run/resolvconf/interface'
 if os.path.isdir(resolvconf_path):
     resolvconf_files = ([f for f in os.listdir(resolvconf_path)
                          if os.path.isfile(os.path.join(resolvconf_path, f))])
-
-    upstream_nameservers = []
 
     for element in resolvconf_files:
         try:
@@ -68,7 +72,18 @@ if os.path.isdir(resolvconf_path):
         except Exception:
             pass
 
-    if '127.0.0.1' in output['nameservers'] and upstream_nameservers:
-        output['upstream_nameservers'] = upstream_nameservers
+# Get the upstream resolvers from systemd-resolved
+systemdresolved_path = '/run/systemd/resolve/resolv.conf'
+if os.path.isfile(systemdresolved_path):
+    nameservers, domain, search = read_resolv_file(systemdresolved_path)
+
+    for server in nameservers:
+        if not server.startswith('127.'):
+            upstream_nameservers.append(server)
+
+
+# 127.0.0.53 is the stub address used by systemd-resolved
+if ('127.0.0.1' in output['nameservers'] or '127.0.0.53' in output['nameservers']) and upstream_nameservers:
+    output['upstream_nameservers'] = upstream_nameservers
 
 print(dumps(output, sort_keys=True, indent=4))

--- a/ansible/roles/debops.resolvconf/templates/etc/ansible/facts.d/resolvconf.fact.j2
+++ b/ansible/roles/debops.resolvconf/templates/etc/ansible/facts.d/resolvconf.fact.j2
@@ -87,9 +87,8 @@ if os.path.isfile(systemdresolved_path):
 # - 127.0.0.1 is the stub address used by resolvconf
 # - 127.0.0.53 is the stub address used by systemd-resolved
 if (('127.0.0.1' in output['nameservers'] or
-    '127.0.0.53' in output['nameservers']) and
-    upstream_nameservers):
-
+        '127.0.0.53' in output['nameservers']) and
+        upstream_nameservers):
     output['upstream_nameservers'] = upstream_nameservers
 
 print(dumps(output, sort_keys=True, indent=4))

--- a/ansible/roles/debops.resolvconf/templates/etc/ansible/facts.d/resolvconf.fact.j2
+++ b/ansible/roles/debops.resolvconf/templates/etc/ansible/facts.d/resolvconf.fact.j2
@@ -13,6 +13,7 @@ def cmd_exists(cmd):
         for path in os.environ["PATH"].split(os.pathsep)
     )
 
+
 def read_resolv_file(file):
     try:
         with open(file, 'r') as f:
@@ -81,9 +82,14 @@ if os.path.isfile(systemdresolved_path):
         if not server.startswith('127.'):
             upstream_nameservers.append(server)
 
+# If nameservers contains a localhost address, and we've found some
+# upstream nameservers, then output the upstream nameservers.
+# - 127.0.0.1 is the stub address used by resolvconf
+# - 127.0.0.53 is the stub address used by systemd-resolved
+if (('127.0.0.1' in output['nameservers'] or
+    '127.0.0.53' in output['nameservers']) and
+    upstream_nameservers):
 
-# 127.0.0.53 is the stub address used by systemd-resolved
-if ('127.0.0.1' in output['nameservers'] or '127.0.0.53' in output['nameservers']) and upstream_nameservers:
     output['upstream_nameservers'] = upstream_nameservers
 
 print(dumps(output, sort_keys=True, indent=4))


### PR DESCRIPTION
Fixes #1078