### PR TITLE
[lxd] Workaround for git commit verification

### DIFF
--- a/ansible/roles/lxd/defaults/main.yml
+++ b/ansible/roles/lxd/defaults/main.yml
@@ -237,6 +237,7 @@ lxd__golang__dependent_packages:
     git:
       - repo: '{{ lxd__upstream_git_repository }}'
         version: '{{ lxd__upstream_git_release }}'
+        depth: 50
         build_script: |
           export GOPATH="${HOME}/go"
           make deps


### PR DESCRIPTION
The 'git' Ansible module does not work correctly when a non-master
branch is checked out and GPG signature verification is enabled. This is
solved by requesting a checkout with a specific depth.

Ref: https://github.com/ansible/ansible/issues/68636