### PR TITLE
[debops.owncloud] Limit LDAP password characters

### DIFF
--- a/ansible/roles/debops.owncloud/defaults/main.yml
+++ b/ansible/roles/debops.owncloud/defaults/main.yml
@@ -1246,7 +1246,8 @@ owncloud__ldap_binddn: '{{ ([ owncloud__ldap_self_rdn ] + owncloud__ldap_device_
 # The password stored in the account LDAP object used by the Nextcloud service
 # to bind to the LDAP directory.
 owncloud__ldap_bindpw: '{{ lookup("password", secret + "/ldap/credentials/"
-                                  + owncloud__ldap_binddn | to_uuid + ".password length=32") }}'
+                                  + owncloud__ldap_binddn | to_uuid + ".password length=32 "
+                                  + "chars=alpha,digits,!@_#$%^&*") }}'
 
                                                                    # ]]]
 # .. envvar:: owncloud__ldap_uri [[[


### PR DESCRIPTION
This patch specifies what characters can be used in the Nextcloud LDAP
password string. This should fix an error where a password with '-' at
the beginning is interpreted as the 'occ' script option.

Fixes #1092