### PR TITLE
[roundcube] Discard cleandb.sh stdout

### DIFF
--- a/ansible/roles/roundcube/tasks/deploy_roundcube.yml
+++ b/ansible/roles/roundcube/tasks/deploy_roundcube.yml
@@ -120,7 +120,7 @@
   cron:
     name: Roundcube daily database housekeeping
     user: '{{ roundcube__user }}'
-    job: '{{ roundcube__git_dest }}/bin/cleandb.sh'
+    job: '{{ roundcube__git_dest }}/bin/cleandb.sh > /dev/null'
     cron_file: 'roundcube'
     hour: '22'
     minute: '0'


### PR DESCRIPTION
The 'Roundcube daily database housekeeping' cronjob has output similar
to this:
```
0 records deleted from 'contacts'
0 records deleted from 'contactgroups'
0 records deleted from 'identities'
```
The output is sent by email to the roundcube user, whose mailbox is
usually forwarded to the postmaster or system administrator. The
receiver of these emails may find them annoying.

This change discards the output by redirecting it to /dev/null. Error
output however should still be forwarded.