### PR TITLE
[cron] Ensure enironment name & value is a list

### DIFF
--- a/ansible/roles/cron/tasks/main.yml
+++ b/ansible/roles/cron/tasks/main.yml
@@ -92,8 +92,8 @@
 - name: Manage cron environment variables
   cron:
     cron_file:  '{{ item.0.file | d(item.0.cron_file) }}'
-    name:       '{{ item.1.keys()[0] }}'
-    value:      '{{ item.1.values()[0] }}'
+    name:       '{{ item.1.keys() | list | first }}'
+    value:      '{{ item.1.values() | list | first }}'
     user:       '{{ item.0.user | d("root") }}'
     state:      'present'
     env:        True


### PR DESCRIPTION
... and select the first item in the list.

Fixes the error;
`The task includes an option with an undefined variable. The error was: dict_keys object has no element 0`
That I get using Ansible 2.9.6 and on Python 3.7.6. Not sure when or what causes the issue.