### PR TITLE
[debops.gitlab] Added variables for gitlab gravatar configuration

### DIFF
--- a/ansible/roles/debops.gitlab/defaults/main.yml
+++ b/ansible/roles/debops.gitlab/defaults/main.yml
@@ -565,6 +565,21 @@ gitlab_passenger_options: ''
 # SSH port for GitLab Shell (does not affect sshd port setting).
 gitlab_shell_ssh_port: '22'
                                                                    # ]]]
+# .. envvar:: gitlab__gravatar_enabled [[[
+#
+# Enable/Disable gitlab gravatar feature.
+gitlab__gravatar_enabled: True
+                                                                   # ]]]
+# .. envvar:: gitlab__gravatar_plain_url [[[
+#
+# Gravatar (HTTP) URL used by gitlab.
+gitlab__gravatar_plain_url: ''
+                                                                   # ]]]
+# .. envvar:: gitlab__gravatar_ssl_url [[[
+#
+# Gravatar SSL (HTTPS) URL used by gitlab.
+gitlab__gravatar_ssl_url: ''
+                                                                   # ]]]
                                                                    # ]]]
 # Compatibility workarounds [[[
 # -----------------------------

--- a/ansible/roles/debops.gitlab/templates/var/local/git/gitlab/config/gitlab.yml.j2
+++ b/ansible/roles/debops.gitlab/templates/var/local/git/gitlab/config/gitlab.yml.j2
@@ -172,10 +172,14 @@ production: &base
   ## Gravatar
   ## For Libravatar see: http://doc.gitlab.com/ce/customization/libravatar.html
   gravatar:
-    enabled: true                 # Use user avatar image from Gravatar.com (default: true)
+    enabled: {{ gitlab__gravatar_enabled }}        # Use user avatar image from Gravatar.com (default: true)
     # gravatar urls: possible placeholders: %{hash} %{size} %{email} %{username}
-    # plain_url: "http://..."     # default: http://www.gravatar.com/avatar/%{hash}?s=%{size}&d=identicon
-    # ssl_url:   "https://..."    # default: https://secure.gravatar.com/avatar/%{hash}?s=%{size}&d=identicon
+{% if gitlab__gravatar_plain_url != '' %}
+    plain_url: "{{ gitlab__gravatar_plain_url }}"  # default: http://www.gravatar.com/avatar/%{hash}?s=%{size}&d=identicon
+{% endif %}
+{% if gitlab__gravatar_ssl_url != '' %}
+    ssl_url:   "{{ gitlab__gravatar_ssl_url }}"    # default: https://secure.gravatar.com/avatar/%{hash}?s=%{size}&d=identicon
+{% endif %}
 
   ## Auxiliary jobs
   # Periodically executed jobs, to self-heal Gitlab, do external synchronizations, etc.


### PR DESCRIPTION
As discussed in IRC yesterday, I added configuration variabled for gitlab gravatar service/feature.
This PR makes all three gravatar configuration entries as documented at https://docs.gitlab.com/ee/administration/libravatar.html configurable via ansible variables.

The default behaviour is not changed as the gitlab__gravatar_enabled variable defaults to True. Both URL variables have a default setting of '' which excludes them from the gitlab.yml file so that the gitlab defaults apply.

As it was mentioned in IRC yesterday: My commit can easily be applied to the current stable-1.2 branch if you should consider backporting this change.