### PR TITLE
[debops.owncloud] Switch double quotes to single

### DIFF
--- a/ansible/roles/debops.owncloud/tasks/ldap.yml
+++ b/ansible/roles/debops.owncloud/tasks/ldap.yml
@@ -33,7 +33,7 @@
   when: owncloud__register_local_facts_ldap is changed
 
 - name: Configure LDAP parameters
-  command: php --file "{{ owncloud__app_home }}/occ" ldap:set-config "{{ owncloud__ldap_config_id }}" "{{ item.name }}" "{{ item.value }}"
+  command: php --file '{{ owncloud__app_home }}/occ' ldap:set-config '{{ owncloud__ldap_config_id }}' '{{ item.name }}' '{{ item.value }}'
   changed_when: False
   become: True
   become_user: '{{ owncloud__app_user }}'


### PR DESCRIPTION
This change should ensure that the strings provided by Ansible to the
shell are not interpreted by the shell by mistake - for example
a randomly generated password could contain a '$' character that could
be interpreted as a variable name.