### PR TITLE
[gitlab] Use 'structure.sql' to init database

### DIFF
--- a/ansible/roles/gitlab/tasks/configure_gitlab_ce.yml
+++ b/ansible/roles/gitlab/tasks/configure_gitlab_ce.yml
@@ -214,7 +214,11 @@
   environment:
     RAILS_ENV: 'production'
     GITLAB_ROOT_EMAIL: '{{ gitlab_admin_email }}'
-  command: 'bundle exec rake db:schema:load setup_postgresql db:seed_fu'
+  command: '{{ "bundle exec rake "
+                + ("db:schema:load setup_postgresql"
+                   if (gitlab_version is version("12.10", "<"))
+                   else "db:structure:load")
+                + " db:seed_fu" }}'
   args:
     chdir: '{{ gitlab_ce_git_checkout }}'
   become: True


### PR DESCRIPTION
From 12.10 GitLab release, the instllation procedure changes to use the
'structure.sql' file instead of 'schema.rb' to set up the application
database.

Ref: https://gitlab.com/gitlab-org/gitlab/-/issues/211487