### PR TITLE
[debops.hashicorp] Local facts template py3 compat

### DIFF
--- a/ansible/roles/debops.hashicorp/templates/etc/ansible/facts.d/hashicorp.fact.j2
+++ b/ansible/roles/debops.hashicorp/templates/etc/ansible/facts.d/hashicorp.fact.j2
@@ -1,12 +1,12 @@
-{% set hashicorp__tpl_application_list = ((ansible_local.hashicorp.applications.keys() if (ansible_local|d() and ansible_local.hashicorp|d() and ansible_local.hashicorp.applications|d()) else []) + hashicorp__applications + hashicorp__dependent_applications) | sort | unique %}
+{% set hashicorp__tpl_application_list = ((ansible_local.hashicorp.applications|list if (ansible_local|d() and ansible_local.hashicorp|d() and ansible_local.hashicorp.applications|d()) else []) + hashicorp__applications + hashicorp__dependent_applications) | sort | unique %}
 {% set hashicorp__tpl_applications = {} %}
 {% for entry in hashicorp__tpl_application_list %}
-{%   if (ansible_local|d() and ansible_local.hashicorp|d() and ansible_local.hashicorp.applications|d() and entry in ansible_local.hashicorp.applications.keys()) %}
+{%   if (ansible_local|d() and ansible_local.hashicorp|d() and ansible_local.hashicorp.applications|d() and entry in ansible_local.hashicorp.applications) %}
 {%     set _ = hashicorp__tpl_applications.update({ entry : ansible_local.hashicorp.applications[entry] }) %}
-{%   elif entry in hashicorp__combined_version_map.keys() %}
+{%   elif entry in hashicorp__combined_version_map %}
 {%     set _ = hashicorp__tpl_applications.update({ entry : hashicorp__combined_version_map[entry] }) %}
 {%   endif %}
-{%   if (entry in hashicorp__combined_version_map.keys() and (hashicorp__tpl_applications[entry] != hashicorp__combined_version_map[entry])) %}
+{%   if (entry in hashicorp__combined_version_map and (hashicorp__tpl_applications[entry] != hashicorp__combined_version_map[entry])) %}
 {%     set _ = hashicorp__tpl_applications.update({ entry : hashicorp__combined_version_map[entry] }) %}
 {%   endif %}
 {% endfor %}


### PR DESCRIPTION
The `debops.hashicorp` local facts Jinja2 template is not Python 3
compatible. Specifically, the keys() operation on the local facts
applications dictionary produces a dict_keys object which is then
attempted to merge with the hashicorp__applications and
hashicorp__dependent_applications lists. This results in a Jinja2
templating error: "unsupported operand type(s) for +: 'dict_keys' and
'list'"

These changes add the "|list" Jinja2 filter to the local fact
dictionary, ensuring supported "+" operation. They also remove the
redundant keys() operations. This solution seems to work fine with both
Python 2.7 and 3.7.

Closes: #1115