### PR TITLE
[debops.slapd] LDAP ACL reorganization

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -129,6 +129,15 @@ LDAP
 - The Access Control List rules can now be tested using the :man:`slapacl(8)`
   command via a generated :ref:`test suite script <slapd__ref_acl_tests>`.
 
+- The default ACL rules have been overhauled to add support for the
+  ``ou=Roles,dc=example,dc=org`` subtree and use of the ``organizationalRole``
+  LDAP objects for authorization. The old set of rules is still active to
+  ensure that the existing environments work as expected.
+
+  If you use a modified ACL configuration, you should include the new rules as
+  well to ensure that changes in the :ref:`debops.ldap` support are working
+  correctly.
+
 :ref:`debops.unbound` role
 ''''''''''''''''''''''''''
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -138,6 +138,11 @@ LDAP
   well to ensure that changes in the :ref:`debops.ldap` support are working
   correctly.
 
+- You can now hide specific LDAP objects from unprivileged users by adding them
+  to a special ``cn=Hidden Objects,ou=Groups,dc=example,dc=org`` LDAP group.
+  The required ACL rule will be enabled by default; the objects used to control
+  visibility will be created by the :file:`ldap/init-directory.yml` playbook.
+
 :ref:`debops.unbound` role
 ''''''''''''''''''''''''''
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -371,6 +371,9 @@ LDAP
   attributes has been restricted to privileged accounts only (administrators,
   entry owner). The values cannot be seen by unprivileged and anonymous users.
 
+- Write access to the ``ou=SUDOers,dc=example,dc=org`` LDAP subtree has been
+  restricted to the members of the "UNIX Administrators" LDAP group.
+
 :ref:`debops.sshd` role
 '''''''''''''''''''''''
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -367,6 +367,10 @@ LDAP
   ``ou=People,dc=example,dc=org`` LDAP subtree to globally unique, due to its
   use for authentication purposes. The attribute will be indexed by default.
 
+- Access to the ``carLicense``, ``homePhone`` and ``homePostalAddress``
+  attributes has been restricted to privileged accounts only (administrators,
+  entry owner). The values cannot be seen by unprivileged and anonymous users.
+
 :ref:`debops.sshd` role
 '''''''''''''''''''''''
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -197,6 +197,26 @@ General
 
   in the :file:`.debops.cfg` configuration file.
 
+LDAP
+''''
+
+- The :file:`ldap/init-directory.yml` playbook has been updated to use the new
+  ``ou=Roles,dc=example,dc=org`` LDAP subtree, which will contain various
+  ``organizationalRole`` objects. After updating the OpenLDAP Access Control
+  List using the :ref:`debops.slapd` role, you can use the playbook on an
+  existing installation to create the missing objects.
+
+  The ``cn=UNIX Administrators`` and ``cn=UNIX SSH users`` LDAP objects will be
+  created in the ``ou=Groups,dc=example,dc=org`` LDAP subtree. On existing
+  installations, these objects need to be moved manually to the new subtree,
+  otherwise the playbook will try to create them and fail due to duplicate
+  UID/GID numbers which are enforced to be unique. You can move the objects
+  using an LDAP client, for example Apache Directory Studio.
+
+  The ``ou=System Groups,dc=example=dc,org`` subtree will not be created
+  anymore. On existing installations this subtree will be left intact and can
+  be safely removed after migration.
+
 :ref:`debops.apt_preferences` role
 ''''''''''''''''''''''''''''''''''
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -143,6 +143,10 @@ LDAP
   The required ACL rule will be enabled by default; the objects used to control
   visibility will be created by the :file:`ldap/init-directory.yml` playbook.
 
+- New "SMS Gateway" LDAP role grants read-only access to the ``mobile``
+  attribute by SMS gateways. This is needed for implementing 2-factor
+  authentication via SMS messages.
+
 :ref:`debops.unbound` role
 ''''''''''''''''''''''''''
 

--- a/ansible/playbooks/ldap/init-directory.yml
+++ b/ansible/playbooks/ldap/init-directory.yml
@@ -72,10 +72,6 @@
         state: 'absent'
         entry_state: 'absent'
 
-      - name: 'Create the {{ ldap__system_groups_rdn }} object'
-        dn: '{{ [ ldap__system_groups_rdn ] + ldap__base_dn }}'
-        objectClass: 'organizationalUnit'
-
       - name: 'Create the {{ ldap__groups_rdn }} object'
         dn: '{{ [ ldap__groups_rdn ] + ldap__base_dn }}'
         objectClass: 'organizationalUnit'
@@ -90,6 +86,10 @@
 
       - name: 'Create the {{ ldap__people_rdn }} object'
         dn: '{{ [ ldap__people_rdn ] + ldap__base_dn }}'
+        objectClass: 'organizationalUnit'
+
+      - name: 'Create the {{ ldap__roles_rdn }} object'
+        dn: '{{ [ ldap__roles_rdn ] + ldap__base_dn }}'
         objectClass: 'organizationalUnit'
 
       - name: 'Create the {{ ldap__services_rdn }} object'
@@ -147,35 +147,30 @@
           host: '*'
           sshPublicKey: '{{ admin_sshkeys }}'
 
-      - name: 'Create cn=LDAP Administrators group'
-        dn: '{{ [ "cn=LDAP Administrators", ldap__system_groups_rdn ] + ldap__base_dn }}'
-        objectClass: 'groupOfNames'
+      - name: 'Create cn=LDAP Administrators role'
+        dn: '{{ [ "cn=LDAP Administrators", ldap__roles_rdn ] + ldap__base_dn }}'
+        objectClass: 'organizationalRole'
         attributes:
           cn: 'LDAP Administrators'
-          member: '{{ admin_dn }}'
-          owner: '{{ admin_dn }}'
+          roleOccupant: '{{ admin_dn }}'
           description: 'People responsible for LDAP infrastructure'
 
-      - name: 'Create cn=LDAP Replicators group'
-        dn: '{{ [ "cn=LDAP Replicators", ldap__system_groups_rdn ] + ldap__base_dn }}'
-        objectClass: 'groupOfNames'
+      - name: 'Create cn=LDAP Replicators role'
+        dn: '{{ [ "cn=LDAP Replicators", ldap__roles_rdn ] + ldap__base_dn }}'
+        objectClass: 'organizationalRole'
         attributes:
           cn: 'LDAP Replicators'
-          member: '{{ admin_dn }}'
-          owner: '{{ admin_dn }}'
           description: 'Service accounts used for LDAP replication'
 
-      - name: 'Create cn=LDAP Editors group'
-        dn: '{{ [ "cn=LDAP Editors", ldap__system_groups_rdn ] + ldap__base_dn }}'
-        objectClass: 'groupOfNames'
+      - name: 'Create cn=LDAP Editors role'
+        dn: '{{ [ "cn=LDAP Editors", ldap__roles_rdn ] + ldap__base_dn }}'
+        objectClass: 'organizationalRole'
         attributes:
           cn: 'LDAP Editors'
-          member: '{{ admin_dn }}'
-          owner: '{{ admin_dn }}'
           description: 'People responsible for LDAP contents'
 
       - name: 'Create cn=UNIX Administrators group'
-        dn: '{{ [ "cn=UNIX Administrators", ldap__system_groups_rdn ] + ldap__base_dn }}'
+        dn: '{{ [ "cn=UNIX Administrators", ldap__groups_rdn ] + ldap__base_dn }}'
         objectClass: [ 'groupOfNames', 'posixGroup', 'posixGroupId',
                        'authorizedServiceObject', 'hostObject' ]
         attributes:
@@ -188,26 +183,22 @@
           authorizedService: '*'
           host: '*'
 
-      - name: 'Create cn=Account Administrators group'
-        dn: '{{ [ "cn=Account Administrators", ldap__system_groups_rdn ] + ldap__base_dn }}'
-        objectClass: 'groupOfNames'
+      - name: 'Create cn=Account Administrators role'
+        dn: '{{ [ "cn=Account Administrators", ldap__roles_rdn ] + ldap__base_dn }}'
+        objectClass: 'organizationalRole'
         attributes:
           cn: 'Account Administrators'
-          member: '{{ admin_dn }}'
-          owner: '{{ admin_dn }}'
           description: 'People responsible for personal accounts'
 
-      - name: 'Create cn=Password Reset Agents group'
-        dn: '{{ [ "cn=Password Reset Agents", ldap__system_groups_rdn ] + ldap__base_dn }}'
-        objectClass: 'groupOfNames'
+      - name: 'Create cn=Password Reset Agents role'
+        dn: '{{ [ "cn=Password Reset Agents", ldap__roles_rdn ] + ldap__base_dn }}'
+        objectClass: 'organizationalRole'
         attributes:
           cn: 'Password Reset Agents'
-          member: '{{ admin_dn }}'
-          owner: '{{ admin_dn }}'
           description: 'Services that can perform password changes on behalf of users'
 
       - name: 'Create cn=UNIX SSH users group'
-        dn: '{{ [ "cn=UNIX SSH users", ldap__system_groups_rdn ] + ldap__base_dn }}'
+        dn: '{{ [ "cn=UNIX SSH users", ldap__groups_rdn ] + ldap__base_dn }}'
         objectClass: [ 'groupOfNames', 'posixGroup', 'posixGroupId',
                        'authorizedServiceObject', 'hostObject' ]
         attributes:

--- a/ansible/playbooks/ldap/init-directory.yml
+++ b/ansible/playbooks/ldap/init-directory.yml
@@ -197,6 +197,13 @@
           cn: 'Password Reset Agent'
           description: 'Services that can perform password changes on behalf of users'
 
+      - name: 'Create cn=SMS Gateway role'
+        dn: '{{ [ "cn=SMS Gateway", ldap__roles_rdn ] + ldap__base_dn }}'
+        objectClass: 'organizationalRole'
+        attributes:
+          cn: 'SMS Gateway'
+          description: 'Devices which send SMS messages to mobile numbers'
+
       - name: 'Create cn=Hidden Object Viewer role'
         dn: '{{ [ "cn=Hidden Object Viewer", ldap__roles_rdn ] + ldap__base_dn }}'
         objectClass: 'organizationalRole'

--- a/ansible/playbooks/ldap/init-directory.yml
+++ b/ansible/playbooks/ldap/init-directory.yml
@@ -147,26 +147,26 @@
           host: '*'
           sshPublicKey: '{{ admin_sshkeys }}'
 
-      - name: 'Create cn=LDAP Administrators role'
-        dn: '{{ [ "cn=LDAP Administrators", ldap__roles_rdn ] + ldap__base_dn }}'
+      - name: 'Create cn=LDAP Administrator role'
+        dn: '{{ [ "cn=LDAP Administrator", ldap__roles_rdn ] + ldap__base_dn }}'
         objectClass: 'organizationalRole'
         attributes:
-          cn: 'LDAP Administrators'
+          cn: 'LDAP Administrator'
           roleOccupant: '{{ admin_dn }}'
           description: 'People responsible for LDAP infrastructure'
 
-      - name: 'Create cn=LDAP Replicators role'
-        dn: '{{ [ "cn=LDAP Replicators", ldap__roles_rdn ] + ldap__base_dn }}'
+      - name: 'Create cn=LDAP Replicator role'
+        dn: '{{ [ "cn=LDAP Replicator", ldap__roles_rdn ] + ldap__base_dn }}'
         objectClass: 'organizationalRole'
         attributes:
-          cn: 'LDAP Replicators'
+          cn: 'LDAP Replicator'
           description: 'Service accounts used for LDAP replication'
 
-      - name: 'Create cn=LDAP Editors role'
-        dn: '{{ [ "cn=LDAP Editors", ldap__roles_rdn ] + ldap__base_dn }}'
+      - name: 'Create cn=LDAP Editor role'
+        dn: '{{ [ "cn=LDAP Editor", ldap__roles_rdn ] + ldap__base_dn }}'
         objectClass: 'organizationalRole'
         attributes:
-          cn: 'LDAP Editors'
+          cn: 'LDAP Editor'
           description: 'People responsible for LDAP contents'
 
       - name: 'Create cn=UNIX Administrators group'
@@ -183,25 +183,25 @@
           authorizedService: '*'
           host: '*'
 
-      - name: 'Create cn=Account Administrators role'
-        dn: '{{ [ "cn=Account Administrators", ldap__roles_rdn ] + ldap__base_dn }}'
+      - name: 'Create cn=Account Administrator role'
+        dn: '{{ [ "cn=Account Administrator", ldap__roles_rdn ] + ldap__base_dn }}'
         objectClass: 'organizationalRole'
         attributes:
-          cn: 'Account Administrators'
+          cn: 'Account Administrator'
           description: 'People responsible for personal accounts'
 
