### PR TITLE
Add 'etesync' Ansible role

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -511,6 +511,15 @@ stages:
     JANE_DIFF_PATTERN: '.*/roles/etherpad/.*'
     JANE_LOG_PATTERN: '\[debops\.etherpad\]'
 
+'etesync role':
+  <<: *test_role_1st_deps
+  variables:
+    JANE_TEST_FACT: 'etesync.fact'
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/etesync.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_etesync'
+    JANE_DIFF_PATTERN: '.*/roles/etesync/.*'
+    JANE_LOG_PATTERN: '\[debops\.etesync\]'
+
 
 # --- f --- [[[2
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -512,7 +512,7 @@ stages:
     JANE_LOG_PATTERN: '\[debops\.etherpad\]'
 
 'etesync role':
-  <<: *test_role_1st_deps
+  <<: *test_role_2nd_deps
   variables:
     JANE_TEST_FACT: 'etesync.fact'
     JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/etesync.yml'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,7 +27,11 @@ New DebOps roles
 - The :ref:`debops.lxd` role brings support for LXD on Debian hosts by building
   the Go binaries from source, without Snap installation.
 
-- The :ref:`debops.etesync` role allows to setup a EteSync server.
+- The :ref:`debops.etesync` role allows to setup a EteSync__ server.
+  EteSync is a cross-platform project to provide secure, end-to-end encrypted,
+  and privacy respecting sync for your contacts, calendars and tasks.
+
+.. __: https://www.etesync.com/
 
 General
 '''''''

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,8 @@ New DebOps roles
 - The :ref:`debops.lxd` role brings support for LXD on Debian hosts by building
   the Go binaries from source, without Snap installation.
 
+- The :ref:`debops.etesync` role allows to setup a EteSync server.
+
 General
 '''''''
 

--- a/ansible/playbooks/service/etesync.yml
+++ b/ansible/playbooks/service/etesync.yml
@@ -1,0 +1,61 @@
+---
+
+- name: Deploy and manage the EteSync server
+  collections: [ 'debops.debops' ]
+  hosts: [ 'debops_service_etesync' ]
+  become: True
+
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
+
+  roles:
+
+    - role: keyring
+      tags: [ 'role::keyring', 'skip::keyring',
+              'role::nginx', 'role::etesync' ]
+      keyring__dependent_apt_keys:
+        - '{{ nginx__keyring__dependent_apt_keys }}'
+      keyring__dependent_gpg_keys:
+        - '{{ etesync__keyring__dependent_gpg_keys }}'
+
+    - role: apt_preferences
+      tags: [ 'role::apt_preferences', 'skip::apt_preferences' ]
+      apt_preferences__dependent_list:
+        - '{{ gunicorn__apt_preferences__dependent_list }}'
+        - '{{ nginx__apt_preferences__dependent_list }}'
+
+    - role: logrotate
+      tags: [ 'role::logrotate', 'skip::logrotate' ]
+      logrotate__dependent_config:
+        - '{{ gunicorn__logrotate__dependent_config }}'
+
+    - role: ferm
+      tags: [ 'role::ferm', 'skip::ferm' ]
+      ferm__dependent_rules:
+        - '{{ nginx__ferm__dependent_rules }}'
+
+    - role: python
+      tags: [ 'role::python', 'skip::python', 'role::gunicorn', 'role::etesync' ]
+      python__dependent_packages3:
+        - '{{ gunicorn__python__dependent_packages3 }}'
+        - '{{ nginx__python__dependent_packages3 }}'
+        - '{{ etesync__python__dependent_packages3 }}'
+      python__dependent_packages2:
+        - '{{ gunicorn__python__dependent_packages2 }}'
+        - '{{ nginx__python__dependent_packages2 }}'
+
+    - role: gunicorn
+      tags: [ 'role::gunicorn', 'skip::gunicorn' ]
+      gunicorn__dependent_applications:
+        - '{{ etesync__gunicorn__dependent_applications }}'
+
+    - role: nginx
+      tags: [ 'role::nginx', 'skip::nginx' ]
+      nginx__dependent_upstreams:
+        - '{{ etesync__nginx__dependent_upstreams }}'
+      nginx__dependent_servers:
+        - '{{ etesync__nginx__dependent_servers }}'
+
+    - role: etesync
+      tags: [ 'role::etesync', 'skip::etesync' ]

--- a/ansible/roles/etckeeper/defaults/main.yml
+++ b/ansible/roles/etckeeper/defaults/main.yml
@@ -176,9 +176,6 @@ etckeeper__default_gitignore:
   - name: 'zfs-zpool-cache'
     ignore: 'zfs/zpool.cache'
 
-  - name: 'etesync-secret'
-    ignore: 'etesync-server/secret.txt'
-
                                                                    # ]]]
 # .. envvar:: etckeeper__gitignore [[[
 #

--- a/ansible/roles/etesync/COPYRIGHT
+++ b/ansible/roles/etesync/COPYRIGHT
@@ -1,0 +1,18 @@
+debops.etesync - Deploy and manage the EteSync server
+
+Copyright (C) 2020 Robin Schneider <ypid@riseup.net>
+Copyright (C) 2020 DebOps https://debops.org/
+
+This Ansible role is part of DebOps.
+
+DebOps is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 3, as
+published by the Free Software Foundation.
+
+DebOps is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with DebOps. If not, see https://www.gnu.org/licenses/.

