### PR TITLE
Fix owncloud occ programm interpreting the key and values of the command as parameters to itself.

### DIFF
--- a/ansible/roles/debops.owncloud/tasks/ldap.yml
+++ b/ansible/roles/debops.owncloud/tasks/ldap.yml
@@ -33,7 +33,7 @@
   when: owncloud__register_local_facts_ldap is changed
 
 - name: Configure LDAP parameters
-  command: php --file "{{ owncloud__app_home }}/occ" ldap:set-config "{{ owncloud__ldap_config_id }}" "{{ item.name }}" "{{ item.value }}"
+  command: php --file "{{ owncloud__app_home }}/occ" ldap:set-config "{{ owncloud__ldap_config_id }}" "'{{ item.name }}'" "'{{ item.value }}'"
   changed_when: False
   become: True
   become_user: '{{ owncloud__app_user }}'


### PR DESCRIPTION
This problem occurs, when for example the LDAP service password for owncloud contains a dash ("-") as the first character :D Then the occ programm will interpret the password, which should be a value, as a parameter and then fail.
Therefore by putting the key and value in apostrophes solves the issue.