### PR TITLE
[ci] Send test e-mail to 'vagrant' account

### DIFF
--- a/lib/tests/scripts/postfix-send-mail
+++ b/lib/tests/scripts/postfix-send-mail
@@ -2,10 +2,10 @@
 
 set -o nounset -o pipefail -o errexit
 
-jane notify info "Sending test mail message to root..."
+jane notify info "Sending test mail message to vagrant..."
 printf "Hello, world!\\n\\nThis is a test message from Jane.\\n" \
     | mail -a "Content-Type: text/plain; charset=utf-8" \
-           -s "Test message" "root@$(hostname -f)"
+           -s "Test message" "vagrant@$(hostname -f)"
 
-jane notify info "Displaying root mailbox..."
-sudo cat /var/mail/root
+jane notify info "Displaying vagrant mailbox..."
+cat /var/mail/vagrant


### PR DESCRIPTION
The default 'debops.etc_aliases' configuration redirects all mail for
the local 'root' account to the 'root' account on the DNS domain
instead. In the Vagrant tests, the domain 'vagrant.test' is a false
domain which doesn't exist. Postfix tries to deliver the mails sent to
the 'root' account to that domain and fails, which also fails the test.

This patch changes the destination account to 'vagrant', which is
a local system account without any forwarding configured by default.
This should make the CI test pass.