### PR TITLE
[debops.docker_server] Add option wether to install python virtualenv

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,11 @@ New DebOps roles
 - The :ref:`debops.lxd` role brings support for LXD on Debian hosts by building
   the Go binaries from source, without Snap installation.
 
+:ref:`debops.docker_server` role
+''''''''''''''''''''''''''''''''
+
+- Add `docker_server__install_virtualenv` setting to disable python virtualvenv installation.
+
 :ref:`debops.nslcd` role
 ''''''''''''''''''''''''
 

--- a/ansible/roles/debops.docker_server/defaults/main.yml
+++ b/ansible/roles/debops.docker_server/defaults/main.yml
@@ -150,6 +150,12 @@ docker_server__version: '{{ ansible_local.docker_server.version
 # The role prepares a separate Python virtualenv for Docker-related commands
 # and Ansible modules. See :ref:`docker_server__ref_virtualenv` for more details.
 
+# .. envvar:: docker_server__install_virtualenv [[[
+#
+# Wether to install Python virtualenv for Docker
+docker_server__install_virtualenv: True
+
+                                                                   # ]]]
 # .. envvar:: docker_server__virtualenv [[[
 #
 # Absolute path of the location of Docker virtualenv.

--- a/ansible/roles/debops.docker_server/tasks/main.yml
+++ b/ansible/roles/debops.docker_server/tasks/main.yml
@@ -84,12 +84,14 @@
   with_flattened:
     - '{{ docker_server__default_pip_packages }}'
     - '{{ docker_server__pip_packages }}'
+  when: docker_server__install_virtualenv
 
 - name: Expose Docker virtualenv for Ansible modules
   file:
     path: '{{ docker_server__virtualenv_python_symlink }}'
     src:  '{{ docker_server__virtualenv_python_interpreter }}'
     state: 'link'
+  when: docker_server__install_virtualenv
 
 - name: Symlink selected Python scripts to /usr/local/bin
   file:
@@ -100,7 +102,8 @@
     - '{{ docker_server__default_pip_packages }}'
     - '{{ docker_server__pip_packages }}'
   when: item.path|d() and item.src|d() and
-        item.state|d('present') != 'absent'
+        item.state|d('present') != 'absent' and
+        docker_server__install_virtualenv
 
 - name: Install ferm post hook
   template:


### PR DESCRIPTION
I don't want to install the virtual python as I use the debian packages for docker-compose.