--- a/ansible/roles/etesync/defaults/main.yml
+++ b/ansible/roles/etesync/defaults/main.yml
@@ -1,0 +1,456 @@
+---
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+
+# .. _etesync__ref_defaults:
+
+# debops.etesync default variables [[[
+# ===================================
+
+# .. contents:: Sections
+#    :local:
+#
+# .. include:: ../../../../includes/global.rst
+
+
+# Domain name configuration [[[
+# -----------------------------
+
+# .. envvar:: etesync__domain [[[
+#
+# The DNS domain used by other variables in the ``debops.etesync`` role.
+etesync__domain: '{{ ansible_local.core.domain
+                     if (ansible_local|d() and ansible_local.core|d() and
+                         ansible_local.core.domain|d())
+                     else ansible_domain }}'
+
+                                                                   # ]]]
+# .. envvar:: etesync__fqdn [[[
+#
+# String of the Fully Qualified domain names on which the EteSync application
+# will be available, used by the webserver.
+etesync__fqdn: 'etesync.{{ etesync__domain }}'
+
+                                                                   # ]]]
+                                                                   # ]]]
+# APT packages [[[
+# ----------------
+
+# .. envvar:: etesync__base_packages [[[
+#
+# List of APT packages which are required by the EteSync server.
+etesync__base_packages:
+  - 'git'
+                                                                   # ]]]
+                                                                   #
+# .. envvar:: etesync__packages [[[
+#
+# List of additional APT packages to install with EteSync.
+etesync__packages: []
+                                                                   # ]]]
+                                                                   # ]]]
+# Application user, group, home [[[
+# ---------------------------------
+
+# .. envvar:: etesync__user [[[
+#
+# Name of the UNIX system account used to manage EteSync.
+etesync__user: 'etesync'
+
+                                                                   # ]]]
+# .. envvar:: etesync__group [[[
+#
+# Name of the UNIX primary group used to manage EteSync.
+etesync__group: 'etesync'
+
+                                                                   # ]]]
+# .. envvar:: etesync__gecos [[[
+#
+# Contents of the GECOS field set for the EteSync account.
+etesync__gecos: 'EteSync'
+
+                                                                   # ]]]
+# .. envvar:: etesync__shell [[[
+#
+# The default shell set on the EteSync account.
+etesync__shell: '/usr/sbin/nologin'
+                                                                   # ]]]
+                                                                   # ]]]
+# Directory paths [[[
+# -------------------
+
+# .. envvar:: etesync__home [[[
+#
+# The EteSync account home directory.
+etesync__home: '{{ (ansible_local.root.home
+                   if (ansible_local|d() and ansible_local.root|d() and
+                       ansible_local.root.home|d())
+                   else "/var/local") + "/" + etesync__user }}'
+
+                                                                   # ]]]
+# .. envvar:: etesync__etc [[[
+#
+# Directory where the role stores EteSync configuration.
+etesync__etc: '/etc/etesync-server'
+
+                                                                   # ]]]
+# .. envvar:: etesync__src [[[
+#
+# Directory where the role stores EteSync version control sources.
+etesync__src: '{{ (ansible_local.root.src
+                  if (ansible_local|d() and ansible_local.root|d() and
+                      ansible_local.root.src|d())
+                  else "/usr/local/src") + "/" + etesync__user }}'
+
+                                                                   # ]]]
+# .. envvar:: etesync__lib [[[
+#
+# Directory where the EteSync server directory is located.
+etesync__lib: '{{ (ansible_local.root.lib
+                  if (ansible_local|d() and ansible_local.root|d() and
+                      ansible_local.root.lib|d())
+                  else "/usr/local/lib") + "/" + etesync__user }}'
+
+                                                                   # ]]]
+# .. envvar:: etesync__data [[[
+#
+# Directory where EteSync data is stored.
+etesync__data: '{{ (ansible_local.root.data
+                   if (ansible_local|d() and ansible_local.root|d() and
+                       ansible_local.root.data|d())
+                   else "/srv") + "/" + etesync__user }}'
+                                                                   # ]]]
+                                                                   # ]]]
+# Application sources and deployment [[[
+# --------------------------------------
+
+# .. envvar:: etesync__git_gpg_key_id [[[
+#
+# The GPG ID of the key used for signing EteSync releases.
+etesync__git_gpg_key_id: '9E21 F091 FC39 5F36 6A47  43E2 D2E5 84C3 7C47 7933'
+
+                                                                   # ]]]
+# .. envvar:: etesync__git_repo [[[
+#
+# The URI of the EteSync :command:`git` source repository.
+etesync__git_repo: 'https://github.com/etesync/server.git'
+
+                                                                   # ]]]
+# .. envvar:: etesync__git_version [[[
+#
+# The :command:`git` branch or tag which will be installed.
+# git commit hash lock to release 0.2.1.
+# Note that this hash locking is not very effective because the main
+# implementation of EteSync is in additional Python packages.
+etesync__git_version: 'cf0dc8e6a81f0b87bfba6d952ce9085d21257c18'
+
+                                                                   # ]]]
+# .. envvar:: etesync__git_dest [[[
+#
+# Path where the :command:`git` source bare repository will be stored.
+etesync__git_dest: '{{ etesync__src + "/" + etesync__git_repo.split("://")[1] }}'
+
+                                                                   # ]]]
+# .. envvar:: etesync__git_checkout [[[
+#
+# Path where EteSync sources will be checked out (installation path).
+etesync__git_checkout: '{{ etesync__lib + "/app" }}'
+                                                                   # ]]]
+                                                                   # ]]]
+# Python virtualenv configuration [[[
+# -----------------------------------
+
+# .. envvar:: etesync__virtualenv [[[
+#
+# Path where the EteSync ``virtualenv`` directory will be stored.
+etesync__virtualenv: '{{ etesync__lib + "/virtualenv" }}'
+
+                                                                   # ]]]
+                                                                   # ]]]
+# EteSync configuration options [[[
+# --------------------------------
+
+# .. envvar:: etesync__config_allowed_hosts [[[
+#
+# List of domain names under which the EteSync server will accept
+# connections. Specify ``*`` to accept connections to any domain name.
+etesync__config_allowed_hosts:
+  - '{{ ansible_hostname }}'
+  - '{{ ansible_fqdn }}'
+  - '{{ etesync__fqdn }}'
+  - 'localhost'
+  - '[::1]'
+  - '127.0.0.1'
+
+                                                                   # ]]]
+# .. envvar:: etesync__config_secret_key [[[
+#
+# The Django secret key used by the EteSync server. It will be shared by
+# all hosts on the same domain.
+etesync__config_secret_key: '{{ lookup("password", secret + "/etesync/" +
+                                etesync__domain + "/config/secret_key length=64") }}'
+
+                                                                   # ]]]
+# .. envvar:: etesync__config_secret_key_filepath [[[
+#
+# File path where the Django secret key will be stored on the remote host.
+etesync__config_secret_key_filepath: '{{ etesync__etc + "/secret.txt" }}'
+
+                                                                   # ]]]
+                                                                   # ]]]
+# Initial superuser account [[[
+# -----------------------------
+
+# .. envvar:: etesync__superuser_name [[[
+#
+# Name of the initial admin account created by the role.
+etesync__superuser_name: '{{ ansible_local.core.admin_users[0]
+                             if (ansible_local|d() and ansible_local.core|d() and
+                                 ansible_local.core.admin_users|d())
+                             else "admin" }}'
+
+                                                                   # ]]]
+# .. envvar:: etesync__superuser_email [[[
+#
+# E-mail address of the initial admin account created by the role.
+etesync__superuser_email: '{{ ansible_local.core.admin_private_email[0]
+                              if (ansible_local|d() and ansible_local.core|d() and
+                                  ansible_local.core.admin_private_email|d())
+                              else ("root@" + etesync__domain) }}'
+
+                                                                   # ]]]
+# .. envvar:: etesync__superuser_password [[[
+#
+# Password set for the initial admin account created by the role.
+etesync__superuser_password: '{{ lookup("password", secret + "/etesync/" +
+                                 inventory_hostname + "/superuser/" +
+                                 etesync__superuser_name + "/password") }}'
+                                                                   # ]]]
+                                                                   # ]]]
+# Internal application settings [[[
+# ---------------------------------
+
+# .. envvar:: etesync__app_name [[[
+#
+# Name of the EteSync server processes (workers) set by the master process.
+etesync__app_name: '{{ etesync__user }}'
+
+                                                                   # ]]]
+# .. envvar:: etesync__app_runtime_dir [[[
+#
+# Name of the subdirectory in the :file:`/run/` directory where the EteSync
+# application will bind its UNIX socket. The default is selected so that
+# configuration of the ``gunicorn`` service is idempotent.
+etesync__app_runtime_dir: '{{ "gunicorn"
+                              if (ansible_distribution_release in
+                                  [ "wheezy", "jessie", "precise", "trusty", "xenial" ])
+                              else "gunicorn-etesync" }}'
+
+                                                                   # ]]]
+# .. envvar:: etesync__app_bind [[[
+#
+# Specify either an UNIX or TCP socket on which the EteSync server should
+# bind and listen for connections.
+etesync__app_bind: 'unix:/run/{{ etesync__app_runtime_dir }}/etesync.sock'
+
+                                                                   # ]]]
+# .. envvar:: etesync__app_workers [[[
+#
+# Number of worker threads to start for EteSync server.
+etesync__app_workers: '{{ ansible_processor_vcpus|int + 1 }}'
+
+                                                                   # ]]]
+# .. envvar:: etesync__app_timeout [[[
+#
+# Number of seconds after which non-responsive worker threads will be killed
+# and restarted. EteSync installations with lots of objects might require longer
+# timeouts for API access.
+etesync__app_timeout: '900'
+
+                                                                   # ]]]
+# .. envvar:: etesync__app_params [[[
+#
+# List of parameters passed to the ``gunicorn`` process manager.
+etesync__app_params:
+  - '--name={{ etesync__app_name }}'
+  - '--bind={{ etesync__app_bind }}'
+  - '--workers={{ etesync__app_workers }}'
+  - '--timeout={{ etesync__app_timeout }}'
+  - 'etesync_server.wsgi'
+                                                                   # ]]]
+                                                                   # ]]]
+# Other variables [[[
+# -------------------
+
+# .. envvar:: etesync__max_file_size [[[
+#
+# Maximum upload size, in MB.
+etesync__max_file_size: '5'
+
+                                                                   # ]]]
+# .. envvar:: etesync__python_version [[[
+#
+# Python version, needed to refer to static files as installed by Python modules.
+etesync__python_version: '{{ ansible_local.python.version3
+                             if (ansible_local|d() and ansible_local.python|d() and
+                                 ansible_local.python.version3|d())
+                             else "3.x" }}'
+
+                                                                   # ]]]
+# .. envvar:: etesync__http_psk_subpath_enabled [[[
+#
+# Whether EteSync should be deployed on a random subpath that acts as a
+# protection of the web app/API from people not knowing this PSK.
+# For a discussion in which scenarios this can make sense, refer to
+# `RFC: Support subpath/subdir hosting for additional security`__.
+#
+# .. __: https://github.com/debops/debops/issues/1233
+etesync__http_psk_subpath_enabled: False
+
+                                                                   # ]]]
+# .. envvar:: etesync__http_psk_subpath [[[
+#
+# PSK used as subpath that acts as the first layer of defense in a security in
+# depth concept if enabled.
+etesync__http_psk_subpath: '{{ lookup("password", secret + "/etesync/" +
+                                 inventory_hostname + "/config/subpath chars=ascii_letters,digits length=23")
+                               if etesync__http_psk_subpath_enabled|bool
+                               else "" }}'
+
+                                                                   # ]]]
+# .. envvar:: etesync__url [[[
+#
+# The URL where the EteSync server will be reachable. Exposed as variable here
+# as you might want to use it in your custom user password lookup for
+# integrating into your password manager.
+etesync__url: '{{ "https://" + etesync__fqdn + "/" + etesync__http_psk_subpath }}'
+
+                                                                   # ]]]
+# .. envvar:: etesync__admin_auth_basic_realm [[[
+#
+# A string which will be displayed as the realm in the browser user/password
+# dialog box during HTTP Basic Authentication for the admin interface.
+etesync__admin_auth_basic_realm: 'Access to EteSync admin interface is restricted'
+
+                                                                   # ]]]
+# .. envvar:: etesync__admin_auth_basic_filename [[[
+#
+# Absolute path to the file that contains usernames and passwords for HTTP
+# Basic Authentication for the admin interface.
+etesync__admin_auth_basic_filename: ''
+
+                                                                   # ]]]
+# Configuration variables for other Ansible roles [[[
+# ---------------------------------------------------
+
+# .. envvar:: etesync__keyring__dependent_gpg_keys [[[
+#
+# Configuration for the :ref:`debops.keyring` Ansible role.
+etesync__keyring__dependent_gpg_keys:
+
+  - user: '{{ etesync__user }}'
+    group: '{{ etesync__group }}'
+    home: '{{ etesync__home }}'
+    id: '{{ etesync__git_gpg_key_id }}'
+
+                                                                   # ]]]
+# .. envvar:: etesync__python__dependent_packages3 [[[
+#
+# Configuration for the :ref:`debops.python` Ansible role.
+etesync__python__dependent_packages3:
+
+  - 'python3-setproctitle'
+
+  - 'python3-dev'
+
+  ## Django>=2.1.7,<2.1.999 is required which is currently only in Debian sid.
+  # - 'python3-django'
+
+  - 'python3-tz'
+
+                                                                   # ]]]
+# .. envvar:: etesync__gunicorn__dependent_applications [[[
+#
+# Configuration for the :ref:`debops.gunicorn` Ansible role.
+etesync__gunicorn__dependent_applications:
+  - name: 'etesync'
+    mode: 'wsgi'
+    working_dir: '{{ etesync__git_checkout }}'
+    python: '{{ etesync__virtualenv + "/bin/python3" }}'
+    user: '{{ etesync__user }}'
+    group: '{{ etesync__group }}'
+    home: '{{ etesync__home }}'
+    system: True
+    timeout: '{{ etesync__app_timeout }}'
+    workers: '{{ etesync__app_workers }}'
+    args: '{{ etesync__app_params }}'
+
+                                                                   # ]]]
+# .. envvar:: etesync__nginx__dependent_upstreams [[[
+#
+# Upstream configuration for the :ref:`debops.nginx` Ansible role.
+etesync__nginx__dependent_upstreams:
+  - name: 'etesync'
+    server: '{{ etesync__app_bind }}'
+
+                                                                   # ]]]
+# .. envvar:: etesync__nginx__dependent_servers [[[
+#
+# Server configuration for the :ref:`debops.nginx` Ansible role.
+etesync__nginx__dependent_servers:
+  - name: '{{ etesync__fqdn }}'
+    by_role: 'debops.etesync'
+    filename: 'debops.etesync'
+    favicon: False
+    http_referrer_policy: 'same-origin'
+    options: |
+      client_max_body_size {{ etesync__max_file_size }}M;
+
+    location_list:
+
+      - pattern: '/'
+        options: |-
+          deny all;
+        enabled: '{{ etesync__http_psk_subpath_enabled|bool }}'
+
+      - pattern: '/static/admin/'
+        options: |-
+          alias {{ etesync__virtualenv + "/lib/python" + (etesync__python_version.split('.')[:2] | join('.')) }}/site-packages/django/contrib/admin/static/admin/;
+
+      - pattern: '/static/rest_framework/'
+        options: |-
+          alias {{ etesync__virtualenv + "/lib/python" + (etesync__python_version.split('.')[:2] | join('.')) }}/site-packages/rest_framework/static/rest_framework/;
+
+      - pattern: '/{{ etesync__http_psk_subpath }}'
+        options: |-
+          proxy_pass http://etesync;
+          proxy_set_header X-Forwarded-Host $server_name;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-Proto $scheme;
+          {% if etesync__http_psk_subpath != "" %}
+          proxy_set_header SCRIPT_NAME /{{ etesync__http_psk_subpath }};
+          {% endif %}
+          proxy_connect_timeout {{ etesync__app_timeout }};
+          proxy_send_timeout {{ etesync__app_timeout }};
+          proxy_read_timeout {{ etesync__app_timeout }};
+
+      - pattern: '{{ (("/" + etesync__http_psk_subpath)
+                      if (etesync__http_psk_subpath != "")
+                      else "") + "/admin" }}'
+        options: |-
+          proxy_pass http://etesync;
+          proxy_set_header X-Forwarded-Host $server_name;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-Proto $scheme;
+          {% if etesync__http_psk_subpath != "" %}
+          proxy_set_header SCRIPT_NAME /{{ etesync__http_psk_subpath }};
+          {% endif %}
+          proxy_connect_timeout {{ etesync__app_timeout }};
+          proxy_send_timeout {{ etesync__app_timeout }};
+          proxy_read_timeout {{ etesync__app_timeout }};
+
+          auth_basic "{{ etesync__admin_auth_basic_realm }}";
+          auth_basic_user_file {{ etesync__admin_auth_basic_filename }};
+        enabled: '{{ True if etesync__admin_auth_basic_filename|d() else False }}'
+# ]]]
+# ]]]
+# ]]]

