### PR TITLE
[nginx] Set HSTS header regardless of status code

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -182,6 +182,12 @@ General
   in case that the DNS infrastructure is not configured. This avoids 60s
   timeouts during Ansible fact gathering in such cases.
 
+:ref:`debops.nginx` role
+''''''''''''''''''''''''
+
+- The role now always sets the HTTP Strict Transport Security header when it is
+  enabled, regardless of the response code.
+
 :ref:`debops.postgresql_server` role
 ''''''''''''''''''''''''''''''''''''
 

--- a/ansible/roles/nginx/templates/etc/nginx/sites-available/default.conf.j2
+++ b/ansible/roles/nginx/templates/etc/nginx/sites-available/default.conf.j2
@@ -664,7 +664,7 @@ server {
 {%         endif                                                %}
 {%     endif                                                    %}
 {%     if item.hsts_enabled|d(True) | bool                      %}
-        add_header                Strict-Transport-Security "max-age={{ nginx_hsts_age }}{{ "; includeSubDomains" if nginx_hsts_subdomains|bool else "" }}{{ "; preload" if ((item.hsts_preload | d(nginx_hsts_preload)) | bool) else "" }}";
+        add_header                Strict-Transport-Security "max-age={{ nginx_hsts_age }}{{ "; includeSubDomains" if nginx_hsts_subdomains|bool else "" }}{{ "; preload" if ((item.hsts_preload | d(nginx_hsts_preload)) | bool) else "" }}" always;
 {% endif                                                    %}
 {% if item.csp_enabled|d(False) | bool %}
         add_header                Content-Security-Policy "{{ item.csp|d("default-src https: ;") + (" " + item.csp_append|d(nginx__http_csp_append) if (item.csp_append|d(nginx__http_csp_append)) else "") }}";


### PR DESCRIPTION
The current Strict-Transport-Security header in the default.conf
template is only added when the response code equals 200, 201 (1.3.10),
204, 206, 301, 302, 303, 304, 307 (1.1.16, 1.0.13), or 308 (1.13.0).

For added security, this change ensures that the HSTS header is always
set, regardless of the response code. This is done by adding the
'always' parameter to the HSTS add_header directive.

I believe that this change is compliant with RFC 6797.

Ref: http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header