### PR TITLE
APT preferences: libapache2-mod-php from Sury

### DIFF
--- a/ansible/roles/php/defaults/main.yml
+++ b/ansible/roles/php/defaults/main.yml
@@ -756,7 +756,8 @@ php__apt_preferences__dependent_list:
 
   - packages: [ 'php', 'php5', 'php5*', 'php7*', 'dh-php', 'php-*',
                 'libpcre2-8-0', 'libpcre3', 'libzip4', 'libpcre16-3',
-                'libpcre32-3', 'libpcrecpp0v5', 'libpcre3-dev' ]
+                'libpcre32-3', 'libpcrecpp0v5', 'libpcre3-dev',
+                'libapache2-mod-php' ]
     pin: 'origin "packages.sury.org"'
     priority: '500'
     reason: 'Prefer PHP packages from the same repository for consistency'

--- a/ansible/roles/php/defaults/main.yml
+++ b/ansible/roles/php/defaults/main.yml
@@ -757,7 +757,7 @@ php__apt_preferences__dependent_list:
   - packages: [ 'php', 'php5', 'php5*', 'php7*', 'dh-php', 'php-*',
                 'libpcre2-8-0', 'libpcre3', 'libzip4', 'libpcre16-3',
                 'libpcre32-3', 'libpcrecpp0v5', 'libpcre3-dev',
-                'libapache2-mod-php' ]
+                'libapache2-mod-php', 'libapache2-mod-php*' ]
     pin: 'origin "packages.sury.org"'
     priority: '500'
     reason: 'Prefer PHP packages from the same repository for consistency'


### PR DESCRIPTION
Otherwise, even with php__sury enable, APT try to install the Debian's version : 
```
apt-cache policy libapache2-mod-php
libapache2-mod-php:
  Installed: (none)
  Candidate: 2:7.3+69
  Version table:
     2:7.4+76+0~20200511.26+debian10~1.gbpc9beb6 100
        100 https://packages.sury.org/php buster/main amd64 Packages
     2:7.3+69 500
        500 http://ftp.fr.debian.org/debian buster/main amd64 Packages
        500 http://deb.debian.org/debian buster/main amd64 Packages
```