--- a/ansible/roles/etesync/defaults/main.yml
+++ b/ansible/roles/etesync/defaults/main.yml
@@ -340,6 +340,36 @@ etesync__admin_auth_basic_realm: 'Access to EteSync admin interface is restricte
 etesync__admin_auth_basic_filename: ''
 
                                                                    # ]]]
+# .. envvar:: etesync__mail_to [[[
+#
+# List of recipients to which a mail will be send with the full URL of the
+# EteSync server in case :envvar:`etesync__http_psk_subpath` is set.
+etesync__mail_to: [ 'root@{{ ansible_domain }}' ]
+
+                                                                   # ]]]
+# .. envvar:: etesync__mail_subject [[[
+#
+# Subject of the Email to be send with the full service URL.
+etesync__mail_subject: 'PSK subpath URL to EteSync on {{ ansible_fqdn }}'
+
+                                                                   # ]]]
+# .. envvar:: etesync__mail_body [[[
+#
+# Body of the Email to be send with the full service URL.
+etesync__mail_body: |
+  EteSync has been deployed for the first time on {{ ansible_fqdn }}.
+  You have chosen to deploy the service on a random subpath thus the URL is
+  needed to access the service.
+
+  URL: {{ etesync__url }}
+
+  You can continue the user setup in the Django administration interface of EteSync over at:
+  {{ etesync__url }}/admin
+
+  Have a nice day :)
+
+# ]]]
+# ]]]
 # Configuration variables for other Ansible roles [[[
 # ---------------------------------------------------
 

