### PR TITLE
Replace include with import_playbook in project directories user guide

### DIFF
--- a/docs/user-guide/project-directories.rst
+++ b/docs/user-guide/project-directories.rst
@@ -248,8 +248,8 @@ in :file:`ansible/playbooks/site.yml`:
 .. code-block:: yaml
 
   ---
-  - include: '{{ lookup("ENV", "HOME") + "/.local/share/debops/debops/ansible/playbooks/site.yml" }}'
-  - include: your_role.yml
+  - import_playbook: '{{ lookup("ENV", "HOME") + "/.local/share/debops/debops/ansible/playbooks/site.yml" }}'
+  - import_playbook: your_role.yml
 
 
 in :file:`ansible/playbooks/your_role.yml`:


### PR DESCRIPTION
The doc for playbook overriding mentions `include: playbook.yml` but it seems outdated, now it should be done with `import_playbook`.