### PR TITLE
Fix issue #1338 - debops-defaults failed if command 'view' not exist

### DIFF
--- a/debops/cmds/__init__.py
+++ b/debops/cmds/__init__.py
@@ -65,7 +65,10 @@ def error_msg(message, severity="Error"):
     """
     Display error message and exit
     """
+    old = sys.stdout
+    sys.stdout = sys.__stdout__
     print(SCRIPT_NAME+':', severity+':', message)
+    sys.stdout = old
     if severity == "Error":
         raise SystemExit(1)
 


### PR DESCRIPTION
Fix issue #1338 - debops-defaults failed if external command 'view' doesn't exist