--- a/ansible/roles/etesync/defaults/main.yml
+++ b/ansible/roles/etesync/defaults/main.yml
@@ -138,10 +138,11 @@ etesync__git_repo: 'https://github.com/etesync/server.git'
 # .. envvar:: etesync__git_version [[[
 #
 # The :command:`git` branch or tag which will be installed.
-# git commit hash lock to release 0.2.1.
+# git commit hash lock to release 0.2.2.
 # Note that this hash locking is not very effective because the main
 # implementation of EteSync is in additional Python packages.
-etesync__git_version: 'cf0dc8e6a81f0b87bfba6d952ce9085d21257c18'
+etesync__git_version: 'b026643cceae07b039942bf0c990ccf917eb072a'
+
 
                                                                    # ]]]
 # .. envvar:: etesync__git_dest [[[

--- a/ansible/roles/etesync/handlers/main.yml
+++ b/ansible/roles/etesync/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Restart gunicorn for etesync
+  service:
+    name: 'gunicorn@etesync'
+    state: 'restarted'
+  when: (ansible_local|d() and ansible_local.gunicorn|d() and
+         ansible_local.gunicorn.installed|bool)

--- a/ansible/roles/etesync/meta/main.yml
+++ b/ansible/roles/etesync/meta/main.yml
@@ -1,0 +1,29 @@
+---
+
+dependencies: []
+
+galaxy_info:
+
+  role_name: 'etcsync'
+  author: 'Robin Schnieder'
+  description: 'Deploy and manage the EteSync server'
+  company: 'DebOps'
+  license: 'GPL-3.0-only'
+  min_ansible_version: '2.1.0'
+  platforms:
+    - name: Ubuntu
+      versions:
+        - trusty
+        - xenial
+        - zesty
+
+    - name: Debian
+      versions:
+        - stretch
+        - buster
+  galaxy_tags:
+    - e2ee
+    - private
+    - privacy
+    - calender
+    - contacts

