### PR TITLE
[roundcube] Use specific version of 'swipe' plugin

### DIFF
--- a/ansible/roles/roundcube/defaults/main.yml
+++ b/ansible/roles/roundcube/defaults/main.yml
@@ -3300,7 +3300,7 @@ roundcube__default_plugins:
     # This plugin provides support for swipe gestures on mobile devices in the
     # Elastic skin.
   - name: 'swipe'
-    package: 'johndoh/swipe'
+    package: 'johndoh/swipe:0.1.0'
     state: 'enabled'
 
     # This plugin includes additional information in Dovecot connections to


### PR DESCRIPTION
The 'swipe' plugin author changed the versioning scheme and the newest
version is not installable on the stable Roundcube release, therefore an
older version of the 'swipe' plugin will be used by default.