### PR TITLE
[debops-tools] set yaml as default stdout_callback

### DIFF
--- a/bin/debops-init
+++ b/bin/debops-init
@@ -60,6 +60,7 @@ DEFAULT_DEBOPS_CONFIG = """
 [ansible defaults]
 display_skipped_hosts = False
 retry_files_enabled = False
+stdout_callback = yaml
 ;callback_plugins = /my/plugins/callback
 ;roles_path = /my/roles
 


### PR DESCRIPTION
Really improve display of errors in tasks.