### PR TITLE
[debops.cron] Redesign randomization algorithm

### DIFF
--- a/ansible/roles/debops.cron/defaults/main.yml
+++ b/ansible/roles/debops.cron/defaults/main.yml
@@ -55,25 +55,33 @@ cron__crontab_seed: '{{ inventory_hostname }}'
 #
 # A list of pseudo-random strings which are randomly added to the base seed in
 # variouse :man:`crontab(5)` entries. High number of pseudo-random strings
-# gives more variety in the final configuration entries.
-cron__crontab_offset_seeds: '{{ ansible_all_ipv4_addresses
-                                + ansible_all_ipv6_addresses
-                                + (ansible_default_ipv4.values() | d([])) | list
-                                + [ ansible_machine_id, ansible_memtotal_mb ]
-                                + [ ansible_product_name, ansible_product_version ]
-                                + [ ansible_kernel ] }}'
+# gives more variety in the final configuration entries. At least 8 seed
+# strings are required by the default configuration.
+#
+# The offset seeds will be stored on the remote hosts in the local fact script
+# to ensure idempotency.
+cron__crontab_offset_seeds: '{{ ansible_local.cron.crontab_offset_seeds
+                                if (ansible_local|d() and ansible_local.cron|d() and
+                                    ansible_local.cron.crontab_offset_seeds|d())
+                                else ((ansible_all_ipv4_addresses
+                                       + ansible_all_ipv6_addresses
+                                       + (ansible_default_ipv4.values() | d([])) | list
+                                       + [ ansible_machine_id, ansible_memtotal_mb ]
+                                       + [ ansible_product_name, ansible_product_version ]
+                                       + [ ansible_kernel ])
+                                      | map("regex_replace", "^(.*)$",
+                                            (ansible_date_time.epoch|string + "\1"))
+                                      | map("hash", "sha256") | list | unique) }}'
 
                                                                    # ]]]
-# .. envvar:: cron__crontab_hour_ranges_map [[[
+# .. envvar:: cron__crontab_hours [[[
 #
-# YAML dictionary which defines the ranges of hours which will be used in the
-# daily, weekly and monthly :man:`crontab(5)` entries. The role will randomly
-# select one range and from it, randomly select an hour; all jobs will be
-# executed in the selected range. The default allows job execution outside of
-# normal workday hours, either in the evening or in the morning.
-cron__crontab_hour_ranges_map:
-  'morning': [ 0, 6 ]
-  'evening': [ 18, 23 ]
+# YAML list which defines the hours which will be used in the daily, weekly and
+# monthly :man:`crontab(5)` entries. The role will randomly select an hour for
+# each job type. The default allows job execution outside of normal workday
+# hours.
+cron__crontab_hours: [ 0, 1, 2, 3, 4, 5, 6,
+                       18, 19, 20, 21, 22, 23 ]
 
                                                                    # ]]]
 # .. envvar:: cron__crontab_weekday_days [[[
