### PR TITLE
[pki] Allow adding contact details to ACME account

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,6 +50,13 @@ New DebOps roles
 
   .. __: https://influxdata.com/
 
+:ref:`debops.pki` role
+''''''''''''''''''''''
+
+- The role can now instruct acme-tiny to register an ACME account with one or
+  more contact URLs. Let's Encrypt for example uses this information to notify
+  you about expiring certificates and emergency revocation.
+
 :ref:`debops.postconf` role
 '''''''''''''''''''''''''''
 

--- a/ansible/roles/pki/defaults/main.yml
+++ b/ansible/roles/pki/defaults/main.yml
@@ -231,6 +231,19 @@ pki_acme_ca_api_map:
   'le-staging-v2': 'https://acme-staging-v02.api.letsencrypt.org/directory'
 
                                                                    # ]]]
+# .. envvar:: pki_acme_contacts [[[
+#
+# List of (mailto:) URLs that the ACME server can use to contact you for issues
+# related to your account. For example, the server may wish to notify you about
+# server-initiated revocation or certificate expiration.
+pki_acme_contacts: [ 'mailto:{{ ansible_local.core.admin_public_email[0]
+                                if (ansible_local|d() and
+                                    ansible_local.core|d() and
+                                    ansible_local.core.admin_public_email|d() and
+                                    ansible_local.core.admin_public_email[0]|d())
+                                else "root@" + ansible_domain }}' ]
+
+                                                                   # ]]]
 # .. envvar:: pki_acme_challenge_dir [[[
 #
 # Directory where the ACME client should store responses to ACME CA challenges.

--- a/ansible/roles/pki/files/usr/local/lib/pki/pki-realm
+++ b/ansible/roles/pki/files/usr/local/lib/pki/pki-realm
@@ -180,6 +180,8 @@ initialize_environment () {
 
     config["acme_ca_api"]="${acme_ca_api_map[${config['acme_ca']}]}"
 
+    config["acme_contacts"]=""
+
     config["acme_expiration_days"]="30"
 
     # shellcheck disable=SC2154
@@ -1080,20 +1082,24 @@ request_acme_tiny_certificate () {
 
         if ! ( check_expiration_time acme/cert.pem "${config['acme_expiration_seconds']}" && check_openssl_key_crt_match private/key.pem acme/cert.pem ) ; then
 
+            local acme_tiny_request_params="--account-key acme/account_key.pem \
+                    --directory-url \"${config['acme_ca_api']}\" --csr acme/request.pem \
+                    --acme-dir \"${config['acme_challenge_dir']}\""
+
+            if [ ! -z "${config['acme_contacts']}" ]; then
+                acme_tiny_request_params+=(" --contact \"${config['acme_contacts']//,/\" \"}\"")
+            fi
+
             if [ "$EUID" -eq 0 ] ; then
 
                 set +e
-                su --shell /bin/sh -c "umask 0022 ; ${config['acme_client_script']} --account-key acme/account_key.pem \
-                    --directory-url \"${config['acme_ca_api']}\" --csr acme/request.pem \
-                    --acme-dir \"${config['acme_challenge_dir']}\" > acme/cert.pem.tmp 2>acme/error.log" "${config['acme_user']}"
+                su --shell /bin/sh -c "umask 0022 ; ${config['acme_client_script']} ${acme_tiny_request_params[*]} > acme/cert.pem.tmp 2>acme/error.log" "${config['acme_user']}"
                 set -e
 
             else
 
                 set +e
-                "${config['acme_client_script']}" --account-key acme/account_key.pem \
-                    --directory-url "${config['acme_ca_api']}" --csr acme/request.pem \
-                    --acme-dir "${config['acme_challenge_dir']}" > acme/cert.pem.tmp 2>acme/error.log
+                "${config['acme_client_script']}" "${acme_tiny_request_params[*]}" > acme/cert.pem.tmp 2>acme/error.log
                 set -e
 
             fi
@@ -2298,6 +2304,12 @@ sub_init () {
                         ;;
                     acme-ca-api=*)
                         args["acme_ca_api"]=${OPTARG#*=}
+                        ;;
+                    acme-contacts)
+                        args["acme_contacts"]="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+                        ;;
+                    acme-contacts=*)
+                        args["acme_contacts"]=${OPTARG#*=}
                         ;;
                     acme-default-subdomains)
                         args["acme_default_subdomains"]="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))

--- a/ansible/roles/pki/files/usr/local/lib/pki/pki-realm
+++ b/ansible/roles/pki/files/usr/local/lib/pki/pki-realm
@@ -1086,7 +1086,7 @@ request_acme_tiny_certificate () {
                     --directory-url \"${config['acme_ca_api']}\" --csr acme/request.pem \
                     --acme-dir \"${config['acme_challenge_dir']}\""
 
-            if [ ! -z "${config['acme_contacts']}" ]; then
+            if [ -n "${config['acme_contacts']}" ]; then
                 acme_tiny_request_params+=(" --contact \"${config['acme_contacts']//,/\" \"}\"")
             fi
 

--- a/ansible/roles/pki/tasks/main.yml
+++ b/ansible/roles/pki/tasks/main.yml
@@ -169,6 +169,7 @@
     --private-file-acl-groups "{{ (item.private_file_acl_groups | d(pki_private_file_acl_groups)) | join('/') }}"
     --acme-ca "{{ item.acme_ca | d(pki_acme_ca) }}"
     --acme-ca-api "{{ item.acme_ca_api | d(pki_acme_ca_api_map[item.acme_ca|d(pki_acme_ca)]) }}"
+    --acme-contacts "{{ item.acme_contacts | d(pki_acme_contacts) | join(',') }}"
     --acme-default-subdomains "{{ (item.acme_default_subdomains | d(pki_acme_default_subdomains)) | join('/') }}"
     --acme-challenge-dir "{{ item.acme_challenge_dir | d(pki_acme_challenge_dir) }}"
     --default-domain "{{ item.default_domain | d(pki_default_domain) }}"

--- a/docs/ansible/roles/pki/defaults-detailed.rst
+++ b/docs/ansible/roles/pki/defaults-detailed.rst
@@ -135,6 +135,12 @@ List of parameters related to the entire PKI realm:
   needed, but support for ACME needs to be present on the remote host for it to
   work (see :envvar:`pki_acme_install` variable).
 
+``acme_contacts``
+  Optional, list of (mailto:) URLs that the ACME server can use to contact you
+  for issues related to your account. For example, the server may wish to
+  notify you about server-initiated revocation or certificate expiration. If
+  not specified, the list defined in :envvar:`pki_acme_contacts` will be used.
+
 ``internal``
   Optional, boolean. Enable or disable support for internal CA certificates in
   a given realm. If you disable internal CA support, an alternative,


### PR DESCRIPTION
These changes allow specifying contact URLs
(e.g. 'mailto:webmaster@example.com') for acme-tiny to use while
registering a new ACME account. Let's Encrypt for example uses this
information to notify you about expiring certificates and emergency
revocation.