### PR TITLE
bionic features dovecot 2.2.33

### DIFF
--- a/ansible/roles/debops.dovecot/templates/etc/dovecot/conf.d/10-ssl.conf.j2
+++ b/ansible/roles/debops.dovecot/templates/etc/dovecot/conf.d/10-ssl.conf.j2
@@ -28,7 +28,7 @@ ssl_dh_parameters_length = {{ dovecot_ssl_dh_parameters_length }}
 {% set dovecot_tpl_tls_key_file     = dovecot_pki_path + "/" + dovecot_pki_realm + "/" + dovecot_pki_key %}
 ssl_cert    = <{{ dovecot_tpl_tls_cert_file }}
 ssl_key     = <{{ dovecot_tpl_tls_key_file }}
-{% if ansible_distribution_release in [ "wheezy", "jessie", "precise", "trusty" ] %}
+{% if ansible_distribution_release in [ "wheezy", "jessie", "precise", "trusty", "bionic" ] %}
 ssl_protocols   = {{ dovecot_ssl_protocols }}
 {% else %}
 ssl_min_protocol = {{ dovecot_ssl_protocols }}


### PR DESCRIPTION
Dovecot < 2.3 needs ssl_protocols instead of ssl_min_protocol in config.
