### PR TITLE
[debops.roundcube] Add PostgreSQL support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -65,6 +65,9 @@ New DebOps roles
   configuration of Sieve filter scripts. The role will use the DNS SRV resource
   records to find the Sieve service host and port to use.
 
+- The role can now use PostgreSQL as a database backend. The database server
+  can be managed with the :ref:`debops.postgresql_server` role.
+
 Changed
 ~~~~~~~
 

--- a/ansible/playbooks/service/roundcube.yml
+++ b/ansible/playbooks/service/roundcube.yml
@@ -44,13 +44,15 @@
         - '{{ nginx__ferm__dependent_rules }}'
 
     - role: debops.python
-      tags: [ 'role::python', 'skip::python', 'role::mariadb' ]
+      tags: [ 'role::python', 'skip::python', 'role::mariadb', 'role::postgresql' ]
       python__dependent_packages3:
         - '{{ mariadb__python__dependent_packages3 if roundcube__database_map[roundcube__database].dbtype == "mysql" else [] }}'
         - '{{ nginx__python__dependent_packages3 }}'
+        - '{{ postgresql__python__dependent_packages3 if roundcube__database_map[roundcube__database].dbtype == "postgresql" else [] }}'
       python__dependent_packages2:
         - '{{ mariadb__python__dependent_packages2 if roundcube__database_map[roundcube__database].dbtype == "mysql" else [] }}'
         - '{{ nginx__python__dependent_packages2 }}'
+        - '{{ postgresql__python__dependent_packages2 if roundcube__database_map[roundcube__database].dbtype == "postgresql" else [] }}'
 
     - role: debops.php
       tags: [ 'role::php', 'skip::php' ]
@@ -84,6 +86,17 @@
           priv_aux: False
       mariadb__server: '{{ roundcube__database_map[roundcube__database].dbhost }}'
       when: roundcube__database_map[roundcube__database].dbtype == 'mysql'
+
+    - role: debops.postgresql
+      tags: [ 'role::postgresql', 'skip::postgresql' ]
+      postgresql__dependent_roles:
+        - db: '{{ roundcube__database_map[roundcube__database].dbname }}'
+          role: '{{ roundcube__database_map[roundcube__database].dbuser }}'
+          password: '{{ roundcube__database_map[roundcube__database].dbpass }}'
+      postgresql__server: '{{ roundcube__database_map[roundcube__database].dbhost
+                              if roundcube__database_map[roundcube__database].dbhost != "localhost"
+                              else "" }}'
+      when: roundcube__database_map[roundcube__database].dbtype == 'postgresql'
 
     - role: debops.roundcube
       tags: [ 'role::roundcube', 'skip::roundcube' ]

--- a/ansible/roles/debops.roundcube/defaults/main.yml
+++ b/ansible/roles/debops.roundcube/defaults/main.yml
@@ -214,7 +214,9 @@ roundcube__database_password: '{{ lookup("password", roundcube__database_passwor
 # .. envvar:: roundcube__database_name [[[
 #
 # Name of the database to use for Roundcube.
-roundcube__database_name: 'roundcubemail'
+roundcube__database_name: '{{ roundcube__database_user
+                              if roundcube__database == "postgresql-default"
+                              else "roundcubemail" }}'
 
                                                                    # ]]]
 # .. envvar:: roundcube__database_map [[[
@@ -235,12 +237,37 @@ roundcube__database_map:
     dbhost: 'localhost'
     dbtableprefix: ''
 
+  postgresql-default:
+    dbtype: 'postgresql'
+    dbname: '{{ roundcube__database_name }}'
+    dbuser: '{{ roundcube__database_user }}'
+    dbpass: '{{ roundcube__database_password }}'
+    dbhost: 'localhost'
+    dbtableprefix: ''
+
+                                                                   # ]]]
+# .. envvar:: roundcube__database_schema_map [[[
+#
+# Database type to schema mapping.
+roundcube__database_schema_map:
+  mysql:      '{{ roundcube__git_dest + "/SQL/mysql.initial.sql" }}'
+  postgresql: '{{ roundcube__git_dest + "/SQL/postgres.initial.sql" }}'
+
                                                                    # ]]]
 # .. envvar:: roundcube__database_schema [[[
 #
 # Initial Roundcube database schema loaded by Ansible.
-roundcube__database_schema: '{{ roundcube__git_dest + "/SQL/mysql.initial.sql"
-    if (roundcube__database_map[roundcube__database].dbtype == "mysql") else ""}}'
+roundcube__database_schema: '{{ roundcube__database_schema_map[
+                                  roundcube__database_map[
+                                    roundcube__database
+                                  ].dbtype
+                                ]
+                                if roundcube__database_schema_map[
+                                     roundcube__database_map[
+                                       roundcube__database
+                                     ].dbtype
+                                   ]|d()
+                                else "" }}'
                                                                    # ]]]
                                                                    # ]]]
 # Cache configuration [[[
