### PR TITLE
[debops.keyring] Ensure that gpg v1.x works

### DIFF
--- a/ansible/roles/debops.keyring/defaults/main.yml
+++ b/ansible/roles/debops.keyring/defaults/main.yml
@@ -44,6 +44,16 @@ keyring__keybase_api: 'https://keybase.io/'
 # The URL of the GPG keyserver to use to retrieve keys that are not
 # available in the local keyring.
 keyring__keyserver: 'hkp://pool.sks-keyservers.net'
+
+                                                                   # ]]]
+# .. envvar:: keyring__gpg_version [[[
+#
+# The version of the :command:`gpg` command in use. This variable is defined
+# via Ansible local facts and can be used for conditional code execution.
+keyring__gpg_version: '{{ ansible_local.keyring.gpg_version
+                          if (ansible_local|d() and ansible_local.keyring|d() and
+                              ansible_local.keyring.gpg_version|d())
+                          else "0.0.0" }}'
                                                                    # ]]]
                                                                    # ]]]
 # APT packages [[[

--- a/ansible/roles/debops.keyring/tasks/main.yml
+++ b/ansible/roles/debops.keyring/tasks/main.yml
@@ -98,25 +98,29 @@
   # In some cases 'apt-key' command refuses to work complaining that it has to
   # be run by root. This task should handle these cases gracefully.
 - name: Import specified GPG keys to account keyring
+  vars:
+    gpg_command: '{{ "gpg --batch"
+                     if (keyring__gpg_version is version("2.0.0", "<"))
+                     else "gpg --no-autostart --batch" }}'
   shell: set -o nounset -o pipefail -o errexit &&
-         gpg --no-autostart --batch --list-keys '{{ (item.id | d(item)) | replace(" ","") }}'
+         {{ gpg_command }} --list-keys '{{ (item.id | d(item)) | replace(" ","") }}'
          {% if item.state | d('present') == 'absent' %}
-         && ( printf "Removing key...\n" && gpg --no-autostart --batch --delete-key {{ (item.id | d(item)) | replace(" ","") }} )
+         && ( printf "Removing key...\n" && {{ gpg_command }} --delete-key {{ (item.id | d(item)) | replace(" ","") }} )
          || true
          {% else %}
          {%   if ((item.id | d(item)) | replace(" ","")) not in keyring__fact_local_keys %}
          {%     if item.url|d() %}
-         || ( printf "Adding key...\n" && curl {{ item.url }} | gpg --no-autostart --batch --import - )
+         || ( printf "Adding key...\n" && curl {{ item.url }} | {{ gpg_command }} --import - )
          {%     elif item.keybase|d() %}
          || ( printf "Adding key...\n" && curl {{ keyring__keybase_api + item.keybase
                                                   + '/pgp_keys.asc?fingerprint='
-                                                  + ((item.id | d(item)) | replace(" ","")) }} | gpg --no-autostart --batch --import - )
+                                                  + ((item.id | d(item)) | replace(" ","")) }} | {{ gpg_command }} --import - )
          {%     elif (item.keyserver | d(keyring__keyserver if keyring__keyserver|d() else False)) %}
          || ( printf "Adding key...\n" && gpg --keyserver {{ item.keyserver | d(keyring__keyserver if keyring__keyserver else "") }} \
                                               --batch --recv-key {{ (item.id | d(item)) | replace(" ","") }} && gpgconf --kill all )
          {%     endif %}
          {%   else %}
-         || ( printf "Adding key...\n" && gpg --no-autostart --batch --import - )
+         || ( printf "Adding key...\n" && {{ gpg_command }} --import - )
          {%   endif %}
          {% endif %}
   args:

--- a/ansible/roles/debops.keyring/templates/etc/ansible/facts.d/keyring.fact.j2
+++ b/ansible/roles/debops.keyring/templates/etc/ansible/facts.d/keyring.fact.j2
@@ -4,11 +4,27 @@
 
 from __future__ import print_function
 from json import loads, dumps
+import subprocess
+import os
 
 
 output = loads('''{{ {"configured": True,
                       "enabled": keyring__enabled,
                       "keyserver": keyring__keyserver}
                      | to_nice_json }}''')
+
+try:
+    with open(os.devnull, 'w') as devnull:
+        gpg_stdout = subprocess.check_output(
+            ["/usr/bin/gpg --version"],
+            shell=True, stderr=devnull).decode('utf-8')
+
+except subprocess.CalledProcessError:
+    pass
+
+if gpg_stdout:
+    for line in gpg_stdout.split('\n'):
+        if '(GnuPG)' in line:
+            output['gpg_version'] = line.split()[2]
 
 print(dumps(output, sort_keys=True, indent=4))


### PR DESCRIPTION
This patch makes sure that the 'debops.keyring' role works with older
versions of GnuPG (1.x).

Fixes #1043 