### PR TITLE
Relax mount device fstype check

### DIFF
--- a/ansible/roles/mount/tasks/main.yml
+++ b/ansible/roles/mount/tasks/main.yml
@@ -57,8 +57,7 @@
             | flatten }}'
   register: mount__register_devices
   when: (mount__enabled|bool and
-         (item.name|d() or item.dest|d() or item.path|d()) and
-         item.src|d() and item.fstype|d())
+         (item.name|d() or item.dest|d() or item.path|d()) and item.src)
 
 - name: Restart 'local-fs.target' systemd unit
   systemd:


### PR DESCRIPTION
As item.fstype is set to d('auto') in the task, it is not required