@@ -142,58 +150,46 @@ cron__crontab_default_jobs:
   - name: 'crontab-hourly'
     minute: '{{ 59 | random(seed=(cron__crontab_seed
                                   + (cron__crontab_offset_seeds
-                                     | random(seed="hourly"))|string)) }}'
+                                     | random(seed=cron__crontab_offset_seeds[0])))) }}'
     user: 'root'
     job: 'cd / && run-parts --report /etc/cron.hourly'
 
   - name: 'crontab-daily'
     minute: '{{ 59 | random(seed=(cron__crontab_seed
                                   + (cron__crontab_offset_seeds
-                                     | random(seed="daily"))|string)) }}'
-    hour: '{{ cron__crontab_hour_ranges_map[(cron__crontab_hour_ranges_map.keys()|list)
-                                            | random(seed=cron__crontab_seed)][1]
-              | random(start=cron__crontab_hour_ranges_map[(cron__crontab_hour_ranges_map.keys()|list)
-                                                           | random(seed=cron__crontab_seed)][0],
-                       seed=(cron__crontab_seed
-                             + (cron__crontab_offset_seeds
-                                | random(seed="daily"))|string)) }}'
+                                     | random(seed=cron__crontab_offset_seeds[1])))) }}'
+    hour: '{{ cron__crontab_hours | random(seed=(cron__crontab_seed
+                                                 + (cron__crontab_offset_seeds
+                                                    | random(seed=cron__crontab_offset_seeds[2])))) }}'
     user: 'root'
     job: 'test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.daily )'
 
   - name: 'crontab-weekly'
     minute: '{{ 59 | random(seed=(cron__crontab_seed
                                   + (cron__crontab_offset_seeds
-                                     | random(seed="weekly"))|string)) }}'
-    hour: '{{ cron__crontab_hour_ranges_map[(cron__crontab_hour_ranges_map.keys()|list)
-                                            | random(seed=cron__crontab_seed)][1]
-              | random(start=cron__crontab_hour_ranges_map[(cron__crontab_hour_ranges_map.keys()|list)
-                                                           | random(seed=cron__crontab_seed)][0],
-                       seed=(cron__crontab_seed
-                             + (cron__crontab_offset_seeds
-                                | random(seed="weekly"))|string)) }}'
+                                     | random(seed=cron__crontab_offset_seeds[3])))) }}'
+    hour: '{{ cron__crontab_hours | random(seed=(cron__crontab_seed
+                                                 + (cron__crontab_offset_seeds
+                                                    | random(seed=cron__crontab_offset_seeds[4])))) }}'
     weekday: '{{ cron__crontab_weekday_days
                  | random(seed=(cron__crontab_seed
                                 + (cron__crontab_offset_seeds
-                                   | random(seed="weekly"))|string)) }}'
+                                   | random(seed=cron__crontab_offset_seeds[5])))) }}'
     user: 'root'
     job: 'test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.weekly )'
 
   - name: 'crontab-monthly'
     minute: '{{ 59 | random(seed=(cron__crontab_seed
                                   + (cron__crontab_offset_seeds
-                                     | random(seed="monthly"))|string)) }}'
-    hour: '{{ cron__crontab_hour_ranges_map[(cron__crontab_hour_ranges_map.keys()|list)
-                                            | random(seed=cron__crontab_seed)][1]
-              | random(start=cron__crontab_hour_ranges_map[(cron__crontab_hour_ranges_map.keys()|list)
-                                                           | random(seed=cron__crontab_seed)][0],
-                       seed=(cron__crontab_seed
-                             + (cron__crontab_offset_seeds
-                                | random(seed="monthly"))|string)) }}'
+                                     | random(seed=cron__crontab_offset_seeds[6])))) }}'
+    hour: '{{ cron__crontab_hours | random(seed=(cron__crontab_seed
+                                                 + (cron__crontab_offset_seeds
+                                                    | random(seed=cron__crontab_offset_seeds[7])))) }}'
     day: '{{ cron__crontab_day_ranges[1]
              | random(start=cron__crontab_day_ranges[0],
                       seed=(cron__crontab_seed
                             + (cron__crontab_offset_seeds
-                               | random(seed="monthly"))|string)) }}'
+                               | random(seed=cron__crontab_offset_seeds[8])))) }}'
     user: 'root'
     job: 'test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.monthly )'
 

--- a/ansible/roles/debops.cron/tasks/main.yml
+++ b/ansible/roles/debops.cron/tasks/main.yml
@@ -12,6 +12,26 @@
   until: cron__register_packages is succeeded
   when: cron__enabled|bool
 
+- name: Make sure that Ansible local facts directory exists
+  file:
+    path: '/etc/ansible/facts.d'
+    state: 'directory'
+    mode: '0755'
+  tags: [ 'role::cron:crontab' ]
+
+- name: Save cron local facts
+  template:
+    src: 'etc/ansible/facts.d/cron.fact.j2'
+    dest: '/etc/ansible/facts.d/cron.fact'
+    mode: '0755'
+  register: cron__register_facts
+  tags: [ 'role::cron:crontab' ]
+
+- name: Update Ansible facts if they were modified
+  action: setup
+  when: cron__register_facts is changed
+  tags: [ 'role::cron:crontab' ]
+
 - name: Divert the original crontab configuration
   dpkg_divert:
     path: '/etc/crontab'
