### PR TITLE
[postfix] Use long form in master.cf

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,12 @@ General
   variables. All role variables have been renamed along with the role inventory
   group, you will have to update your inventory.
 
+:ref:`debops.postfix` role
+''''''''''''''''''''''''''
+
+- Postfix main.cf configuration overrides are now written to master.cf in 'long
+  form'. This allows specifying parameter values that contain whitespace.
+
 Fixed
 ~~~~~
 

--- a/ansible/roles/postfix/templates/etc/postfix/master.cf.j2
+++ b/ansible/roles/postfix/templates/etc/postfix/master.cf.j2
@@ -115,7 +115,7 @@
 {%         if parsed_options | count > 0 %}
 {%           for thing in parsed_options %}
 {%             set thing_commented = ('#' if thing.state|d('present') == 'comment' else '') %}
-{{ '{}  -o {}={}'.format(option_commented if option_commented else thing_commented, thing.name, ([ thing.value ] if thing.value is string else thing.value) | join(',')) }}
+{{ '{}  -o {{ {} = {} }}'.format(option_commented if option_commented else thing_commented, thing.name, ([ thing.value ] if thing.value is string else thing.value) | join(', ')) }}
 {%           endfor %}
 {%         endif %}
 {%       endif %}


### PR DESCRIPTION
Postfix main.cf configuration overrides are now written to master.cf in 'long form'. This allows specifying parameter values that contain whitespace, for example:

`-o { smtpd_sender_restrictions = check_sasl_access ldap:${config_directory}/ldap_known_sender_relays.cf, reject_authenticated_sender_login_mismatch }`

Ref: https://manpages.debian.org/master.5.html