### PR TITLE
[pki] Fixed symbolic link paths for openssl selfsigned root cert

### DIFF
--- a/ansible/roles/pki/files/usr/local/lib/pki/pki-realm
+++ b/ansible/roles/pki/files/usr/local/lib/pki/pki-realm
@@ -816,7 +816,7 @@ selfsign_openssl_request () {
             test -r "${sign_out}.tmp" && mv "${sign_out}.tmp" "${sign_out}"
             if [ -r "${sign_out}" ] && [ ! -r "${root_out}" ] ; then
                 cd "$(dirname "${root_out}")" || exit 1
-                ln -s "${sign_out}" "${root_out}"
+                ln -s "$(basename ${sign_out})" "$(basename "${root_out}")"
                 cd - > /dev/null
             fi
 


### PR DESCRIPTION
Added basename command to symbolic linking of the selfsigned root certificate in the openssl function that mirrors the same line in the gnutls function. This fixes the error "failed to create symbolic link 'selfsigned/root.pem': No such file or directory" from the pki-realm command when creating a realm that uses selfsigned certificate and the openssl library.