### PR TITLE
[debops.docker_server] Replace deprecated graph option with data-root

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -122,6 +122,11 @@ LDAP
   role no longer generates the :command:`ferm` configuration files directly,
   instead using the :ref:`debops.ferm` role as a dependency.
 
+:ref:`debops.docker_server` role
+''''''''''''''''''''''''''''''''
+
+- Replace deprecated `docker_server__graph` option with `docker_server__data_root`.
+
 :ref:`debops.memcached` role
 ''''''''''''''''''''''''''''
 

--- a/ansible/roles/debops.docker_server/defaults/main.yml
+++ b/ansible/roles/debops.docker_server/defaults/main.yml
@@ -368,10 +368,10 @@ docker_server__debug: False
 docker_server__live_restore: False
 
                                                                    # ]]]
-# .. envvar:: docker_server__graph [[[
+# .. envvar:: docker_server__data_root [[[
 #
 # Alternative root path of the docker runtime.
-docker_server__graph: '/var/lib/docker'
+docker_server__data_root: '/var/lib/docker'
 
                                                                    # ]]]
 # .. envvar:: docker_server__registry_mirrors [[[

--- a/ansible/roles/debops.docker_server/templates/etc/default/docker.j2
+++ b/ansible/roles/debops.docker_server/templates/etc/default/docker.j2
@@ -6,8 +6,8 @@
 #DOCKER="/usr/local/bin/docker"
 
 {% set docker_server__tpl_options = [] %}
-{% if docker_server__graph|d() %}
-{%   set _ = docker_server__tpl_options.append("--graph " + docker_server__graph) %}
+{% if docker_server__data_root|d() %}
+{%   set _ = docker_server__tpl_options.append("--data-root " + docker_server__data_root) %}
 {% endif %}
 {% if docker_server__bridge|d() %}
 {%   set _ = docker_server__tpl_options.append("--bridge " + docker_server__bridge) %}

--- a/ansible/roles/debops.docker_server/templates/etc/docker/daemon.json.j2
+++ b/ansible/roles/debops.docker_server/templates/etc/docker/daemon.json.j2
@@ -7,8 +7,8 @@
 {%    set lv_value = true if docker_server__live_restore else false %}
 {%    set _  = docker_server__tpl_options.update({"live-restore": lv_value}) %}
 {%- endif %}
-{%  if docker_server__graph|d() -%}
-{%    set _ = docker_server__tpl_options.update({"graph": docker_server__graph}) %}
+{%  if docker_server__data_root|d() -%}
+{%    set _ = docker_server__tpl_options.update({"data-root": docker_server__data_root}) %}
 {%- endif %}
 {%  if docker_server__fixed_cidr|d() -%}
 {%    set _ = docker_server__tpl_options.update({"fixed-cidr": docker_server__fixed_cidr}) %}


### PR DESCRIPTION
I was debugging why my dockerd was not starting and found the following warning and fixed it.
```
level=warning msg="The \"graph\" config file option is deprecated. Please use \"data-root\" instead."
```

I am not sure what a proper migration path is. Suggestions are welcome!