### PR TITLE
[nginx] Enable TLSv1.3 for nginx 1.13.0 and up

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -111,6 +111,11 @@ General
   .. __: https://reuse.software/spec/
   .. __: https://spdx.org/ids
 
+:ref:`debops.nginx` role
+''''''''''''''''''''''''
+
+- TLSv1.3 is now enabled by default for nginx version 1.13.0 and up.
+
 :ref:`debops.owncloud` role
 '''''''''''''''''''''''''''
 

--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -511,7 +511,13 @@ nginx_default_ssl_ciphers: 'bettercrypto_org__set_b_pfs'
                                                                    # ]]]
 # .. envvar:: nginx_default_tls_protocols [[[
 #
-nginx_default_tls_protocols: [ 'TLSv1', 'TLSv1.1', 'TLSv1.2' ]
+# Default set of TLS protocols to use. TLSv1.3 is only supported on nginx
+# version 1.13.0 and up.
+#
+# See also: https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols
+nginx_default_tls_protocols: '{{ [ "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3" ]
+                                 if ansible_local.nginx.version|d("0.0.0") is version("1.13.0", ">=")
+                                 else [ "TLSv1", "TLSv1.1", "TLSv1.2" ] }}'
 
                                                                    # ]]]
 # .. envvar:: nginx_default_ssl_curve [[[


### PR DESCRIPTION
The nginx web server supports TLSv1.3 since version 1.13.0. These
changes enable TLSv1.3 by default when nginx 1.13.0+ is used.

Note that TLSv1.3 only works in nginx with OpenSSL 1.1.1. OpenSSL also
needs to be build with TLSv1.3 support (which is the case in Debian
stable).