### PR TITLE
fix potential logic error for interfaces managed by systemd

### DIFF
--- a/ansible/roles/ifupdown/files/script/ifupdown-reconfigure-interfaces
+++ b/ansible/roles/ifupdown/files/script/ifupdown-reconfigure-interfaces
@@ -287,7 +287,7 @@ if [ -d "${interface_request_path}" ] ; then
                     if ifquery --state "${iface_name}" > /dev/null 2>&1 ; then
 
                         # The interface in question was definitely not set up by 'ifup@.service'
-                        if ! containsElement "${iface_name}" "${systemd_interface_instances[@]:-}" ; then
+                        if containsElement "${iface_name}" "${systemd_interface_instances[@]:-}" ; then
 
                             log_message -m "The '${iface_name}' interface is still active, shutting down networking service"
                             stop_networking

--- a/ansible/roles/ifupdown/files/script/ifupdown-reconfigure-interfaces
+++ b/ansible/roles/ifupdown/files/script/ifupdown-reconfigure-interfaces
@@ -130,6 +130,8 @@ containsElement () {
 # Stop the entre networking service at once
 stop_networking () {
 
+    echo "Pause for a few seconds before stopping network, to give control a bit of head start"
+    sleep 3
     if is_systemd ; then
         systemctl stop networking.service
     else


### PR DESCRIPTION
the way i understand this code is that `systemd_interface_instances` track all
the interfaces that are managed by systemd. so if `iface_name` is not in
`systemd_interface_instances` then restart networking and sync.

Where correctly it should be if `iface_name` is in `systemd_interface_instances`
then state is correct and continue with restarting networking and sync.

This resulting in errors like these when I attempt to use this script, with
added debug lines. Let me know if i'm off or this was a red herring since I'm
new to this code base.

```
$ sudo /usr/local/lib/ifupdown-reconfigure-interfaces
Detected interfaces to reconfigure: bond0,enp1s0f0,enp1s0f1
Detected interfaces to reconfigure: bond0,enp1s0f0,enp1s0f1
Found active systemd ifup@ instances: bond0,enp1s0f0,enp1s0f1
Found active systemd iface@ instances: bond0,enp1s0f0,enp1s0f1,
Found active systemd iface@ instances: bond0,enp1s0f0,enp1s0f1,
Bringing down 'enp1s0f1' interface
inspect enp1s0f1, and active systemd iface@ instances: bond0,enp1s0f0,enp1s0f1,,
Error: Script was working on 'enp1s0f1' network interface when it lost knowledge about the network interface state. The '/etc/network/interfaces.d/' might be desynchronized. Exiting to avoid loss of connectivity, investigate the issue.

```

thanks,