### PR TITLE
[debops.owncloud] Fix when running playbook with --tags role::nginx

### DIFF
--- a/ansible/roles/debops.owncloud/tasks/setup_owncloud.yml
+++ b/ansible/roles/debops.owncloud/tasks/setup_owncloud.yml
@@ -132,7 +132,7 @@
   loop_control:
     loop_var: 'owncloud__apps_item'
   with_dict: '{{ owncloud__apps_config_combined|d({}) }}'
-  when: (owncloud__do_autosetup|bool and not ansible_check_mode)
+  when: (owncloud__do_autosetup|d()|bool and not ansible_check_mode)
   tags: [ 'role::owncloud:occ_config' ]
 
 # .. ]]]


### PR DESCRIPTION
`owncloud__do_autosetup` is set by a `set_fact` task which is not run with `role::nginx` for example.


fatal: [cloud.example.org]: FAILED! => {"msg": "The conditional check '(owncloud__do_autosetup|bool and not ansible_check_mode)' failed. The error was: error while evaluating conditional ((owncloud__do_autosetup|bool and not ansible_check_mode)): 'owncloud__do_autosetup' is undefined\n\nThe error appears to have been in '/home/user/.ansible/ypid-ansible-common/submodules/debops/ansible/roles/debops.owncloud/tasks/setup_owncloud.yml': line 130, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Set ownCloud apps configuration for each app\n  ^ here\n"}

Related to: #1112