### PR TITLE
Add variable to set chrony cmdport, which was disabled in #1236

### DIFF
--- a/ansible/roles/ntp/defaults/main.yml
+++ b/ansible/roles/ntp/defaults/main.yml
@@ -164,6 +164,17 @@ ntp__purge_packages:
 ntp__openntpd_options: '-f /etc/openntpd/ntpd.conf -s'
                                                                    # ]]]
                                                                    # ]]]
+# Chrony configuration [[[
+# --------------------------
+
+# .. envvar:: ntp__chrony_cmdport [[[
+#
+# Set the ``chrony`` cmdport option. 323 is the chrony default, but
+# debops recommends you default to 0 to disable UDP connections which
+# requires ``chronyc`` be run as root to connect over unix socket.
+ntp__chrony_cmdport: 0
+                                                                   # ]]]
+                                                                   # ]]]
 # Network accessibility [[[
 # -------------------------
 

--- a/ansible/roles/ntp/templates/etc/chrony/chrony.conf.j2
+++ b/ansible/roles/ntp/templates/etc/chrony/chrony.conf.j2
@@ -26,8 +26,8 @@ bindaddress {{ address }}
 # Only listen on localhost for command connections
 bindcmdaddress 127.0.0.1
 
-# Do not listen on udp control port on loopback. chronyc can still talk to chronyd via Unix sockets.
-cmdport 0
+# Set the udp control port on loopback. 0 means that chronyc can only talk to chronyd via Unix sockets.
+cmdport {{ ntp__chrony_cmdport }}
 
 {% if ntp__allow == False %}
 # Allow all hosts to connect to the server


### PR DESCRIPTION
In #1236 chrony's `cmdport` setting was set to `0` which disabled localhost UDP monitoring commands.

An example use where that doesn't work, it using [telegraf](https://github.com/influxdata/telegraf) to monitor chrony. When `telegraf` runs as its own user, it cannot read from the `chrony` UNIX socket. (chrony has no option to modify its permissions - it is only for root and the *user* chrony, no the *group* chrony)

It should be safe in many circumstances to allow `chrony` to listen for commands on the localhost address. It only allows read-only commands. From the [`chronyc` man page](https://chrony.tuxfamily.org/doc/3.5/chronyc.html):
> Only the following monitoring commands, which do not affect the behaviour of chronyd, are allowed from the network

I'm also working on [adding sudo support into telegraf](https://github.com/influxdata/telegraf/pull/7669) when running `chronyc`, but that's going to take a bit longer than simply changing the `cmdport` setting.