### PR TITLE
[debops.gitlab] Bump Gitlab to latest stable v12.9

### DIFF
--- a/ansible/roles/gitlab/defaults/main.yml
+++ b/ansible/roles/gitlab/defaults/main.yml
@@ -1130,6 +1130,7 @@ gitlab__etc_services__dependent_list:
 gitlab__apt_preferences__dependent_list:
 
   - package: 'git git-*'
+    state: 'present'
     backports: [ 'jessie' ]
     reason:  'Meet version requirement of GitLab 8.17 (Git version >= 2.7.3) on Debian Jessie.'
     by_role: 'debops.gitlab'

--- a/ansible/roles/gitlab/defaults/main.yml
+++ b/ansible/roles/gitlab/defaults/main.yml
@@ -1134,6 +1134,12 @@ gitlab__apt_preferences__dependent_list:
     reason:  'Meet version requirement of GitLab 8.17 (Git version >= 2.7.3) on Debian Jessie.'
     by_role: 'debops.gitlab'
 
+  - package: 'golang-go golang-src'
+    state: 'present'
+    backports: [ 'buster' ]
+    reason:  'Compatibility with stable Gitlab releases >= 12.7. Gitaly dependency needs go>=1.14 on Debian Buster.'
+    by_role: 'debops.gitlab'
+
                                                                    # ]]]
 # .. envvar:: gitlab__logrotate__dependent_config [[[
 #

--- a/ansible/roles/gitlab/templates/var/local/git/gitaly/config.toml.j2
+++ b/ansible/roles/gitlab/templates/var/local/git/gitaly/config.toml.j2
@@ -6,7 +6,7 @@
 # {{ ansible_managed }}
 
 socket_path = "{{ gitlab_ce_git_checkout }}/tmp/sockets/private/gitaly.socket"
-bin_dir = "{{ gitlab_shell_git_checkout }}"
+bin_dir = "{{ gitlab__gitaly_checkout }}"
 
 # # Optional: listen on a TCP socket. This is insecure (no authentication)
 # listen_addr = "localhost:9999"

--- a/ansible/roles/golang/tasks/golang_build_install.yml
+++ b/ansible/roles/golang/tasks/golang_build_install.yml
@@ -19,7 +19,7 @@
 - name: 'Install {{ build.name }} APT packages'
   package:
     name: '{{ build.apt_packages }}'
-    state: 'present'
+    state: 'latest'
   register: golang__register_install_apt_packages
   until: golang__register_install_apt_packages is succeeded
   when: (not (build.upstream|d())|bool and

--- a/ansible/roles/golang/tasks/golang_build_install.yml
+++ b/ansible/roles/golang/tasks/golang_build_install.yml
@@ -19,7 +19,7 @@
 - name: 'Install {{ build.name }} APT packages'
   package:
     name: '{{ build.apt_packages }}'
-    state: 'latest'
+    state: 'present'
   register: golang__register_install_apt_packages
   until: golang__register_install_apt_packages is succeeded
   when: (not (build.upstream|d())|bool and


### PR DESCRIPTION
As discussed in the IRC, using a newer golang version (>=1.14) from buster-backports I was able to install the latest Gitlab stable version.