### PR TITLE
[owncloud] No parameter validate in module file.

### DIFF
--- a/ansible/roles/owncloud/tasks/setup_owncloud.yml
+++ b/ansible/roles/owncloud/tasks/setup_owncloud.yml
@@ -48,7 +48,6 @@
   file:
     path: '{{ owncloud__deploy_path }}/config/mail.config.php'
     state: 'absent'
-    validate: 'php -f %s'
   when: ((owncloud__mail_conf_map.keys() | length) == 0)
 
 - name: Ensure deprecated configuration files are absent


### PR DESCRIPTION
ansible file module has no parameter validate. Looks like a cut&paste error from block above.