### PR TITLE
Allow custom default inventory in .debops.cfg

### DIFF
--- a/bin/debops
+++ b/bin/debops
@@ -238,7 +238,7 @@ def main(cmd_args):
         if play:
             play_list.append(play)
 
-    inventory_path = find_inventorypath(project_root)
+    inventory_path = find_inventorypath(config, project_root)
     os.environ['ANSIBLE_INVENTORY'] = inventory_path
 
     global_vars_file = os.path.join(inventory_path + '/../global-vars.yml')

--- a/bin/debops-padlock
+++ b/bin/debops-padlock
@@ -41,6 +41,7 @@ from pkg_resources import resource_filename
 
 from debops import INVENTORY, ENCFS_PREFIX, SECRET_NAME, PADLOCK_CMD
 from debops import ENCFS_CONFIGFILE, ENCFS_KEYFILE, ENCFS_KEYFILE_LENGTH
+from debops import read_config
 from debops import subprocess
 from debops import padlock_lock, padlock_unlock, shquote
 
@@ -81,6 +82,7 @@ GPG = 'gpg'
 
 def main(subcommand_func, **kwargs):
     project_root = find_debops_project(required=True)
+    config = read_config(project_root)
     # :todo: Source DebOps configuration file
     # [ -r ${debops_config} ] && source ${debops_config}
 
@@ -93,7 +95,7 @@ def main(subcommand_func, **kwargs):
     else:
         require_commands(ENCFS, FIND, FUSERMOUNT, GPG)
 
-    inventory_path = find_inventorypath(project_root, required=False)
+    inventory_path = find_inventorypath(config, project_root, required=False)
     # If inventory hasn't been found automatically, assume it's the default
     if not inventory_path:
         inventory_path = os.path.join(project_root, 'ansible', INVENTORY)

--- a/bin/debops-task
+++ b/bin/debops-task
@@ -48,7 +48,7 @@ DEBOPS_RESERVED_NAMES = ["task", "init", "update", "defaults", "padlock"]
 project_root = find_debops_project(required=True)
 # Source DebOps configuration file
 # todo: need to decide on semantics!
-# config = read_config(project_root)
+config = read_config(project_root)
 
 # External programms used. List here for easy substitution for
 # hard-coded paths.
@@ -59,7 +59,7 @@ ANSIBLE = 'ansible'
 # Make sure required commands are present
 require_commands(ANSIBLE)
 
-ansible_inventory = find_inventorypath(project_root)
+ansible_inventory = find_inventorypath(config, project_root)
 
 # Get module name from the script name if script is named 'debops-*'
 module_name = SCRIPT_NAME.rsplit('-', 1)[-1]

--- a/debops/__init__.py
+++ b/debops/__init__.py
@@ -164,10 +164,14 @@ def find_playbookpath(config, project_root):
             return playbook_path
 
 
-def find_inventorypath(project_root):
+def find_inventorypath(config, project_root):
     """
     Search Ansible inventory in local directories.
     """
+    user_defined_inventorypath = config.get('ansible defaults', {}) \
+                                       .get('inventory')
+    if user_defined_inventorypath:
+        return user_defined_inventorypath
     for inventory_path in ANSIBLE_INVENTORY_PATHS:
         ansible_inventory = os.path.join(project_root, inventory_path)
         if os.path.isdir(ansible_inventory):

--- a/debops/__init__.py
+++ b/debops/__init__.py
@@ -171,7 +171,10 @@ def find_inventorypath(config, project_root):
     user_defined_inventorypath = config.get('ansible defaults', {}) \
                                        .get('inventory')
     if user_defined_inventorypath:
-        return user_defined_inventorypath
+        if os.path.isabs(user_defined_inventorypath):
+            return user_defined_inventorypath
+        else:
+            return os.path.join(project_root, user_defined_inventorypath)
     for inventory_path in ANSIBLE_INVENTORY_PATHS:
         ansible_inventory = os.path.join(project_root, inventory_path)
         if os.path.isdir(ansible_inventory):

--- a/debops/cmds/__init__.py
+++ b/debops/cmds/__init__.py
@@ -109,8 +109,8 @@ def find_playbookpath(config, project_root, required=True):
     return playbooks_path
 
 
-def find_inventorypath(project_root, required=True):
-    inventory = _find_inventorypath(project_root)
+def find_inventorypath(config, project_root, required=True):
+    inventory = _find_inventorypath(config, project_root)
     if required and not inventory:
         error_msg("Ansible inventory not found")
     return inventory


### PR DESCRIPTION
Currently debops generates ansible.cfg with default inventory set automatically. A user may need to define another default inventory (for instance it there are multiple inventory files in ansible/inventory and only one of them has to be targeted by default)