--- a/ansible/roles/etesync/meta/watch-etesync
+++ b/ansible/roles/etesync/meta/watch-etesync
@@ -1,0 +1,6 @@
+# Role: etesync
+# Package: etesync
+# Version: 0.2.1
+
+version=4
+https://github.com/etesync/server/tags .*/v?(\d\S+)\.tar\.gz

--- a/ansible/roles/etesync/meta/watch-etesync
+++ b/ansible/roles/etesync/meta/watch-etesync
@@ -1,6 +1,6 @@
 # Role: etesync
 # Package: etesync
-# Version: 0.2.1
+# Version: 0.2.2
 
 version=4
 https://github.com/etesync/server/tags .*/v?(\d\S+)\.tar\.gz

--- a/ansible/roles/etesync/tasks/main.yml
+++ b/ansible/roles/etesync/tasks/main.yml
@@ -155,13 +155,14 @@
     SUPERUSER_NAME: '{{ etesync__superuser_name }}'
     SUPERUSER_EMAIL: '{{ etesync__superuser_email }}'
     SUPERUSER_PASSWORD: '{{ etesync__superuser_password }}'
-  shell: |
+  shell:
     ## -o nounset can be enabled with virtualenv >= 16.2.
     ## Ref: https://github.com/pypa/virtualenv/pull/922
     set -o pipefail -o errexit;
-    source {{ etesync__virtualenv }}/bin/activate
+    source {{ etesync__virtualenv }}/bin/activate;
     echo "from django.contrib.auth.models import User;
-          User.objects.create_superuser('${SUPERUSER_NAME}', '${SUPERUSER_EMAIL}', '${SUPERUSER_PASSWORD}')" | ./manage.py shell
+          User.objects.create_superuser('${SUPERUSER_NAME}', '${SUPERUSER_EMAIL}', '${SUPERUSER_PASSWORD}')"
+    | ./manage.py shell
   args:
     chdir: '{{ etesync__git_checkout }}'
     executable: 'bash'

--- a/ansible/roles/etesync/tasks/main.yml
+++ b/ansible/roles/etesync/tasks/main.yml
@@ -176,6 +176,17 @@
          etesync__register_migration is not changed)
   no_log: True
 
+# Send PSK subpath URL to admin if needed [[[1
+- name: Send mail with the full URL of the EteSync server
+  mail:
+    from: 'root@{{ ansible_fqdn }}'
+    subject: '{{ etesync__mail_subject }}'
+    to: '{{ etesync__mail_to|d([]) | list | join(",") }}'
+    charset: 'utf8'
+    body: '{{ etesync__mail_body }}'
+  when: (etesync__http_psk_subpath != "" and etesync__mail_to|d() and "etesync" not in ansible_local)
+
+# Save EteSync local facts [[[1
 - name: Make sure that Ansible local facts directory exists
   file:
     path: '/etc/ansible/facts.d'
