### PR TITLE
[debops.postconf] Install 'libsasl2-modules' pkg

### DIFF
--- a/ansible/playbooks/service/postconf.yml
+++ b/ansible/playbooks/service/postconf.yml
@@ -31,6 +31,8 @@
 
     - role: debops.postfix
       tags: [ 'role::postfix', 'skip::postfix' ]
+      postfix__dependent_packages:
+        - '{{ postconf__postfix__dependent_packages }}'
       postfix__dependent_maincf:
         - role: 'postconf'
           config: '{{ postconf__postfix__dependent_maincf }}'

--- a/ansible/roles/debops.postconf/defaults/main.yml
+++ b/ansible/roles/debops.postconf/defaults/main.yml
@@ -211,6 +211,16 @@ postconf__combined_lookup_tables: '{{ postconf__default_lookup_tables
 # Configuration for other Ansible roles [[[
 # -----------------------------------------
 
+# .. envvar:: postconf__postfix__dependent_packages [[[
+#
+# List of APT packages to install passed to the :ref:`debops.postfix` Ansible
+# role.
+postconf__postfix__dependent_packages:
+  - '{{ "libsasl2-modules"
+        if ("auth" in postconf__combined_capabilities)
+        else [] }}'
+
+                                                                   # ]]]
 # .. envvar:: postconf__postfix__dependent_lookup_tables [[[
 #
 # Lookup table configuration passed to the :ref:`debops.postfix` Ansible role.


### PR DESCRIPTION
The 'libsasl2-modules' APT package will be installed automatically when
the 'auth' Postfix capability is enabled.

Fix #169 