### PR TITLE
[postgresql_server] Support more efficient backukp compression

### DIFF
--- a/ansible/roles/postgresql_server/defaults/main.yml
+++ b/ansible/roles/postgresql_server/defaults/main.yml
@@ -563,7 +563,9 @@ postgresql_server__auto_backup_encryption_suffix: '.enc'
                                                                    # ]]]
 # .. envvar:: postgresql_server__auto_backup_compression [[[
 #
-# Specify compression method to use for snapshots.
+# Specify compression method to use for snapshots. The special value
+# ``pg_dump`` causes pg_dump to compress the backup internally without
+# writing an uncompress dump first and compressing it afterwards.
 postgresql_server__auto_backup_compression: 'gzip'
 
                                                                    # ]]]

--- a/ansible/roles/postgresql_server/templates/etc/default/autopostgresqlbackup.j2
+++ b/ansible/roles/postgresql_server/templates/etc/default/autopostgresqlbackup.j2
@@ -59,18 +59,21 @@ SEPDIR={{ "yes" if ((item.auto_backup_isolate_databases | d(postgresql_server__a
 # Which day do you want weekly backups? (1 to 7 where 1 is Monday)
 DOWEEKLY={{ item.auto_backup_weekly | d(postgresql_server__auto_backup_weekly) }}
 
+{% set auto_backup_compression = item.auto_backup_compression
+                                 | d(postgresql_server__auto_backup_compression) %}
 # Choose Compression type. (gzip or bzip2)
-COMP="{{ item.auto_backup_compression | d(postgresql_server__auto_backup_compression) }}"
+COMP="{{ auto_backup_compression }}"
 
-# Compress communications between backup server and PostgreSQL server?
+# Compress backup on the fly with pg_dump (instead of afterwards with gzip or bzip2)
 # set compression level from 0 to 9 (0 means no compression)
-COMMCOMP=0
+COMMCOMP={{ item.auto_backup_compression_level
+            | default((auto_backup_compression == "pg_dump") | ternary(6,0)) }}
 
 # Additionally keep a copy of the most recent backup in a seperate directory.
 LATEST=no
 
 # Backup files extension
-EXT="sql"
+EXT="sql{{ (auto_backup_compression == "pg_dump") | ternary(".gz", "") }}"
 
 # Encyrption settings
 # (inspired by http://blog.altudov.com/2010/09/27/using-openssl-for-asymmetric-encryption-of-backups/)


### PR DESCRIPTION
Add configuration options to configure autopostgresqlbackup to compress
the backups directly with pg_dump instead of first dumping an
uncompressed file and then compressing it.

This uses the autopostgresqlbackup configuration option COMMCOMP which
adds the --compress option to pg_dump. Unfortunately this is labeled as
"communication compression" in the original file, but it has nothing to
do with compressing the communication. See the pg_dump manpage for
details about the --compress option.