### PR TITLE
[ci] Avoid building documentation on Vagrant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ sdist: clean-sdist man
 	@python3 setup.py sdist
 
 .PHONY: sdist-quiet
-sdist-quiet: clean-sdist man
+sdist-quiet: clean-sdist
 	@python3 setup.py --quiet sdist
 
 .PHONY: sdist-sign
@@ -92,7 +92,7 @@ wheel: clean-wheel man
 	@python3 setup.py bdist_wheel
 
 .PHONY: wheel-quiet
-wheel-quiet: clean-wheel man
+wheel-quiet: clean-wheel
 	@python3 setup.py --quiet bdist_wheel
 
 .PHONY: wheel-sign

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -485,7 +485,7 @@ if [ -z "${JANE_BOX_INIT:-}" ] ; then
         mkdir /tmp/build
         rsync -a --exclude '.vagrant' /vagrant/ /tmp/build
         cd /tmp/build
-        make sdist > /dev/null
+        make sdist-quiet > /dev/null
         pip3 install dist/*
         cd - > /dev/null
     fi
@@ -603,7 +603,7 @@ if [ -n "${debops_from_devel}" ] ; then
     mkdir /tmp/build
     rsync -a --exclude '.vagrant' /vagrant/ /tmp/build
     cd /tmp/build
-    make sdist > /dev/null
+    make sdist-quiet > /dev/null
     sudo pip3 install dist/*
     cd - > /dev/null
 fi

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,9 @@ try:
     import pypandoc
     README = pypandoc.convert_file('README.md', 'rst')
 except(IOError, ImportError):
-    print('Error: The "pandoc" support is required to convert '
+    print('Warning: The "pandoc" support is required to convert '
           'the README.md to reStructuredText format')
-    exit(1)
+    README = open('README.md').read()
 
 try:
     unicode
@@ -34,8 +34,7 @@ if os.path.exists('docs/_build/man'):
                 manpage.endswith('.5')):
             MANPAGES_5.append(os.path.join('docs/_build/man', manpage))
 else:
-    print('Error: manual pages not built, aborting')
-    exit(1)
+    print('Warning: manual pages not built')
 
 # Retrieve the project version from 'git describe' command and store it in the
 # VERSION file, needed for correct installation of the Python package


### PR DESCRIPTION
This shuld fix an issue on Vagrant where latest changes would require
installation of Sphinx and Pandoc, and long build of the documentation.
We avoid that to speed up GitLab CI tests that use Vagrant boxes.