### PR TITLE
[apt] Install gnupg before downloading PGP keys

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,7 +46,7 @@ General
 ''''''''''''''''''''''
 
 - Fixed an issue where the role would attempt adding APT keys from a PGP
-  keyserver without installing gnupg2 first.
+  keyserver without installing gnupg first.
 
 
 `debops v2.1.0`_ - 2020-06-21

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,12 @@ General
 - Fixed an issue where the :command:`debops` scripts did not expand the
   :file:`~/` prefix of the file and directory paths in user home directories.
 
+:ref:`debops.apt` role
+''''''''''''''''''''''
+
+- Fixed an issue where the role would attempt adding APT keys from a PGP
+  keyserver without installing gnupg2 first.
+
 
 `debops v2.1.0`_ - 2020-06-21
 -----------------------------

--- a/ansible/roles/apt/defaults/main.yml
+++ b/ansible/roles/apt/defaults/main.yml
@@ -104,7 +104,7 @@ apt__base_packages:
             [ "wheezy", "jessie", "stretch",
               "precise", "trusty", "xenial" ])
         else [] }}'
-  - 'gnupg2'
+  - 'gnupg'
 
                                                                    # ]]]
 # .. envvar:: apt__packages [[[

--- a/ansible/roles/apt/defaults/main.yml
+++ b/ansible/roles/apt/defaults/main.yml
@@ -104,6 +104,7 @@ apt__base_packages:
             [ "wheezy", "jessie", "stretch",
               "precise", "trusty", "xenial" ])
         else [] }}'
+  - 'gnupg2'
 
                                                                    # ]]]
 # .. envvar:: apt__packages [[[


### PR DESCRIPTION
I noticed this while running the bootstrap playbook: the apt role, when
configured to do so through inventory variables, tries to add APT keys
from a PGP keyserver without installing gnupg2 first. This results in
the following error:

`Failed to find required executable gpg in paths: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`