### PR TITLE
[nullmailer] Don't dig empty DNS domains

### DIFF
--- a/ansible/roles/nullmailer/defaults/main.yml
+++ b/ansible/roles/nullmailer/defaults/main.yml
@@ -241,7 +241,8 @@ nullmailer__starttls: True
 # List which contains the result of the :command:`dig` query for SMTP
 # server ``SRV`` resource records in the host's domain. See
 # :rfc:`6186` for details.
-nullmailer__smtp_srv_rr: '{{ q("dig", "_smtp._tcp." + nullmailer__domain + "./SRV", "flat=0") }}'
+nullmailer__smtp_srv_rr: '{{ q("dig", "_smtp._tcp." + nullmailer__domain + "./SRV", "flat=0")
+                             if nullmailer__domain|d() else [] }}'
 
                                                                    # ]]]
 # .. envvar:: nullmailer__smtp_port [[[


### PR DESCRIPTION
If the 'ansible_domain' variable is empty (no DNS domain configured on
a host), don't use the 'dig' lookup plugin to find the '_smtp._tcp' SRV
resource record. This fixes the "dns.resolver unhandled exception A DNS
label is empty." error during Ansible execution.