### PR TITLE
Reorder 'machine' role in 'common.yml' playbook

### DIFF
--- a/ansible/playbooks/bootstrap-ldap.yml
+++ b/ansible/playbooks/bootstrap-ldap.yml
@@ -126,6 +126,9 @@
     - role: pki
       tags: [ 'role::pki', 'skip::pki' ]
 
+    - role: machine
+      tags: [ 'role::machine', 'skip::machine' ]
+
     # LDAP client initialization should be done separately to prepare local
     # facts for other roles to use in configuration.
     - role: ldap

--- a/ansible/playbooks/common.yml
+++ b/ansible/playbooks/common.yml
@@ -112,6 +112,9 @@
     - role: pki
       tags: [ 'role::pki', 'skip::pki' ]
 
+    - role: machine
+      tags: [ 'role::machine', 'skip::machine' ]
+
     # LDAP client initialization should be done separately to prepare local
     # facts for other roles to use in configuration.
     - role: ldap
@@ -176,9 +179,6 @@
 
     - role: auth
       tags: [ 'role::auth', 'skip::auth' ]
-
-    - role: machine
-      tags: [ 'role::machine', 'skip::machine' ]
 
     - role: users
       tags: [ 'role::users', 'skip::users' ]


### PR DESCRIPTION
The 'machine' role defines an Ansible local fact which is used by the
'ldap' role to configure its own local fact which is then used by the
'sshd' role.

This patch changes the order of the 'machine' role in the 'common.yml'
playbook to ensure that it is executed before the 'ldap' role. This
should fix an idempotency issue where the 'ldap' and 'sshd'
configuration was changed on the second run of the 'common.yml'
playbook to apply changes introducted by the 'machine' role.

The 'machine' role is also added to the 'bootstrap-ldap.yml' playbook to
ensure that the desired configuration is applied at the host
provisioning stage.