### PR TITLE
[debops.rsyslog] Fix setting perimssions on /var/log

### DIFF
--- a/ansible/roles/debops.rsyslog/tasks/main.yml
+++ b/ansible/roles/debops.rsyslog/tasks/main.yml
@@ -45,8 +45,9 @@
   shell: |
     [ ! -d {{ rsyslog__home }} ] \
       || ( [ "$(stat -c '%G' {{ rsyslog__home }})" = "{{ rsyslog__group }}" ] \
-             || ( chown -v root:{{ rsyslog__group }} {{ rsyslog__home }} ; \
-                  chmod -v 775 {{ rsyslog__home }} ) )
+             || chown -v root:{{ rsyslog__group }} {{ rsyslog__home }} ; \
+           [ "$(stat -c '%a' {{ rsyslog__home }})" = "775" ] \
+             || chmod -v 775 {{ rsyslog__home }} )
     for i in {{ rsyslog__default_logfiles | join(" ") }} ; do
       [ ! -f ${i} ] || \
         ( [ "$(stat -c '%U' ${i})" = "{{ rsyslog__file_owner }}" ] \


### PR DESCRIPTION
The command to update directory and file permissions only changed the
permissions on /var/log if the group was not correct. If the group was
correct but the permissions were wrong, the permissions were not fixed.
As the group for /var/log is already fixed when creating the the system
group, the permissions stayed wrong.

This is fixed by adding an independent check for the permissions and
fixing them if they don't match.