### PR TITLE
[debops.mount] omit owner/group if not specified when ensuring mount …

### DIFF
--- a/ansible/roles/mount/tasks/main.yml
+++ b/ansible/roles/mount/tasks/main.yml
@@ -16,8 +16,8 @@
 - name: Ensure that the mount points exist
   file:
     path:    '{{ item.path    | d(item.dest | d(item.name)) }}'
-    owner:   '{{ item.owner   | d("root") }}'
-    group:   '{{ item.group   | d(item.owner | d("root")) }}'
+    owner:   '{{ item.owner   | d(omit) }}'
+    group:   '{{ item.group   | d(item.owner | d(omit)) }}'
     mode:    '{{ item.mode    | d("0755") }}'
     state:   'directory'
   loop: '{{ (mount__devices
@@ -72,8 +72,8 @@
 - name: Manage directories
   file:
     path:    '{{ item.path    | d(item.dest | d(item.name)) }}'
-    owner:   '{{ item.owner   | d("root") }}'
-    group:   '{{ item.group   | d(item.owner | d("root")) }}'
+    owner:   '{{ item.owner   | d(omit) }}'
+    group:   '{{ item.group   | d(item.owner | d(omit)) }}'
     mode:    '{{ item.mode    | d("0755") }}'
     recurse: '{{ item.recurse | d(omit) }}'
     state:   '{{ item.state   | d("directory") }}'


### PR DESCRIPTION
…point exists

If the mount point already exists, the mount role should not update its owner/group if not required by the user

If the mount point does not already exist and the user does not explicitly set owner/group, the current behavior won't be changed because the mount role is run as root