### PR TITLE
tinc interfaces doesnt become bridge member #1398

### DIFF
--- a/ansible/roles/tinc/templates/etc/systemd/system/tinc@.service.j2
+++ b/ansible/roles/tinc/templates/etc/systemd/system/tinc@.service.j2
@@ -11,6 +11,7 @@ Documentation=man:tincd(8) man:tinc.conf(5)
 Documentation=http://tinc-vpn.org/docs/
 PartOf=tinc.service
 ReloadPropagatedFrom=tinc.service
+After=network-online.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
I made the change for the systemd unit. But since I'm not very familiar with systemd I'm still unsure how parameters of the tinc.service are inherited by tinc@.service.

In tinc.service there is 

Wants=network-online.target

But neither this is sufficient nor it does make a difference if we put this in tinc.service.j2
```
After=local-fs.target network-pre.target apparmor.service systemd-sysctl.service systemd-modules-load.service networking.service ifup-allow-all-auto.service ifup-allow-boot.service
```
so it doesn't inherit here anything from tinc.service.