@@ -196,9 +207,3 @@
 - name: Update Ansible facts if they were modified
   action: setup
   when: etesync__register_facts is changed
-
-- name: Print URL entry point if EteSync is deployed on a subpath
-  debug:
-    msg: 'URL: {{ etesync__url }}'
-  when: etesync__http_psk_subpath != ""
-  tags: [ 'role::etesync:show_url' ]

--- a/ansible/roles/etesync/tasks/main.yml
+++ b/ansible/roles/etesync/tasks/main.yml
@@ -43,11 +43,6 @@
     - '{{ etesync__lib }}'
     - '{{ etesync__data }}'
 
-- name: Check if EteSync is installed
-  stat:
-    path: '{{ etesync__git_checkout }}'
-  register: etesync__register_installed
-
 # Download EteSync server [[[1
 - name: Clone EteSync source code
   git:
@@ -172,8 +167,7 @@
     executable: 'bash'
   become: True
   become_user: '{{ etesync__user }}'
-  when: (not etesync__register_installed.stat.exists|bool and
-         etesync__register_migration is not changed)
+  when: ("etesync" not in ansible_local)
   no_log: True
 
 # Send PSK subpath URL to admin if needed [[[1

--- a/ansible/roles/etesync/tasks/main.yml
+++ b/ansible/roles/etesync/tasks/main.yml
@@ -97,6 +97,16 @@
   when: etesync__register_source is changed
 
 # Configure EteSync server [[[1
+- name: Exclude secret files from etckeeper
+  copy:
+    content: |
+      secret.txt
+    dest: '{{ etesync__etc + "/.gitignore" }}'
+    owner: 'root'
+    group: 'root'
+    mode: '0600'
+  tags: [ 'role::etesync:config' ]
+
 - name: Generate EteSync configuration
   template:
     src: 'etc/etesync-server/etesync-server.ini.j2'

--- a/ansible/roles/etesync/tasks/main.yml
+++ b/ansible/roles/etesync/tasks/main.yml
@@ -1,0 +1,194 @@
+---
+
+- import_role:
+    name: 'secret'
+
+# Install packages [[[1
+- name: Install required packages
+  package:
+    name: '{{ q("flattened", (etesync__base_packages
+                              + etesync__packages)) }}'
+    state: 'present'
+  register: etesync__register_packages
+  until: etesync__register_packages is succeeded
+
+# Create EteSync system user [[[1
+- name: Create EteSync system group
+  group:
+    name: '{{ etesync__group }}'
+    state: 'present'
+    system: True
+
+- name: Create EteSync system user
+  user:
+    name: '{{ etesync__user }}'
+    group: '{{ etesync__group }}'
+    home: '{{ etesync__home }}'
+    comment: '{{ etesync__gecos }}'
+    shell: '{{ etesync__shell }}'
+    state: 'present'
+    system: True
+
+- name: Create additional directories used by EteSync
+  file:
+    path: '{{ item }}'
+    state: 'directory'
+    owner: '{{ etesync__user }}'
+    group: '{{ etesync__group }}'
+    mode: '0755'
+  with_items:
+    - '{{ etesync__etc }}'
+    - '{{ etesync__src }}'
+    - '{{ etesync__git_dest | dirname }}'
+    - '{{ etesync__lib }}'
+    - '{{ etesync__data }}'
+
+- name: Check if EteSync is installed
+  stat:
+    path: '{{ etesync__git_checkout }}'
+  register: etesync__register_installed
+
+# Download EteSync server [[[1
+- name: Clone EteSync source code
+  git:
+    repo: '{{ etesync__git_repo }}'
+    dest: '{{ etesync__git_checkout }}'
+    separate_git_dir: '{{ etesync__git_dest }}'
+    version: '{{ etesync__git_version }}'
+    update: True
+    ## The module cannot hash lock and verify the tag referring to the locked
+    ## commit thus we need to verify the tag in the following task.
+    # verify_commit: True
+  become: True
+  become_user: '{{ etesync__user }}'
+  register: etesync__register_source
+
+- name: Verify git tag signature
+  shell: git verify-tag --raw "$(git describe)"
+  args:
+    chdir: '{{ etesync__git_checkout }}'
+  become: True
+  become_user: '{{ etesync__user }}'
+  changed_when: False
+  ## Always run this to also cover the case where the playbook is interrupted
+  ## before we can verify.
+  # when: etesync__register_source is changed
+
+- name: Install EteSync requirements in virtualenv
+  pip:
+    virtualenv: '{{ etesync__virtualenv }}'
+    virtualenv_python: 'python3'
+    virtualenv_site_packages: True
+    requirements: '{{ etesync__git_checkout + "/requirements.txt" }}'
+    extra_args: '--upgrade'
+  register: etesync__register_pip_install
+  until: etesync__register_pip_install is succeeded
+  become: True
+  become_user: '{{ etesync__user }}'
+  notify: [ 'Restart gunicorn for etesync' ]
+  when: etesync__register_source is changed
+
+- name: Clean up stale Python bytecode
+  command: find . -name '*.pyc' -delete
+  args:
+    chdir: '{{ etesync__git_checkout }}'
+  become: True
+  become_user: '{{ etesync__user }}'
+  when: etesync__register_source is changed
+
+# Configure EteSync server [[[1
+- name: Generate EteSync configuration
+  template:
+    src: 'etc/etesync-server/etesync-server.ini.j2'
+    dest: '{{ etesync__etc + "/etesync-server.ini" }}'
+    owner: '{{ etesync__user }}'
+    group: '{{ etesync__group }}'
+    mode: '0640'
+  register: etesync__register_config
+  notify: [ 'Restart gunicorn for etesync' ]
+  tags: [ 'role::etesync:config' ]
+
+- name: Generate extended EteSync configuration
+  template:
+    src: 'usr/local/lib/etesync/app/etesync_site_settings.py.j2'
+    dest: '{{ etesync__git_checkout + "/etesync_site_settings.py" }}'
+    owner: '{{ etesync__user }}'
+    group: '{{ etesync__group }}'
+    mode: '0640'
+  register: etesync__register_config
+  notify: [ 'Restart gunicorn for etesync' ]
+  tags: [ 'role::etesync:config' ]
+
+- name: Generate EteSync secret.txt file
+  template:
+    src: 'etc/etesync-server/secret.txt.j2'
+    dest: '{{ etesync__config_secret_key_filepath }}'
+    owner: '{{ etesync__user }}'
+    group: '{{ etesync__group }}'
+    mode: '0640'
+  notify: [ 'Restart gunicorn for etesync' ]
+  tags: [ 'role::etesync:config' ]
+
+- name: Perform database installation or migration
+  shell: |
+    ## -o nounset can be enabled with virtualenv >= 16.2.
+    ## Ref: https://github.com/pypa/virtualenv/pull/922
+    set -o pipefail -o errexit;
+    source {{ etesync__virtualenv }}/bin/activate
+    ./manage.py migrate
+  args:
+    chdir: '{{ etesync__git_checkout }}'
+    executable: 'bash'
+  become: True
+  become_user: '{{ etesync__user }}'
+  changed_when: ("No migrations to apply." not in etesync__register_migration.stdout)
+  when: etesync__register_source is changed or etesync__register_config is changed
+  register: etesync__register_migration
+
+- name: Create superuser account
+  environment:
+    SUPERUSER_NAME: '{{ etesync__superuser_name }}'
+    SUPERUSER_EMAIL: '{{ etesync__superuser_email }}'
+    SUPERUSER_PASSWORD: '{{ etesync__superuser_password }}'
+  shell: |
+    ## -o nounset can be enabled with virtualenv >= 16.2.
+    ## Ref: https://github.com/pypa/virtualenv/pull/922
+    set -o pipefail -o errexit;
+    source {{ etesync__virtualenv }}/bin/activate
+    echo "from django.contrib.auth.models import User;
+          User.objects.create_superuser('${SUPERUSER_NAME}', '${SUPERUSER_EMAIL}', '${SUPERUSER_PASSWORD}')" | ./manage.py shell
+  args:
+    chdir: '{{ etesync__git_checkout }}'
+    executable: 'bash'
+  become: True
+  become_user: '{{ etesync__user }}'
+  when: (not etesync__register_installed.stat.exists|bool and
+         etesync__register_migration is not changed)
+  no_log: True
+
+- name: Make sure that Ansible local facts directory exists
+  file:
+    path: '/etc/ansible/facts.d'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+
+- name: Save EteSync local facts
+  template:
+    src: 'etc/ansible/facts.d/etesync.fact.j2'
+    dest: '/etc/ansible/facts.d/etesync.fact'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+  register: etesync__register_facts
+
+- name: Update Ansible facts if they were modified
+  action: setup
+  when: etesync__register_facts is changed
+
+- name: Print URL entry point if EteSync is deployed on a subpath
+  debug:
+    msg: 'URL: {{ etesync__url }}'
+  when: etesync__http_psk_subpath != ""
+  tags: [ 'role::etesync:show_url' ]

