### PR TITLE
[nginx] Document content_type_options

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,12 @@ General
 - Fixed an issue where the :command:`debops` scripts did not expand the
   :file:`~/` prefix of the file and directory paths in user home directories.
 
+:ref:`debops.nginx`
+'''''''''''''''''''
+
+- Documented the previously undocumented ``content_type_options`` variable for
+  server blocks.
+
 
 `debops v2.1.0`_ - 2020-06-21
 -----------------------------

--- a/docs/ansible/roles/nginx/defaults-detailed.rst
+++ b/docs/ansible/roles/nginx/defaults-detailed.rst
@@ -479,6 +479,13 @@ Locations
 HTTP security headers
 ~~~~~~~~~~~~~~~~~~~~~
 
+``content_type_options``
+  Optional, string. Defaults to ``nosniff``, which indicates to browsers that
+  MIME types advertised in the Content-Type headers should not be changed and be
+  followed. This prevents MIME type sniffing and is the reason why site security
+  testers usually expect this header to be set. Set this variable to
+  ``{{ omit }}`` to exclude the header from all responses.
+
 ``csp``
   Optional, string. Defaults to: ``default-src https: ;`` (force all assets to be loaded over HTTPS).
   Sets the first part of the ``Content-Security-Policy`` header.


### PR DESCRIPTION
This explains the previously undocumented content_type_options variable for nginx__servers.