### PR TITLE
[debops.ferm] Update default ruleset to allow DHCPv6 multicast solicits

### DIFF
--- a/ansible/roles/ferm/defaults/main.yml
+++ b/ansible/roles/ferm/defaults/main.yml
@@ -497,6 +497,18 @@ ferm__default_rules:
     recent_remove: True
     recent_log: False
 
+  - name: 'accept_dhcpv6_client_solicit'
+    type: 'accept'
+    weight_class: 'any-service'
+    comment: 'Initial DHCPv6 Solicit message is sent to multicast'
+    domain: [ 'ip6' ]
+    saddr: [ 'fe80::/10' ]
+    daddr: [ 'ff02::1:2/128' ]
+    protocol: [ 'udp' ]
+    sport: [ 'dhcpv6-client' ]
+    dport: [ 'dhcpv6-server' ]
+    rule_state: '{{ "present" if ("ip6" in ferm__domains) else "absent" }}'
+
   - name: 'accept_dhcpv6_client'
     type: 'accept'
     weight_class: 'any-service'
@@ -508,6 +520,8 @@ ferm__default_rules:
     sport: [ 'dhcpv6-server' ]
     dport: [ 'dhcpv6-client' ]
     rule_state: '{{ "present" if ("ip6" in ferm__domains) else "absent" }}'
+
+
 
     # Avahi is usually installed by default on workstations and laptops where
     # it is useful. To manage Avahi on servers, you should enable the

--- a/ansible/roles/ferm/defaults/main.yml
+++ b/ansible/roles/ferm/defaults/main.yml
@@ -521,8 +521,6 @@ ferm__default_rules:
     dport: [ 'dhcpv6-client' ]
     rule_state: '{{ "present" if ("ip6" in ferm__domains) else "absent" }}'
 
-
-
     # Avahi is usually installed by default on workstations and laptops where
     # it is useful. To manage Avahi on servers, you should enable the
     # 'debops.avahi' Ansible role which will set up the same firewall rule.


### PR DESCRIPTION
While `accept_dhcpv6_client` allows UDP DHCPv6 responses out to local systems, the initial solicit messages are still dropped on a default install. The very initial *Solicit* message is sent to `ff02::1:2` - a multicast address. Example log message of the dropped packet:

    Jan 15 17:46:58 talktoobot kernel: [ 6596.844327] IN=enp1s0.2 OUT= MAC=33:33:00:01:00:02:3c:07:54:1d:6c:3d:86:dd SRC=fe80:0000:0000:0000:3e07:54ff:fe1d:6c3d DST=ff02:0000:0000:0000:0000:0000:0001:0002 LEN=104 TC=0 HOPLIMIT=1 FLOWLBL=794967 PROTO=UDP SPT=546 DPT=547 LEN=64

Do we need a rule like this that allows the initial multicast solicitation UDP packet in?