### PR TITLE
[debops.owncloud] Default to Nextcloud 16.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -150,6 +150,13 @@ LDAP
   ``memcached__*`` to create the role namespace. You need to update the
   inventory accordingly.
 
+:ref:`debops.owncloud` role
+'''''''''''''''''''''''''''
+
+- Drop Nextcloud 15 support because it is EOL. You need to upgrade Nextcloud
+  manually if you are running version 15 or below. The role now defaults to
+  Nextcloud 16 for new installations.
+
 :ref:`debops.roundcube` role
 ''''''''''''''''''''''''''''
 

--- a/ansible/roles/debops.owncloud/defaults/main.yml
+++ b/ansible/roles/debops.owncloud/defaults/main.yml
@@ -419,7 +419,6 @@ owncloud__variant_name_map:
 #
 # * ownCloud ``10.0``
 #
-# * Nextcloud ``15.0``
 # * Nextcloud ``16.0``
 #
 # For Nextcloud refer to the `Nextcloud Maintenance and Release Schedule <https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule>`_.
@@ -429,7 +428,7 @@ owncloud__variant_name_map:
 # and the `package index <https://download.owncloud.org/download/repositories/>`_ for more details.
 owncloud__release: '{{ "10.0"
                        if (owncloud__variant == "owncloud")
-                       else "15.0" }}'
+                       else "16.0" }}'
 
 
 # .. envvar:: owncloud__distribution

--- a/ansible/roles/debops.owncloud/meta/watch-nextcloud
+++ b/ansible/roles/debops.owncloud/meta/watch-nextcloud
@@ -1,6 +1,6 @@
 # Role: debops.owncloud
 # Package: nextcloud
-# Version: 14.0
+# Version: 16.0
 
 version=4
 https://download.nextcloud.com/server/releases/ nextcloud-(.+)\.tar\.bz2


### PR DESCRIPTION
Not sure if Nextcloud 16.0 has been tested well enough with `debops.owncloud`. I'm currently running 16.0.7 which seems to work fine. Let me know if there are specific things that need testing, I'd love to help out!

Is there already someone working on updating this role for Nextcloud 17.0 or can I give it a shot?

Upstream support for Nextcloud 15.0 ended on 2019-12-30:
https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule/1151d4f7ba20455edb8fa717878df16fd1d03472