-      - name: 'Create cn=Password Reset Agents role'
-        dn: '{{ [ "cn=Password Reset Agents", ldap__roles_rdn ] + ldap__base_dn }}'
+      - name: 'Create cn=Password Reset Agent role'
+        dn: '{{ [ "cn=Password Reset Agent", ldap__roles_rdn ] + ldap__base_dn }}'
         objectClass: 'organizationalRole'
         attributes:
-          cn: 'Password Reset Agents'
+          cn: 'Password Reset Agent'
           description: 'Services that can perform password changes on behalf of users'
 
-      - name: 'Create cn=Hidden Object Viewers role'
-        dn: '{{ [ "cn=Hidden Object Viewers", ldap__roles_rdn ] + ldap__base_dn }}'
+      - name: 'Create cn=Hidden Object Viewer role'
+        dn: '{{ [ "cn=Hidden Object Viewer", ldap__roles_rdn ] + ldap__base_dn }}'
         objectClass: 'organizationalRole'
         attributes:
-          cn: 'Hidden Object Viewers'
+          cn: 'Hidden Object Viewer'
           memberOf: '{{ ([ "cn=Hidden Objects", ldap__groups_rdn ] + ldap__base_dn) | join(",") }}'
           description: 'LDAP objects which can see hidden objects'
 
@@ -212,7 +212,7 @@
           cn: 'Hidden Objects'
           member:
             - '{{ ([ "cn=Hidden Objects", ldap__groups_rdn ] + ldap__base_dn) | join(",") }}'
-            - '{{ ([ "cn=Hidden Object Viewers", ldap__roles_rdn ] + ldap__base_dn) | join(",") }}'
+            - '{{ ([ "cn=Hidden Object Viewer", ldap__roles_rdn ] + ldap__base_dn) | join(",") }}'
           memberOf: '{{ ([ "cn=Hidden Objects", ldap__groups_rdn ] + ldap__base_dn) | join(",") }}'
           owner: '{{ admin_dn }}'
           description: 'LDAP objects which are accessible only by privileged accounts'

--- a/ansible/playbooks/ldap/init-directory.yml
+++ b/ansible/playbooks/ldap/init-directory.yml
@@ -197,6 +197,26 @@
           cn: 'Password Reset Agents'
           description: 'Services that can perform password changes on behalf of users'
 