--- a/ansible/roles/etesync/tasks/main.yml
+++ b/ansible/roles/etesync/tasks/main.yml
@@ -111,7 +111,7 @@
   template:
     src: 'etc/etesync-server/etesync-server.ini.j2'
     dest: '{{ etesync__etc + "/etesync-server.ini" }}'
-    owner: '{{ etesync__user }}'
+    owner: 'root'
     group: '{{ etesync__group }}'
     mode: '0640'
   register: etesync__register_config
@@ -133,7 +133,7 @@
   template:
     src: 'etc/etesync-server/secret.txt.j2'
     dest: '{{ etesync__config_secret_key_filepath }}'
-    owner: '{{ etesync__user }}'
+    owner: 'root'
     group: '{{ etesync__group }}'
     mode: '0640'
   notify: [ 'Restart gunicorn for etesync' ]

--- a/ansible/roles/etesync/templates/etc/ansible/facts.d/etesync.fact.j2
+++ b/ansible/roles/etesync/templates/etc/ansible/facts.d/etesync.fact.j2
@@ -1,0 +1,11 @@
+#!{{ ansible_python['executable'] }}
+
+# {{ ansible_managed }}
+
+from __future__ import print_function
+from json import dumps
+from sys import exit
+
+output = {'installed': True}
+
+print(dumps(output, sort_keys=True, indent=4))

--- a/ansible/roles/etesync/templates/etc/etesync-server/etesync-server.ini.j2
+++ b/ansible/roles/etesync/templates/etc/etesync-server/etesync-server.ini.j2
@@ -1,0 +1,16 @@
+# {{ ansible_managed }}
+
+[global]
+secret_file = {{ etesync__config_secret_key_filepath }}
+debug = false
+
+[allowed_hosts]
+{% for host in ([ etesync__config_allowed_hosts ]
+				if etesync__config_allowed_hosts is string
+				else etesync__config_allowed_hosts) %}
+allowed_host{{ loop.index }} = {{ host }}
+{% endfor %}
+
+[database]
+engine = django.db.backends.sqlite3
+name = {{ etesync__data }}/db.sqlite3

--- a/ansible/roles/etesync/templates/etc/etesync-server/secret.txt.j2
+++ b/ansible/roles/etesync/templates/etc/etesync-server/secret.txt.j2
@@ -1,0 +1,1 @@
+{{ etesync__config_secret_key }}

