### PR TITLE
[rsnapshot] Fix dry run error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,12 @@ General
 - Fixed an issue where the :command:`debops` scripts did not expand the
   :file:`~/` prefix of the file and directory paths in user home directories.
 
+:ref:`debops.rsnapshot` role
+''''''''''''''''''''''''''''
+
+- Fixed an issue which caused dry runs of the :ref:`debops.rsnapshot` role to
+  fail.
+
 
 `debops v2.1.0`_ - 2020-06-21
 -----------------------------

--- a/ansible/roles/rsnapshot/tasks/main.yml
+++ b/ansible/roles/rsnapshot/tasks/main.yml
@@ -199,6 +199,7 @@
   register: rsnapshot__register_known_hosts
   changed_when: False
   failed_when: False
+  check_mode: False
 
 - name: Scan SSH fingerprints of the configured hosts
   shell: 'ssh-keyscan -H -T 10 -p {{ item.item.ssh_port | d("22") }}


### PR DESCRIPTION
The 'Scan SSH fingerprints of the configured hosts' task fails because
it needs a list of already scanned host fingerprints, which is not
populated on dry runs. This change makes the 'Get list of already
scanned host fingerprints' task execute during dry runs as well.