@@ -96,24 +116,3 @@
     - '{{ cron__combined_jobs }}'
     - 'jobs'
   when: cron__enabled|bool and item.0.state|d('present') not in [ 'absent', 'ignore' ]
-
-- name: Make sure that Ansible local facts directory exists
-  file:
-    path: '/etc/ansible/facts.d'
-    state: 'directory'
-    owner: 'root'
-    group: 'root'
-    mode: '0755'
-
-- name: Save cron local facts
-  template:
-    src: 'etc/ansible/facts.d/cron.fact.j2'
-    dest: '/etc/ansible/facts.d/cron.fact'
-    owner: 'root'
-    group: 'root'
-    mode: '0755'
-  register: cron__register_facts
-
-- name: Update Ansible facts if they were modified
-  action: setup
-  when: cron__register_facts is changed

--- a/ansible/roles/debops.cron/templates/etc/ansible/facts.d/cron.fact.j2
+++ b/ansible/roles/debops.cron/templates/etc/ansible/facts.d/cron.fact.j2
@@ -3,9 +3,21 @@
 # {{ ansible_managed }}
 
 from __future__ import print_function
-from json import dumps
+from json import dumps, loads
 from sys import exit
+import os
 
-output = {'installed': True, 'enabled': True}
+
+def cmd_exists(cmd):
+    return any(
+        os.access(os.path.join(path, cmd), os.X_OK)
+        for path in os.environ["PATH"].split(os.pathsep)
+    )
+
+
+output = {'installed': cmd_exists('cron'), 'enabled': True}
+
+output['crontab_offset_seeds'] = loads('''{{ cron__crontab_offset_seeds
+                                             | to_nice_json }}''')
 
 print(dumps(output, sort_keys=True, indent=4))

--- a/docs/ansible/roles/debops.cron/getting-started.rst
+++ b/docs/ansible/roles/debops.cron/getting-started.rst
@@ -17,10 +17,9 @@ Ubuntu ``cron`` package. The randomization is defined with the following rules:
 - Each type of :command:`cron` job will have randomized minute at which the
   jobs will be executed.
 
-- On each host, the role will choose the hourly execution time either at night
-  (0-6) or in the evening (18-23). From that range, a specific hour will be
-  chosen for each of the ``daily``, ``weekly`` and ``monthly`` jobs. This can
-  be controlled using the :envvar:`cron__crontab_hour_ranges_map` variable.
+- On each host, the role will choose a specific hour for each of the ``daily``,
+  ``weekly`` and ``monthly`` jobs. The list of allowed hours is defined in the
+  :envvar:`cron__crontab_hours` variable.
 
 - The ``weekly`` :command:`cron` jobs will be executed on either Saturday or
   Sunday, chosen randomly. you can specify what days to choose from using the
@@ -32,10 +31,11 @@ Ubuntu ``cron`` package. The randomization is defined with the following rules:
 
 The randomization is based on the :envvar:`cron__crontab_seed` variable (by
 default uses the value of the ``inventory_hostname`` Ansible fact), as well as
-some additional pseudo-random strings defined in the
-:envvar:`cron__crontab_offset_seeds` list. The selected random values should be
-stable across multiple :ref:`debops.cron` role executions, but may change
-occasionally when other host configuration is changed.
+some additional pseudo-random strings hashed in the
+:envvar:`cron__crontab_offset_seeds` list. The hashes are stored in the
+:ref:`debops.cron` Ansible local fact script for idempotency; the script can be
+removed to regenerate a new set of hashes if the resulting execution times are
+not the desired ones.
 
 
 Example inventory


### PR DESCRIPTION
The patch changes the 'debops.cron' /etc/crontab randomization algorithm
to be a bit more random and stores the seeds used to randomize execution
times on the host via facts. The changes aren't ideal, the values still
sometimes repeat on a given host more than I would like but it should do
for now.