### PR TITLE
Configure Managesieve mail filtering easily 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -133,6 +133,13 @@ LDAP
   role no longer generates the :command:`ferm` configuration files directly,
   instead using the :ref:`debops.ferm` role as a dependency.
 
+- Add option to enable ManageSieve by default without the need to update the config_maps,
+  to allow configuration of Sieve filter scripts.
+
+- Restored :envvar:`dovecot_mail_location` to original value of `maildir:~/Maildir`. It was
+  wrongfully changed to `/var/vmail/%d/%n/mailbox` if LDAP was enabled. See also
+  :envvar:`dovecot_vmail_home`.
+
 :ref:`debops.memcached` role
 ''''''''''''''''''''''''''''
 

--- a/ansible/roles/debops.dovecot/defaults/main.yml
+++ b/ansible/roles/debops.dovecot/defaults/main.yml
@@ -75,15 +75,21 @@ dovecot_user_accounts: '{{ [ "deny", "ldap" ]
 dovecot_deny_users: [ 'root' ]
 
                                                                    # ]]]
+# .. envvar:: dovecot_vmail_home [[[
+#
+# The vmail home directory is a per-user directory where Dovecot can save user-specific files.
+# Dovecot's home directories have nothing to do with system users' home directories.
+# It's irrelevant if it's under /home/ or /var/mail/ or wherever.
+# For more information see: `Home Directories for Virtual Users <https://wiki.dovecot.org/VirtualUsers/Home>`_.
+dovecot_vmail_home: '/var/vmail/%d/%n'
+
+                                                                   # ]]]
 # .. envvar:: dovecot_mail_location [[[
 #
 # Mailbox location. For mbox set something like ``mbox:~/mail:INBOX=/var/mail/%u``.
 # For more information about the supported format, check `Dovecot Mail
 # Location <https://doc.dovecot.org/configuration_manual/mail_location/>`_
-dovecot_mail_location: 'maildir:{{ "/var/vmail/%d/%n/mailbox"
-                                  if (dovecot__ldap_enabled|d(False))
-                                  else
-                                  "~/Maildir" }}'
+dovecot_mail_location: 'maildir:~/Maildir'
 
                                                                    # ]]]
 # .. envvar:: dovecot__auth_default_realm [[[
@@ -407,6 +413,15 @@ dovecot_imap_default_config_map:
         ssl: 'yes'
 
                                                                    # ]]]
+
+# .. envvar:: dovecot_mail_plugins [[[
+#
+# Mail plugins enabled in dovecot.
+dovecot_mail_plugins: '$mail_plugins {{ "sieve"
+                                        if ("managesieve" in dovecot_protocols|d([]) and
+                                        dovecot_sieve_enabled|bool) else "" }}'
+
+                                                                   # ]]]
 # .. envvar:: dovecot_imap_config_map [[[
 #
 # Custom IMAP configuration properties. See :ref:`dovecot_imap_config_map`
@@ -440,16 +455,29 @@ dovecot_pop3_listeners: '{{ [ "pop3", "pop3s" ]
 dovecot_pop3_config_map: {}
 
                                                                    # ]]]
-# .. envvar:: dovecot_sieve [[[
+# .. envvar:: dovecot_sieve_enabled [[[
+#
+# Enable/disable the sieve mail plugin
+dovecot_sieve_enabled: true
+
+                                                                   # ]]]
+# .. envvar:: dovecot_sieve_port [[[
+#
+# Managesieve port
+dovecot_sieve_port: 4190
+
+                                                                   # ]]]
+
+# .. envvar:: dovecot_sieve_active_script [[[
 #
 # Location of link to active sieve script
-dovecot_sieve: '~/.dovecot.sieve'
+dovecot_sieve_active_script: '~/.dovecot.sieve'
 
                                                                    # ]]]
 # .. envvar:: dovecot_sieve_dir [[[
 #
 # Storage directory for sieve scripts uploaded by ManageSieve
-dovecot_sieve_dir: '~/sieve'
+dovecot_sieve_dir: 'file:~/sieve'
 
                                                                    # ]]]
 # .. envvar:: dovecot_managesieve_listeners [[[
@@ -463,14 +491,25 @@ dovecot_managesieve_listeners: [ 'sieve' ]
 #
 # Custom ManageSieve configuration properties. See :ref:`dovecot_managesieve_config_map`
 # for more details.
-dovecot_managesieve_config_map: {}
+dovecot_managesieve_config_map:
+
+  login-service:
+    inet_listener:
+      sieve:
+        port: '{{ dovecot_sieve_port|int }}'
+
+  plugin:
+    sieve: '{{ dovecot_sieve_dir }}'
+    active: '{{ dovecot_sieve_active_script }}'
 
                                                                    # ]]]
 # .. envvar:: dovecot_lda_config_map [[[
 #
 # Custom LDA configuration properties. See :ref:`dovecot_lda_config_map`
 # for more details.
-dovecot_lda_config_map: {}
+dovecot_lda_config_map:
+  protocol:
+    mail_plugins: '{{ dovecot_mail_plugins }}'
 
                                                                    # ]]]
 # .. envvar:: dovecot_lmtp_listeners [[[
@@ -491,6 +530,9 @@ dovecot_lmtp_config_map:
         user: 'postfix'
         group: 'postfix'
         mode: 0600
+
+  protocol:
+    mail_plugins: '{{ dovecot_mail_plugins }}'
 
                                                                    # ]]]
 # .. envvar:: dovecot_postfix_transport [[[
@@ -718,6 +760,7 @@ dovecot__ldap_start_tls: '{{ ansible_local.ldap.start_tls
 # .. envvar:: dovecot__ldap_user_filter [[[
 #
 # The LDAP filter used to look up user accounts in the directory.
+# See :ref:`ldap__ref_admin` for more information.
 dovecot__ldap_user_filter: '(&
                               (objectClass=inetOrgPerson)
                               (|

--- a/ansible/roles/debops.dovecot/templates/etc/dovecot/conf.d/10-mail.conf.j2
+++ b/ansible/roles/debops.dovecot/templates/etc/dovecot/conf.d/10-mail.conf.j2
@@ -11,7 +11,12 @@ setup, you can provide your own template via lookup mechanism.
 ## Mailbox locations and namespaces
 ##
 
+{% if dovecot__ldap_enabled|d(False) %}
+# The vmail home directory is a per-user directory where Dovecot can save user-specific files.
+mail_home = {{ dovecot_vmail_home }}
+{% endif %}
 {% if dovecot_mail_location is defined and dovecot_mail_location %}
+# Mailbox location.
 mail_location = {{ dovecot_mail_location }}
 {% else %}
 # The default is empty, which means that Dovecot tries to find the mailboxes

--- a/ansible/roles/debops.dovecot/templates/etc/dovecot/conf.d/90-sieve.conf.j2
+++ b/ansible/roles/debops.dovecot/templates/etc/dovecot/conf.d/90-sieve.conf.j2
@@ -6,12 +6,17 @@ that are configurable via DebOps variables. If you need a more customized
 setup, you can provide your own template via lookup mechanism.
 
 #}
+{% import 'dovecot_macros.j2' as macros with context %}
 
 ##
 ## Settings for the Sieve interpreter
 ##
 
 plugin {
-  sieve = {{ dovecot_sieve }}
-  sieve_dir = {{ dovecot_sieve_dir }}
+{% if dovecot_managesieve_config_map is defined and dovecot_managesieve_config_map %}
+{%   if 'plugin' in dovecot_managesieve_config_map %}
+{%     set dovecot_tpl_sieve_plugin_map = dovecot_managesieve_config_map['plugin'] %}
+{%   endif %}
+{% endif %}
+{{ macros.dovecot_properties(dovecot_tpl_sieve_plugin_map|default({})) }}
 }

--- a/ansible/roles/debops.dovecot/templates/etc/dovecot/dovecot-ldap-userdb.conf.j2
+++ b/ansible/roles/debops.dovecot/templates/etc/dovecot/dovecot-ldap-userdb.conf.j2
@@ -27,6 +27,6 @@ user_attrs = \
     uid=%u,\
     mailQuota=quota_rule=*:bytes=%{ldap:{{ dovecot__ldap_quota_attribute }}}:storage=%$,\
     mailGroupACL=acl_groups,\
-    mailExpungeTrash=namespace/inbox/mailbox/Trash/autoexpunge
+    mailExpungeTrash=namespace/inbox/Maildir/Trash/autoexpunge
 
 user_filter = {{ dovecot__ldap_user_filter }}

--- a/ansible/roles/debops.postldap/defaults/main.yml
+++ b/ansible/roles/debops.postldap/defaults/main.yml
@@ -334,7 +334,7 @@ postldap__postfix__dependent_lookup_tables:
                     )
                   )'
     result_attribute: 'mail'
-    result_format: '/%d/%u/mailbox/'
+    result_format: '/%d/%u/Maildir/'
 
   - name: 'ldap_virtual_mailbox_domains.cf'
     state: 'present'

--- a/docs/ansible/roles/debops.ldap/ldap-access.rst
+++ b/docs/ansible/roles/debops.ldap/ldap-access.rst
@@ -272,6 +272,8 @@ Find all LDAP entries which can send e-mail messages or have global access:
    ldapsearch -Z -b "dc=example,dc=org" \
               "(| (authorizedService=all) (authorizedService=mail:send) )" dn
 
+.. _ldap__ref_ldap_known_access_controls:
+
 Known access controls
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/news/upgrades.rst
+++ b/docs/news/upgrades.rst
@@ -69,15 +69,24 @@ Inventory variable changes
   +--------------------------+------------------------------------+---------------+
 
 - A few of the default variables in the :ref:`debops.dovecot` role have been
-  renamed:
+  renamed. Additionally some variables related to the Sieve plugin configuration also
+  changed:
 
-  +---------------------------+---------------------------------------+---------------+
-  | Old variable name         | New variable name                     | Changed value |
-  +===========================+=======================================+===============+
-  | ``dovecot_ssl_protocols`` | :envvar:`dovecot_ssl_min_protocol`    | No            |
-  +---------------------------+---------------------------------------+---------------+
-  | ``dovecot_firewall``      | Removed, see "Firewall configuration" | No            |
-  +---------------------------+---------------------------------------+---------------+
+  +------------------------------------+------------------------------------------+---------------+
+  | Old variable name                  | New variable name                        | Changed value |
+  +====================================+==========================================+===============+
+  | ``dovecot_ssl_protocols``          | :envvar:`dovecot_ssl_min_protocol`       | No            |
+  +------------------------------------+------------------------------------------+---------------+
+  | ``dovecot_firewall``               | Removed, see "Firewall configuration"    | No            |
+  +------------------------------------+------------------------------------------+---------------+
+  | ``dovecot_mail_location``          | :envvar:`dovecot_mail_location`          | Yes           |
+  +------------------------------------+------------------------------------------+---------------+
+  | ``dovecot_sieve``                  | :envvar:`dovecot_sieve_active_script`    | No            |
+  +------------------------------------+------------------------------------------+---------------+
+  | ``dovecot_managesieve_config_map`` | :envvar:`dovecot_managesieve_config_map` | Yes           |
+  +------------------------------------+------------------------------------------+---------------+
+  | ``dovecot_lda_config_map``         | :envvar:`dovecot_lda_config_map`         | Yes           |
+  +------------------------------------+------------------------------------------+---------------+
 
 - Some of the variables in the :ref:`debops.roundcube` role have been renamed:
 


### PR DESCRIPTION
Add bool variable to dovecot config to enable sieve, instead of changing several config maps vars in the  inventory.
Sadly during dev of this feature I found out an error in the value of the `dovecot_mail_location`. Fixing this issue is needed in order for sieve to work, due to the necessity of `dovecot_vmail_home`