### PR TITLE
[mailman3] Add mailman3 role

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -953,6 +953,15 @@ stages:
     JANE_DIFF_PATTERN: '.*/roles/mailman/.*'
     JANE_LOG_PATTERN: '\[debops\.mailman\]'
 
+'mailman3 role':
+  <<: *test_role_3rd_deps
+  variables:
+    JANE_TEST_FACT: 'mailman3.fact'
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/mailman3.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_mailman3'
+    JANE_DIFF_PATTERN: '.*/roles/mailman3/.*'
+    JANE_LOG_PATTERN: '\[debops\.mailman3\]'
+
 'mariadb role':
   <<: *test_role_1st_deps
   variables:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,6 +54,11 @@ New DebOps roles
   used to install the InfluxDB time series database service and manage its
   databases and users, respectively.
 
+- The :ref:`debops.mailman3` role manages Mailman Suite installations, which
+  consist of the Mailman Core backend, Postorius web frontend and Hyperkitty
+  list archiver. The role manages the database with debconf, integrates with
+  NGINX and Postfix and configures LDAP authentication for superusers.
+
 :ref:`debops.pki` role
 ''''''''''''''''''''''
 

--- a/ansible/playbooks/app/all.yml
+++ b/ansible/playbooks/app/all.yml
@@ -42,3 +42,5 @@
 - import_playbook: debops_api.yml
 
 - import_playbook: roundcube.yml
+
+- import_playbook: mailman3.yml

--- a/ansible/playbooks/app/mailman3.yml
+++ b/ansible/playbooks/app/mailman3.yml
@@ -1,0 +1,1 @@
+../service/mailman3.yml

--- a/ansible/playbooks/service/mailman3.yml
+++ b/ansible/playbooks/service/mailman3.yml
@@ -1,0 +1,59 @@
+---
+# Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+# Copyright (C) 2020 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Manage Mailman 3 Suite
+  collections: [ 'debops.debops', 'debops.roles01',
+                 'debops.roles02', 'debops.roles03' ]
+  hosts: [ 'debops_service_mailman3' ]
+  become: True
+
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
+
+  pre_tasks:
+
+    - import_role:
+        name: 'postfix'
+        tasks_from: 'main_env'
+      vars:
+        postfix__dependent_maincf:
+          - role: 'mailman3'
+            config: '{{ mailman3__postfix__dependent_maincf }}'
+      tags: [ 'role::postfix', 'skip::postfix' ]
+
+  roles:
+
+    - role: etc_services
+      tags: [ 'role::etc_services', 'skip::etc_services' ]
+      etc_services__dependent_list:
+        - '{{ mailman3__etc_services__dependent_list }}'
+
+    - role: ldap
+      tags: [ 'role::ldap', 'skip::ldap' ]
+      ldap__dependent_tasks:
+        - '{{ mailman3__ldap__dependent_tasks }}'
+      when: mailman3__ldap
+
+    - role: python
+      tags: [ 'role::python', 'skip::python' ]
+      python__dependent_packages2:
+        - '{{ mailman3__python__dependent_packages2 }}'
+      python__dependent_packages3:
+        - '{{ mailman3__python__dependent_packages3 }}'
+
+    - role: nginx
+      tags: [ 'role::nginx', 'skip::nginx' ]
+      nginx__dependent_servers:
+        - '{{ mailman3__nginx__dependent_servers }}'
+
+    - role: mailman3
+      tags: [ 'role::mailman3', 'skip::mailman3' ]
+
+    - role: postfix
+      tags: [ 'role::postfix', 'skip::postfix' ]
+      postfix__dependent_maincf:
+        - role: 'mailman3'
+          config: '{{ mailman3__postfix__dependent_maincf }}'

--- a/ansible/roles/mailman3/COPYRIGHT
+++ b/ansible/roles/mailman3/COPYRIGHT
@@ -1,0 +1,19 @@
+debops.mailman3 - Manage Mailman Suite using Ansible
+
+Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+Copyright (C) 2020 DebOps <https://debops.org/>
+SPDX-License-Identifier: GPL-3.0-or-later
+
+This Ansible role is part of DebOps.
+
+DebOps is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 3, as
+published by the Free Software Foundation.
+
+DebOps is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with DebOps. If not, see https://www.gnu.org/licenses/.

--- a/ansible/roles/mailman3/defaults/main.yml
+++ b/ansible/roles/mailman3/defaults/main.yml
@@ -1,0 +1,501 @@
+---
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+
+# .. Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+# .. Copyright (C) 2020 DebOps <https://debops.org/>
+# .. SPDX-License-Identifier: GPL-3.0-or-later
+
+# .. _mailman3__ref_defaults:
+
+# debops.mailman3 default variables [[[
+# ====================================
+
+# .. contents:: Sections
+#    :local:
+#
+# .. include:: ../../../../includes/global.rst
+
+
+# Packages and installation [[[
+# -----------------------------
+
+# .. envvar:: mailman3__base_packages [[[
+#
+# List of base APT packages to install. The dbconfig package will be used to set
+# up the database.
+mailman3__base_packages:
+
+  - 'mailman3-full'
+  - 'dbconfig-{{ mailman3__database_map[mailman3__database_type] }}'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__packages [[[
+#
+# List of additional packages to install.
+mailman3__packages: []
+                                                                   # ]]]
+                                                                   # ]]]
+# Domain names [[[
+# ----------------
+
+# .. envvar:: mailman3__fqdns [[[
+#
+# List of Fully Qualified Domain Names used for the Mailman installation.
+# Postfix will be configured to accept mail for these domains, and NGINX will
+# show the Mailman 3 web interface (Postorius and Hyperkitty) to visitors,
+# optionally after redirecting them to the first domain in the list.
+mailman3__fqdns: '{{ [ "lists." + ansible_domain ] }}'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__redirect [[[
+#
+# Whether to redirect visitors to the first domain in the ``mailman3__fqdns``
+# list.
+mailman3__redirect: True
+                                                                   # ]]]
+                                                                   # ]]]
+# Superuser [[[
+# -------------
+
+# .. envvar:: mailman3__superuser_name [[[
+#
+# The username of the Mailman 3 web interface superuser.
+mailman3__superuser_name: 'admin'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__superuser_mail [[[
+#
+# The email address of the Mailman 3 web interface superuser.
+mailman3__superuser_mail: 'postmaster@{{ mailman3__emailname }}'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__superuser_password [[[
+#
+# The password of the Mailman 3 web interface superuser.
+mailman3__superuser_password: '{{ lookup("password", secret + "/credentials/"
+                                                     + inventory_hostname + "/"
+                                                     + "mailman3/superuser/"
+                                                     + "password chars=ascii_letters,digits length=14") }}'
+                                                                   # ]]]
+                                                                   # ]]]
+# Application configuration [[[
+# -----------------------------
+
+# .. envvar:: mailman3__archiver_from [[[
+#
+# List of IP addresses that are allowed to access the Hyperkitty list archiver
+# API. This may not be needed anymore in future versions of Mailman:
+# https://gitlab.com/mailman/hyperkitty/-/merge_requests/86
+mailman3__archiver_from: '{{ [ "127.0.0.1", "::1" ]
+                             + ansible_all_ipv4_addresses|d([])
+                             + (ansible_all_ipv6_addresses|d([])
+                                | difference(ansible_all_ipv6_addresses|d([])
+                                             | ipaddr("link-local"))) }}'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__emailname [[[
+#
+# If the Mailman3 web interface sends emails, this domain will be used for the
+# sender addresses. In particular, it will be 'postorius@<domain>' for internal
+# authentication and 'root@<domain>' for error messages.
+mailman3__emailname: '{{ ansible_fqdn }}'
+                                                                   # ]]]
+# API credentials [[[
+# -------------------
+
+# .. envvar:: mailman3__rest_api_user [[[
+#
+# Username used to access the Mailman 3 REST API.
+mailman3__rest_api_user: 'restadmin'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__rest_api_pass [[[
+#
+# Password used to access the Mailman 3 REST API.
+mailman3__rest_api_pass: '{{ lookup("password", secret + "/credentials/"
+                                                + inventory_hostname + "/"
+                                                + "mailman3/rest_api/"
+                                                + "password chars=ascii_letters,digits length=22") }}'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__hyperkitty_api_key [[[
+#
+# API key used to access the HyperKitty archiver.
+mailman3__hyperkitty_api_key: '{{ lookup("password", secret + "/credentials/"
+                                                + inventory_hostname + "/"
+                                                + "mailman3/hyperkitty/"
+                                                + "api_key chars=ascii_letters,digits length=22") }}'
+                                                                   # ]]]
+                                                                   # ]]]
+# Django defaults [[[
+# -------------------
+
+# .. envvar:: mailman3__django_secret_key [[[
+#
+# Secret key used by Django for cryptographic signing. Should be set to a
+# unique, unpredictable value.
+mailman3__django_secret_key: '{{ lookup("password", secret + "/credentials/"
+                                                + inventory_hostname + "/"
+                                                + "mailman3/django/"
+                                                + "secret_key chars=ascii_letters,digits,!@#$%^&*(-_=+) length=50") }}'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__django_time_zone [[[
+#
+# Time zone configuration for Django.
+# See https://docs.djangoproject.com/en/1.11/topics/i18n/timezones/
+mailman3__django_time_zone: '{{ ansible_local.timezone
+                                if (ansible_local|d() and
+                                    ansible_local.timezone|d())
+                                else "UTC" }}'
+                                                                   # ]]]
+# Database configuration [[[
+# --------------------------
+
+# .. envvar:: mailman3__database_type [[[
+#
+# The database type to use for Mailman 3 Core and Web. Can be one of 'mariadb',
+# 'postgresql' or 'sqlite3'.
+mailman3__database_type: '{{ "postgresql"
+                             if (ansible_local|d() and ansible_local.postgresql|d())
+                             else "mariadb"
+                                  if (ansible_local|d() and ansible_local.mariadb|d())
+                                  else "sqlite3" }}'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__database_map [[[
+#
+# Mapping from DebOps-recognized database names to names used by dbconfig.
+mailman3__database_map:
+  'mariadb': 'mysql'
+  'postgresql': 'pgsql'
+  'sqlite3': 'sqlite3'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__database_port [[[
+#
+# The database port. Leave empty for sqlite3.
+mailman3__database_port: '{{ ansible_local[mailman3__database_type].port
+                            if (ansible_local|d() and
+                                ansible_local[mailman3__database_type]|d() and
+                                ansible_local[mailman3__database_type].port|d())
+                            else "" }}'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__database_core_name [[[
+#
+# The database name (or SQLite filename) for Mailman Core.
+mailman3__database_core_name: '{{ "mailman.db"
+                                  if mailman3__database_type == "sqlite3"
+                                  else "mailman3" }}'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__database_core_user [[[
+#
+# The database user for Mailman Core. Not used with SQLite.
+mailman3__database_core_user: 'mailman3'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__database_core_password [[[
+#
+# The database password for Mailman Core. Not used with SQLite.
+mailman3__database_core_password: '{{ (lookup("password", secret + "/"
+                                                          + mailman3__database_type + "/"
+                                                          + inventory_hostname + "/"
+                                                          + ((mailman3__database_port + "/")
+                                                             if mailman3__database_type == "postgresql"
+                                                             else "")
+                                                          + "credentials/"
+                                                          + mailman3__database_core_user + "/"
+                                                          + "password chars=ascii_letters,digits length=22"))
+                                      if mailman3__database_type != "sqlite3"
+                                      else "" }}'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__database_web_name [[[
+#
+# The database name (or SQLite filename) for Mailman's web frontend.
+mailman3__database_web_name: '{{ "mailman3web.db"
+                                 if mailman3__database_type == "sqlite3"
+                                 else "mailman3web" }}'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__database_web_user [[[
+#
+# The database user for Mailman's web frontend. Not used with SQLite.
+mailman3__database_web_user: 'mailman3web'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__database_web_password [[[
+#
+# The database password for Mailman's web frontend. Not used with SQLite.
+mailman3__database_web_password: '{{ (lookup("password", secret + "/"
+                                                         + mailman3__database_type + "/"
+                                                         + inventory_hostname + "/"
+                                                         + ((mailman3__database_port + "/")
+                                                            if mailman3__database_type == "postgresql"
+                                                            else "")
+                                                         + "credentials/"
+                                                         + mailman3__database_web_user + "/"
+                                                         + "password chars=ascii_letters,digits length=22"))
+                                     if mailman3__database_type != "sqlite3"
+                                     else "" }}'
+                                                                   # ]]]
+                                                                   # ]]]
+# LDAP configuration [[[
+# ----------------------
+
+# .. envvar:: mailman3__ldap [[[
+#
+# Enable or disable LDAP authentication in the web interface.
+mailman3__ldap: '{{ ansible_local.ldap.enabled
+                    if (ansible_local|d() and ansible_local.ldap|d() and
+                        ansible_local.ldap.enabled|d())
+                    else False }}'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__ldap_uri [[[
+#
+# List of LDAP server URIs.
+mailman3__ldap_uri: '{{ ansible_local.ldap.uri
+                        if (ansible_local|d() and
+                            ansible_local.ldap|d() and
+                            ansible_local.ldap.uri|d())
+                        else [ "ldap://ldap." + ansible_domain ] }}'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__ldap_device_dn [[[
+#
+# The Distinguished Name of the device LDAP object, defined as a YAML list. It
+# will be used as a base for the Mailman 3 service account object. The role will
+# not create the account object automatically if this list is empty.
+mailman3__ldap_device_dn: '{{ ansible_local.ldap.device_dn
+                              if (ansible_local|d() and
+                                  ansible_local.ldap|d() and
+                                  ansible_local.ldap.device_dn|d())
+                              else [] }}'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__ldap_self_rdn [[[
+#
+# The Relative Distinguished Name of the service account object that Mailman 3
+# uses to access the LDAP directory.
+mailman3__ldap_self_rdn: 'uid=mailman'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__ldap_self_object_classes [[[
+#
+# List of object classes that will be used to create the LDAP service account.
+mailman3__ldap_self_object_classes: [ 'account', 'simpleSecurityObject' ]
+
+                                                                   # ]]]
+# .. envvar:: mailman3__ldap_self_attributes [[[
+#
+# YAML dictionary that defines the attributes of the LDAP service account.
+mailman3__ldap_self_attributes:
+  uid: '{{ mailman3__ldap_self_rdn.split("=")[1] }}'
+  userPassword: '{{ mailman3__ldap_bind_password }}'
+  host: '{{ [ ansible_fqdn, ansible_hostname ] | unique }}'
+  description: 'Account used by the "mailman" service to access the LDAP directory'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__ldap_starttls [[[
+#
+# Enable or disable StartTLS for encrypted connections to the LDAP server.
+mailman3__ldap_starttls: True
+
+                                                                   # ]]]
+# .. envvar:: mailman3__ldap_bind_dn [[[
+#
+# The Distinguished Name of the service account object that Mailman 3 uses to
+# access the LDAP directory.
+mailman3__ldap_bind_dn: '{{ ([ mailman3__ldap_self_rdn ]
+                             + mailman3__ldap_device_dn) | join(",") }}'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__ldap_bind_password [[[
+#
+# The password used by Mailman 3 to access the LDAP directory.
+mailman3__ldap_bind_password: '{{ lookup("password", secret + "/ldap/credentials/"
+                                                     + mailman3__ldap_bind_dn | to_uuid
+                                                     + ".password chars=ascii_letters,digits length=22") }}'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__ldap_base_dn [[[
+#
+# The base Distinguished Name of the LDAP directory, defined as a YAML list.
+mailman3__ldap_base_dn: '{{ ansible_local.ldap.basedn
+                            if (ansible_local|d() and
+                                ansible_local.ldap|d() and
+                                ansible_local.ldap.basedn|d())
+                            else "dc=" + ansible_domain.split(".")
+                                         | join(",dc=") }}'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__ldap_people_rdn [[[
+#
+# The Relative Distinguished Name of the LDAP subtree that contains personal
+# entries.
+mailman3__ldap_people_rdn: '{{ ansible_local.ldap.people_rdn
+                            if (ansible_local|d() and
+                                ansible_local.ldap|d() and
+                                ansible_local.ldap.people_rdn|d())
+                            else "ou=People" }}'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__ldap_groups_rdn [[[
+#
+# The Relative Distinguished Name of the LDAP subtree that contains group
+# entries.
+mailman3__ldap_groups_rdn: '{{ ansible_local.ldap.groups_rdn
+                               if (ansible_local|d() and
+                                   ansible_local.ldap|d() and
+                                   ansible_local.ldap.groups_rdn|d())
+                               else "ou=Groups" }}'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__ldap_people_dn [[[
+#
+# The Distinguished Name of the LDAP subtree that contains personal entries.
+mailman3__ldap_people_dn: '{{ mailman3__ldap_people_rdn + ","
+                              + mailman3__ldap_base_dn }}'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__ldap_groups_dn [[[
+#
+# The Distinguished Name of the LDAP subtree that contains group entries.
+mailman3__ldap_groups_dn: '{{ mailman3__ldap_groups_rdn + ","
+                              + mailman3__ldap_base_dn }}'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__ldap_people_filter [[[
+#
+# The LDAP filter to query personal entries with.
+mailman3__ldap_people_filter: '(&
+                                 (objectClass=inetOrgPerson)
+                                 (uid=%(user)s)
+                                 (|
+                                   (authorizedService=all)
+                                   (authorizedService=mailman)
+                                 )
+                               )'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__ldap_groups_filter [[[
+#
+# The LDAP filter to query group entries with.
+mailman3__ldap_groups_filter: '(objectClass=groupOfNames)'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__ldap_superusers_group [[[
+#
+# The name of the LDAP group that contains the superusers. Members of this group
+# are given full administrative privileges in the Mailman 3 web interface.
+mailman3__ldap_superusers_group: 'UNIX Administrators'
+                                                                   # ]]]
+                                                                   # ]]]
+# Configuration for other Ansible roles [[[
+# -----------------------------------------
+
+# .. envvar:: mailman3__etc_services__dependent_list [[[
+#
+# Configuration for the :ref:`debops.etc_services` role.
+mailman3__etc_services__dependent_list:
+
+  - name: 'mailman-api'
+    port: '8001'
+    protocols: [ 'tcp' ]
+    comment: 'Added by debops.mailman3 Ansible role.'
+
+  - name: 'mailman-lmtp'
+    port: '8024'
+    protocols: [ 'tcp' ]
+    comment: 'Added by debops.mailman3 Ansible role.'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__ldap_dependent_tasks [[[
+#
+# Configuration for the :ref:`debops.ldap` role.
+mailman3__ldap__dependent_tasks:
+
+  - name: '{{ "Create Mailman 3 account for "
+              + mailman3__ldap_device_dn | join(",") }}'
+    dn: '{{ mailman3__ldap_bind_dn }}'
+    objectClass: '{{ mailman3__ldap_self_object_classes }}'
+    attributes: '{{ mailman3__ldap_self_attributes }}'
+    no_log: '{{ secret__no_log|d(True) }}'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__nginx__servers [[[
+#
+# Configuration for the `debops.nginx` Ansible role.
+mailman3__nginx__dependent_servers:
+
+  - name: '{{ mailman3__fqdns }}'
+    redirect_from: '{{ mailman3__redirect }}'
+    by_role: 'debops.mailman3'
+    filename: 'debops.mailman3'
+    webroot_create: False
+    location:
+      '/': |
+        uwsgi_pass unix:/run/mailman3-web/uwsgi.sock;
+        include /etc/nginx/uwsgi_params;
+
+      '/mailman3/static': |
+        alias /var/lib/mailman3/web/static;
+
+      '/mailman3/static/favicon.ico': |
+        alias /var/lib/mailman3/web/static/postorius/img/favicon.ico;
+
+# ]]]
+# .. envvar:: mailman3__postfix__dependent_maincf [[[
+#
+# Configuration of Postfix ``main.cf`` in :ref:`debops.postfix` role.
+mailman3__postfix__dependent_maincf:
+
+  - name: 'owner_request_special'
+    value: False
+    state: 'present'
+
+  - name: 'transport_maps'
+    value: [ 'hash:/var/lib/mailman3/data/postfix_lmtp' ]
+    state: 'present'
+
+  - name: 'local_recipient_maps'
+    value:
+      - 'proxy:unix:passwd.byname'
+      - '$alias_maps'
+      - 'hash:/var/lib/mailman3/data/postfix_lmtp'
+    state: 'present'
+
+  - name: 'relay_domains'
+    value: [ 'hash:/var/lib/mailman3/data/postfix_domains' ]
+    state: 'present'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__python__dependent_packages2 [[[
+#
+# Configuration for the :ref:`debops.python` role.
+mailman3__python__dependent_packages2: '{{ ([ "python-django-auth-ldap" ]
+                                            if mailman3__ldap else [])
+                                           + ([ "python-pymysql" ]
+                                              if mailman3__database_type == "mariadb"
+                                              else [])
+                                           + ([ "python-psycopg2" ]
+                                              if mailman3__database_type == "postgresql"
+                                              else []) }}'
+
+                                                                   # ]]]
+# .. envvar:: mailman3__python__dependent_packages3 [[[
+#
+# Configuration for the :ref:`debops.python` role.
+mailman3__python__dependent_packages3: '{{ ([ "python3-django-auth-ldap" ]
+                                            if mailman3__ldap else [])
+                                           + ([ "python3-pymysql" ]
+                                              if mailman3__database_type == "mariadb"
+                                              else [])
+                                           + ([ "python3-psycopg2" ]
+                                              if mailman3__database_type == "postgresql"
+                                              else []) }}'
+                                                                   # ]]]
+                                                                   # ]]]

--- a/ansible/roles/mailman3/handlers/main.yml
+++ b/ansible/roles/mailman3/handlers/main.yml
@@ -1,0 +1,14 @@
+---
+# Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+# Copyright (C) 2020 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Reload mailman3
+  service:
+    name: 'mailman3'
+    state: 'reloaded'
+
+- name: Restart mailman3-web
+  service:
+    name: 'mailman3-web'
+    state: 'restarted'

--- a/ansible/roles/mailman3/tasks/main.yml
+++ b/ansible/roles/mailman3/tasks/main.yml
@@ -1,0 +1,182 @@
+---
+# Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+# Copyright (C) 2020 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- import_role:
+    name: 'secret'
+
+- name: Configure custom mailman3.service
+  template:
+    src: 'etc/systemd/system/mailman3.service.j2'
+    dest: '/etc/systemd/system/mailman3.service'
+  when: mailman3__database_type != "sqlite3"
+  register: mailman3__register_service_configure
+
+- name: Remove custom mailman3.service
+  file:
+    path: '/etc/systemd/system/mailman3.service'
+    state: 'absent'
+  when: mailman3__database_type == "sqlite3"
+  register: mailman3__register_service_remove
+
+- name: Reload systemd units
+  systemd:
+    daemon_reload: True
+  when: mailman3__register_service_configure.changed or mailman3__register_service_remove.changed
+
+- name: Configure mailman3 with debconf
+  debconf:
+    name: 'mailman3'
+    question: 'mailman3/{{ item.question }}'
+    vtype: '{{ item.vtype }}'
+    value: '{{ item.value }}'
+  loop:
+
+    - question: 'dbconfig-install'
+      vtype: 'boolean'
+      value: 'true'
+
+    - question: 'dbconfig-upgrade'
+      vtype: 'boolean'
+      value: 'true'
+
+    - question: 'database-type'
+      vtype: 'select'
+      value: '{{ mailman3__database_map[mailman3__database_type] }}'
+
+    - question: 'db/dbname'
+      vtype: 'string'
+      value: '{{ mailman3__database_core_name }}'
+
+    - question: 'db/app-user'
+      vtype: 'string'
+      value: '{{ mailman3__database_core_user }}'
+
+    - question: 'mysql/app-pass'
+      vtype: 'password'
+      value: '{{ mailman3__database_core_password }}'
+
+    - question: 'pgsql/app-pass'
+      vtype: 'password'
+      value: '{{ mailman3__database_core_password }}'
+
+    - question: 'app-password-confirm'
+      vtype: 'password'
+      value: '{{ mailman3__database_core_password }}'
+  changed_when: False  # Otherwise Ansible will wrongly show that database password has changed
+  no_log: '{{ secret__no_log|d(True) }}'
+
+- name: Configure mailman3-web with debconf
+  debconf:
+    name: 'mailman3-web'
+    question: 'mailman3-web/{{ item.question }}'
+    vtype: '{{ item.vtype }}'
+    value: '{{ item.value }}'
+  loop:
+
+    - question: 'dbconfig-install'
+      vtype: 'boolean'
+      value: 'true'
+
+    - question: 'dbconfig-upgrade'
+      vtype: 'boolean'
+      value: 'true'
+
+    - question: 'database-type'
+      vtype: 'select'
+      value: '{{ mailman3__database_map[mailman3__database_type] }}'
+
+    - question: 'db/dbname'
+      vtype: 'string'
+      value: '{{ mailman3__database_web_name }}'
+
+    - question: 'db/app-user'
+      vtype: 'string'
+      value: '{{ mailman3__database_web_user }}'
+
+    - question: 'mysql/app-pass'
+      vtype: 'password'
+      value: '{{ mailman3__database_web_password }}'
+
+    - question: 'pgsql/app-pass'
+      vtype: 'password'
+      value: '{{ mailman3__database_web_password }}'
+
+    - question: 'app-password-confirm'
+      vtype: 'password'
+      value: '{{ mailman3__database_web_password }}'
+
+    - question: 'superuser-name'
+      vtype: 'string'
+      value: '{{ mailman3__superuser_name }}'
+
+    - question: 'superuser-mail'
+      vtype: 'string'
+      value: '{{ mailman3__superuser_mail }}'
+
+    - question: 'superuser-password'
+      vtype: 'password'
+      value: '{{ mailman3__superuser_password }}'
+  changed_when: False  # Otherwise Ansible will wrongly show that database password has changed
+  no_log: '{{ secret__no_log|d(True) }}'
+
+- name: Install APT packages
+  package:
+    name: '{{ (mailman3__base_packages + mailman3__packages)|flatten }}'
+    state: 'present'
+  register: mailman3__register_packages
+  until: mailman3__register_packages is succeeded
+
+- name: Divert the original mailman3 and mailman3-web configuration files
+  command: |
+    dpkg-divert --quiet --local \
+      --divert /etc/mailman3/{{ item }}.dpkg-divert \
+      --rename /etc/mailman3/{{ item }}
+  loop: [ 'mailman.cfg', 'mailman-hyperkitty.cfg', 'mailman-web.py' ]
+  args:
+    creates: '/etc/mailman3/mailman-web.py.dpkg-divert'
+
+- name: Configure mailman3
+  template:
+    src: 'etc/mailman3/mailman.cfg.j2'
+    dest: '/etc/mailman3/mailman.cfg'
+    owner: 'root'
+    group: 'list'
+    mode: '0640'
+  notify: [ 'Reload mailman3' ]
+
+- name: Configure mailman3-web
+  template:
+    src: 'etc/mailman3/{{ item.file }}.j2'
+    dest: '/etc/mailman3/{{ item.file }}'
+    owner: 'root'
+    group: '{{ item.group }}'
+    mode: '0640'
+  loop:
+    - file: 'mailman-hyperkitty.cfg'
+      group: 'list'
+    - file: 'mailman-web.py'
+      group: 'www-data'
+  notify: [ 'Restart mailman3-web' ]
+
+- name: Ensure Postfix lookup tables exist
+  command: 'mailman aliases'
+  args:
+    creates: '/var/lib/mailman3/data/postfix_domains'
+  become: True
+  become_user: 'list'
+
+- name: Ensure that Ansible local fact directory exists
+  file:
+    path: '/etc/ansible/facts.d'
+    state: 'directory'
+    mode: '0755'
+
+- name: Save local facts
+  template:
+    src: 'etc/ansible/facts.d/mailman3.fact.j2'
+    dest: '/etc/ansible/facts.d/mailman3.fact'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'

--- a/ansible/roles/mailman3/templates/etc/ansible/facts.d/mailman3.fact.j2
+++ b/ansible/roles/mailman3/templates/etc/ansible/facts.d/mailman3.fact.j2
@@ -1,0 +1,20 @@
+#!{{ ansible_python['executable'] }}
+
+# Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+# Copyright (C) 2020 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+# {{ ansible_managed }}
+
+from json import dumps
+import apt
+
+cache = apt.Cache()
+output = {}
+
+try:
+    output['installed'] = cache['mailman3'].is_installed
+except KeyError:
+    output['installed'] = False
+
+print(dumps(output, sort_keys=True, indent=4))

--- a/ansible/roles/mailman3/templates/etc/ansible/facts.d/mailman3.fact.j2
+++ b/ansible/roles/mailman3/templates/etc/ansible/facts.d/mailman3.fact.j2
@@ -1,20 +1,22 @@
 #!{{ ansible_python['executable'] }}
 
-# Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
-# Copyright (C) 2020 DebOps <https://debops.org/>
+# Copyright (C) 2018 Maciej Delmanowski <drybjed@gmail.com>
+# Copyright (C) 2018 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-only
 
 # {{ ansible_managed }}
 
 from json import dumps
-import apt
+import os
 
-cache = apt.Cache()
-output = {}
 
-try:
-    output['installed'] = cache['mailman3'].is_installed
-except KeyError:
-    output['installed'] = False
+def cmd_exists(cmd):
+    return any(
+        os.access(os.path.join(path, cmd), os.X_OK)
+        for path in os.environ["PATH"].split(os.pathsep)
+    )
+
+
+output = {'installed': cmd_exists('mailman')}
 
 print(dumps(output, sort_keys=True, indent=4))

--- a/ansible/roles/mailman3/templates/etc/mailman3/mailman-hyperkitty.cfg.j2
+++ b/ansible/roles/mailman3/templates/etc/mailman3/mailman-hyperkitty.cfg.j2
@@ -1,0 +1,27 @@
+{# Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+ # Copyright (C) 2020 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-or-later
+ #}
+
+# {{ ansible_managed }}
+
+# This is the mailman extension configuration file to enable HyperKitty as an
+# archiver. Remember to add the following lines in the mailman.cfg file:
+#
+# [archiver.hyperkitty]
+# class: mailman_hyperkitty.Archiver
+# enable: yes
+# configuration: /etc/mailman3/mailman-hyperkitty.cfg
+#
+
+[general]
+
+# This is your HyperKitty installation, preferably on the localhost. This
+# address will be used by Mailman to forward incoming emails to HyperKitty
+# for archiving. It does not need to be publicly available, in fact it's
+# better if it is not.
+base_url: https://{{ mailman3__fqdns[0] }}/hyperkitty/
+
+# Shared API key, must be the identical to the value in HyperKitty's
+# settings.
+api_key: {{ mailman3__hyperkitty_api_key }}

--- a/ansible/roles/mailman3/templates/etc/mailman3/mailman-web.py.j2
+++ b/ansible/roles/mailman3/templates/etc/mailman3/mailman-web.py.j2
@@ -1,0 +1,238 @@
+{# Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+ # Copyright (C) 2020 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-or-later
+ #}
+
+# {{ ansible_managed }}
+
+# This file is imported by the Mailman Suite. It is used to override
+# the default settings from /usr/share/mailman3-web/settings.py.
+
+{% if mailman3__ldap %}
+import ldap
+from django_auth_ldap.config import LDAPSearch, GroupOfNamesType
+{% endif %}
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = '{{ mailman3__django_secret_key }}'
+
+ADMINS = (
+     ('Mailman Suite Admin', '{{ mailman3__superuser_mail }}'),
+)
+
+# Hosts/domain names that are valid for this site; required if DEBUG is False
+# See https://docs.djangoproject.com/en/1.8/ref/settings/#allowed-hosts
+# Set to '*' per default in the Deian package to allow all hostnames. Mailman3
+# is meant to run behind a webserver reverse proxy anyway.
+ALLOWED_HOSTS = [
+    '{{ mailman3__fqdns|join("', '") }}'
+]
+
+# Mailman API credentials
+MAILMAN_REST_API_URL = 'http://localhost:8001'
+MAILMAN_REST_API_USER = '{{ mailman3__rest_api_user }}'
+MAILMAN_REST_API_PASS = '{{ mailman3__rest_api_pass }}'
+MAILMAN_ARCHIVER_KEY = '{{ mailman3__hyperkitty_api_key }}'
+MAILMAN_ARCHIVER_FROM = ('{{ mailman3__archiver_from|join("', '") }}')
+
+{% if mailman3__ldap %}
+# django-auth-ldap
+# https://django-auth-ldap.readthedocs.io/en/latest/reference.html
+AUTH_LDAP_SERVER_URI = "{{ mailman3__ldap_uri|join(' ') }}"
+AUTH_LDAP_START_TLS = {{ mailman3__ldap_starttls }}
+AUTH_LDAP_BIND_DN = '{{ mailman3__ldap_bind_dn }}'
+AUTH_LDAP_BIND_PASSWORD = '{{ mailman3__ldap_bind_password }}'
+AUTH_LDAP_USER_SEARCH = LDAPSearch(
+    '{{ mailman3__ldap_people_dn }}',
+    ldap.SCOPE_SUBTREE,
+    '{{ mailman3__ldap_people_filter }}',
+)
+AUTH_LDAP_GROUP_SEARCH = LDAPSearch(
+    '{{ mailman3__ldap_groups_dn }}',
+    ldap.SCOPE_SUBTREE,
+    '{{ mailman3__ldap_groups_filter }}',
+)
+AUTH_LDAP_GROUP_TYPE = GroupOfNamesType(name_attr='cn')
+AUTH_LDAP_USER_ATTR_MAP = {
+    'first_name': 'givenName',
+    'last_name': 'sn',
+    'email': 'mail',
+}
+AUTH_LDAP_USER_FLAGS_BY_GROUP = {
+    'is_staff': 'cn={{ mailman3__ldap_superusers_group }},{{ mailman3__ldap_groups_dn }}',
+    'is_superuser': 'cn={{ mailman3__ldap_superusers_group }},{{ mailman3__ldap_groups_dn }}',
+}
+AUTH_LDAP_FIND_GROUP_PERMS = True
+AUTH_LDAP_CACHE_TIMEOUT = 3600
+AUTHENTICATION_BACKENDS = [
+    'django_auth_ldap.backend.LDAPBackend',
+    'django.contrib.auth.backends.ModelBackend',
+]
+{% endif %}
+
+# Application definition
+
+INSTALLED_APPS = (
+    'hyperkitty',
+    'postorius',
+    'django_mailman3',
+    # Uncomment the next line to enable the admin:
+    'django.contrib.admin',
+    # Uncomment the next line to enable admin documentation:
+    # 'django.contrib.admindocs',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.sites',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'rest_framework',
+    'django_gravatar',
+    'compressor',
+    'haystack',
+    'django_extensions',
+    'django_q',
+    'allauth',
+    'allauth.account',
+    'allauth.socialaccount',
+    #'django_mailman3.lib.auth.fedora',
+    #'allauth.socialaccount.providers.openid',
+    #'allauth.socialaccount.providers.github',
+    #'allauth.socialaccount.providers.gitlab',
+    #'allauth.socialaccount.providers.google',
+    #'allauth.socialaccount.providers.facebook',
+    #'allauth.socialaccount.providers.twitter',
+    #'allauth.socialaccount.providers.stackexchange',
+)
+
+# Database
+# https://docs.djangoproject.com/en/1.8/ref/settings/#databases
+
+DATABASES = {
+    'default': {
+        # Use 'sqlite3', 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
+        {% if mailman3__database_type == 'mariadb' %}
+        'ENGINE': 'django.db.backends.mysql',
+        {% elif mailman3__database_type == 'postgresql' %}
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        {% else %}
+        'ENGINE': 'django.db.backends.sqlite3',
+        {% endif %}
+        # DB name or path to database file if using sqlite3.
+        'NAME': '{{ ("/var/lib/mailman3/web/" if mailman3__database_type == "sqlite3" else "") + mailman3__database_web_name }}',
+        # The following settings are not used with sqlite3:
+        'USER': '{{ mailman3__database_web_user }}',
+        'PASSWORD': '{{ mailman3__database_web_password }}',
+        # HOST: empty for localhost through domain sockets or '127.0.0.1' for
+        # localhost through TCP.
+        'HOST': 'localhost',
+        # PORT: set to empty string for default.
+        'PORT': '{{ mailman3__database_port }}',
+        # OPTIONS: Extra parameters to use when connecting to the database.
+        'OPTIONS': {
+            {% if mailman3__database_type == 'mariadb' %}
+            # Set sql_mode to 'STRICT_TRANS_TABLES' for MySQL. See
+            # https://docs.djangoproject.com/en/1.11/ref/
+            #     databases/#setting-sql-mode
+            'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
+            {% endif %}
+        },
+    }
+}
+
+# If you're behind a proxy, use the X-Forwarded-Host header
+# See https://docs.djangoproject.com/en/1.8/ref/settings/#use-x-forwarded-host
+USE_X_FORWARDED_HOST = True
+
+# And if your proxy does your SSL encoding for you, set SECURE_PROXY_SSL_HEADER
+# https://docs.djangoproject.com/en/1.8/ref/settings/#secure-proxy-ssl-header
+# SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+# SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_SCHEME', 'https')
+
+# Other security settings
+# SECURE_SSL_REDIRECT = True
+# If you set SECURE_SSL_REDIRECT to True, make sure the SECURE_REDIRECT_EXEMPT
+# contains at least this line:
+# SECURE_REDIRECT_EXEMPT = [
+#     "archives/api/mailman/.*",  # Request from Mailman.
+#     ]
+# SESSION_COOKIE_SECURE = True
+# SECURE_CONTENT_TYPE_NOSNIFF = True
+# SECURE_BROWSER_XSS_FILTER = True
+# CSRF_COOKIE_SECURE = True
+# CSRF_COOKIE_HTTPONLY = True
+# X_FRAME_OPTIONS = 'DENY'
+
+
+# Internationalization
+# https://docs.djangoproject.com/en/1.8/topics/i18n/
+
+LANGUAGE_CODE = 'en-us'
+
+TIME_ZONE = '{{ mailman3__django_time_zone }}'
+
+USE_I18N = True
+USE_L10N = True
+USE_TZ = True
+
+
+# Set default domain for email addresses.
+EMAILNAME = '{{ mailman3__emailname }}'
+
+# If you enable internal authentication, this is the address that the emails
+# will appear to be coming from. Make sure you set a valid domain name,
+# otherwise the emails may get rejected.
+# https://docs.djangoproject.com/en/1.8/ref/settings/#default-from-email
+# DEFAULT_FROM_EMAIL = "mailing-lists@you-domain.org"
+DEFAULT_FROM_EMAIL = 'www-data@{}'.format(EMAILNAME)
+
+# If you enable email reporting for error messages, this is where those emails
+# will appear to be coming from. Make sure you set a valid domain name,
+# otherwise the emails may get rejected.
+# https://docs.djangoproject.com/en/1.8/ref/settings/#std:setting-SERVER_EMAIL
+# SERVER_EMAIL = 'root@your-domain.org'
+SERVER_EMAIL = 'www-data@{}'.format(EMAILNAME)
+
+
+# Django Allauth
+ACCOUNT_DEFAULT_HTTP_PROTOCOL = "https"
+
+
+#
+# Social auth
+#
+SOCIALACCOUNT_PROVIDERS = {
+    #'openid': {
+    #    'SERVERS': [
+    #        dict(id='yahoo',
+    #             name='Yahoo',
+    #             openid_url='http://me.yahoo.com'),
+    #    ],
+    #},
+    #'google': {
+    #    'SCOPE': ['profile', 'email'],
+    #    'AUTH_PARAMS': {'access_type': 'online'},
+    #},
+    #'facebook': {
+    #   'METHOD': 'oauth2',
+    #   'SCOPE': ['email'],
+    #   'FIELDS': [
+    #       'email',
+    #       'name',
+    #       'first_name',
+    #       'last_name',
+    #       'locale',
+    #       'timezone',
+    #       ],
+    #   'VERSION': 'v2.4',
+    #},
+}
+
+# On a production setup, setting COMPRESS_OFFLINE to True will bring a
+# significant performance improvement, as CSS files will not need to be
+# recompiled on each requests. It means running an additional "compress"
+# management command after each code upgrade.
+# http://django-compressor.readthedocs.io/en/latest/usage/#offline-compression
+COMPRESS_OFFLINE = True
+
+POSTORIUS_TEMPLATE_BASE_URL = 'https://{{ mailman3__fqdns[0] }}/'

--- a/ansible/roles/mailman3/templates/etc/mailman3/mailman.cfg.j2
+++ b/ansible/roles/mailman3/templates/etc/mailman3/mailman.cfg.j2
@@ -1,0 +1,292 @@
+{# Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+ # Copyright (C) 2020 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-or-later
+ #}
+
+# {{ ansible_managed }}
+
+# Copyright (C) 2008-2017 by the Free Software Foundation, Inc.
+#
+# This file is part of GNU Mailman.
+#
+# GNU Mailman is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+#
+# GNU Mailman is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# GNU Mailman.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file contains the Debian configuration for mailman.  It uses ini-style
+# formats under the lazr.config regime to define all system configuration
+# options.  See <https://launchpad.net/lazr.config> for details.
+
+
+[mailman]
+# This address is the "site owner" address.  Certain messages which must be
+# delivered to a human, but which can't be delivered to a list owner (e.g. a
+# bounce from a list owner), will be sent to this address.  It should point to
+# a human.
+site_owner: {{ mailman3__superuser_mail }}
+
+# This is the local-part of an email address used in the From field whenever a
+# message comes from some entity to which there is no natural reply recipient.
+# Mailman will append '@' and the host name of the list involved.  This
+# address must not bounce and it must not point to a Mailman process.
+noreply_address: noreply
+
+# The default language for this server.
+default_language: en
+
+# Membership tests for posting purposes are usually performed by looking at a
+# set of headers, passing the test if any of their values match a member of
+# the list.  Headers are checked in the order given in this variable.  The
+# value From_ means to use the envelope sender.  Field names are case
+# insensitive.  This is a space separate list of headers.
+sender_headers: from from_ reply-to sender
+
+# Mail command processor will ignore mail command lines after designated max.
+email_commands_max_lines: 10
+
+# Default length of time a pending request is live before it is evicted from
+# the pending database.
+pending_request_life: 3d
+
+# How long should files be saved before they are evicted from the cache?
+cache_life: 7d
+
+# A callable to run with no arguments early in the initialization process.
+# This runs before database initialization.
+pre_hook:
+
+# A callable to run with no arguments late in the initialization process.
+# This runs after adapters are initialized.
+post_hook:
+
+# Which paths.* file system layout to use.
+# You should not change this variable.
+layout: debian
+
+# Can MIME filtered messages be preserved by list owners?
+filtered_messages_are_preservable: no
+
+# How should text/html parts be converted to text/plain when the mailing list
+# is set to convert HTML to plaintext?  This names a command to be called,
+# where the substitution variable $filename is filled in by Mailman, and
+# contains the path to the temporary file that the command should read from.
+# The command should print the converted text to stdout.
+html_to_plain_text_command: /usr/bin/lynx -dump $filename
+
+# Specify what characters are allowed in list names.  Characters outside of
+# the class [-_.+=!$*{}~0-9a-z] matched case insensitively are never allowed,
+# but this specifies a subset as the only allowable characters.  This must be
+# a valid character class regexp or the effect on list creation is
+# unpredictable.
+listname_chars: [-_.0-9a-z]
+
+
+[shell]
+# `mailman shell` (also `withlist`) gives you an interactive prompt that you
+# can use to interact with an initialized and configured Mailman system.  Use
+# --help for more information.  This section allows you to configure certain
+# aspects of this interactive shell.
+
+# Customize the interpreter prompt.
+prompt: >>>
+
+# Banner to show on startup.
+banner: Welcome to the GNU Mailman shell
+
+# Use IPython as the shell, which must be found on the system.  Valid values
+# are `no`, `yes`, and `debug` where the latter is equivalent to `yes` except
+# that any import errors will be displayed to stderr.
+use_ipython: no
+
+# Set this to allow for command line history if readline is available.  This
+# can be as simple as $var_dir/history.py to put the file in the var directory.
+history_file:
+
+
+[paths.debian]
+# Important directories for Mailman operation.  These are defined here so that
+# different layouts can be supported.   For example, a developer layout would
+# be different from a FHS layout.  Most paths are based off the var_dir, and
+# often just setting that will do the right thing for all the other paths.
+# You might also have to set spool_dir though.
+#
+# Substitutions are allowed, but must be of the form $var where 'var' names a
+# configuration variable in the paths.* section.  Substitutions are expanded
+# recursively until no more $-variables are present.  Beware of infinite
+# expansion loops!
+#
+# This is the root of the directory structure that Mailman will use to store
+# its run-time data.
+var_dir: /var/lib/mailman3
+# This is where the Mailman queue files directories will be created.
+queue_dir: $var_dir/queue
+# This is the directory containing the Mailman 'runner' and 'master' commands
+# if set to the string '$argv', it will be taken as the directory containing
+# the 'mailman' command.
+bin_dir: /usr/lib/mailman3/bin
+# All list-specific data.
+list_data_dir: $var_dir/lists
+# Directory where log files go.
+log_dir: /var/log/mailman3
+# Directory for system-wide locks.
+lock_dir: $var_dir/locks
+# Directory for system-wide data.
+data_dir: $var_dir/data
+# Cache files.
+cache_dir: $var_dir/cache
+# Directory for configuration files and such.
+etc_dir: /etc/mailman3
+# Directory containing Mailman plugins.
+ext_dir: $var_dir/ext
+# Directory where the default IMessageStore puts its messages.
+messages_dir: $var_dir/messages
+# Directory for archive backends to store their messages in.  Archivers should
+# create a subdirectory in here to store their files.
+archive_dir: $var_dir/archives
+# Root directory for site-specific template override files.
+template_dir: $var_dir/templates
+# There are also a number of paths to specific file locations that can be
+# defined.  For these, the directory containing the file must already exist,
+# or be one of the directories created by Mailman as per above.
+#
+# This is where PID file for the master runner is stored.
+pid_file: /run/mailman3/master.pid
+# Lock file.
+lock_file: $lock_dir/master.lck
+
+
+[database]
+# class: The class implementing the IDatabase.
+# url: Use this to set the Storm database engine URL.  You generally have one
+# primary database connection for all of Mailman.  List data and most rosters
+# will store their data in this database, although external rosters may access
+# other databases in their own way.  This string supports standard
+# 'configuration' substitutions.
+{% if mailman3__database_type == "mariadb" %}
+class: mailman.database.mysql.MySQLDatabase
+url: mysql+pymysql://{{ mailman3__database_core_user }}:{{ mailman3__database_core_password }}@localhost/{{ mailman3__database_core_name }}?charset=utf8&use_unicode=1
+{% elif mailman3__database_type == "postgresql" %}
+class: mailman.database.postgresql.PostgreSQLDatabase
+url: postgres://{{ mailman3__database_core_user }}:{{ mailman3__database_core_password }}@localhost/{{ mailman3__database_core_name }}
+{% else %}
+class: mailman.database.sqlite.SQLiteDatabase
+sqlite:///$DATA_DIR/{{ mailman3__database_core_name }}
+{% endif %}
+
+debug: no
+
+
+[logging.debian]
+# This defines various log settings.  The options available are:
+#
+# - level     -- Overrides the default level; this may be any of the
+#                standard Python logging levels, case insensitive.
+# - format    -- Overrides the default format string
+# - datefmt   -- Overrides the default date format string
+# - path      -- Overrides the default logger path.  This may be a relative
+#                path name, in which case it is relative to Mailman's LOG_DIR,
+#                or it may be an absolute path name.  You cannot change the
+#                handler class that will be used.
+# - propagate -- Boolean specifying whether to propagate log message from this
+#                logger to the root "mailman" logger.  You cannot override
+#                settings for the root logger.
+#
+# In this section, you can define defaults for all loggers, which will be
+# prefixed by 'mailman.'.  Use subsections to override settings for specific
+# loggers.  The names of the available loggers are:
+#
+# - archiver        --  All archiver output
+# - bounce          --  All bounce processing logs go here
+# - config          --  Configuration issues
+# - database        --  Database logging (SQLAlchemy and Alembic)
+# - debug           --  Only used for development
+# - error           --  All exceptions go to this log
+# - fromusenet      --  Information related to the Usenet to Mailman gateway
+# - http            --  Internal wsgi-based web interface
+# - locks           --  Lock state changes
+# - mischief        --  Various types of hostile activity
+# - runner          --  Runner process start/stops
+# - smtp            --  Successful SMTP activity
+# - smtp-failure    --  Unsuccessful SMTP activity
+# - subscribe       --  Information about leaves/joins
+# - vette           --  Message vetting information
+format: %(asctime)s (%(process)d) %(message)s
+datefmt: %b %d %H:%M:%S %Y
+propagate: no
+level: info
+path: mailman.log
+
+[webservice]
+# The hostname at which admin web service resources are exposed.
+hostname: localhost
+
+# The port at which the admin web service resources are exposed.
+port: 8001
+
+# Whether or not requests to the web service are secured through SSL.
+use_https: no
+
+# Whether or not to show tracebacks in an HTTP response for a request that
+# raised an exception.
+show_tracebacks: yes
+
+# The API version number for the current (highest) API.
+api_version: 3.1
+
+# The administrative username.
+admin_user: {{ mailman3__rest_api_user }}
+
+# The administrative password.
+admin_pass: {{ mailman3__rest_api_pass }}
+
+[mta]
+# The class defining the interface to the incoming mail transport agent.
+#incoming: mailman.mta.exim4.LMTP
+incoming: mailman.mta.postfix.LMTP
+
+# The callable implementing delivery to the outgoing mail transport agent.
+# This must accept three arguments, the mailing list, the message, and the
+# message metadata dictionary.
+outgoing: mailman.mta.deliver.deliver
+
+# How to connect to the outgoing MTA.  If smtp_user and smtp_pass is given,
+# then Mailman will attempt to log into the MTA when making a new connection.
+smtp_host: localhost
+smtp_port: 25
+smtp_user:
+smtp_pass:
+
+# Where the LMTP server listens for connections.  Use 127.0.0.1 instead of
+# localhost for Postfix integration, because Postfix only consults DNS
+# (e.g. not /etc/hosts).
+lmtp_host: 127.0.0.1
+lmtp_port: 8024
+
+# Where can we find the mail server specific configuration file?  The path can
+# be either a file system path or a Python import path.  If the value starts
+# with python: then it is a Python import path, otherwise it is a file system
+# path.  File system paths must be absolute since no guarantees are made about
+# the current working directory.  Python paths should not include the trailing
+# .cfg, which the file must end with.
+#configuration: python:mailman.config.exim4
+configuration: python:mailman.config.postfix
+
+# The following lines are specific to mailing lists archiving using
+# HyperKitty. They require 'python3-mailman-hyperkitty' to be installed
+# and will produce errors otherwise.
+#
+# If you don't want to use HyperKitty, please comment them out.
+
+[archiver.hyperkitty]
+class: mailman_hyperkitty.Archiver
+enable: yes
+configuration: /etc/mailman3/mailman-hyperkitty.cfg

--- a/ansible/roles/mailman3/templates/etc/systemd/system/mailman3.service.j2
+++ b/ansible/roles/mailman3/templates/etc/systemd/system/mailman3.service.j2
@@ -1,0 +1,30 @@
+{# Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+ # Copyright (C) 2020 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-or-later
+ #}
+
+# {{ ansible_managed }}
+
+# systemd service template for mailman3 program
+
+[Unit]
+Description=Mailman3 server
+Documentation=man:mailman(1)
+Documentation=https://mailman.readthedocs.io/
+ConditionPathExists=/etc/mailman3/mailman.cfg
+
+# Delay mailman3 service startup until database service is running
+After={{ mailman3__database_type }}.service
+
+[Service]
+ExecStart=/usr/bin/mailman -C /etc/mailman3/mailman.cfg start --force
+ExecReload=/usr/bin/mailman -C /etc/mailman3/mailman.cfg restart
+ExecStop=/usr/bin/mailman -C /etc/mailman3/mailman.cfg stop
+Type=forking
+PIDFile=/run/mailman3/master.pid
+SyslogIdentifier=mailman3
+User=list
+Group=list
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/ansible/role-index.rst
+++ b/docs/ansible/role-index.rst
@@ -32,6 +32,7 @@ etc.
 - :ref:`debops.kibana`
 - :ref:`debops.librenms`
 - :ref:`debops.mailman`
+- :ref:`debops.mailman3`
 - :ref:`debops.netbox`
 - :ref:`debops.owncloud`
 - :ref:`debops.etesync`
@@ -215,6 +216,7 @@ Mail services
 - :ref:`debops.dovecot`
 - :ref:`debops.etc_aliases`
 - :ref:`debops.mailman`
+- :ref:`debops.mailman3`
 - :ref:`debops.nullmailer`
 - :ref:`debops.opendkim`
 - :ref:`debops.postconf`

--- a/docs/ansible/roles/mailman3/getting-started.rst
+++ b/docs/ansible/roles/mailman3/getting-started.rst
@@ -1,0 +1,72 @@
+.. Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+.. Copyright (C) 2020 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-or-later
+
+Getting started
+===============
+
+.. only:: html
+
+   .. contents::
+      :local:
+
+Database integration
+--------------------
+
+The role currently configures these databases through debconf:
+
+- mariadb
+- postgresql
+- sqlite3
+
+The role will configure the MariaDB or PostgreSQL database if the
+:ref:`debops.mariadb_server` or :ref:`debops.postgresql_server` roles have been
+run against the host, falling back to a SQLite 3 database. Note that external
+databases are not supported at this time.
+
+LDAP support
+------------
+
+If the host has been configured with :ref:`debops.ldap`, this role will set up
+LDAP authentication in the Mailman 3 web frontend. The backend for this
+functionality is provided by `django-auth-ldap`__. The default configuration
+will allow full administrative access to the members of the 'UNIX
+Administrators' group.
+
+.. __: https://django-auth-ldap.readthedocs.io/en/latest/
+
+A local administrator with (by default) username 'admin' and a random password
+is created to allow list administration when the LDAP server cannot be used.
+
+SMTP service integration
+------------------------
+
+The role provides configuration for the :ref:`debops.postfix` role. This
+dependent configuration sets Postfix up for LMTP delivery to Mailman Core.
+
+HTTP service integration
+------------------------
+
+The role provides configuration for the :ref:`debops.nginx` role that will
+configure the Postorius web interface using :program:`nginx` and ``uWSGI``.
+
+Example inventory
+-----------------
+
+To configure Mailman Suite on a host, you need to add it to the
+``[debops_service_mailman3]`` Ansible inventory group. Example inventory::
+
+    # inventory/hosts
+    [debops_service_mailman3]
+    hostname
+
+Example playbook
+----------------
+
+:ref:`debops.mailman3` uses a set of other roles to configure additional
+services like the HTTP and SMTP server. Here is an example playbook with all of
+the required DebOps services:
+
+.. literalinclude:: ../../../../ansible/playbooks/service/mailman3.yml
+   :language: yaml
+   :lines: 1,5-

--- a/docs/ansible/roles/mailman3/index.rst
+++ b/docs/ansible/roles/mailman3/index.rst
@@ -1,0 +1,28 @@
+.. Copyright (C) 2014-2017 Maciej Delmanowski <drybjed@gmail.com>
+.. Copyright (C) 2014-2017 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+.. _debops.mailman3:
+
+debops.mailman3
+===============
+
+.. include:: man_description.rst
+   :start-line: 7
+
+.. toctree::
+   :maxdepth: 2
+
+   getting-started
+   defaults/main
+
+Copyright
+---------
+
+.. literalinclude:: ../../../../ansible/roles/mailman3/COPYRIGHT
+
+..
+ Local Variables:
+ mode: rst
+ ispell-local-dictionary: "american"
+ End:

--- a/docs/ansible/roles/mailman3/man_description.rst
+++ b/docs/ansible/roles/mailman3/man_description.rst
@@ -1,0 +1,14 @@
+.. Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+.. Copyright (C) 2020 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-or-later
+
+Description
+===========
+
+The :ref:`debops.mailman3` Ansible role can be used to manage the
+`Mailman Suite <https://docs.mailman3.org/en/latest/>`_, which consists of
+Mailman 3 Core, the Django-based Postorius web frontend and the Hyperkitty list
+archiver.
+
+The role provides integration with the :ref:`debops.ldap`, :ref:`debops.nginx`
+and :ref:`debops.nginx` roles through dependent configuration.

--- a/docs/ansible/roles/mailman3/man_index.rst
+++ b/docs/ansible/roles/mailman3/man_index.rst
@@ -1,0 +1,21 @@
+:orphan:
+
+.. Copyright (C) 2014-2017 Maciej Delmanowski <drybjed@gmail.com>
+.. Copyright (C) 2014-2017 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+debops.mailman
+==============
+
+.. toctree::
+   :maxdepth: 2
+
+   man_synopsis
+   man_description
+   getting-started
+
+..
+ Local Variables:
+ mode: rst
+ ispell-local-dictionary: "american"
+ End:

--- a/docs/ansible/roles/mailman3/man_synopsis.rst
+++ b/docs/ansible/roles/mailman3/man_synopsis.rst
@@ -1,0 +1,8 @@
+.. Copyright (C) 2014-2017 Maciej Delmanowski <drybjed@gmail.com>
+.. Copyright (C) 2014-2017 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+Synopsis
+========
+
+``debops service/mailman3`` [**--limit** `group,host,`...] [**--diff**] [**--check**] [**--tags** `tag1,tag2,`...] [**--skip-tags** `tag1,tag2,`...] [<``ansible-playbook`` options>] ...

--- a/lib/tests/check-pep8
+++ b/lib/tests/check-pep8
@@ -33,7 +33,8 @@ done < <(find . -type f -not -iwholename "./.git/*" \
     -not -wholename "./docs/ansible/roles/system_users/defaults-detailed.rst" \
     -not -wholename "./docs/ansible/roles/users/defaults-detailed.rst" \
     -not -wholename "./ansible/roles/gunicorn/templates/etc/gunicorn/application.conf.py.j2" \
-    -not -wholename "./ansible/roles/mailman/templates/etc/mailman/mm_cfg.py.j2")
+    -not -wholename "./ansible/roles/mailman/templates/etc/mailman/mm_cfg.py.j2" \
+    -not -wholename "./ansible/roles/mailman3/templates/etc/mailman3/mailman-web.py.j2")
 
 printf " %s\\n" "found ${#file_list[@]} Python scripts"
 


### PR DESCRIPTION
The `debops.mailman3` role manages Mailman Suite installations, which consist of the Mailman Core backend, Postorius web frontend and Hyperkitty list archiver. The role manages the database with debconf, integrates with NGINX and Postfix and configures LDAP authentication for superusers.

I opted for writing a new role for Mailman 3 instead of updating the existing `debops.mailman` role, because of the many backwards-incompatible changes. The Debian Mailman Team made the same choice.

We're using this role at CipherMail to manage https://lists.ciphermail.com/ with a PostgreSQL database. Support for MariaDB and SQLite 3 has been tested in a Vagrant box.