+      - name: 'Create cn=Hidden Object Viewers role'
+        dn: '{{ [ "cn=Hidden Object Viewers", ldap__roles_rdn ] + ldap__base_dn }}'
+        objectClass: 'organizationalRole'
+        attributes:
+          cn: 'Hidden Object Viewers'
+          memberOf: '{{ ([ "cn=Hidden Objects", ldap__groups_rdn ] + ldap__base_dn) | join(",") }}'
+          description: 'LDAP objects which can see hidden objects'
+
+      - name: 'Create cn=Hidden Objects group'
+        dn: '{{ [ "cn=Hidden Objects", ldap__groups_rdn ] + ldap__base_dn }}'
+        objectClass: 'groupOfNames'
+        attributes:
+          cn: 'Hidden Objects'
+          member:
+            - '{{ ([ "cn=Hidden Objects", ldap__groups_rdn ] + ldap__base_dn) | join(",") }}'
+            - '{{ ([ "cn=Hidden Object Viewers", ldap__roles_rdn ] + ldap__base_dn) | join(",") }}'
+          memberOf: '{{ ([ "cn=Hidden Objects", ldap__groups_rdn ] + ldap__base_dn) | join(",") }}'
+          owner: '{{ admin_dn }}'
+          description: 'LDAP objects which are accessible only by privileged accounts'
+
       - name: 'Create cn=UNIX SSH users group'
         dn: '{{ [ "cn=UNIX SSH users", ldap__groups_rdn ] + ldap__base_dn }}'
         objectClass: [ 'groupOfNames', 'posixGroup', 'posixGroupId',

--- a/ansible/roles/debops.ldap/defaults/main.yml
+++ b/ansible/roles/debops.ldap/defaults/main.yml
@@ -179,6 +179,8 @@ ldap__people_rdn: 'ou=People'
 # The RDN added to the BaseDN that contains LDAP System Group objects, for
 # example ``groupOfNames`` or ``groupOfUniqueNames``. This group is used for
 # internal LDAP administration.
+#
+# This variable is obsolete and will be removed in the future.
 ldap__system_groups_rdn: 'ou=System Groups'
 
                                                                    # ]]]
@@ -205,6 +207,13 @@ ldap__hosts_rdn: 'ou=Hosts'
 # branch is meant to be used for client machines that require access to the
 # LDAP directory.
 ldap__machines_rdn: 'ou=Machines'
+
+                                                                   # ]]]
+# .. envvar:: ldap__roles_rdn [[[
+#
+# The RDN added to the BaseDN that contains LDAP Role objects, for example
+# ``organizationalRole``.
+ldap__roles_rdn: 'ou=Roles'
 
                                                                    # ]]]
 # .. envvar:: ldap__services_rdn [[[
@@ -630,12 +639,6 @@ ldap__default_tasks:
     attributes:
       ou: '{{ ldap__people_rdn.split("=")[1] }}'
 
-  - name: 'Ensure that {{ ldap__system_groups_rdn }} object exists in LDAP directory'
-    dn: '{{ [ ldap__system_groups_rdn ] + ldap__base_dn }}'
-    objectClass: [ 'organizationalUnit' ]
-    attributes:
-      ou: '{{ ldap__system_groups_rdn.split("=")[1] }}'
-
   - name: 'Ensure that {{ ldap__groups_rdn }} object exists in LDAP directory'
     dn: '{{ [ ldap__groups_rdn ] + ldap__base_dn }}'
     objectClass: [ 'organizationalUnit' ]
@@ -655,6 +658,12 @@ ldap__default_tasks:
     attributes:
       ou: '{{ ldap__machines_rdn.split("=")[1] }}'
       description: 'Client machines'
+
+  - name: 'Ensure that {{ ldap__roles_rdn }} object exists in LDAP directory'
+    dn: '{{ [ ldap__roles_rdn ] + ldap__base_dn }}'
+    objectClass: [ 'organizationalUnit' ]
+    attributes:
+      ou: '{{ ldap__roles_rdn.split("=")[1] }}'
 
   - name: 'Ensure that {{ ldap__services_rdn }} object exists in LDAP directory'
     dn: '{{ [ ldap__services_rdn ] + ldap__base_dn }}'

--- a/ansible/roles/debops.ldap/templates/etc/ansible/facts.d/ldap.fact.j2
+++ b/ansible/roles/debops.ldap/templates/etc/ansible/facts.d/ldap.fact.j2
@@ -21,6 +21,7 @@ output = loads('''{{ {"configured": False,
                       "hosts_rdn": ldap__hosts_rdn,
                       "machines_rdn": ldap__machines_rdn,
                       "people_rdn": ldap__people_rdn,
+                      "roles_rdn": ldap__roles_rdn,
                       "services_rdn": ldap__services_rdn,
                       "device_dn": (ldap__device_dn
                                     if ldap__device_enabled|bool

--- a/ansible/roles/debops.owncloud/defaults/main.yml
+++ b/ansible/roles/debops.owncloud/defaults/main.yml
@@ -2007,7 +2007,7 @@ owncloud__ldap__dependent_tasks:
     state: '{{ "present" if owncloud__ldap_device_dn|d() else "ignore" }}'
 
   - name: 'Enable password management by {{ owncloud__ldap_binddn }}'
-    dn: '{{ ([ "cn=Password Reset Agents", "ou=Roles" ] + owncloud__ldap_base_dn) | join(",") }}'
+    dn: '{{ ([ "cn=Password Reset Agent", "ou=Roles" ] + owncloud__ldap_base_dn) | join(",") }}'
     attributes:
       roleOccupant: '{{ owncloud__ldap_binddn }}'
     state: '{{ "present" if owncloud__ldap_device_dn|d() else "ignore" }}'

--- a/ansible/roles/debops.owncloud/defaults/main.yml
+++ b/ansible/roles/debops.owncloud/defaults/main.yml
@@ -2007,9 +2007,9 @@ owncloud__ldap__dependent_tasks:
     state: '{{ "present" if owncloud__ldap_device_dn|d() else "ignore" }}'
 
   - name: 'Enable password management by {{ owncloud__ldap_binddn }}'
-    dn: '{{ ([ "cn=Password Reset Agents", "ou=System Groups" ] + owncloud__ldap_base_dn) | join(",") }}'
+    dn: '{{ ([ "cn=Password Reset Agents", "ou=Roles" ] + owncloud__ldap_base_dn) | join(",") }}'
     attributes:
-      member: '{{ owncloud__ldap_binddn }}'
+      roleOccupant: '{{ owncloud__ldap_binddn }}'
     state: '{{ "present" if owncloud__ldap_device_dn|d() else "ignore" }}'
 
                                                                    # ]]]

--- a/ansible/roles/debops.slapd/defaults/main.yml
+++ b/ansible/roles/debops.slapd/defaults/main.yml
@@ -654,6 +654,8 @@ slapd__acl_tasks:
 
         - |-
           to dn.subtree="{{ slapd__basedn }}"
+          by group/organizationalRole/roleOccupant.exact="cn=LDAP Administrators, ou=Roles,{{ slapd__basedn }}" manage
+          by group/organizationalRole/roleOccupant.exact="cn=LDAP Replicators,    ou=Roles,{{ slapd__basedn }}" read
           by group/groupOfNames/member.exact="cn=LDAP Administrators, ou=System Groups,{{ slapd__basedn }}" manage
           by group/groupOfNames/member.exact="cn=LDAP Replicators,    ou=System Groups,{{ slapd__basedn }}" read
           by * break
@@ -661,6 +663,7 @@ slapd__acl_tasks:
         - |-
           to filter="(| (objectClass=posixAccount) (objectClass=posixGroup) (objectClass=posixGroupId) )"
              attrs="uid,uidNumber,gid,gidNumber,homeDirectory"
+          by group/groupOfNames/member="cn=UNIX Administrators, ou=Groups,{{ slapd__basedn }}"        write
           by group/groupOfNames/member="cn=UNIX Administrators, ou=System Groups,{{ slapd__basedn }}" write
           by users read
 
@@ -668,6 +671,9 @@ slapd__acl_tasks:
           to dn.subtree="ou=People,{{ slapd__basedn }}"
              attrs="shadowLastChange"
           by self write
+          by group/organizationalRole/roleOccupant.exact="cn=LDAP Editors,           ou=Roles,{{ slapd__basedn }}" write
+          by group/organizationalRole/roleOccupant.exact="cn=Account Administrators, ou=Roles,{{ slapd__basedn }}" write
+          by group/organizationalRole/roleOccupant.exact="cn=Password Reset Agents,  ou=Roles,{{ slapd__basedn }}" =w
           by group/groupOfNames/member.exact="cn=LDAP Editors,           ou=System Groups,{{ slapd__basedn }}" write
           by group/groupOfNames/member.exact="cn=Account Administrators, ou=System Groups,{{ slapd__basedn }}" write
           by group/groupOfNames/member.exact="cn=Password Reset Agents,  ou=System Groups,{{ slapd__basedn }}" =w
@@ -677,6 +683,9 @@ slapd__acl_tasks:
           to dn.subtree="ou=People,{{ slapd__basedn }}"
              attrs="userPassword"
           by self =w
+          by group/organizationalRole/roleOccupant.exact="cn=LDAP Editors,           ou=Roles,{{ slapd__basedn }}" =w
+          by group/organizationalRole/roleOccupant.exact="cn=Account Administrators, ou=Roles,{{ slapd__basedn }}" =w
+          by group/organizationalRole/roleOccupant.exact="cn=Password Reset Agents,  ou=Roles,{{ slapd__basedn }}" =w
           by group/groupOfNames/member.exact="cn=LDAP Editors,           ou=System Groups,{{ slapd__basedn }}" =w
           by group/groupOfNames/member.exact="cn=Account Administrators, ou=System Groups,{{ slapd__basedn }}" =w
           by group/groupOfNames/member.exact="cn=Password Reset Agents,  ou=System Groups,{{ slapd__basedn }}" =w
@@ -690,12 +699,30 @@ slapd__acl_tasks:
           by *         none
 
         - |-
+          to dn.regex="^cn=(LDAP Administrators|LDAP Replicators), ou=Roles,{{ slapd__basedn }}$"
+          by group/organizationalRole/roleOccupant.exact="cn=LDAP Editors,           ou=Roles,{{ slapd__basedn }}" read
+          by group/organizationalRole/roleOccupant.exact="cn=Account Administrators, ou=Roles,{{ slapd__basedn }}" read
+          by group/groupOfNames/member.exact="cn=LDAP Editors,           ou=System Groups,{{ slapd__basedn }}" read
+          by group/groupOfNames/member.exact="cn=Account Administrators, ou=System Groups,{{ slapd__basedn }}" read
+          by * break
+
+        - |-
+          to dn.subtree="cn=UNIX Administrators, ou=Groups,{{ slapd__basedn }}"
+          by group/organizationalRole/roleOccupant.exact="cn=LDAP Editors,           ou=Roles,{{ slapd__basedn }}" read
+          by group/organizationalRole/roleOccupant.exact="cn=Account Administrators, ou=Roles,{{ slapd__basedn }}" read
+          by group/groupOfNames/member.exact="cn=LDAP Editors,           ou=System Groups,{{ slapd__basedn }}" read
+          by group/groupOfNames/member.exact="cn=Account Administrators, ou=System Groups,{{ slapd__basedn }}" read
+          by * break
+
+        - |-
           to dn.subtree="ou=System Groups,{{ slapd__basedn }}"
+          by group/organizationalRole/roleOccupant.exact="cn=LDAP Editors, ou=Roles,{{ slapd__basedn }}" read
           by group/groupOfNames/member.exact="cn=LDAP Editors, ou=System Groups,{{ slapd__basedn }}" read
           by * break
 
         - |-
           to dn.subtree="{{ slapd__basedn }}"
+          by group/organizationalRole/roleOccupant.exact="cn=LDAP Editors, ou=Roles,{{ slapd__basedn }}" write
           by group/groupOfNames/member.exact="cn=LDAP Editors, ou=System Groups,{{ slapd__basedn }}" write
           by * break
 
@@ -708,11 +735,13 @@ slapd__acl_tasks:
         - |-
           to dn.regex="^([^,]+,)?ou=(People|Groups|Machines),{{ slapd__basedn }}$"
              attrs="children,entry"
+          by group/organizationalRole/roleOccupant.exact="cn=Account Administrators, ou=Roles,{{ slapd__basedn }}" write
           by group/groupOfNames/member.exact="cn=Account Administrators, ou=System Groups,{{ slapd__basedn }}" write
           by * break
 
         - |-
           to dn.regex="^[^,]+,ou=(People|Groups|Machines),{{ slapd__basedn }}$"
+          by group/organizationalRole/roleOccupant.exact="cn=Account Administrators, ou=Roles,{{ slapd__basedn }}" write
           by group/groupOfNames/member.exact="cn=Account Administrators, ou=System Groups,{{ slapd__basedn }}" write
           by * break
 
@@ -914,11 +943,20 @@ slapd__slapacl_test_rdn_map:
   # LDAP Editor (see most things, write access to most things)
   ldap_editor_rdn:   'uid=<user>'
 
+  # UNIX Administrator (manages UNIX environment)
+  unix_admin_rdn:    'uid=<user>'
+
   # Account Administrator (write access to personal objects)
   account_admin_rdn: 'uid=<user>'
 
   # An unprivileged user account
   person_rdn:        'uid=<user>'
+
+  # Distinguished Name of a LDAP Replicator
+  ldap_replicator_dn: ''
+
+  # Distinguished Name of a Password Reset Agent
+  password_reset_dn: ''
 
                                                                    # ]]]
 # .. envvar:: slapd__slapacl_default_tests [[[

--- a/ansible/roles/debops.slapd/defaults/main.yml
+++ b/ansible/roles/debops.slapd/defaults/main.yml
@@ -768,6 +768,12 @@ slapd__acl_tasks:
           by * none
 
         - |-
+          to attrs="mobile"
+          by self write
+          by group/organizationalRole/roleOccupant.exact="cn=SMS Gateway, ou=Roles,{{ slapd__basedn }}" read
+          by * none
+
+        - |-
           to *
           by users read
           by * none
@@ -979,6 +985,9 @@ slapd__slapacl_test_rdn_map:
 
   # Distinguished Name of a Password Reset Agent
   password_reset_dn: ''
+
+  # Distinguished Name of a SMS Gateway object
+  sms_gateway_dn: ''
 
                                                                    # ]]]
 # .. envvar:: slapd__slapacl_default_tests [[[

--- a/ansible/roles/debops.slapd/defaults/main.yml
+++ b/ansible/roles/debops.slapd/defaults/main.yml
@@ -757,6 +757,11 @@ slapd__acl_tasks:
           by * break
 
         - |-
+          to attrs="carLicense,homePhone,homePostalAddress"
+          by self write
+          by * none
+
+        - |-
           to *
           by users read
           by * none

--- a/ansible/roles/debops.slapd/defaults/main.yml
+++ b/ansible/roles/debops.slapd/defaults/main.yml
@@ -661,6 +661,17 @@ slapd__acl_tasks:
           by * break
 
         - |-
+          to dn.subtree="{{ slapd__basedn }}" filter="(memberOf=cn=Hidden Objects, ou=Groups,{{ slapd__basedn }})"
+             attrs="children,entry"
+          by self break
+          by group/organizationalRole/roleOccupant.exact="cn=LDAP Administrators,    ou=Roles,{{ slapd__basedn }}" break
+          by group/organizationalRole/roleOccupant.exact="cn=LDAP Editors,           ou=Roles,{{ slapd__basedn }}" break
+          by group/organizationalRole/roleOccupant.exact="cn=Hidden Object Viewers,  ou=Roles,{{ slapd__basedn }}" break
+          by group/groupOfNames/member.exact="cn=LDAP Administrators,    ou=System Groups,{{ slapd__basedn }}" break
+          by group/groupOfNames/member.exact="cn=LDAP Editors,           ou=System Groups,{{ slapd__basedn }}" break
+          by * none
+
+        - |-
           to filter="(| (objectClass=posixAccount) (objectClass=posixGroup) (objectClass=posixGroupId) )"
              attrs="uid,uidNumber,gid,gidNumber,homeDirectory"
           by group/groupOfNames/member="cn=UNIX Administrators, ou=Groups,{{ slapd__basedn }}"        write

--- a/ansible/roles/debops.slapd/defaults/main.yml
+++ b/ansible/roles/debops.slapd/defaults/main.yml
@@ -679,6 +679,12 @@ slapd__acl_tasks:
           by users read
 
         - |-
+          to dn.subtree="ou=SUDOers,{{ slapd__basedn }}"
+          by group/groupOfNames/member="cn=UNIX Administrators, ou=Groups,{{ slapd__basedn }}"        write
+          by group/groupOfNames/member="cn=UNIX Administrators, ou=System Groups,{{ slapd__basedn }}" write
+          by users read
+
+        - |-
           to dn.subtree="ou=People,{{ slapd__basedn }}"
              attrs="shadowLastChange"
           by self write

--- a/ansible/roles/debops.slapd/defaults/main.yml
+++ b/ansible/roles/debops.slapd/defaults/main.yml
@@ -654,8 +654,8 @@ slapd__acl_tasks:
 
         - |-
           to dn.subtree="{{ slapd__basedn }}"
-          by group/organizationalRole/roleOccupant.exact="cn=LDAP Administrators, ou=Roles,{{ slapd__basedn }}" manage
-          by group/organizationalRole/roleOccupant.exact="cn=LDAP Replicators,    ou=Roles,{{ slapd__basedn }}" read
+          by group/organizationalRole/roleOccupant.exact="cn=LDAP Administrator, ou=Roles,{{ slapd__basedn }}" manage
+          by group/organizationalRole/roleOccupant.exact="cn=LDAP Replicator,    ou=Roles,{{ slapd__basedn }}" read
           by group/groupOfNames/member.exact="cn=LDAP Administrators, ou=System Groups,{{ slapd__basedn }}" manage
           by group/groupOfNames/member.exact="cn=LDAP Replicators,    ou=System Groups,{{ slapd__basedn }}" read
           by * break
@@ -664,9 +664,9 @@ slapd__acl_tasks:
           to dn.subtree="{{ slapd__basedn }}" filter="(memberOf=cn=Hidden Objects, ou=Groups,{{ slapd__basedn }})"
              attrs="children,entry"
           by self break
-          by group/organizationalRole/roleOccupant.exact="cn=LDAP Administrators,    ou=Roles,{{ slapd__basedn }}" break
-          by group/organizationalRole/roleOccupant.exact="cn=LDAP Editors,           ou=Roles,{{ slapd__basedn }}" break
-          by group/organizationalRole/roleOccupant.exact="cn=Hidden Object Viewers,  ou=Roles,{{ slapd__basedn }}" break
+          by group/organizationalRole/roleOccupant.exact="cn=LDAP Administrator,    ou=Roles,{{ slapd__basedn }}" break
+          by group/organizationalRole/roleOccupant.exact="cn=LDAP Editor,           ou=Roles,{{ slapd__basedn }}" break
+          by group/organizationalRole/roleOccupant.exact="cn=Hidden Object Viewer,  ou=Roles,{{ slapd__basedn }}" break
           by group/groupOfNames/member.exact="cn=LDAP Administrators,    ou=System Groups,{{ slapd__basedn }}" break
           by group/groupOfNames/member.exact="cn=LDAP Editors,           ou=System Groups,{{ slapd__basedn }}" break
           by * none
@@ -682,9 +682,9 @@ slapd__acl_tasks:
           to dn.subtree="ou=People,{{ slapd__basedn }}"
              attrs="shadowLastChange"
           by self write
-          by group/organizationalRole/roleOccupant.exact="cn=LDAP Editors,           ou=Roles,{{ slapd__basedn }}" write
-          by group/organizationalRole/roleOccupant.exact="cn=Account Administrators, ou=Roles,{{ slapd__basedn }}" write
-          by group/organizationalRole/roleOccupant.exact="cn=Password Reset Agents,  ou=Roles,{{ slapd__basedn }}" =w
+          by group/organizationalRole/roleOccupant.exact="cn=LDAP Editor,           ou=Roles,{{ slapd__basedn }}" write
+          by group/organizationalRole/roleOccupant.exact="cn=Account Administrator, ou=Roles,{{ slapd__basedn }}" write
+          by group/organizationalRole/roleOccupant.exact="cn=Password Reset Agent,  ou=Roles,{{ slapd__basedn }}" =w
           by group/groupOfNames/member.exact="cn=LDAP Editors,           ou=System Groups,{{ slapd__basedn }}" write
           by group/groupOfNames/member.exact="cn=Account Administrators, ou=System Groups,{{ slapd__basedn }}" write
           by group/groupOfNames/member.exact="cn=Password Reset Agents,  ou=System Groups,{{ slapd__basedn }}" =w
@@ -694,9 +694,9 @@ slapd__acl_tasks:
           to dn.subtree="ou=People,{{ slapd__basedn }}"
              attrs="userPassword"
           by self =w
-          by group/organizationalRole/roleOccupant.exact="cn=LDAP Editors,           ou=Roles,{{ slapd__basedn }}" =w
-          by group/organizationalRole/roleOccupant.exact="cn=Account Administrators, ou=Roles,{{ slapd__basedn }}" =w
-          by group/organizationalRole/roleOccupant.exact="cn=Password Reset Agents,  ou=Roles,{{ slapd__basedn }}" =w
+          by group/organizationalRole/roleOccupant.exact="cn=LDAP Editor,           ou=Roles,{{ slapd__basedn }}" =w
+          by group/organizationalRole/roleOccupant.exact="cn=Account Administrator, ou=Roles,{{ slapd__basedn }}" =w
+          by group/organizationalRole/roleOccupant.exact="cn=Password Reset Agent,  ou=Roles,{{ slapd__basedn }}" =w
           by group/groupOfNames/member.exact="cn=LDAP Editors,           ou=System Groups,{{ slapd__basedn }}" =w
           by group/groupOfNames/member.exact="cn=Account Administrators, ou=System Groups,{{ slapd__basedn }}" =w
           by group/groupOfNames/member.exact="cn=Password Reset Agents,  ou=System Groups,{{ slapd__basedn }}" =w
@@ -710,30 +710,30 @@ slapd__acl_tasks:
           by *         none
 
         - |-
-          to dn.regex="^cn=(LDAP Administrators|LDAP Replicators), ou=Roles,{{ slapd__basedn }}$"
-          by group/organizationalRole/roleOccupant.exact="cn=LDAP Editors,           ou=Roles,{{ slapd__basedn }}" read
-          by group/organizationalRole/roleOccupant.exact="cn=Account Administrators, ou=Roles,{{ slapd__basedn }}" read
+          to dn.regex="^cn=(LDAP Administrator|LDAP Replicator), ou=Roles,{{ slapd__basedn }}$"
+          by group/organizationalRole/roleOccupant.exact="cn=LDAP Editor,           ou=Roles,{{ slapd__basedn }}" read
+          by group/organizationalRole/roleOccupant.exact="cn=Account Administrator, ou=Roles,{{ slapd__basedn }}" read
           by group/groupOfNames/member.exact="cn=LDAP Editors,           ou=System Groups,{{ slapd__basedn }}" read
           by group/groupOfNames/member.exact="cn=Account Administrators, ou=System Groups,{{ slapd__basedn }}" read
           by * break
 
         - |-
           to dn.subtree="cn=UNIX Administrators, ou=Groups,{{ slapd__basedn }}"
-          by group/organizationalRole/roleOccupant.exact="cn=LDAP Editors,           ou=Roles,{{ slapd__basedn }}" read
-          by group/organizationalRole/roleOccupant.exact="cn=Account Administrators, ou=Roles,{{ slapd__basedn }}" read
+          by group/organizationalRole/roleOccupant.exact="cn=LDAP Editor,           ou=Roles,{{ slapd__basedn }}" read
+          by group/organizationalRole/roleOccupant.exact="cn=Account Administrator, ou=Roles,{{ slapd__basedn }}" read
           by group/groupOfNames/member.exact="cn=LDAP Editors,           ou=System Groups,{{ slapd__basedn }}" read
           by group/groupOfNames/member.exact="cn=Account Administrators, ou=System Groups,{{ slapd__basedn }}" read
           by * break
 
         - |-
           to dn.subtree="ou=System Groups,{{ slapd__basedn }}"
-          by group/organizationalRole/roleOccupant.exact="cn=LDAP Editors, ou=Roles,{{ slapd__basedn }}" read
+          by group/organizationalRole/roleOccupant.exact="cn=LDAP Editor, ou=Roles,{{ slapd__basedn }}" read
           by group/groupOfNames/member.exact="cn=LDAP Editors, ou=System Groups,{{ slapd__basedn }}" read
           by * break
 
         - |-
           to dn.subtree="{{ slapd__basedn }}"
-          by group/organizationalRole/roleOccupant.exact="cn=LDAP Editors, ou=Roles,{{ slapd__basedn }}" write
+          by group/organizationalRole/roleOccupant.exact="cn=LDAP Editor, ou=Roles,{{ slapd__basedn }}" write
           by group/groupOfNames/member.exact="cn=LDAP Editors, ou=System Groups,{{ slapd__basedn }}" write
           by * break
 
@@ -746,13 +746,13 @@ slapd__acl_tasks:
         - |-
           to dn.regex="^([^,]+,)?ou=(People|Groups|Machines),{{ slapd__basedn }}$"
              attrs="children,entry"
-          by group/organizationalRole/roleOccupant.exact="cn=Account Administrators, ou=Roles,{{ slapd__basedn }}" write
+          by group/organizationalRole/roleOccupant.exact="cn=Account Administrator, ou=Roles,{{ slapd__basedn }}" write
           by group/groupOfNames/member.exact="cn=Account Administrators, ou=System Groups,{{ slapd__basedn }}" write
           by * break
 
         - |-
           to dn.regex="^[^,]+,ou=(People|Groups|Machines),{{ slapd__basedn }}$"
-          by group/organizationalRole/roleOccupant.exact="cn=Account Administrators, ou=Roles,{{ slapd__basedn }}" write
+          by group/organizationalRole/roleOccupant.exact="cn=Account Administrator, ou=Roles,{{ slapd__basedn }}" write
           by group/groupOfNames/member.exact="cn=Account Administrators, ou=System Groups,{{ slapd__basedn }}" write
           by * break
 

--- a/docs/ansible/roles/debops.ldap/ldap-dit.rst
+++ b/docs/ansible/roles/debops.ldap/ldap-dit.rst
@@ -83,4 +83,6 @@ Child nodes
 
 - :envvar:`ansible_local.ldap.machines_rdn <ldap__machines_rdn>`
 
+- :envvar:`ansible_local.ldap.roles_rdn <ldap__roles_rdn>`
+
 - :envvar:`ansible_local.ldap.services_rdn <ldap__services_rdn>`

--- a/docs/ansible/roles/debops.ldap/ldap-dit.rst
+++ b/docs/ansible/roles/debops.ldap/ldap-dit.rst
@@ -38,11 +38,11 @@ Directory structure
       - :envvar:`ou=Machines <ldap__machines_rdn>`
       - :envvar:`ou=Services <ldap__services_rdn>`
 
-      - :envvar:`ou=System Groups <ldap__system_groups_rdn>`
+      - :envvar:`ou=Roles <ldap__roles_rdn>`
 
         - ``cn=Password Reset Agents`` (via the :file:`ldap/init-directory.yml` playbook)
 
-          - ``member``: :ref:`uid=nextcloud,cn=host.example.org,... <owncloud__ref_ldap_dit>` -> :ref:`debops.owncloud`
+          - ``roleOccupant``: :ref:`uid=nextcloud,cn=host.example.org,... <owncloud__ref_ldap_dit>` -> :ref:`debops.owncloud`
 
 
 Object Classes and Attributes

--- a/docs/ansible/roles/debops.ldap/ldap-dit.rst
+++ b/docs/ansible/roles/debops.ldap/ldap-dit.rst
@@ -40,7 +40,7 @@ Directory structure
 
       - :envvar:`ou=Roles <ldap__roles_rdn>`
 
-        - ``cn=Password Reset Agents`` (via the :file:`ldap/init-directory.yml` playbook)
+        - ``cn=Password Reset Agent`` (via the :file:`ldap/init-directory.yml` playbook)
 
           - ``roleOccupant``: :ref:`uid=nextcloud,cn=host.example.org,... <owncloud__ref_ldap_dit>` -> :ref:`debops.owncloud`
 

--- a/docs/ansible/roles/debops.owncloud/ldap-dit.rst
+++ b/docs/ansible/roles/debops.owncloud/ldap-dit.rst
@@ -16,7 +16,7 @@ Directory structure
 
 - :ref:`ou=Roles <ldap__ref_ldap_dit>` -> :ref:`debops.ldap`
 
-  - ``cn=Password Reset Agents``
+  - ``cn=Password Reset Agent``
 
     - ``roleOccupant``: :envvar:`uid=nextcloud,cn=host.example.org,... <owncloud__ldap_binddn>`
 

--- a/docs/ansible/roles/debops.owncloud/ldap-dit.rst
+++ b/docs/ansible/roles/debops.owncloud/ldap-dit.rst
@@ -14,11 +14,11 @@ Directory structure
 
   - :envvar:`uid=nextcloud <owncloud__ldap_self_rdn>`
 
-- :ref:`ou=System Groups <ldap__ref_ldap_dit>` -> :ref:`debops.ldap`
+- :ref:`ou=Roles <ldap__ref_ldap_dit>` -> :ref:`debops.ldap`
 
   - ``cn=Password Reset Agents``
 
-    - ``member``: :envvar:`uid=nextcloud,cn=host.example.org,... <owncloud__ldap_binddn>`
+    - ``roleOccupant``: :envvar:`uid=nextcloud,cn=host.example.org,... <owncloud__ldap_binddn>`
 
 
 Object Classes and Attributes

--- a/docs/ansible/roles/debops.slapd/ldap-acl.rst
+++ b/docs/ansible/roles/debops.slapd/ldap-acl.rst
@@ -69,474 +69,218 @@ If some of the schemas specified here are not present, the default ACL
 configuration will not be enabled correctly.
 
 
-Important Distinguished Names
------------------------------
+Directory groups
+----------------
 
-This section of the documentation lists various LDAP objects that can be
-present in the LDAP directory and are included in the ACL. They might not be
-present initially and might need to be created by the administrator to perform
-their function. The LDAP Distinguished Names used in the documentation assume
-that the ``example.org`` DNS domain is used by the OpenLDAP server.
+In this section of the documentation you can find a list of LDAP groups which
+are used in the default :ref:`debops.slapd` Access Control List rules. These
+groups can be created in the directory using the
+:file:`ldap/init-directory.yml` Ansible playbook included in DebOps. The LDAP
+Distinguished Names used in the documentation assume that the ``example.org``
+DNS domain is used by the OpenLDAP server.
 
 The "Test RDN" and "Test DN" attributes refer to the
 :ref:`slapd__ref_acl_tests` and specifically to the
 :envvar:`slapd__slapacl_test_rdn_map` variable.
 
-.. _slapd__ref_acl_dn_ldap_admin:
+.. _slapd__ref_acl_group_unix_admins:
 
-cn=LDAP Administrator,ou=Roles,dc=example,dc=org
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+UNIX Administrators
+~~~~~~~~~~~~~~~~~~~
 
-:Test RDN: ``ldap_admin_rdn``
-:Obsolete: cn=LDAP Administrators,ou=System Groups,dc=example,dc=org
-
-This is an ``organizationalRole`` LDAP object that defines via its
-``roleOccupant`` attribute the Distinguished Names of the people who have full,
-privileged access to the LDAP directory.
-
-.. _slapd__ref_acl_dn_ldap_replicator:
-
-cn=LDAP Replicator,ou=Roles,dc=example,dc=org
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Test DN:  ``ldap_replicator_dn``
-:Obsolete: cn=LDAP Replicators,ou=System Groups,dc=example,dc=org
-
-The is an ``organizationalRole`` LDAP object that defines via its
-``roleOccupant`` attribute the Distinguished Names of the objects that are used
-for authenticated access to data replication by other OpenLDAP servers. This
-group should have full access to the LDAP directory for successful replication.
-
-.. _slapd__ref_acl_dn_unix_admins:
-
-cn=UNIX Administrators,ou=Groups,dc=example,dc=org
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
+:DN:       cn=UNIX Administrators,ou=Groups,dc=example,dc=org
 :Test RDN: ``unix_admin_rdn``
 :Obsolete: cn=UNIX Administrators,ou=System Groups,dc=example,dc=org
 
-This is a ``groupOfNames`` LDAP object that defines via its ``member``
-attribute the Distinguished Names of the UNIX administrators. These accounts
-will be able to manipulate the LDAP attributes of certain objects
-(``posixAccount``, ``posixGroup``, ``posixGroupId``) which can affect the
-security boundary in an UNIX-like environment.
+- Members of this group have write access to the ``uid``, ``uidNumber``,
+  ``gid``, ``gidNumber`` and ``homeDirectory`` attributes of the
+  ``posixAccount``, ``posixGroup`` and ``posixGroupId`` LDAP objects. Everyone
+  else has read-only access to these attributes.
 
-.. _slapd__ref_acl_dn_ldap_editor:
+- Access to the group is restricted to Read-only by role occupants of the
+  :ref:`slapd__ref_acl_role_ldap_editor` and the
+  :ref:`slapd__ref_acl_role_account_admin` LDAP roles.
 
-cn=LDAP Editor,ou=Roles,dc=example,dc=org
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. _slapd__ref_acl_group_hidden_objects:
 
+Hidden Objects
+~~~~~~~~~~~~~~
+
+:DN: cn=Hidden Objects,ou=Groups,dc=example,dc=org
+
+- Objects in this group are visible only to themselves as well as people and
+  other entities with the :ref:`slapd__ref_acl_role_ldap_admin`, the
+  :ref:`slapd__ref_acl_role_ldap_editor` and the
+  :ref:`slapd__ref_acl_role_hidden_object_viewer` roles.
+
+- The access control list checks the ``memberOf`` attribute of an LDAP object
+  and grants or denies access to it depending on its membership status.
+
+.. note:: Due to limitations of the OpenLDAP Access Control List features, to
+   hide the children objects of a given LDAP object, all of them need to be
+   also included as separate ``member`` attributes in the
+   :ref:`slapd__ref_acl_group_hidden_objects` group. Otherwise the children of
+   hidden objects can be still visible in general LDAP searches, for example
+   ``(objectClass=*)``. The DN attribute of such entries can also disclose the
+   presence of a hidden object.
+
+
+Directory roles
+---------------
+
+In this section of the documentation you can find a list of LDAP roles which
+are used in the default :ref:`debops.slapd` Access Control List rules. These
+roles can be created in the directory using the :file:`ldap/init-directory.yml`
+Ansible playbook included in DebOps. The LDAP Distinguished Names used in the
+documentation assume that the ``example.org`` DNS domain is used by the
+OpenLDAP server.
+
+The "Test RDN" and "Test DN" attributes refer to the
+:ref:`slapd__ref_acl_tests` and specifically to the
+:envvar:`slapd__slapacl_test_rdn_map` variable.
+
+.. _slapd__ref_acl_role_ldap_admin:
+
+LDAP Administrator
+~~~~~~~~~~~~~~~~~~
+
+:DN:       cn=LDAP Administrator,ou=Roles,dc=example,dc=org
+:Test RDN: ``ldap_admin_rdn``
+:Obsolete: cn=LDAP Administrators,ou=System Groups,dc=example,dc=org
+
+- Role grants full access to the entire LDAP directory.
+
+- Access to the role is restricted to read-only by role occupants of the
+  :ref:`slapd__ref_acl_role_ldap_editor` and the
+  :ref:`slapd__ref_acl_role_account_admin` LDAP roles.
+
+.. _slapd__ref_acl_role_ldap_replicator:
+
+LDAP Replicator
+~~~~~~~~~~~~~~~
+
+:DN:       cn=LDAP Replicator,ou=Roles,dc=example,dc=org
+:Test DN:  ``ldap_replicator_dn``
+:Obsolete: cn=LDAP Replicators,ou=System Groups,dc=example,dc=org
+
+- Role grants read-only access to the entire LDAP directory.
+
+- Access to the role is restricted to read-only by role occupants of the
+  :ref:`slapd__ref_acl_role_ldap_editor` and the
+  :ref:`slapd__ref_acl_role_account_admin` LDAP roles.
+
+.. _slapd__ref_acl_role_ldap_editor:
+
+LDAP Editor
+~~~~~~~~~~~
+
+:DN:       cn=LDAP Editor,ou=Roles,dc=example,dc=org
 :Test RDN: ``ldap_editor_rdn``
 :Obsolete: cn=LDAP Editors,ou=System Groups,dc=example,dc=org
 
-This is an ``organizationalRole`` LDAP object that defines via its
-``roleOccupant`` attribute the Distinguished Names of the LDAP editors. The
-editors are expected to be proficient in LDAP management and are granted write
-access to most of the LDAP directory, apart from the LDAP Administrators and
-the LDAP Replicators roles, the UNIX Administrators group, the ``ou=System
-Groups`` subtree and UNIX attributes.
+- Role grants write access to most of the LDAP directory, apart from the
+  privileged groups and roles.
 
-.. _slapd__ref_acl_dn_account_admin:
+.. _slapd__ref_acl_role_account_admin:
 
-cn=Account Administrator,ou=Roles,dc=example,dc=org
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Account Administrator
+~~~~~~~~~~~~~~~~~~~~~
 
+:DN:       cn=Account Administrator,ou=Roles,dc=example,dc=org
 :Test RDN: ``account_admin_rdn``
 :Obsolete: cn=Account Administrators,ou=System Groups,dc=example,dc=org
 
-This is an ``organizationalRole`` LDAP object that defines via its
-``roleOccupant`` attribute the Distinguished Names of the account
-administrators. They are responsible for managing the user accounts of people,
-client machines, organizational groups and other user-specific data.
+- Role grants write access to the ``shadowLastChange`` and write-only access to
+  the ``userPassword`` attributes in the ``ou=People,dc=example,dc=org`` LDAP
+  subtree to allow password changes in personal accounts.
 
-.. _slapd__ref_acl_dn_password_reset:
+- Role grants write access in the ``ou=People,dc=example,dc=org``,
+  ``ou=Groups,dc=example,dc=org`` and the ``ou=Machines,dc=example,dc=org``
+  LDAP subtrees.
 
-cn=Password Reset Agent,ou=Roles,dc=example,dc=org
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. note:: Purpose of this role is too broad and in the future it will be split
+   into separate, more focused LDAP roles.
 
+.. _slapd__ref_acl_role_password_reset:
+
+Password Reset Agent
+~~~~~~~~~~~~~~~~~~~~
+
+:DN:       cn=Password Reset Agent,ou=Roles,dc=example,dc=org
 :Test RDN: ``password_reset_dn``
 :Obsolete: cn=Password Reset Agents,ou=System Groups,dc=example,dc=org
 
-This is an ``organizationRole`` LDAP object that defines via its
-``roleOccupant`` attribute the Distinguished Names of the Password Reset
-Agents, usually application(s) that act on behalf of the users to allow them to
-perform password changes after out-of-band authentication. This group should
-have access to user passwords to be able to reset them.
+- Role grants write-only access to the ``shadowLastChange`` and the
+  ``userPassword`` attributes in the ``ou=People,dc=example,dc=org`` LDAP
+  subtree to allow password changes in personal accounts.
 
-.. _slapd__ref_acl_dn_hidden_objects:
+- This role is meant for applications that act on behalf of the users to allow
+  them to perform password changes after out-of-band authentication.
 
-cn=Hidden Objects,ou=Groups,dc=example,dc=org
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. _slapd__ref_acl_role_hidden_object_viewer:
 
-This is a ``groupOfNames`` LDAP object that defines via its ``member``
-attribute the Distinguished Names of the LDAP objects which should be visible
-only to LDAP Administrators, LDAP Editors and LDAP objects present in the
-:ref:`slapd__ref_acl_dn_hidden_object_viewer` role. The access control list
-checks the ``memberOf`` attribute of an LDAP object and grants or denies access
-to it depending on the member status.
+Hidden Object Viewer
+~~~~~~~~~~~~~~~~~~~~
 
-Due to limitations of the OpenLDAP Access Control List features, to hide the
-children objects of a given LDAP object, all of them need to be also included
-as separate ``member`` attributes in the ``cn=Hidden Objects`` group.
-Otherwise the children of hidden objects can be still visible in general LDAP
-searches, for example ``(objectClass=*)``. The DN attribute of such entries can
-also disclose the presence of a hidden object.
+:DN: cn=Hidden Object Viewer,ou=Roles,dc=example,dc=org
 
-.. _slapd__ref_acl_dn_hidden_object_viewer:
+- Role occupants can see LDAP objects included in the
+  :ref:`slapd__ref_acl_group_hidden_objects` LDAP group.
 
-cn=Hidden Object Viewer,ou=Roles,dc=example,dc=org
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This is an ``organizationalRole`` LDAP object which can be used to give other
-LDAP objects a way to see the LDAP objects hidden by the
-:ref:`slapd__ref_acl_dn_hidden_objects` group, after adding them using the
-``roleOccupant`` attribute. LDAP Administrators and LDAP Editors don't have to
-be included here because they see the hidden LDAP objects by default.
+Other directory objects
+-----------------------
 
+This section of the documentation describes various other LDAP objects and
+their default access policy defined by the :ref:`debops.slapd` Ansible role.
 
-Access Control List rules
--------------------------
+System Groups
+~~~~~~~~~~~~~
 
-This section of the documentation contains human-readable explanation of the
-ACL rules defined in the :envvar:`slapd__acl_tasks` default variable. These
-rules should be kept up to date with changes to the ACL contents.
+:DN: ou=System Groups,dc=example,dc=org
 
+- This subtree was used to hold LDAP objects related to access control, which
+  have been converted to normal groups and roles. It can be safely removed from
+  existing LDAP directories; the ACL rules for this LDAP object will be removed
+  at a later date to allow for secure migration to the new directory layout.
 
-.. _slapd__ref_acl_rule0:
+Group owners
+~~~~~~~~~~~~
 
-Rule 0: full access by LDAP admins and replicators
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- The owners of the LDAP groups under the ``ou=Groups,dc=example,dc=org`` LDAP
+  subtree, defined by the ``owner`` attribute, can add, modify or remove
+  members in their respecitve groups, using the ``member`` attribute.
 
-:Access to: main LDAP directory tree
-:Manage by: :ref:`slapd__ref_acl_dn_ldap_admin`
-:Read by:   :ref:`slapd__ref_acl_dn_ldap_replicator`
-:Others:    continue evaluation
+Object owners
+~~~~~~~~~~~~~
 
-- Grant full access to the entire LDAP directory tree by the members of the
-  :ref:`slapd__ref_acl_dn_ldap_admin` role, including passwords and other
-  confidential data.
+:DN: self
 
-- Grant read-only access to the entire LDAP directory tree by the members of
-  the :ref:`slapd__ref_acl_dn_ldap_replicator` role, including passwords and
-  other confidential data.
+- Object owners see their own LDAP objects even if they are hidden using the
+  :ref:`slapd__ref_acl_group_hidden_objects` LDAP group.
 
-- Continue evaluation of the ACL rules for anyone else.
+- Object owners have write access to the ``shadowLastChange`` attribute, and
+  write-only access to the ``userPassword`` attribute in their own LDAP objects
+  to allow password changes.
 
-.. note::
-   LDAP administrators and replicator accounts should have full access to the
-   entire LDAP directory.
+Authenticated users
+~~~~~~~~~~~~~~~~~~~
 
+:DN: users
+:Test RDN: ``person_rdn``
 
-.. _slapd__ref_acl_rule1:
+- Authenticated users have read-only access to most of the LDAP directory,
+  depending on the restrictions defined by the ACL rules.
 
-Rule 1: certain LDAP objects are visible only to privileged accounts
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Anonymous users
+~~~~~~~~~~~~~~~
 
-:Access to:     members of the ``cn=Hidden Objects`` group
-:Skipped by:    object owners (self), :ref:`slapd__ref_acl_dn_ldap_admin`,
-                :ref:`slapd__ref_acl_dn_ldap_editor`,
-                :ref:`slapd__ref_acl_dn_hidden_object_viewer`
-:Others:        no access
+:DN: anonymous
 
-- Skip rule evaluation for the hidden LDAP objects themselves, for the members
-  of the :ref:`slapd__ref_acl_dn_ldap_admin`, the
-  :ref:`slapd__ref_acl_dn_ldap_editor` and the
-  :ref:`slapd__ref_acl_dn_hidden_object_viewer` LDAP roles. In effect it
-  makes the hidden objects visible to these entities.
+- Anonymous users can authenticate to the LDAP directory via the
+  ``userPassword`` attribute.
 
-- Deny access to the hidden objects to anyone else.
-
-
-.. _slapd__ref_acl_rule2:
-
-Rule 2: restrict access to POSIX attributes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Access to: POSIX objects with specific attributes
-:Write by:  UNIX Administrators
-:Read by:   authenticated users
-
-- Grant write access to the ``uid``, ``uidNumber``, ``gid``, ``gidNumber`` and
-  ``homeDirectory`` attributes in ``posixAccount``, ``posixGroup`` and
-  ``posixGroupId`` LDAP objects by the members of the
-  :ref:`slapd__ref_acl_dn_unix_admins` group.
-
-- Authenticated users can read contents of the specific POSIX attributes, but
-  not modify them.
-
-.. note::
-   The POSIX/UNIX environment is treated as a separate security domain with its
-   own rules, different than the LDAP directory domain. Only a specific subset
-   of UNIX administrators should be able to manage this security domain.
-
-
-.. _slapd__ref_acl_rule3:
-
-Rule 3: restrict access to shadow database of the personal accounts
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Access to:     ``shadowLastChange`` attribute in personal accounts
-:Write by:      object owners (self), LDAP Editors, Account Administrators
-:Write-only by: Password Reset Agents
-:Read by:       authenticated users
-
-- Grant write access to the ``shadowLastChange`` attribute in all objects under
-  the ``ou=People,dc=example,dc=org`` Distinguished Name by the object owners
-  (self) to allow for password changes by the users themselves.
-
-- Grant write access to the ``shadowLastChange`` attribute in all objects under
-  the ``ou=People,dc=example,dc=org`` Distinguished Name by the members of the
-  :ref:`slapd__ref_acl_dn_ldap_editor` and
-  :ref:`slapd__ref_acl_dn_account_admin` roles.
-
-- Grant write-only access to the ``shadowLastChange`` attribute in all objects
-  under the ``ou=People,dc=example,dc=org`` Distinguished Name by the members
-  of the :ref:`slapd__ref_acl_dn_password_reset` role to allow successfull
-  password resets.
-
-- Grant read-only access to the ``shadowLastChange`` attribute in all objects
-  under the ``ou=People,dc=example,dc=org`` Distinguished Name by the
-  authenticated users.
-
-.. note::
-   This rule is required for successful password changes performed by the
-   object owners and other entities that are allowed to set new passwords or
-   change existing ones.
-
-
-.. _slapd__ref_acl_rule4:
-
-Rule 4: restrict access to password attribute of the personal accounts
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Access to:     ``userPassword`` attribute in personal accounts
-:Write-only by: object owners (self), LDAP Editors, Account Administrators,
-                Password Reset Agents
-:Auth by:       anonymous users
-:Others:        no access
-
-- Grant write-only access to the ``userPassword`` attribute in all objects
-  under the ``ou=People,dc=example,dc=org`` Distinguished Name by the object
-  owners (self) to allow for password changes by the users themselves.
-
-- Grant write-only access to the ``userPassword`` attribute in all objects
-  under the ``ou=People,dc=example,dc=org`` Distinguished Name by the members
-  of the :ref:`slapd__ref_acl_dn_ldap_editor`,
-  :ref:`slapd__ref_acl_dn_account_admin` and
-  :ref:`slapd__ref_acl_dn_password_reset` roles.
-
-- Permit authentication attempts using the ``userPassword`` attribute in all
-  objects under the ``ou=People,dc=example,dc=org`` Distinguished Name by the
-  anonymous users.
-
-- Deny access to the ``userPassword`` attribute in all objects under the
-  ``ou=People,dc=example,dc=org`` Distinguished Name to everyone else.
-
-.. note::
-   This rule is required for successful user account password changes performed
-   by the object owners and other entities that are allowed to set new
-   passwords or change existing ones, and to allow authentication by anonymous
-   users. Hashed password strings should not be available to unprivileged users
-   to limit brute-force attempts.
-
-
-.. _slapd__ref_acl_rule5:
-
-Rule 5: restrict access to password attribute in LDAP directory
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Access to:     ``userPassword`` attribute in all objects
-:Write-only by: object owners (self)
-:Auth by:       anonymous users
-:Others:        no access
-
-- Grant write-only access to the ``userPassword`` attribute in all objects in
-  the LDAP directory  by the object owners (self) to allow for password changes
-  by the users themselves.
-
-- Permit authentication attempts using the ``userPassword`` attribute in all
-  objects in the LDAP directory by the anonymous users.
-
-- Deny access to the ``userPassword`` attribute in all objects in the LDAP
-  directory to everyone else.
-
-.. note::
-   This rule is required for successful password changes performed by the
-   object owners and to allow authentication by anonymous users. Hashed
-   password strings should not be available to unprivileged users to limit
-   brute-force attempts.
-
-
-.. _slapd__ref_acl_rule6:
-
-Rule 6: restrict access to privileged roles by administration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Access to:    the :ref:`slapd__ref_acl_dn_ldap_admin` and the :ref:`slapd__ref_acl_dn_ldap_replicator` roles
-:Read-only by: LDAP Editors, Account Administrators
-:Others:       continue evaluation
-
-- Grant read-only access to the :ref:`slapd__ref_acl_dn_ldap_admin` and the
-  :ref:`slapd__ref_acl_dn_ldap_replicator` roles by the members of the
-  :ref:`slapd__ref_acl_dn_ldap_editor` and the
-  :ref:`slapd__ref_acl_dn_account_admin` roles.
-
-- Continue evaluation of the ACL rules for anyone else.
-
-.. note::
-   The :ref:`slapd__ref_acl_dn_ldap_admin` and the
-   :ref:`slapd__ref_acl_dn_ldap_replicator` roles are used to control
-   privileged access to the LDAP directory and other security contexts. LDAP
-   Editors and Account Administrators should not be allowed to modify them,
-   otherwise they could easily grant themselves more privileged access.
-
-
-.. _slapd__ref_acl_rule7:
-
-Rule 7: restrict access to privileged UNIX group by administration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Access to:    the :ref:`slapd__ref_acl_dn_unix_admins` group
-:Read-only by: LDAP Editors, Account Administrators
-:Others:       continue evaluation
-
-- Grant read-only access to the :ref:`slapd__ref_acl_dn_unix_admins` group by
-  the members of the :ref:`slapd__ref_acl_dn_ldap_editor` and the
-  :ref:`slapd__ref_acl_dn_account_admin` roles.
-
-- Continue evaluation of the ACL rules for anyone else.
-
-.. note::
-   The :ref:`slapd__ref_acl_dn_unix_admins` group is used to control privileged
-   access to the UNIX environment. LDAP Editors and Account Administrators
-   should not be allowed to modify it, otherwise they could easily grant
-   themselves more privileged access.
-
-
-.. _slapd__ref_acl_rule8:
-
-Rule 8: restrict access to System Groups by LDAP editors
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Access to:    objects under the ``ou=System Groups,dc=example,dc=org`` DN
-:Read-only by: LDAP Editors
-:Others:       continue evaluation
-
-- Grant read-only access to all objects under the ``ou=System
-  Groups,dc=example,dc=org`` Distinguished Name by the members of the
-  :ref:`slapd__ref_acl_dn_ldap_editor` role.
-
-- Continue evaluation of the ACL rules for anyone else.
-
-.. note::
-   The objects under the ``ou=System Groups,dc=example,dc=org`` Distinguished
-   Name are used to control privileged access to the LDAP directory and other
-   security contexts. LDAP Editors should not be allowed to modify them,
-   otherwise they could easily grant themselves more privileged access.
-
-
-.. _slapd__ref_acl_rule9:
-
-Rule 9: write access to most of the directory by LDAP editors
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Access to: most sections of the main LDAP directory tree
-:Write by:  :ref:`slapd__ref_acl_dn_ldap_editor`
-:Others:    continue evaluation
-
-- Grant write access to the most parts of the main LDAP directory tree by the
-  members of the :ref:`slapd__ref_acl_dn_ldap_editor` role.
-
-- Continue evaluation of the ACL rules for anyone else.
-
-.. note::
-   The LDAP Editors have write access to the entire LDAP directory tree, apart
-   from the restrictions set in the previous ACL rules.
-
-
-.. _slapd__ref_acl_rule10:
-
-Rule 10: group owners can add or remove members of their groups
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Access to: ``member`` attribute of the ``System Groups`` or ``Groups`` LDAP
-            objects
-:Write by:  owners of a given group
-:Others:    continue evaluation
-
-- Grant write access to the ``member`` attribute of the child objects under the
-  ``ou=System Groups,dc=example,dc=org`` or ``ou=Groups,dc=example,dc=org``
-  Distinguished Names by the accounts defined in the ``owner`` attribute of
-  a given child object.
-
-- Continue evaluation of the ACL rules for anyone else.
-
-.. note::
-   The owners of the groups defined under the ``ou=System
-   Groups,dc=example,dc=org`` or ``ou=Groups,dc=example,dc=org`` Distinguished
-   Names should be able to add or remove members in their own group.
-
-
-.. _slapd__ref_acl_rule11:
-
-Rule 11: account admins can create new child objects under specific DNs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Access to: new child objects of specific Distinguished Names
-:Write by:  :ref:`slapd__ref_acl_dn_account_admin`
-:Others:    continue evaluation
-
-- Grant write access to new children objects and the entries of the
-  ``ou=People,dc=example,dc=org``, ``ou=Machines,dc=example,dc=org`` and
-  ``ou=Groups,dc=example,dc=org`` Distinguished Names by the members of the
-  :ref:`slapd__ref_acl_dn_account_admin` role.
-
-- Continue evaluation of the ACL rules for anyone else.
-
-.. note::
-   Account administrators should be able to add new user and client machine
-   accounts, as well as create new groups in the LDAP directory. Access to the
-   parent objects themselves is granted only when children are specified, to
-   allow creation of new children objects.
-
-
-.. _slapd__ref_acl_rule12:
-
-Rule 12: account admins can modify existing child objects under specific DNs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Access to: existing child objects of specific Distinguished Names
-:Write by:  :ref:`slapd__ref_acl_dn_account_admin`
-:Others:    continue evaluation
-
-- Grant write access to existing children objects of the
-  ``ou=People,dc=example,dc=org``, ``ou=Machines,dc=example,dc=org`` and
-  ``ou=Groups,dc=example,dc=org`` Distinguished Names by the members of the
-  :ref:`slapd__ref_acl_dn_account_admin` role.
-
-- Continue evaluation of the ACL rules for anyone else.
-
-.. note::
-   Account administrators should be able to modify user and client machine
-   accounts, as well as modify existing groups in the LDAP directory.
-
-
-.. _slapd__ref_acl_rule13:
-
-Rule 13: grant read access to authenticated users
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Access to: entire LDAP directory
-:Read by:   authenticated users
-:Others:    no access
-
-- Grant read access to entire LDAP directory by authenticated users.
-
-- Deny access to all objects in the LDAP directory to everyone else.
-
-.. note::
-   Authenticated users should be able to read contents of the LDAP directory,
-   apart from any restrictions imposed by earlier ACL rules.
+- No other access is granted to anonymous users.
 
 
 Current issues with the default ACL

--- a/docs/ansible/roles/debops.slapd/ldap-acl.rst
+++ b/docs/ansible/roles/debops.slapd/ldap-acl.rst
@@ -44,8 +44,9 @@ Default security policy
   to it.
 
 - Grant LDAP editors write access to most of the LDAP directory. They don't
-  have write access to ``ou=System Groups`` subtree as well as to the UNIX
-  attributes, they cannot see passwords (but can change them).
+  have write access to the LDAP Administrators and the LDAP Replicators roles,
+  the UNIX Administrators group, the ``ou=System Groups`` subtree as well as to
+  the UNIX attributes, they cannot see passwords (but can change them).
 
 - Group owners should be able to add or remove members of their own group.
 
@@ -77,29 +78,42 @@ present initially and might need to be created by the administrator to perform
 their function. The LDAP Distinguished Names used in the documentation assume
 that the ``example.org`` DNS domain is used by the OpenLDAP server.
 
+The "Test RDN" and "Test DN" attributes refer to the
+:ref:`slapd__ref_acl_tests` and specifically to the
+:envvar:`slapd__slapacl_test_rdn_map` variable.
+
 .. _slapd__ref_acl_dn_ldap_admins:
 
-cn=LDAP Administrators,ou=System Groups,dc=example,dc=org
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+cn=LDAP Administrators,ou=Roles,dc=example,dc=org
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This is a ``groupOfNames`` LDAP object that defines via its ``member``
-attribute the Distinguished Names of the people who have full, privileged
-access to the LDAP directory.
+:Test RDN: ``ldap_admin_rdn``
+:Obsolete: cn=LDAP Administrators,ou=System Groups,dc=example,dc=org
+
+This is an ``organizationalRole`` LDAP object that defines via its
+``roleOccupant`` attribute the Distinguished Names of the people who have full,
+privileged access to the LDAP directory.
 
 .. _slapd__ref_acl_dn_ldap_replicators:
 
-cn=LDAP Replicators,ou=System Groups,dc=example,dc=org
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+cn=LDAP Replicators,ou=Roles,dc=example,dc=org
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The is a ``groupOfNames`` LDAP object that defines via its ``member`` attribute
-the Distinguished Names of the objects that are used for authenticated access
-to data replication by other OpenLDAP servers. This group should have full
-access to the LDAP directory for successful replication.
+:Test DN:  ``ldap_replicator_dn``
+:Obsolete: cn=LDAP Replicators,ou=System Groups,dc=example,dc=org
+
+The is an ``organizationalRole`` LDAP object that defines via its
+``roleOccupant`` attribute the Distinguished Names of the objects that are used
+for authenticated access to data replication by other OpenLDAP servers. This
+group should have full access to the LDAP directory for successful replication.
 
 .. _slapd__ref_acl_dn_unix_admins:
 
-cn=UNIX Administrators,ou=System Groups,dc=example,dc=org
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+cn=UNIX Administrators,ou=Groups,dc=example,dc=org
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Test RDN: ``unix_admin_rdn``
+:Obsolete: cn=UNIX Administrators,ou=System Groups,dc=example,dc=org
 
 This is a ``groupOfNames`` LDAP object that defines via its ``member``
 attribute the Distinguished Names of the UNIX administrators. These accounts
@@ -109,29 +123,45 @@ security boundary in an UNIX-like environment.
 
 .. _slapd__ref_acl_dn_ldap_editors:
 
-cn=LDAP Editors,ou=System Groups,dc=example,dc=org
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+cn=LDAP Editors,ou=Roles,dc=example,dc=org
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This is a ``groupOfNames`` LDAP object that defines via its ``member``
-attribute the Distinguished Names of the LDAP editors. The editors are expected
-to be proficient in LDAP management and are granted write access to most of the
-LDAP directory, apart from the ``ou=System Groups`` subtree and UNIX
-attributes.
+:Test RDN: ``ldap_editor_rdn``
+:Obsolete: cn=LDAP Editors,ou=System Groups,dc=example,dc=org
+
+This is an ``organizationalRole`` LDAP object that defines via its
+``roleOccupant`` attribute the Distinguished Names of the LDAP editors. The
+editors are expected to be proficient in LDAP management and are granted write
+access to most of the LDAP directory, apart from the LDAP Administrators and
+the LDAP Replicators roles, the UNIX Administrators group, the ``ou=System
+Groups`` subtree and UNIX attributes.
 
 .. _slapd__ref_acl_dn_account_admins:
 
-cn=Account Administrators,ou=System Groups,dc=example,dc=org
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+cn=Account Administrators,ou=Roles,dc=example,dc=org
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This is a ``groupOfNames`` LDAP object that defines via its ``member``
-attribute the Distinguished Names of the account administrators. They are
-responsible for managing the user accounts of people, client machines,
-organizational groups and other user-specific data.
+:Test RDN: ``account_admin_rdn``
+:Obsolete: cn=Account Administrators,ou=System Groups,dc=example,dc=org
+
+This is an ``organizationalRole`` LDAP object that defines via its
+``roleOccupant`` attribute the Distinguished Names of the account
+administrators. They are responsible for managing the user accounts of people,
+client machines, organizational groups and other user-specific data.
 
 .. _slapd__ref_acl_dn_password_reset:
 
-cn=Password Reset Agents,ou=System Groups,dc=example,dc=org
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+cn=Password Reset Agents,ou=Roles,dc=example,dc=org
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Test RDN: ``password_reset_dn``
+:Obsolete: cn=Password Reset Agents,ou=System Groups,dc=example,dc=org
+
+This is an ``organizationRole`` LDAP object that defines via its
+``roleOccupant`` attribute the Distinguished Names of the Password Reset
+Agents, usually application(s) that act on behalf of the users to allow them to
+perform password changes after out-of-band authentication. This group should
+have access to user passwords to be able to reset them.
 
 This is a ``groupOfNames`` LDAP object that defines via its ``member``
 attribute the Distinguished Names of the Password Reset Agents, usually
@@ -159,11 +189,11 @@ Rule 0: full access by LDAP admins and replicators
 :Others:    continue evaluation
 
 - Grant full access to the entire LDAP directory tree by the members of the
-  :ref:`slapd__ref_acl_dn_ldap_admins` group, including passwords and other
+  :ref:`slapd__ref_acl_dn_ldap_admins` role, including passwords and other
   confidential data.
 
 - Grant read-only access to the entire LDAP directory tree by the members of
-  the :ref:`slapd__ref_acl_dn_ldap_replicators` group, including passwords and
+  the :ref:`slapd__ref_acl_dn_ldap_replicators` role, including passwords and
   other confidential data.
 
 - Continue evaluation of the ACL rules for anyone else.
@@ -213,11 +243,11 @@ Rule 2: restrict access to shadow database of the personal accounts
 - Grant write access to the ``shadowLastChange`` attribute in all objects under
   the ``ou=People,dc=example,dc=org`` Distinguished Name by the members of the
   :ref:`slapd__ref_acl_dn_ldap_editors` and
-  :ref:`slapd__ref_acl_dn_account_admins` groups.
+  :ref:`slapd__ref_acl_dn_account_admins` roles.
 
 - Grant write-only access to the ``shadowLastChange`` attribute in all objects
   under the ``ou=People,dc=example,dc=org`` Distinguished Name by the members
-  of the :ref:`slapd__ref_acl_dn_password_reset` group to allow successfull
+  of the :ref:`slapd__ref_acl_dn_password_reset` role to allow successfull
   password resets.
 
 - Grant read-only access to the ``shadowLastChange`` attribute in all objects
@@ -249,7 +279,7 @@ Rule 3: restrict access to password attribute of the personal accounts
   under the ``ou=People,dc=example,dc=org`` Distinguished Name by the members
   of the :ref:`slapd__ref_acl_dn_ldap_editors`,
   :ref:`slapd__ref_acl_dn_account_admins` and
-  :ref:`slapd__ref_acl_dn_password_reset` groups.
+  :ref:`slapd__ref_acl_dn_password_reset` roles.
 
 - Permit authentication attempts using the ``userPassword`` attribute in all
   objects under the ``ou=People,dc=example,dc=org`` Distinguished Name by the
@@ -295,7 +325,53 @@ Rule 4: restrict access to password attribute in LDAP directory
 
 .. _slapd__ref_acl_rule5:
 
-Rule 5: restrict access to System Groups by LDAP editors
+Rule 5: restrict access to privileged roles by administration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Access to:    the :ref:`slapd__ref_acl_dn_ldap_admins` and the :ref:`slapd__ref_acl_dn_ldap_replicators` roles
+:Read-only by: LDAP Editors, Account Administrators
+:Others:       continue evaluation
+
+- Grant read-only access to the :ref:`slapd__ref_acl_dn_ldap_admins` and the
+  :ref:`slapd__ref_acl_dn_ldap_replicators` roles by the members of the
+  :ref:`slapd__ref_acl_dn_ldap_editors` and the
+  :ref:`slapd__ref_acl_dn_account_admins` roles.
+
+- Continue evaluation of the ACL rules for anyone else.
+
+.. note::
+   The :ref:`slapd__ref_acl_dn_ldap_admins` and the
+   :ref:`slapd__ref_acl_dn_ldap_replicators` roles are used to control
+   privileged access to the LDAP directory and other security contexts. LDAP
+   Editors and Account Administrators should not be allowed to modify them,
+   otherwise they could easily grant themselves more privileged access.
+
+
+.. _slapd__ref_acl_rule6:
+
+Rule 6: restrict access to privileged UNIX group by administration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Access to:    the :ref:`slapd__ref_acl_dn_unix_admins` group
+:Read-only by: LDAP Editors, Account Administrators
+:Others:       continue evaluation
+
+- Grant read-only access to the :ref:`slapd__ref_acl_dn_unix_admins` group by
+  the members of the :ref:`slapd__ref_acl_dn_ldap_editors` and the
+  :ref:`slapd__ref_acl_dn_account_admins` roles.
+
+- Continue evaluation of the ACL rules for anyone else.
+
+.. note::
+   The :ref:`slapd__ref_acl_dn_unix_admins` group is used to control privileged
+   access to the UNIX environment. LDAP Editors and Account Administrators
+   should not be allowed to modify it, otherwise they could easily grant
+   themselves more privileged access.
+
+
+.. _slapd__ref_acl_rule7:
+
+Rule 7: restrict access to System Groups by LDAP editors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Access to:    objects under the ``ou=System Groups,dc=example,dc=org`` DN
@@ -304,7 +380,7 @@ Rule 5: restrict access to System Groups by LDAP editors
 
 - Grant read-only access to all objects under the ``ou=System
   Groups,dc=example,dc=org`` Distinguished Name by the members of the
-  :ref:`slapd__ref_acl_dn_ldap_editors` group.
+  :ref:`slapd__ref_acl_dn_ldap_editors` role.
 
 - Continue evaluation of the ACL rules for anyone else.
 
@@ -315,9 +391,9 @@ Rule 5: restrict access to System Groups by LDAP editors
    otherwise they could easily grant themselves more privileged access.
 
 
-.. _slapd__ref_acl_rule6:
+.. _slapd__ref_acl_rule8:
 
-Rule 6: write access to most of the directory by LDAP editors
+Rule 8: write access to most of the directory by LDAP editors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Access to: most sections of the main LDAP directory tree
@@ -325,7 +401,7 @@ Rule 6: write access to most of the directory by LDAP editors
 :Others:    continue evaluation
 
 - Grant write access to the most parts of the main LDAP directory tree by the
-  members of the :ref:`slapd__ref_acl_dn_ldap_editors` group.
+  members of the :ref:`slapd__ref_acl_dn_ldap_editors` role.
 
 - Continue evaluation of the ACL rules for anyone else.
 
@@ -334,9 +410,9 @@ Rule 6: write access to most of the directory by LDAP editors
    from the restrictions set in the previous ACL rules.
 
 
-.. _slapd__ref_acl_rule7:
+.. _slapd__ref_acl_rule9:
 
-Rule 7: group owners can add or remove members of their groups
+Rule 9: group owners can add or remove members of their groups
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Access to: ``member`` attribute of the ``System Groups`` or ``Groups`` LDAP
@@ -357,10 +433,10 @@ Rule 7: group owners can add or remove members of their groups
    Names should be able to add or remove members in their own group.
 
 
-.. _slapd__ref_acl_rule8:
+.. _slapd__ref_acl_rule10:
 
-Rule 8: account admins can create new child objects under specific DNs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Rule 10: account admins can create new child objects under specific DNs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Access to: new child objects of specific Distinguished Names
 :Write by:  :ref:`slapd__ref_acl_dn_account_admins`
@@ -369,7 +445,7 @@ Rule 8: account admins can create new child objects under specific DNs
 - Grant write access to new children objects and the entries of the
   ``ou=People,dc=example,dc=org``, ``ou=Machines,dc=example,dc=org`` and
   ``ou=Groups,dc=example,dc=org`` Distinguished Names by the members of the
-  :ref:`slapd__ref_acl_dn_account_admins` group.
+  :ref:`slapd__ref_acl_dn_account_admins` role.
 
 - Continue evaluation of the ACL rules for anyone else.
 
@@ -380,10 +456,10 @@ Rule 8: account admins can create new child objects under specific DNs
    allow creation of new children objects.
 
 
-.. _slapd__ref_acl_rule9:
+.. _slapd__ref_acl_rule11:
 
-Rule 9: account admins can modify existing child objects under specific DNs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Rule 11: account admins can modify existing child objects under specific DNs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Access to: existing child objects of specific Distinguished Names
 :Write by:  :ref:`slapd__ref_acl_dn_account_admins`
@@ -392,7 +468,7 @@ Rule 9: account admins can modify existing child objects under specific DNs
 - Grant write access to existing children objects of the
   ``ou=People,dc=example,dc=org``, ``ou=Machines,dc=example,dc=org`` and
   ``ou=Groups,dc=example,dc=org`` Distinguished Names by the members of the
-  :ref:`slapd__ref_acl_dn_account_admins` group.
+  :ref:`slapd__ref_acl_dn_account_admins` role.
 
 - Continue evaluation of the ACL rules for anyone else.
 
@@ -401,9 +477,9 @@ Rule 9: account admins can modify existing child objects under specific DNs
    accounts, as well as modify existing groups in the LDAP directory.
 
 
-.. _slapd__ref_acl_rule10:
+.. _slapd__ref_acl_rule12:
 
-Rule 10: grant read access to authenticated users
+Rule 12: grant read access to authenticated users
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Access to: entire LDAP directory

--- a/docs/ansible/roles/debops.slapd/ldap-acl.rst
+++ b/docs/ansible/roles/debops.slapd/ldap-acl.rst
@@ -82,10 +82,10 @@ The "Test RDN" and "Test DN" attributes refer to the
 :ref:`slapd__ref_acl_tests` and specifically to the
 :envvar:`slapd__slapacl_test_rdn_map` variable.
 
-.. _slapd__ref_acl_dn_ldap_admins:
+.. _slapd__ref_acl_dn_ldap_admin:
 
-cn=LDAP Administrators,ou=Roles,dc=example,dc=org
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+cn=LDAP Administrator,ou=Roles,dc=example,dc=org
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Test RDN: ``ldap_admin_rdn``
 :Obsolete: cn=LDAP Administrators,ou=System Groups,dc=example,dc=org
@@ -94,10 +94,10 @@ This is an ``organizationalRole`` LDAP object that defines via its
 ``roleOccupant`` attribute the Distinguished Names of the people who have full,
 privileged access to the LDAP directory.
 
-.. _slapd__ref_acl_dn_ldap_replicators:
+.. _slapd__ref_acl_dn_ldap_replicator:
 
-cn=LDAP Replicators,ou=Roles,dc=example,dc=org
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+cn=LDAP Replicator,ou=Roles,dc=example,dc=org
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Test DN:  ``ldap_replicator_dn``
 :Obsolete: cn=LDAP Replicators,ou=System Groups,dc=example,dc=org
@@ -121,10 +121,10 @@ will be able to manipulate the LDAP attributes of certain objects
 (``posixAccount``, ``posixGroup``, ``posixGroupId``) which can affect the
 security boundary in an UNIX-like environment.
 
-.. _slapd__ref_acl_dn_ldap_editors:
+.. _slapd__ref_acl_dn_ldap_editor:
 
-cn=LDAP Editors,ou=Roles,dc=example,dc=org
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+cn=LDAP Editor,ou=Roles,dc=example,dc=org
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Test RDN: ``ldap_editor_rdn``
 :Obsolete: cn=LDAP Editors,ou=System Groups,dc=example,dc=org
@@ -136,10 +136,10 @@ access to most of the LDAP directory, apart from the LDAP Administrators and
 the LDAP Replicators roles, the UNIX Administrators group, the ``ou=System
 Groups`` subtree and UNIX attributes.
 
-.. _slapd__ref_acl_dn_account_admins:
+.. _slapd__ref_acl_dn_account_admin:
 
-cn=Account Administrators,ou=Roles,dc=example,dc=org
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+cn=Account Administrator,ou=Roles,dc=example,dc=org
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Test RDN: ``account_admin_rdn``
 :Obsolete: cn=Account Administrators,ou=System Groups,dc=example,dc=org
@@ -151,8 +151,8 @@ client machines, organizational groups and other user-specific data.
 
 .. _slapd__ref_acl_dn_password_reset:
 
-cn=Password Reset Agents,ou=Roles,dc=example,dc=org
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+cn=Password Reset Agent,ou=Roles,dc=example,dc=org
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Test RDN: ``password_reset_dn``
 :Obsolete: cn=Password Reset Agents,ou=System Groups,dc=example,dc=org
@@ -171,7 +171,7 @@ cn=Hidden Objects,ou=Groups,dc=example,dc=org
 This is a ``groupOfNames`` LDAP object that defines via its ``member``
 attribute the Distinguished Names of the LDAP objects which should be visible
 only to LDAP Administrators, LDAP Editors and LDAP objects present in the
-:ref:`slapd__ref_acl_dn_hidden_object_viewers` role. The access control list
+:ref:`slapd__ref_acl_dn_hidden_object_viewer` role. The access control list
 checks the ``memberOf`` attribute of an LDAP object and grants or denies access
 to it depending on the member status.
 
@@ -182,10 +182,10 @@ Otherwise the children of hidden objects can be still visible in general LDAP
 searches, for example ``(objectClass=*)``. The DN attribute of such entries can
 also disclose the presence of a hidden object.
 
-.. _slapd__ref_acl_dn_hidden_object_viewers:
+.. _slapd__ref_acl_dn_hidden_object_viewer:
 
-cn=Hidden Object Viewers,ou=Roles,dc=example,dc=org
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+cn=Hidden Object Viewer,ou=Roles,dc=example,dc=org
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This is an ``organizationalRole`` LDAP object which can be used to give other
 LDAP objects a way to see the LDAP objects hidden by the
@@ -208,16 +208,16 @@ Rule 0: full access by LDAP admins and replicators
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Access to: main LDAP directory tree
-:Manage by: :ref:`slapd__ref_acl_dn_ldap_admins`
-:Read by:   :ref:`slapd__ref_acl_dn_ldap_replicators`
+:Manage by: :ref:`slapd__ref_acl_dn_ldap_admin`
+:Read by:   :ref:`slapd__ref_acl_dn_ldap_replicator`
 :Others:    continue evaluation
 
 - Grant full access to the entire LDAP directory tree by the members of the
-  :ref:`slapd__ref_acl_dn_ldap_admins` role, including passwords and other
+  :ref:`slapd__ref_acl_dn_ldap_admin` role, including passwords and other
   confidential data.
 
 - Grant read-only access to the entire LDAP directory tree by the members of
-  the :ref:`slapd__ref_acl_dn_ldap_replicators` role, including passwords and
+  the :ref:`slapd__ref_acl_dn_ldap_replicator` role, including passwords and
   other confidential data.
 
 - Continue evaluation of the ACL rules for anyone else.
@@ -233,15 +233,15 @@ Rule 1: certain LDAP objects are visible only to privileged accounts
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Access to:     members of the ``cn=Hidden Objects`` group
-:Skipped by:    object owners (self), :ref:`slapd__ref_acl_dn_ldap_admins`,
-                :ref:`slapd__ref_acl_dn_ldap_editors`,
-                :ref:`slapd__ref_acl_dn_hidden_object_viewers`
+:Skipped by:    object owners (self), :ref:`slapd__ref_acl_dn_ldap_admin`,
+                :ref:`slapd__ref_acl_dn_ldap_editor`,
+                :ref:`slapd__ref_acl_dn_hidden_object_viewer`
 :Others:        no access
 
 - Skip rule evaluation for the hidden LDAP objects themselves, for the members
-  of the :ref:`slapd__ref_acl_dn_ldap_admins`, the
-  :ref:`slapd__ref_acl_dn_ldap_editors` and the
-  :ref:`slapd__ref_acl_dn_hidden_object_viewers` LDAP groups. In effect it
+  of the :ref:`slapd__ref_acl_dn_ldap_admin`, the
+  :ref:`slapd__ref_acl_dn_ldap_editor` and the
+  :ref:`slapd__ref_acl_dn_hidden_object_viewer` LDAP roles. In effect it
   makes the hidden objects visible to these entities.
 
 - Deny access to the hidden objects to anyone else.
@@ -286,8 +286,8 @@ Rule 3: restrict access to shadow database of the personal accounts
 
 - Grant write access to the ``shadowLastChange`` attribute in all objects under
   the ``ou=People,dc=example,dc=org`` Distinguished Name by the members of the
-  :ref:`slapd__ref_acl_dn_ldap_editors` and
-  :ref:`slapd__ref_acl_dn_account_admins` roles.
+  :ref:`slapd__ref_acl_dn_ldap_editor` and
+  :ref:`slapd__ref_acl_dn_account_admin` roles.
 
 - Grant write-only access to the ``shadowLastChange`` attribute in all objects
   under the ``ou=People,dc=example,dc=org`` Distinguished Name by the members
@@ -321,8 +321,8 @@ Rule 4: restrict access to password attribute of the personal accounts
 
 - Grant write-only access to the ``userPassword`` attribute in all objects
   under the ``ou=People,dc=example,dc=org`` Distinguished Name by the members
-  of the :ref:`slapd__ref_acl_dn_ldap_editors`,
-  :ref:`slapd__ref_acl_dn_account_admins` and
+  of the :ref:`slapd__ref_acl_dn_ldap_editor`,
+  :ref:`slapd__ref_acl_dn_account_admin` and
   :ref:`slapd__ref_acl_dn_password_reset` roles.
 
 - Permit authentication attempts using the ``userPassword`` attribute in all
@@ -372,20 +372,20 @@ Rule 5: restrict access to password attribute in LDAP directory
 Rule 6: restrict access to privileged roles by administration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:Access to:    the :ref:`slapd__ref_acl_dn_ldap_admins` and the :ref:`slapd__ref_acl_dn_ldap_replicators` roles
+:Access to:    the :ref:`slapd__ref_acl_dn_ldap_admin` and the :ref:`slapd__ref_acl_dn_ldap_replicator` roles
 :Read-only by: LDAP Editors, Account Administrators
 :Others:       continue evaluation
 
-- Grant read-only access to the :ref:`slapd__ref_acl_dn_ldap_admins` and the
-  :ref:`slapd__ref_acl_dn_ldap_replicators` roles by the members of the
-  :ref:`slapd__ref_acl_dn_ldap_editors` and the
-  :ref:`slapd__ref_acl_dn_account_admins` roles.
+- Grant read-only access to the :ref:`slapd__ref_acl_dn_ldap_admin` and the
+  :ref:`slapd__ref_acl_dn_ldap_replicator` roles by the members of the
+  :ref:`slapd__ref_acl_dn_ldap_editor` and the
+  :ref:`slapd__ref_acl_dn_account_admin` roles.
 
 - Continue evaluation of the ACL rules for anyone else.
 
 .. note::
-   The :ref:`slapd__ref_acl_dn_ldap_admins` and the
-   :ref:`slapd__ref_acl_dn_ldap_replicators` roles are used to control
+   The :ref:`slapd__ref_acl_dn_ldap_admin` and the
+   :ref:`slapd__ref_acl_dn_ldap_replicator` roles are used to control
    privileged access to the LDAP directory and other security contexts. LDAP
    Editors and Account Administrators should not be allowed to modify them,
    otherwise they could easily grant themselves more privileged access.
@@ -401,8 +401,8 @@ Rule 7: restrict access to privileged UNIX group by administration
 :Others:       continue evaluation
 
 - Grant read-only access to the :ref:`slapd__ref_acl_dn_unix_admins` group by
-  the members of the :ref:`slapd__ref_acl_dn_ldap_editors` and the
-  :ref:`slapd__ref_acl_dn_account_admins` roles.
+  the members of the :ref:`slapd__ref_acl_dn_ldap_editor` and the
+  :ref:`slapd__ref_acl_dn_account_admin` roles.
 
 - Continue evaluation of the ACL rules for anyone else.
 
@@ -424,7 +424,7 @@ Rule 8: restrict access to System Groups by LDAP editors
 
 - Grant read-only access to all objects under the ``ou=System
   Groups,dc=example,dc=org`` Distinguished Name by the members of the
-  :ref:`slapd__ref_acl_dn_ldap_editors` role.
+  :ref:`slapd__ref_acl_dn_ldap_editor` role.
 
 - Continue evaluation of the ACL rules for anyone else.
 
@@ -441,11 +441,11 @@ Rule 9: write access to most of the directory by LDAP editors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Access to: most sections of the main LDAP directory tree
-:Write by:  :ref:`slapd__ref_acl_dn_ldap_editors`
+:Write by:  :ref:`slapd__ref_acl_dn_ldap_editor`
 :Others:    continue evaluation
 
 - Grant write access to the most parts of the main LDAP directory tree by the
-  members of the :ref:`slapd__ref_acl_dn_ldap_editors` role.
+  members of the :ref:`slapd__ref_acl_dn_ldap_editor` role.
 
 - Continue evaluation of the ACL rules for anyone else.
 
@@ -483,13 +483,13 @@ Rule 11: account admins can create new child objects under specific DNs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Access to: new child objects of specific Distinguished Names
-:Write by:  :ref:`slapd__ref_acl_dn_account_admins`
+:Write by:  :ref:`slapd__ref_acl_dn_account_admin`
 :Others:    continue evaluation
 
 - Grant write access to new children objects and the entries of the
   ``ou=People,dc=example,dc=org``, ``ou=Machines,dc=example,dc=org`` and
   ``ou=Groups,dc=example,dc=org`` Distinguished Names by the members of the
-  :ref:`slapd__ref_acl_dn_account_admins` role.
+  :ref:`slapd__ref_acl_dn_account_admin` role.
 
 - Continue evaluation of the ACL rules for anyone else.
 
@@ -506,13 +506,13 @@ Rule 12: account admins can modify existing child objects under specific DNs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Access to: existing child objects of specific Distinguished Names
-:Write by:  :ref:`slapd__ref_acl_dn_account_admins`
+:Write by:  :ref:`slapd__ref_acl_dn_account_admin`
 :Others:    continue evaluation
 
 - Grant write access to existing children objects of the
   ``ou=People,dc=example,dc=org``, ``ou=Machines,dc=example,dc=org`` and
   ``ou=Groups,dc=example,dc=org`` Distinguished Names by the members of the
-  :ref:`slapd__ref_acl_dn_account_admins` role.
+  :ref:`slapd__ref_acl_dn_account_admin` role.
 
 - Continue evaluation of the ACL rules for anyone else.
 

--- a/docs/ansible/roles/debops.slapd/ldap-acl.rst
+++ b/docs/ansible/roles/debops.slapd/ldap-acl.rst
@@ -97,6 +97,10 @@ UNIX Administrators
   ``posixAccount``, ``posixGroup`` and ``posixGroupId`` LDAP objects. Everyone
   else has read-only access to these attributes.
 
+- Members of this group have write access to the
+  ``ou=SUDOers,dc=example,dc=org`` LDAP subtree which contains
+  :man:`sudoers.ldap(5)` configuration. Everyone else has read-only access.
+
 - Access to the group is restricted to Read-only by role occupants of the
   :ref:`slapd__ref_acl_role_ldap_editor` and the
   :ref:`slapd__ref_acl_role_account_admin` LDAP roles.

--- a/docs/ansible/roles/debops.slapd/ldap-acl.rst
+++ b/docs/ansible/roles/debops.slapd/ldap-acl.rst
@@ -211,7 +211,7 @@ Password Reset Agent
 ~~~~~~~~~~~~~~~~~~~~
 
 :DN:       cn=Password Reset Agent,ou=Roles,dc=example,dc=org
-:Test RDN: ``password_reset_dn``
+:Test DN: ``password_reset_dn``
 :Obsolete: cn=Password Reset Agents,ou=System Groups,dc=example,dc=org
 
 - Role grants write-only access to the ``shadowLastChange`` and the
@@ -220,6 +220,17 @@ Password Reset Agent
 
 - This role is meant for applications that act on behalf of the users to allow
   them to perform password changes after out-of-band authentication.
+
+.. _slapd__ref_acl_role_sms_gateway:
+
+SMS Gateway
+~~~~~~~~~~~
+
+:DN:       cn=SMS Gateway,ou=Roles,dc=example,dc=org
+:Test DN: ``sms_gateway_dn``
+
+- Role grants read-only access to the ``mobile`` LDAP attribute, required by
+  the SMS gateways to send SMS messages.
 
 .. _slapd__ref_acl_role_hidden_object_viewer:
 
@@ -267,9 +278,9 @@ Object owners
   write-only access to the ``userPassword`` attribute in their own LDAP objects
   to allow password changes.
 
-- Object owners have write access to the ``carLicense``, ``homePhone`` and
-  ``homePostalAddress`` attributes in their own objects. These attributes
-  cannot be seen by other unprivileged users.
+- Object owners have write access to the ``mobile``, ``carLicense``,
+  ``homePhone`` and ``homePostalAddress`` attributes in their own objects.
+  These attributes cannot be seen by other unprivileged users.
 
 Authenticated users
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/ansible/roles/debops.slapd/ldap-acl.rst
+++ b/docs/ansible/roles/debops.slapd/ldap-acl.rst
@@ -53,7 +53,7 @@ Default security policy
 - Object owners should be able to modify passwords in their own objects.
 
 - Authenticated users should have read access to most of the directory, apart
-  from security-sensitive data like passwords or private keys.
+  from security-sensitive data like passwords or private information.
 
 
 Required LDAP schemas
@@ -262,6 +262,10 @@ Object owners
 - Object owners have write access to the ``shadowLastChange`` attribute, and
   write-only access to the ``userPassword`` attribute in their own LDAP objects
   to allow password changes.
+
+- Object owners have write access to the ``carLicense``, ``homePhone`` and
+  ``homePostalAddress`` attributes in their own objects. These attributes
+  cannot be seen by other unprivileged users.
 
 Authenticated users
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I found a way to make migration of the ACLs to the new layout described in https://github.com/debops/debops/issues/1110 as easy as possible (just the UNIX groups need to be moved by hand), so I decided to go ahead with the change early, as well as backport the changes to the stable releases for consistency.

Fixes #1110