### PR TITLE
[ferm] Fix incorrect removal of avahi rule

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -108,6 +108,12 @@ Removed
 Fixed
 ~~~~~
 
+:ref:`debops.ferm` role
+'''''''''''''''''''''''
+
+- Fixed incorrect removal of the ferm rule set by :ref:`debops.avahi` on
+  IPv6-enabled systems.
+
 :ref:`debops.netbase` role
 ''''''''''''''''''''''''''
 

--- a/ansible/roles/ferm/defaults/main.yml
+++ b/ansible/roles/ferm/defaults/main.yml
@@ -533,8 +533,10 @@ ferm__default_rules:
     rule_state: '{{ "present"
                     if ((ansible_local|d() and ansible_local.nsswitch|d() and
                          ansible_local.nsswitch.conf|d() and
-                         "mdns4_minimal" in q("flattened",
-                                              ansible_local.nsswitch.conf.hosts|d([]))) and
+                         ("mdns4_minimal" in q("flattened",
+                                               ansible_local.nsswitch.conf.hosts|d([])) or
+                          "mdns_minimal" in q("flattened",
+                                              ansible_local.nsswitch.conf.hosts|d([])))) and
                         (ansible_local|d(True) and ansible_local.avahi|d(True) and
                          ((ansible_local["avahi"]|d({})).enabled|d(True))|bool))
                     else "absent" }}'


### PR DESCRIPTION
The `ferm` role kept removing the dependent rule set by the `avahi`
role on IPv6-enabled systems. This happended because the default avahi
rule in the `ferm` role only detected the `mdns4_minimal` NSS service,
while it should detect the `mdns_minimal` NSS service as well.

Closes #1183