### PR TITLE
Reorder 'netbase' and 'resolvconf' roles in plays

### DIFF
--- a/ansible/playbooks/bootstrap-ldap.yml
+++ b/ansible/playbooks/bootstrap-ldap.yml
@@ -88,6 +88,12 @@
 
   roles:
 
+    - role: resolvconf
+      tags: [ 'role::resolvconf', 'skip::resolvconf' ]
+
+    - role: netbase
+      tags: [ 'role::netbase', 'skip::netbase' ]
+
     - role: secret
       tags: [ 'role::secret', 'role::pki', 'role::pki:secret' ]
       secret_directories:
@@ -104,12 +110,6 @@
       python__dependent_packages2:
         - '{{ netbase__python__dependent_packages2 }}'
         - '{{ ldap__python__dependent_packages2 }}'
-
-    - role: resolvconf
-      tags: [ 'role::resolvconf', 'skip::resolvconf' ]
-
-    - role: netbase
-      tags: [ 'role::netbase', 'skip::netbase' ]
 
     - role: apt_preferences
       tags: [ 'role::apt_preferences', 'skip::apt_preferences' ]

--- a/ansible/playbooks/bootstrap.yml
+++ b/ansible/playbooks/bootstrap.yml
@@ -81,6 +81,12 @@
 
   roles:
 
+    - role: resolvconf
+      tags: [ 'role::resolvconf', 'skip::resolvconf' ]
+
+    - role: netbase
+      tags: [ 'role::netbase', 'skip::netbase' ]
+
     - role: fhs
       tags: [ 'role::fhs', 'skip::fhs' ]
 
@@ -90,12 +96,6 @@
         - '{{ netbase__python__dependent_packages3 }}'
       python__dependent_packages2:
         - '{{ netbase__python__dependent_packages2 }}'
-
-    - role: resolvconf
-      tags: [ 'role::resolvconf', 'skip::resolvconf' ]
-
-    - role: netbase
-      tags: [ 'role::netbase', 'skip::netbase' ]
 
     - role: sudo
       tags: [ 'role::sudo', 'skip::sudo', 'role::system_groups' ]

--- a/ansible/playbooks/common.yml
+++ b/ansible/playbooks/common.yml
@@ -66,6 +66,12 @@
     - role: environment
       tags: [ 'role::environment', 'skip::environment' ]
 
+    - role: resolvconf
+      tags: [ 'role::resolvconf', 'skip::resolvconf' ]
+
+    - role: netbase
+      tags: [ 'role::netbase', 'skip::netbase' ]
+
     - role: secret
       tags: [ 'role::secret', 'role::pki', 'role::pki:secret' ]
       secret_directories:
@@ -82,12 +88,6 @@
       python__dependent_packages2:
         - '{{ netbase__python__dependent_packages2 }}'
         - '{{ ldap__python__dependent_packages2 }}'
-
-    - role: resolvconf
-      tags: [ 'role::resolvconf', 'skip::resolvconf' ]
-
-    - role: netbase
-      tags: [ 'role::netbase', 'skip::netbase' ]
 
     - role: apt_preferences
       tags: [ 'role::apt_preferences', 'skip::apt_preferences' ]


### PR DESCRIPTION
The 'netbase' and 'resolvconf' roles should be executed before the
'secret' role on the common and bootstrap playbooks to set the host name
and domain before the 'secret' role creates directories on the Ansible
Controller. Otherwise the host rename causes the 'pki' role to use wrong
directory names during operation.