### PR TITLE
[icinga] Also listen on IPv6 addresses

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,13 @@ New DebOps roles
   :file:`secret/` directory in a predetermined location to avoid exposing it
   via the Ansible inventory. See the role documentation for details.
 
+:ref:`debops.icinga` role
+'''''''''''''''''''''''''
+
+- The role now configures the Icinga REST API to also listen on IPv6 addresses.
+  It is possible to change the listen address and port through the
+  ``icinga__api_listen`` and ``icinga__api_port`` variables.
+
 :ref:`debops.nslcd` role
 ''''''''''''''''''''''''
 

--- a/ansible/roles/icinga/defaults/main.yml
+++ b/ansible/roles/icinga/defaults/main.yml
@@ -198,9 +198,16 @@ icinga__group_allow: []
 icinga__host_allow: []
 
                                                                    # ]]]
+# .. envvar:: icinga__api_listen [[[
+#
+# IP address on which the Icinga 2 REST API should listen. Defaults to all IPv4
+# and IPv6 addresses.
+icinga__api_listen: '::'
+
+                                                                   # ]]]
 # .. envvar:: icinga__api_port [[[
 #
-# The Icinga 2 REST API port.
+# The TCP port on which the Icinga 2 REST API should listen.
 icinga__api_port: '5665'
 
                                                                    # ]]]
@@ -694,6 +701,9 @@ icinga__default_configuration:
     comment: 'The API listener is used for distributed monitoring setups.'
     value: |
       object ApiListener "api" {
+        bind_host = "{{ icinga__api_listen }}"
+        bind_port = {{ icinga__api_port }}
+
       {% if icinga__pki_enabled|bool %}
         cert_path = "{{ icinga__pki_cert_path }}"
         key_path  = "{{ icinga__pki_key_path }}"


### PR DESCRIPTION
The Icinga REST API included with the Icinga 2 version in Debian Buster
listens only on IPv4 addresses by default. This commit adds a role
variable to configure the listen address, which defaults to '::' (all
IPv4 and IPv6 addresses).