### PR TITLE
[nginx] Support for configurable PHP location

### DIFF
--- a/ansible/roles/nginx/templates/etc/nginx/sites-available/php.conf.j2
+++ b/ansible/roles/nginx/templates/etc/nginx/sites-available/php.conf.j2
@@ -64,7 +64,7 @@
         # CVE-2019-11043 mitigation (https://security-tracker.debian.org/tracker/CVE-2019-11043)
         # Based on: https://bugs.php.net/bug.php?id=78599
         rewrite ^(.*?)\n $1;
-        location ~ ^(?!.+\.php/)(?<script_name>.+\.php)$ {
+        location {{ item.php_location_script_name | d("~ ^(?!.+\.php/)(?<script_name>.+\.php)$") }} {
 {%      if item.php_limit_except|d() %}
                 limit_except {{ item.php_limit_except if item.php_limit_except is string else item.php_limit_except | join(' ') }} { deny all; }
 
@@ -98,7 +98,7 @@
         # CVE-2019-11043 mitigation (https://security-tracker.debian.org/tracker/CVE-2019-11043)
         # Based on: https://bugs.php.net/bug.php?id=78599
         rewrite ^(.*?)\n $1;
-        location ~ ^(?<script_name>.+\.php)(?<path_info>/.*)$ {
+        location {{ item.php_location_path_info | d("~ ^(?<script_name>.+\.php)(?<path_info>/.*)$") }} {
 {%     if item.php_limit_except|d() %}
                 limit_except {{ item.php_limit_except if item.php_limit_except is string else item.php_limit_except | join(' ') }} { deny all; }
 

--- a/docs/ansible/roles/nginx/defaults-detailed.rst
+++ b/docs/ansible/roles/nginx/defaults-detailed.rst
@@ -792,6 +792,22 @@ Available when ``item.type`` is set to ``php`` for a server.
   defined in the PHP location blocks. If not defined, the default is to use the
   ``$script_name`` and ``=404`` values.
 
+``php_location_script_name``
+  Optional. This parameter allows modification of the location matching rule
+  used for PHP scripts without additional parameters, by default:
+
+  .. code-block:: none
+
+     ~ ^(?!.+\.php/)(?<script_name>.+\.php)$
+
+``php_location_path_info``
+  Optional. This parameter allows modification of the location matching rule
+  used for PHP scripts with additional parameters, by default:
+
+  .. code-block:: none
+
+     ~ ^(?<script_name>.+\.php)(?<path_info>/.*)$
+
 ``php_options``
   Optional, string. Additional options to append to php location.
 


### PR DESCRIPTION
This patch adds support for configurable PHP location match for scripts
with and without additional parameters in the nginx server
configuration. This might be needed by certain PHP applications.