### PR TITLE
[owncloud] Fix dry run errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,12 @@ General
 - Fixed an issue where the :command:`debops` scripts did not expand the
   :file:`~/` prefix of the file and directory paths in user home directories.
 
+:ref:`debops.owncloud` role
+''''''''''''''''''''''''''''
+
+- Fixed multiple issues which caused dry runs of the :ref:`debops.owncloud` role
+  to incorrectly show pending changes or fail altogether.
+
 
 `debops v2.1.0`_ - 2020-06-21
 -----------------------------

--- a/ansible/roles/owncloud/tasks/tarball.yml
+++ b/ansible/roles/owncloud/tasks/tarball.yml
@@ -58,6 +58,7 @@
         executable: 'sh'
       register: owncloud__register_full_version
       changed_when: False
+      check_mode: False
       tags: [ 'role::nextcloud:verify' ]
 
     # Nextcloud application archive download [[[2
@@ -80,6 +81,7 @@
         - 'zip.asc'
         - 'zip.sha512'
       register: owncloud__register_download_assurance
+      when: not ansible_check_mode
       tags: [ 'role::nextcloud:download', 'role::nextcloud:verify' ]
 
     # Nextcloud application archive authenticity verification [[[2
@@ -93,6 +95,7 @@
         executable: 'sh'
       changed_when: False
       register: owncloud__register_checksum
+      when: not ansible_check_mode  # Latest checksum file may not be available
       tags: [ 'role::nextcloud:download', 'role::nextcloud:verify' ]
 
     - name: Download application archive


### PR DESCRIPTION
I identified the following issues with the tasks in tarball.yml when performing a dry run:

- 'Create source directories' fails, because `owncloud__register_full_version` is not set during dry run.
  Fix: force the task setting `owncloud__register_full_version` to run during dry run. This will trigger a 'changed' notice in the 'Create source directories' task when a new version is available.

- 'Download application files needed for verification' is always changed in dry run mode.
  Fix: skip this task in dry run mode. This should not have a negative impact because these files only need to be downloaded when actually updating the ownCloud version, which does not happen in dry run mode.

- 'Read checksum from file' will fail when there is a new version available, because the verification files have not been downloaded.
  Fix: skip this task in dry run mode.

For a related PR (but for the rsnapshot role), see https://github.com/debops/debops/pull/1409