### PR TITLE
Ensure mkhomedir get update on change

### DIFF
--- a/ansible/roles/nslcd/tasks/main.yml
+++ b/ansible/roles/nslcd/tasks/main.yml
@@ -14,7 +14,7 @@
   register: nslcd__register_mkhomedir
 
 - name: Enable mkhomedir PAM module
-  shell: pam-auth-update --package --enable mkhomedir 2>/dev/null
+  shell: pam-auth-update --package --remove mkhomedir 2>/dev/null && pam-auth-update --package --enable mkhomedir 2>/dev/null
   when: nslcd__register_mkhomedir is changed
 
 - name: Install packages for nslcd support


### PR DESCRIPTION
When `pam-auth-update` is ran with `--enable mkhomedir`, pam-auth-update will
add this file to the seen list at `/var/lib/pam/seen` which prevents all future
updates to the package `mkhomedir`.

Subsequence runs of this will cause `pam-auth-update --package --enable
mkhomedir` will be noop, which is not the intention of the task here. We
want to ensure that if the mkhomedir is change, the change get remove and
re-added.

Since this operation is highly order depended, if `mkhomedir` wasn't correct the
first time, it's not possible to update it due the `seen` mechanism.

Remove when `mkhomedir` doesn't exist is also a noop and return 0 so it's safe
to run without worry about order.

```
root@host:~# cat /var/lib/pam/seen
unix
ldap
systemd
root@host:~# pam-auth-update --package --remove mkhomedir
root@host:~# echo $?
0
```