### PR TITLE
Fix Postfix SMTP auth

### DIFF
--- a/ansible/roles/debops.dovecot/defaults/main.yml
+++ b/ansible/roles/debops.dovecot/defaults/main.yml
@@ -502,14 +502,14 @@ dovecot_postfix_transport: 'lmtp:unix:private/dovecot-lmtp'
                                                                    # ]]]
 # .. envvar:: dovecot_auth_listeners [[[
 #
-# List of LMTP ``inet_listeners`` or ``unix_listeners`` which will be enabled.
+# List of AUTH ``unix_listeners`` which will be enabled.
 # See :ref:`dovecot_auth_listeners` for more details.
 dovecot_auth_listeners: [ '/var/spool/postfix/private/auth' ]
 
                                                                    # ]]]
 # .. envvar:: dovecot_auth_config_map [[[
 #
-# Custom LMTP configuration properties. See :ref:`dovecot_auth_config_map`
+# Custom AUTH service configuration properties. See :ref:`dovecot_auth_config_map`
 # for more details.
 dovecot_auth_config_map:
   service:

--- a/ansible/roles/debops.dovecot/defaults/main.yml
+++ b/ansible/roles/debops.dovecot/defaults/main.yml
@@ -500,6 +500,27 @@ dovecot_lmtp_config_map:
 dovecot_postfix_transport: 'lmtp:unix:private/dovecot-lmtp'
 
                                                                    # ]]]
+# .. envvar:: dovecot_auth_listeners [[[
+#
+# List of LMTP ``inet_listeners`` or ``unix_listeners`` which will be enabled.
+# See :ref:`dovecot_auth_listeners` for more details.
+dovecot_auth_listeners: [ '/var/spool/postfix/private/auth' ]
+
+                                                                   # ]]]
+# .. envvar:: dovecot_auth_config_map [[[
+#
+# Custom LMTP configuration properties. See :ref:`dovecot_auth_config_map`
+# for more details.
+dovecot_auth_config_map:
+  service:
+    # Postfix smtp-auth socket.
+    unix_listener:
+      /var/spool/postfix/private/auth:
+        user: 'postfix'
+        group: 'postfix'
+        mode: 0600
+
+                                                                   # ]]]
 # .. envvar:: dovecot_custom_localconf [[[
 #
 # Dovecot custom configuration added at the end of ``/etc/dovecot/local.conf``

--- a/docs/ansible/roles/debops.dovecot/defaults-detailed.rst
+++ b/docs/ansible/roles/debops.dovecot/defaults-detailed.rst
@@ -162,6 +162,19 @@ The only valid key is ``protocol`` which references a YAML dict defining the
 ``protocol lda {}`` section. The ``protocol`` dict then accepts the upstream
 Dovecot configuration options such as ``mail_plugins``.
 
+.. _dovecot_auth_config_map:
+
+dovecot_auth_config_map
+-----------------------
+
+Configuration dictionary related to user authentication when sending emails over
+the SMTP protocol configuration. Postfix uses the `/var/spool/postfix/private/auth`
+UNIX socket to communicate with Dovecot in order to authenticate an user, while
+sending emails. See also `smtpd_sasl_type` and `smtpd_sasl_path` values in
+:envvar:`postconf__postfix__dependent_maincf`.
+
+Please refer to the :ref:`dovecot_imap_config_map` for a description of the dict
+layout.
 
 Example
 ~~~~~~~

--- a/docs/ansible/roles/debops.dovecot/defaults-detailed.rst
+++ b/docs/ansible/roles/debops.dovecot/defaults-detailed.rst
@@ -176,6 +176,16 @@ sending emails. See also `smtpd_sasl_type` and `smtpd_sasl_path` values in
 Please refer to the :ref:`dovecot_imap_config_map` for a description of the dict
 layout.
 
+.. _dovecot_auth_listeners:
+
+dovecot_auth_listeners
+----------------------
+
+List of AUTH unix listener names which will be created. The AUTH
+listeners configuration works like the :ref:`dovecot_lmtp_listeners`.
+Each listeners mentioned in :envvar:`dovecot_auth_listeners` must also be defined
+in :ref:`dovecot_auth_config_map`.
+
 Example
 ~~~~~~~
 


### PR DESCRIPTION
I found the missing config in Dovecot in order for Postfix to authenticate an user which is trying to send an email over SMTP.

See `/etc/dovecot/conf.d/10-master.conf.dpkg-divert`

The missing snippet is:
```
service auth {
  # Postfix smtp-auth
  unix_listener /var/spool/postfix/private/auth {
    group = postfix
    mode = 0660
    user = postfix
  }
}
```

Although I updated the debops.dovecot role to include this config (analogous to LMTP), ansible is not creating the correct template. @drybjed can you please take a look?
