### PR TITLE
Add 'clean-git' target in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,11 @@ check: fail-if-git-dirty
 clean:          ## Clean up project directory
 clean: clean-tests clean-sdist clean-wheel
 
+.PHONY: clean-git
+clean-git:      ## Clean up directories and files ignored by git
+clean-git:
+	@git clean -X -d -f
+
 .PHONY: collection
 collection:     ## Build collection of Ansible artifacts with ansible-galaxy
 collection: make-collection
@@ -87,7 +92,7 @@ sdist-sign: sdist
 	@gpg --detach-sign --armor dist/debops-*.tar.gz
 
 .PHONY: make-collection
-make-collection:
+make-collection: clean clean-git
 	@lib/ansible-galaxy/make-collection
 
 .PHONY: clean-sdist


### PR DESCRIPTION
The 'clean-git' target will remove files and directories in the current
'git' worktree which are ignored by 'git'. This will be used to remove
any extra files for Ansible Collection generation.