--- a/ansible/roles/etesync/templates/usr/local/lib/etesync/app/etesync_site_settings.py.j2
+++ b/ansible/roles/etesync/templates/usr/local/lib/etesync/app/etesync_site_settings.py.j2
@@ -1,0 +1,3 @@
+# {{ ansible_managed }}
+
+CSRF_TRUSTED_ORIGINS = ['{{ etesync__fqdn }}']

--- a/docs/ansible/role-index.rst
+++ b/docs/ansible/role-index.rst
@@ -30,6 +30,7 @@ etc.
 - :ref:`debops.mailman`
 - :ref:`debops.netbox`
 - :ref:`debops.owncloud`
+- :ref:`debops.etesync`
 - :ref:`debops.prosody`
 - :ref:`debops.roundcube`
 - :ref:`debops.rstudio_server`

--- a/docs/ansible/roles/etesync/getting-started.rst
+++ b/docs/ansible/roles/etesync/getting-started.rst
@@ -9,7 +9,7 @@ Getting started
 Example inventory
 -----------------
 
-To configure Docker on a given remote host, it needs to be added to the
+To configure EteSync on a given remote host, it needs to be added to the
 ``[debops_service_etesync]`` Ansible inventory group:
 
 .. code-block:: none
@@ -21,7 +21,7 @@ To configure Docker on a given remote host, it needs to be added to the
 Example playbook
 ----------------
 
-Here's an example playbook that can be used to manage Docker:
+Here's an example playbook that can be used to manage EteSync:
 
 .. literalinclude:: ../../../../ansible/playbooks/service/etesync.yml
    :language: yaml

--- a/docs/ansible/roles/etesync/getting-started.rst
+++ b/docs/ansible/roles/etesync/getting-started.rst
@@ -1,0 +1,48 @@
+Getting started
+===============
+
+.. only:: html
+
+   .. contents::
+      :local:
+
+Example inventory
+-----------------
+
+To configure Docker on a given remote host, it needs to be added to the
+``[debops_service_etesync]`` Ansible inventory group:
+
+.. code-block:: none
+
+   [debops_service_etesync]
+   hostname
+
+
+Example playbook
+----------------
+
+Here's an example playbook that can be used to manage Docker:
+
+.. literalinclude:: ../../../../ansible/playbooks/service/etesync.yml
+   :language: yaml
+
+
+Ansible tags
+------------
+
+You can use Ansible ``--tags`` or ``--skip-tags`` parameters to limit what
+tasks are performed during Ansible run. This can be used after a host was first
+configured to speed up playbook execution, when you are sure that most of the
+configuration is already in the desired state.
+
+Available role tags:
+
+``role::etesync``
+  Main role tag, should be used in the playbook to execute all of the role
+  tasks as well as role dependencies.
+
+``role::etesync:config``
+  Run tasks related to EteSync configuration.
+
+``role::etesync:show_url``
+  Print URL entry point if EteSync is deployed on a subpath.

--- a/docs/ansible/roles/etesync/index.rst
+++ b/docs/ansible/roles/etesync/index.rst
@@ -7,6 +7,13 @@ Deploys a `EteSync`_ server. EteSync is a cross-platform project to provide
 secure, end-to-end encrypted, and privacy respecting sync for your contacts,
 calendars and tasks.
 
+Note that the role only sets up the "API" server without the user web interface
+that can be used to edit contacts and calendars in a browser. Therefore, after
+the setup is completed, you will need to use a EteSync client program to work
+with the service. The only "graphical" interface provided is the administration
+web interface, that you can use to manage EteSync users (available under
+``/admin``).
+
 .. _EteSync: https://www.etesync.com/
 
 .. toctree::

--- a/docs/ansible/roles/etesync/index.rst
+++ b/docs/ansible/roles/etesync/index.rst
@@ -7,7 +7,7 @@ Deploys a `EteSync`_ server. `EteSync`_ is a cross-platform project to provide
 secure, end-to-end encrypted, and privacy respecting sync for your contacts,
 calendars and tasks.
 
-.. _Docker: https://www.etesync.com/
+.. _EteSync: https://www.etesync.com/
 
 .. toctree::
    :maxdepth: 2

--- a/docs/ansible/roles/etesync/index.rst
+++ b/docs/ansible/roles/etesync/index.rst
@@ -1,0 +1,33 @@
+.. _debops.etesync:
+
+debops.etesync
+==============
+
+Deploys a `EteSync`_ server. `EteSync`_ is a cross-platform project to provide
+secure, end-to-end encrypted, and privacy respecting sync for your contacts,
+calendars and tasks.
+
+.. _Docker: https://www.etesync.com/
+
+.. toctree::
+   :maxdepth: 2
+
+   getting-started
+
+.. only:: html
+
+   .. toctree::
+      :maxdepth: 2
+
+      defaults/main
+
+   Copyright
+   ---------
+
+   .. literalinclude:: ../../../../ansible/roles/etesync/COPYRIGHT
+
+..
+ Local Variables:
+ mode: rst
+ ispell-local-dictionary: "american"
+ End:

--- a/docs/ansible/roles/etesync/index.rst
+++ b/docs/ansible/roles/etesync/index.rst
@@ -3,7 +3,7 @@
 debops.etesync
 ==============
 
-Deploys a `EteSync`_ server. `EteSync`_ is a cross-platform project to provide
+Deploys a `EteSync`_ server. EteSync is a cross-platform project to provide
 secure, end-to-end encrypted, and privacy respecting sync for your contacts,
 calendars and tasks.
 


### PR DESCRIPTION
The first new DebOps role of the decade :)

Project: https://www.etesync.com/

WIP: @drybjed I am not sure if the integration test is ok. I have not yet played with the current testing approach enough.

Implements: #1233 
Updates: #1230

Reasons to update #1230:

* The etckeeper role should not get bloated by each and every application that could possibly write secret files to /etc.
* Users might not use the DebOps etckeeper role and instead only use the application roles and would then not have secret files excluded from Etckeeper if they still use it.