### PR TITLE
[debops.postgresql] Drop role/database if requested and fix issues with when clauses

### DIFF
--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -96,8 +96,7 @@
   become: True
   become_user: '{{ postgresql__user }}'
   delegate_to: '{{ postgresql__delegate_to }}'
-  when: (((item.name|d() and item.name) or (item.role|d() and item.role)) and
-         (item.state is undefined or item.state != 'absent'))
+  when: item.state|d('present') == 'present'
   no_log: True
 
 - name: Create PostgreSQL databases
@@ -117,11 +116,10 @@
   become: True
   become_user: '{{ postgresql__user }}'
   delegate_to: '{{ postgresql__delegate_to }}'
-  when: (((item.name|d() and item.name) or (item.database|d() and item.database)) and
-         (item.state is undefined or item.state != 'absent') and
-         (item.create_db is undefined or item.create_db))
+  when: (item.state|d('present') == 'present') and
+        item.create_db|d(True)
 
-- name: Enable specified database extensions
+- name: Enable or disable specified database extensions
   postgresql_ext:
     db: '{{ item.database }}'
     name: '{{ item.extension }}'
@@ -133,7 +131,7 @@
   become: True
   become_user: '{{ postgresql__user }}'
   delegate_to: '{{ postgresql__delegate_to }}'
-  when: (item.extension|d() and item.database|d())
+  when: item.state|d('present') in ['present', 'absent']
 
 - name: Grant public schema permissions
   postgresql_privs:
@@ -152,9 +150,8 @@
   become: True
   become_user: '{{ postgresql__user }}'
   delegate_to: '{{ postgresql__delegate_to }}'
-  when: (((item.name|d() and item.name) or (item.database|d() and item.database)) and
-         (item.state is undefined or item.state != 'absent') and
-         (item.owner|d() and item.owner))
+  when: (item.state|d('present') == 'present') and
+        item.owner|d()
 
 - name: Grant PostgreSQL groups
   postgresql_privs:
@@ -172,10 +169,8 @@
   become: True
   become_user: '{{ postgresql__user }}'
   delegate_to: '{{ postgresql__delegate_to }}'
-  when: ((item.roles|d() and item.roles) and
-         (item.groups|d() and item.groups) and
-         (item.database|d() and item.database) and
-         (item.enabled is undefined or item.enabled|bool))
+  when: (item.state|d('present') == 'present') and
+        item.enabled|d(True)|bool
 
 - name: Grant database privileges to PostgreSQL roles
   postgresql_user:
@@ -191,10 +186,8 @@
   become: True
   become_user: '{{ postgresql__user }}'
   delegate_to: '{{ postgresql__delegate_to }}'
-  when: (((item.name|d() and item.name) or (item.role|d() and item.role)) and
-         (item.state is undefined or item.state != 'absent') and
-         (item.db|d() and item.db) and
-         (item.priv|d() and item.priv))
+  when: (item.state|d('present') == 'present') and
+        (item.db|d() and item.priv|d())
   no_log: True
 
 - name: Make sure required system groups exist
@@ -206,7 +199,6 @@
     - '{{ postgresql__pgpass }}'
     - '{{ postgresql_pgpass|d([]) }}'
     - '{{ postgresql__dependent_pgpass }}'
-  when: item.owner|d() and item.owner
   no_log: True
 
 - name: Make sure required system accounts exist
@@ -220,7 +212,6 @@
     - '{{ postgresql__pgpass }}'
     - '{{ postgresql_pgpass|d([]) }}'
     - '{{ postgresql__dependent_pgpass }}'
-  when: item.owner|d() and item.owner
   no_log: True
 
 - name: Populate ~/.pgpass file
@@ -256,5 +247,4 @@
     - '{{ postgresql__pgpass }}'
     - '{{ postgresql_pgpass|d([]) }}'
     - '{{ postgresql__dependent_pgpass }}'
-  when: item.owner|d() and item.owner
   no_log: True

--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -76,6 +76,21 @@
   when: postgresql__register_local_facts|d() and
         postgresql__register_local_facts is changed
 
+- name: Drop PostgreSQL roles if requested
+  postgresql_user:
+    name: '{{ item.name | d(item.role) }}'
+    port: '{{ item.port | d(postgresql__port if postgresql__port else omit) }}'
+    state: 'absent'
+  with_flattened:
+    - '{{ postgresql__roles }}'
+    - '{{ postgresql_roles|d([]) }}'
+    - '{{ postgresql__dependent_roles }}'
+  become: True
+  become_user: '{{ postgresql__user }}'
+  delegate_to: '{{ postgresql__delegate_to }}'
+  when: item.state|d('present') == 'absent'
+  no_log: True
+
 - name: Create PostgreSQL roles
   postgresql_user:
     name: '{{ item.name | d(item.role) }}'
@@ -98,6 +113,20 @@
   delegate_to: '{{ postgresql__delegate_to }}'
   when: item.state|d('present') == 'present'
   no_log: True
+
+- name: Drop PostgreSQL databases if requested
+  postgresql_db:
+    name: '{{ item.name | d(item.database) }}'
+    port: '{{ item.port | d(postgresql__port if postgresql__port else omit) }}'
+    state: 'absent'
+  with_flattened:
+    - '{{ postgresql__databases }}'
+    - '{{ postgresql_databases|d([]) }}'
+    - '{{ postgresql__dependent_databases }}'
+  become: True
+  become_user: '{{ postgresql__user }}'
+  delegate_to: '{{ postgresql__delegate_to }}'
+  when: item.state|d('present') == 'absent'
 
 - name: Create PostgreSQL databases
   postgresql_db:


### PR DESCRIPTION
This PR is meant to fulfil the following goals:

- currently postgresql role doesn't take into account `state: 'ignore'` in `postgresql__*_databases` items nor `postgresql__*_roles` nor `postgresql__*_extensions`
- tasks should fail instead of being skipped when a required key is not defined in `postgresql__*` dictionaries
- databases and roles can be dropped with `state: 'absent'` in `postgresql__*_roles` and `postgresql__*_databases`