@@ -2843,6 +2870,15 @@ roundcube__default_configuration:
                           + roundcube__database_map[roundcube__database].dbname|d() }}'
     state: '{{ "present"
                if (roundcube__database_map[roundcube__database].dbtype == "mysql")
+               else "ignore" }}'
+
+  - name: 'db_dsnw'
+    value: '{{ "pgsql://" + roundcube__database_map[roundcube__database].dbuser|d() + ":"
+                          + roundcube__database_map[roundcube__database].dbpass|d() + "@"
+                          + roundcube__database_map[roundcube__database].dbhost|d() + "/"
+                          + roundcube__database_map[roundcube__database].dbname|d() }}'
+    state: '{{ "present"
+               if (roundcube__database_map[roundcube__database].dbtype == "postgresql")
                else "ignore" }}'
 
   - name: 'log_driver'

--- a/ansible/roles/debops.roundcube/tasks/configure_postgresql.yml
+++ b/ansible/roles/debops.roundcube/tasks/configure_postgresql.yml
@@ -1,0 +1,20 @@
+---
+
+- name: Create Roundcube PostgreSQL database
+  postgresql_db:
+    name: '{{ roundcube__database_map[roundcube__database].dbname }}'
+    owner: '{{ roundcube__database_map[roundcube__database].dbuser }}'
+    state: 'present'
+  delegate_to: '{{ ansible_local.postgresql.delegate_to }}'
+  register: roundcube__register_postgresql_status
+
+- name: Import initial database schema
+  postgresql_db:
+    name: '{{ roundcube__database_map[roundcube__database].dbname }}'
+    state: 'restore'
+    target: '{{ roundcube__database_schema }}'
+    login_user: '{{ roundcube__database_map[roundcube__database].dbuser }}'
+    login_password: '{{ roundcube__database_map[roundcube__database].dbpass }}'
+    login_host: '{{ roundcube__database_map[roundcube__database].dbhost }}'
+  when: (roundcube__register_postgresql_status|d() is defined and
+         roundcube__register_postgresql_status is changed)

--- a/ansible/roles/debops.roundcube/tasks/main.yml
+++ b/ansible/roles/debops.roundcube/tasks/main.yml
@@ -68,6 +68,10 @@
   when: roundcube__database_map[roundcube__database].dbtype == 'mysql'
   tags: [ 'role::roundcube:database' ]
 
+- include_tasks: configure_postgresql.yml
+  when: roundcube__database_map[roundcube__database].dbtype == 'postgresql'
+  tags: [ 'role::roundcube:database' ]
+
 - name: Generate Roundcube configuration
   template:
     src: 'srv/www/sites/roundcube/public/config/config.inc.php.j2'

--- a/docs/ansible/roles/debops.roundcube/getting-started.rst
+++ b/docs/ansible/roles/debops.roundcube/getting-started.rst
@@ -76,9 +76,10 @@ Example inventory
 
 To install and configure Roundcube on a host, it needs to be present in the
 ``[debops_service_roundcube]`` Ansible inventory group. Additional services
-like :ref:`memcached <debops.memcached>`, :ref:`Redis <debops.redis_server>`
-and :ref:`MariaDB database <debops.mariadb_server>` can help increase the
-website performance.
+like :ref:`memcached <debops.memcached>`, :ref:`Redis <debops.redis_server>`,
+:ref:`MariaDB <debops.mariadb_server>` and
+:ref:`PostgreSQL <debops.postgresql_server>` can help increase the website
+performance.
 
 .. code-block:: none
 
@@ -89,6 +90,9 @@ website performance.
    webmail
 
    [debops_service_memcached]
+   webmail
+
+   [debops_service_postgresql_server]
    webmail
 
    [debops_service_redis_server]


### PR DESCRIPTION
Thanks a lot for your recent `debops.roundcube` improvements, @drybjed! I'm really happy with the LDAP address book support. Let's see if I can contribute something as well :)

These changes add PostgreSQL support to the `debops.roundcube` role in
a backwards-compatible way. The configuration is similar to the
pre-existing MySQL support, with two noticeable changes:

1. The name of the default PostgreSQL database equals the name of the
   PostgreSQL role instead of 'roundcubemail'. This is because of the
   'samerole' requirement in pg_hba.conf.

2. The role now uses a database type to schema file mapping in order to
   import the correct initial database schema. The new mapping can be
   found in roundcube__database_schema_map.