### PR TITLE
[keyring] Switch 'gpg' package to 'gnupg'

### DIFF
--- a/ansible/roles/keyring/defaults/main.yml
+++ b/ansible/roles/keyring/defaults/main.yml
@@ -65,7 +65,7 @@ keyring__gpg_version: '{{ ansible_local.keyring.gpg_version
 keyring__base_packages:
   - 'curl'
   - 'ca-certificates'
-  - 'gpg'
+  - 'gnupg'
   - '{{ "apt-transport-https"
         if (ansible_distribution_release in
             [ "wheezy", "jessie", "stretch",


### PR DESCRIPTION
The 'gnupg' APT package includes additional features like support for
network access needed to install GPG keys from keyservers.