### PR TITLE
[debops.nginx] Fix custom location try_files bug

### DIFF
--- a/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/php.conf.j2
+++ b/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/php.conf.j2
@@ -90,7 +90,7 @@
                 limit_except {{ item.php_limit_except if item.php_limit_except is string else item.php_limit_except | join(' ') }} { deny all; }
 
 {%     endif %}
-                try_files $script_name =404;
+                try_files {{ (([ item.try_files ] if item.try_files is string else item.try_files) if item.try_files|d() else ["$script_name =404"]) | join(' ') }};
 
 {%     if (item.php_include is undefined or item.php_include|d()) %}
                 include {{ item.php_include | default('fastcgi_params') }};


### PR DESCRIPTION
I've tried to fix #1119 bug. I've saved the existing config if there is no `try_files` defined. Please let me know if something is wrong.