### PR TITLE
Allow to enable or disable the Gitlab backup procedure

### DIFF
--- a/ansible/roles/gitlab/defaults/main.yml
+++ b/ansible/roles/gitlab/defaults/main.yml
@@ -334,6 +334,12 @@ gitlab_postgresql_database_connection: 'socket'
 # GitLab backup options [[[
 # -------------------------
 
+# .. envvar:: gitlab_backup_enabled [[[
+#
+# Enable or disable Gitlab backup.
+gitlab_backup_enabled: True
+
+                                                                   # ]]]
 # .. envvar:: gitlab_backup_frequency [[[
 #
 # Backup frequency (daily, weekly, monthly)

--- a/ansible/roles/gitlab/tasks/configure_gitlab_ce.yml
+++ b/ansible/roles/gitlab/tasks/configure_gitlab_ce.yml
@@ -271,6 +271,9 @@
   cron:
     name: 'Create GitLab backup'
     special_time: '{{ gitlab_backup_frequency }}'
+    disabled: '{{ False
+                  if (gitlab_backup_enabled|d(True))
+                  else True }}'
     state: 'present'
     user: '{{ gitlab_user }}'
     job: 'cd {{ gitlab_ce_git_checkout }} \

--- a/ansible/roles/gitlab/tasks/configure_gitlab_ce.yml
+++ b/ansible/roles/gitlab/tasks/configure_gitlab_ce.yml
@@ -272,7 +272,7 @@
     name: 'Create GitLab backup'
     special_time: '{{ gitlab_backup_frequency }}'
     disabled: '{{ False
-                  if (gitlab_backup_enabled|d(True))
+                  if (gitlab_backup_enabled|bool)
                   else True }}'
     state: 'present'
     user: '{{ gitlab_user }}'


### PR DESCRIPTION
For example in order to save space under `/var/backups`.