### PR TITLE
[gitlab_runner] Replace GitLab APT repo key

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -189,6 +189,12 @@ General
                applied. See the patch files in the role :file:`files/patches/`
                directory for more information.
 
+- The GitLab package repository signing key has been replaced with the new key
+  that has been in use since 2020-04-06, allowing APT to update package lists
+  again. See the `GitLab.com blog`__ for more information about this change.
+
+  .. __: https://about.gitlab.com/releases/2020/03/30/gpg-key-for-gitlab-package-repositories-metadata-changing/
+
 :ref:`debops.minio` role
 ''''''''''''''''''''''''
 

--- a/ansible/roles/gitlab_runner/defaults/main.yml
+++ b/ansible/roles/gitlab_runner/defaults/main.yml
@@ -30,7 +30,7 @@ gitlab_runner__apt_upstream: True
 # .. envvar:: gitlab_runner__apt_key [[[
 #
 # GPG key which signs the upstream APT repository package list.
-gitlab_runner__apt_key: '1A4C919DB987D435939638B914219A96E15E78F4'
+gitlab_runner__apt_key: 'F6403F6544A38863DAA0B6E03F01618A51312F3F'
 
                                                                    # ]]]
 # .. envvar:: gitlab_runner__apt_repo [[[
@@ -735,6 +735,10 @@ gitlab_runner__keyring__dependent_apt_keys:
   - id: '{{ gitlab_runner__apt_key }}'
     repo: '{{ gitlab_runner__apt_repo }}'
     state: '{{ "present" if gitlab_runner__apt_upstream|bool else "absent" }}'
+
+  # Old GitLab package repository signing key, used until 2020-04-06.
+  - id: '1A4C919DB987D435939638B914219A96E15E78F4'
+    state: 'absent'
                                                                    # ]]]
                                                                    # ]]]
                                                                    # ]]]

--- a/ansible/roles/gitlab_runner/defaults/main.yml
+++ b/ansible/roles/gitlab_runner/defaults/main.yml
@@ -735,10 +735,6 @@ gitlab_runner__keyring__dependent_apt_keys:
   - id: '{{ gitlab_runner__apt_key }}'
     repo: '{{ gitlab_runner__apt_repo }}'
     state: '{{ "present" if gitlab_runner__apt_upstream|bool else "absent" }}'
-
-  # Old GitLab package repository signing key, used until 2020-04-06.
-  - id: '1A4C919DB987D435939638B914219A96E15E78F4'
-    state: 'absent'
                                                                    # ]]]
                                                                    # ]]]
                                                                    # ]]]


### PR DESCRIPTION
GitLab.com is using a new package repository signing key:
https://about.gitlab.com/releases/2020/03/30/gpg-key-for-gitlab-package-repositories-metadata-changing/

These changes make Ansible install the new key and remove the old one.