### PR TITLE
[nullmailer] Make nullmailer-smtpd dual stacked

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -123,6 +123,13 @@ General
 
 - TLSv1.3 is now enabled by default for nginx version 1.13.0 and up.
 
+:ref:`debops.nullmailer` role
+'''''''''''''''''''''''''''''
+
+- The Nullmailer smtpd service can now listen on both IPv4 and IPv6 addresses.
+  It listens on both loopback addresses by default, where it used to only
+  listen on the IPv6 loopback address.
+
 :ref:`debops.owncloud` role
 '''''''''''''''''''''''''''
 

--- a/ansible/roles/nullmailer/defaults/main.yml
+++ b/ansible/roles/nullmailer/defaults/main.yml
@@ -423,9 +423,16 @@ nullmailer__smtpd: False
                                                                    # ]]]
 # .. envvar:: nullmailer__smtpd_bind [[[
 #
-# Specify the IP address on which the :program:`xinetd` SMTP server should listen for
-# new connections. By default it listens only on ``lo`` interface.
-nullmailer__smtpd_bind: 'localhost'
+# Specify the IPv4 address on which the :program:`xinetd` SMTP server should
+# listen for new connections. By default it listens only on ``lo`` interface.
+nullmailer__smtpd_bind: '127.0.0.1'
+
+                                                                   # ]]]
+# .. envvar:: nullmailer__smtpd_bind6 [[[
+#
+# Specify the IPv6 address on which the :program:`xinetd` SMTP server should
+# listen for new connections. By default it listens only on ``lo`` interface.
+nullmailer__smtpd_bind6: '::1'
 
                                                                    # ]]]
 # .. envvar:: nullmailer__smtpd_port [[[
@@ -510,6 +517,7 @@ nullmailer__dpkg_cleanup__dependent_packages:
       - '/etc/ferm/ferm.d/50_debops.nullmailer_accept_25.conf'
       - '/etc/hosts.allow.d/50_nullmailer_dependent_allow'
       - '/etc/xinetd.d/nullmailer-smtpd'
+      - '/etc/xinetd.d/nullmailer-smtpd6'
     reload_services:
       - 'xinetd'
     restart_services:

--- a/ansible/roles/nullmailer/tasks/main.yml
+++ b/ansible/roles/nullmailer/tasks/main.yml
@@ -78,20 +78,26 @@
           item.state|d('present') == 'absent'))
   no_log: True
 
-- name: Configure nullmailer-smtpd service in xinetd
+- name: Configure nullmailer services in xinetd
   template:
-    src: 'etc/xinetd.d/nullmailer-smtpd.j2'
-    dest: '/etc/xinetd.d/nullmailer-smtpd'
+    src: 'etc/xinetd.d/{{ item }}.j2'
+    dest: '/etc/xinetd.d/{{ item }}'
     owner: 'root'
     group: 'root'
     mode: '0644'
+  loop:
+    - 'nullmailer-smtpd'
+    - 'nullmailer-smtpd6'
   notify: [ 'Reload xinetd' ]
   when: (nullmailer__deploy_state|d('present') != 'absent' and nullmailer__smtpd|bool)
 
 - name: Disable nullmailer-smtpd service in xinetd
   file:
-    path: '/etc/xinetd.d/nullmailer-smtpd'
+    path: '/etc/xinetd.d/{{ item }}'
     state: 'absent'
+  loop:
+    - 'nullmailer-smtpd'
+    - 'nullmailer-smtpd6'
   notify: [ 'Reload xinetd' ]
   when: ((nullmailer__deploy_state|d() and nullmailer__deploy_state == 'absent') or
          not nullmailer__smtpd|bool)

--- a/ansible/roles/nullmailer/templates/etc/xinetd.d/nullmailer-smtpd6.j2
+++ b/ansible/roles/nullmailer/templates/etc/xinetd.d/nullmailer-smtpd6.j2
@@ -1,0 +1,21 @@
+{# Copyright (C) 2016 Maciej Delmanowski <drybjed@gmail.com>
+ # Copyright (C) 2016 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-only
+ #}
+# {{ ansible_managed }}
+
+service sendmail
+{
+    disable        = {{ 'no' if nullmailer__smtpd|bool else 'yes' }}
+    bind           = {{ nullmailer__smtpd_bind6 }}
+    port           = {{ nullmailer__smtpd_port }}
+    socket_type    = stream
+    protocol       = tcp
+    wait           = no
+    user           = mail
+    server         = /usr/sbin/sendmail
+    server_args    = -bs
+    type           = unlisted
+    log_type       = SYSLOG mail info
+    log_on_failure = ATTEMPT
+}


### PR DESCRIPTION
With these changes, the Nullmailer SMTPD service will listen on both 127.0.0.1 and ::1.
It used to only listen on ::1. This is implemented by adding a second
xinetd.conf file so that xinetd can be configured to bind to another IP
address.