### PR TITLE
Fix bool conditions based on non-bool values

### DIFF
--- a/ansible/roles/pki/defaults/main.yml
+++ b/ansible/roles/pki/defaults/main.yml
@@ -485,7 +485,9 @@ pki_scheduler_interval: 'weekly'
 # Specify if Diffie-Hellman parameters should be appended to the certificate
 # chain. This is required by applications that don't support DHE parameters in
 # a separate file like HAproxy, ZNC.
-pki_dhparam: '{{ ansible_local.dhparam.default|d() }}'
+pki_dhparam: '{{ True
+                 if ansible_local.dhparam.default|d()
+                 else False }}'
 
                                                                    # ]]]
 # .. envvar:: pki_dhparam_file [[[

--- a/ansible/roles/root_account/defaults/main.yml
+++ b/ansible/roles/root_account/defaults/main.yml
@@ -152,7 +152,9 @@ root_account__fix_no_tty: True
 #
 # Enable or disable dotfiles management, depending on the availablility of the
 # dotfiles repository installed by the :ref:`debops.yadm` role.
-root_account__dotfiles_enabled: '{{ ansible_local.yadm.dotfiles|d() }}'
+root_account__dotfiles_enabled: '{{ True
+                                    if ansible_local.yadm.dotfiles|d()
+                                    else False }}'
 
                                                                    # ]]]
 # .. envvar:: root_account__dotfiles_repo [[[

--- a/ansible/roles/system_users/defaults/main.yml
+++ b/ansible/roles/system_users/defaults/main.yml
@@ -145,7 +145,9 @@ system_users__admin_groups: '{{ ansible_local.system_groups.access.root
 #
 # Enable or disable management of user dotfiles via :command:`yadm` script. See
 # the :ref:`debops.yadm` role for script installation and dotfile mirroring.
-system_users__dotfiles_enabled: '{{ ansible_local.yadm.dotfiles|d() }}'
+system_users__dotfiles_enabled: '{{ True
+                                    if ansible_local.yadm.dotfiles|d()
+                                    else False }}'
 
                                                                    # ]]]
 # .. envvar:: system_users__dotfiles_repo [[[


### PR DESCRIPTION
Some of the DebOps roles ('pki', 'root_account', 'system_users') use
default variables with boolean values that are conditionally derived
from non-boolean Ansible local facts. These values need to be handled
explicitly by emitting True/False values because Jinja templating can
interpret non-boolean values passed via Ansible local facts in a wrong
way, for example a string which contains a path can be interpreted as
boolean False.