### PR TITLE
mosquitto: Ignore meta variables for bridge file generation

### DIFF
--- a/ansible/roles/mosquitto/templates/etc/mosquitto/conf.d/bridge.conf.j2
+++ b/ansible/roles/mosquitto/templates/etc/mosquitto/conf.d/bridge.conf.j2
@@ -11,7 +11,7 @@
 {% endif %}
 connection {{ bridge_name }}
 {% for config_key, config_value in bridge.items() %}
-{%   if config_key not in [ 'connection', 'state', 'comment' ] %}
+{%   if config_key not in [ 'connection', 'state', 'comment', 'group', 'mode' ] %}
 {%     if config_value is string and config_value != '' %}
 {{ "%s %s" | format(config_key, config_value) }}
 {%     elif config_value is not string and config_value is not mapping %}


### PR DESCRIPTION
To set the linux file owner group and permission mode, one can set the variables 'mode' and 'group' see (https://github.com/debops/debops/blob/master/ansible/roles/mosquitto/tasks/main.yml#L172), but those variables need also to be ignored when generating the configfile from the template, otherwise the resulting configfile will be invalid.