### PR TITLE
Update nginx security directives

### DIFF
--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -476,10 +476,14 @@ nginx_pki_hook_action: 'reload'
 # .. envvar:: nginx_ssl_dhparam [[[
 #
 # Path to the file with Diffie-Hellman parameters to use by the webserver.
-nginx_ssl_dhparam: '{{ (ansible_local.dhparam[nginx_ssl_dhparam_set]
-                        if (ansible_local|d() and ansible_local.dhparam|d() and
-                            ansible_local.dhparam[nginx_ssl_dhparam_set]|d())
-                        else "") }}'
+nginx_ssl_dhparam: '{{ (""
+                        if nginx_default_tls_protocols|length == 1 and
+                           nginx_default_tls_protocols[0] == "TLSv1.3"
+                        else
+                           (ansible_local.dhparam[nginx_ssl_dhparam_set]
+                            if (ansible_local|d() and ansible_local.dhparam|d() and
+                                ansible_local.dhparam[nginx_ssl_dhparam_set]|d())
+                            else "")) }}'
 
                                                                    # ]]]
 # .. envvar:: nginx_ssl_dhparam_set [[[

--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -523,7 +523,7 @@ nginx_default_tls_protocols: '{{ [ "TLSv1.2", "TLSv1.3" ]
 #
 # See also: https://security.stackexchange.com/questions/31772/
 # Set to ``False`` to disable ECC.
-nginx_default_ssl_curve: 'secp384r1:secp256r1:X448:X25519'
+nginx_default_ssl_curve: 'secp384r1:secp256r1'
 
                                                                    # ]]]
 # .. envvar:: nginx_default_ssl_verify_client [[[

--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -492,7 +492,7 @@ nginx_ssl_dhparam_set: 'default'
 #
 # Default set of cipher suites to use.
 # Refer to ``nginx_ssl_ciphers`` for details.
-nginx_default_ssl_ciphers: 'bettercrypto_org__set_b_pfs'
+nginx_default_ssl_ciphers: 'mozilla_intermediate'
 
                                                                    # ]]]
 # .. envvar:: nginx_default_tls_protocols [[[
@@ -501,9 +501,9 @@ nginx_default_ssl_ciphers: 'bettercrypto_org__set_b_pfs'
 # version 1.13.0 and up.
 #
 # See also: https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols
-nginx_default_tls_protocols: '{{ [ "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3" ]
+nginx_default_tls_protocols: '{{ [ "TLSv1.2", "TLSv1.3" ]
                                  if ansible_local.nginx.version|d("0.0.0") is version("1.13.0", ">=")
-                                 else [ "TLSv1", "TLSv1.1", "TLSv1.2" ] }}'
+                                 else [ "TLSv1.2" ] }}'
 
                                                                    # ]]]
 # .. envvar:: nginx_default_ssl_curve [[[
@@ -516,7 +516,7 @@ nginx_default_tls_protocols: '{{ [ "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3" ]
 #
 # See also: https://security.stackexchange.com/questions/31772/
 # Set to ``False`` to disable ECC.
-nginx_default_ssl_curve: 'secp384r1'
+nginx_default_ssl_curve: 'secp521r1:secp384r1:prime256v1'
 
                                                                    # ]]]
 # .. envvar:: nginx_default_ssl_verify_client [[[
@@ -1146,6 +1146,19 @@ nginx_ssl_ciphers:
   # String taken on 2014-04-11
   mozilla: 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-ECDSA-RC4-SHA:AES128:AES256:RC4-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!3DES:!MD5:!PSK'
 
+  # Modern TLS recommendation from Mozilla (https://ssl-config.mozilla.org/)
+  # Nginx already uses these ciphers automatically, if the only protocol is TLSv1.3.
+  # This list is therefore included only for completeness.
+  mozilla_modern: 'TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256'
+
+  # Intermediate TLS recommendation from Mozilla (https://ssl-config.mozilla.org/)
+  # String taken on 2020-07-27
+  mozilla_intermediate: 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384'
+
+  # Old TLS recommendation from Mozilla (https://ssl-config.mozilla.org/)
+  # String taken on 2020-07-27
+  mozilla_old: 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA'
+
   # FIPS 140-2 compliant (https://en.wikipedia.org/wiki/FIPS_140-2)
   # https://community.qualys.com/thread/12182
   fips: 'FIPS@STRENGTH:!aNULL:!eNULL'
@@ -1156,6 +1169,7 @@ nginx_ssl_ciphers:
 
   # This cipher set disables the 'ssl_ciphers' option in 'nginx' and the
   # default set of SSL ciphers for a given platform will be used.
+  # This is recommended when TLSv1.3 is the only protocol in use.
   default: ''
                                                                    # ]]]
                                                                    # ]]]

--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -1156,8 +1156,11 @@ nginx_ssl_ciphers:
   # Modern TLS recommendation from Mozilla (https://ssl-config.mozilla.org/)
   # Actually they do not specify a ciphersuite, because "modern" means TLSv1.3 only,
   # which has its own ciphers, while TLSv1.2 and lower ciphers are not used.
-  # Thus, the nginx default is specified here.
-  mozilla_modern: 'HIGH:!aNULL:!MD5'
+  # Therefore, we just repeat mozilla_intermediate here, to avoid a security hole
+  # that would be created with nginx default ciphersuite and accidential
+  # activation of TLSv1.2 or lower.
+  # String taken on 2020-07-27
+  mozilla_modern: 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384'
 
   # Intermediate TLS recommendation from Mozilla (https://ssl-config.mozilla.org/)
   # String taken on 2020-07-27

--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -1154,9 +1154,10 @@ nginx_ssl_ciphers:
   mozilla: 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-ECDSA-RC4-SHA:AES128:AES256:RC4-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!3DES:!MD5:!PSK'
 
   # Modern TLS recommendation from Mozilla (https://ssl-config.mozilla.org/)
-  # Nginx already uses these ciphers automatically, if the only protocol is TLSv1.3.
-  # This list is therefore included only for completeness.
-  mozilla_modern: 'TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256'
+  # Actually they do not specify a ciphersuite, because "modern" means TLSv1.3 only,
+  # which has its own ciphers, while TLSv1.2 and lower ciphers are not used.
+  # Thus, the nginx default is specified here.
+  mozilla_modern: 'HIGH:!aNULL:!MD5'
 
   # Intermediate TLS recommendation from Mozilla (https://ssl-config.mozilla.org/)
   # String taken on 2020-07-27

--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -496,7 +496,10 @@ nginx_ssl_dhparam_set: 'default'
 #
 # Default set of cipher suites to use.
 # Refer to ``nginx_ssl_ciphers`` for details.
-nginx_default_ssl_ciphers: 'mozilla_intermediate'
+nginx_default_ssl_ciphers: '{{ "mozilla_modern"
+                               if nginx_default_tls_protocols|length == 1 and
+                                  nginx_default_tls_protocols[0] == "TLSv1.3"
+                               else "mozilla_intermediate" }}'
 
                                                                    # ]]]
 # .. envvar:: nginx_default_tls_protocols [[[

--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -523,7 +523,7 @@ nginx_default_tls_protocols: '{{ [ "TLSv1.2", "TLSv1.3" ]
 #
 # See also: https://security.stackexchange.com/questions/31772/
 # Set to ``False`` to disable ECC.
-nginx_default_ssl_curve: 'secp384r1:secp256r1:x448:x25519'
+nginx_default_ssl_curve: 'secp384r1:secp256r1:X448:X25519'
 
                                                                    # ]]]
 # .. envvar:: nginx_default_ssl_verify_client [[[

--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -523,7 +523,7 @@ nginx_default_tls_protocols: '{{ [ "TLSv1.2", "TLSv1.3" ]
 #
 # See also: https://security.stackexchange.com/questions/31772/
 # Set to ``False`` to disable ECC.
-nginx_default_ssl_curve: 'secp384r1:secp256r1'
+nginx_default_ssl_curve: 'secp384r1'
 
                                                                    # ]]]
 # .. envvar:: nginx_default_ssl_verify_client [[[

--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -523,7 +523,7 @@ nginx_default_tls_protocols: '{{ [ "TLSv1.2", "TLSv1.3" ]
 #
 # See also: https://security.stackexchange.com/questions/31772/
 # Set to ``False`` to disable ECC.
-nginx_default_ssl_curve: 'secp521r1:secp384r1:prime256v1'
+nginx_default_ssl_curve: 'secp384r1:secp256r1:x448:x25519'
 
                                                                    # ]]]
 # .. envvar:: nginx_default_ssl_verify_client [[[

--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -571,8 +571,8 @@ nginx_ocsp_resolvers: []
 # https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security
 # Maximum age in seconds for which clients should remember to only make secure
 # connections.
-# Defaults to six earth months.
-nginx_hsts_age: '15768000'
+# Defaults to two earth years.
+nginx_hsts_age: '63072000'
 
                                                                    # ]]]
 # .. envvar:: nginx_hsts_subdomains [[[

--- a/ansible/roles/nginx/templates/etc/nginx/nginx.conf.j2
+++ b/ansible/roles/nginx/templates/etc/nginx/nginx.conf.j2
@@ -37,7 +37,7 @@ events {
 
 http {
         include {{ nginx_etc_path }}/conf.d/*.conf;
-	include {{ nginx_etc_path }}/snippets/ssl.conf;
+        include {{ nginx_etc_path }}/snippets/ssl.conf;
         include /etc/nginx/mime.types;
         default_type application/octet-stream;
 

--- a/ansible/roles/nginx/templates/etc/nginx/nginx.conf.j2
+++ b/ansible/roles/nginx/templates/etc/nginx/nginx.conf.j2
@@ -37,6 +37,7 @@ events {
 
 http {
         include {{ nginx_etc_path }}/conf.d/*.conf;
+	include {{ nginx_etc_path }}/snippets/ssl.conf;
         include /etc/nginx/mime.types;
         default_type application/octet-stream;
 

--- a/ansible/roles/nginx/templates/etc/nginx/sites-available/default.conf.j2
+++ b/ansible/roles/nginx/templates/etc/nginx/sites-available/default.conf.j2
@@ -633,7 +633,10 @@ server {
         ssl_certificate           {{ nginx_tpl_ssl_certificate }};
         ssl_certificate_key       {{ nginx_tpl_ssl_certificate_key }};
         ssl_protocols             {{ (item.tls_protocols | d(nginx_default_tls_protocols)) | join(" ") }};
-        ssl_prefer_server_ciphers off;
+        ssl_prefer_server_ciphers {{ "off"
+                                      if nginx_default_tls_protocols|length == 1 and
+                                         nginx_default_tls_protocols[0] == "TLSv1.3"
+                                      else "on" }};
 {%     if (nginx_ssl_ciphers[item.ssl_ciphers | d(nginx_default_ssl_ciphers)]) %}
         ssl_ciphers               "{{ nginx_ssl_ciphers[item.ssl_ciphers | default(nginx_default_ssl_ciphers)] }}"; # TLS cipher suites set: {{ item.ssl_ciphers | default(nginx_default_ssl_ciphers) }}
 {%     else %}

--- a/ansible/roles/nginx/templates/etc/nginx/sites-available/default.conf.j2
+++ b/ansible/roles/nginx/templates/etc/nginx/sites-available/default.conf.j2
@@ -639,7 +639,7 @@ server {
 {%     else %}
         #ssl_ciphers              "default set of ciphers used by this nginx install";
 {%     endif %}
-{%     if nginx_tpl_ssl_dhparam                             %}
+{%     if nginx_tpl_ssl_dhparam and nginx_tpl_ssl_dhparam != '' %}
         ssl_dhparam               {{ nginx_tpl_ssl_dhparam }};
 {%     endif                                                %}
 {%     if item.ssl_curve | default(nginx_default_ssl_curve) %}

--- a/ansible/roles/nginx/templates/etc/nginx/sites-available/default.conf.j2
+++ b/ansible/roles/nginx/templates/etc/nginx/sites-available/default.conf.j2
@@ -633,7 +633,7 @@ server {
         ssl_certificate           {{ nginx_tpl_ssl_certificate }};
         ssl_certificate_key       {{ nginx_tpl_ssl_certificate_key }};
         ssl_protocols             {{ (item.tls_protocols | d(nginx_default_tls_protocols)) | join(" ") }};
-        ssl_prefer_server_ciphers on;
+        ssl_prefer_server_ciphers off;
 {%     if (nginx_ssl_ciphers[item.ssl_ciphers | d(nginx_default_ssl_ciphers)]) %}
         ssl_ciphers               "{{ nginx_ssl_ciphers[item.ssl_ciphers | default(nginx_default_ssl_ciphers)] }}"; # TLS cipher suites set: {{ item.ssl_ciphers | default(nginx_default_ssl_ciphers) }}
 {%     else %}

--- a/ansible/roles/nginx/templates/etc/nginx/snippets/ssl.conf.j2
+++ b/ansible/roles/nginx/templates/etc/nginx/snippets/ssl.conf.j2
@@ -8,7 +8,10 @@
 # Define default SSL configuration options
 
 ssl_protocols               {{ nginx_default_tls_protocols | join(" ") }};
-ssl_prefer_server_ciphers   off;
+ssl_prefer_server_ciphers   {{ "off"
+                               if nginx_default_tls_protocols|length == 1 and
+                                  nginx_default_tls_protocols[0] == "TLSv1.3"
+                               else "on" }};
 ssl_ciphers                 {{ nginx_ssl_ciphers[nginx_default_ssl_ciphers] }};
 {% if nginx_ssl_dhparam != '' %}
 ssl_dhparam                 {{ nginx_ssl_dhparam }};

--- a/ansible/roles/nginx/templates/etc/nginx/snippets/ssl.conf.j2
+++ b/ansible/roles/nginx/templates/etc/nginx/snippets/ssl.conf.j2
@@ -8,7 +8,7 @@
 # Define default SSL configuration options
 
 ssl_protocols               {{ nginx_default_tls_protocols | join(" ") }};
-ssl_prefer_server_ciphers   on;
+ssl_prefer_server_ciphers   off;
 ssl_ciphers                 {{ nginx_ssl_ciphers[nginx_default_ssl_ciphers] }};
 ssl_dhparam                 {{ nginx_ssl_dhparam }};
 ssl_ecdh_curve              {{ nginx_default_ssl_curve }};

--- a/ansible/roles/nginx/templates/etc/nginx/snippets/ssl.conf.j2
+++ b/ansible/roles/nginx/templates/etc/nginx/snippets/ssl.conf.j2
@@ -10,5 +10,7 @@
 ssl_protocols               {{ nginx_default_tls_protocols | join(" ") }};
 ssl_prefer_server_ciphers   off;
 ssl_ciphers                 {{ nginx_ssl_ciphers[nginx_default_ssl_ciphers] }};
+{% if nginx_ssl_dhparam != '' %}
 ssl_dhparam                 {{ nginx_ssl_dhparam }};
+{% endif %}
 ssl_ecdh_curve              {{ nginx_default_ssl_curve }};

--- a/docs/ansible/roles/nginx/getting-started.rst
+++ b/docs/ansible/roles/nginx/getting-started.rst
@@ -12,6 +12,40 @@ Getting started
       :local:
 
 
+Security defaults
+-----------------
+
+Following `Mozilla intermediate level recommendations`_, this role
+configures nginx with only TLSv1.2 and TLSv1.3 enabled. All modern
+browsers are supported with the default cipher suite. If you need
+support for older clients, see ``nginx_default_ssl_ciphers`` and
+``nginx_default_tls_protocols``. To follow modern level
+recommendation, enable only TLSv1.3 in
+``nginx_default_tls_protocols``. Note that there is still limited
+client support for TLSv1.3.
+
+Only one TLS curve is enabled by default: ``secp256r1``. While
+`NCSC-NL`_ recommends three other curves, these are not supported by
+openssl (in Debian Buster, as checked on 2020-08-06).
+
+If TLSv1.3 is the only protocol in use, clients are allowed to choose
+ciphers, because they know best if they have support for
+hardware-accelerated AES. If TLSv1.2 or lower is used, server ciphers
+are preferred, because those protocols allow downgrade attacks.
+
+No dhparam is set if the only protocol is TLSv1.3, because that
+protocol uses `Ephemeral Diffie-Hellman key exchange`_, which employs
+one-time keys for the current network session. Omitting the option is
+purely cosmetic, resulting in cleaner configuration file.
+
+If `HTTP Strict Transport Security`_ is enabled, the default age is 2
+years.
+
+.. _Mozilla intermediate level recommendations: https://ssl-config.mozilla.org/#server=nginx&version=1.17.7&config=intermediate&openssl=1.1.1d&guideline=5.6
+.. _NCSC-NL: https://english.ncsc.nl/publications/publications/2019/juni/01/it-security-guidelines-for-transport-layer-security-tls
+.. _Ephemeral Diffie-Hellman key exchange: https://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange
+.. _HTTP Strict Transport Security: https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html
+
 Example inventory
 -----------------
 


### PR DESCRIPTION
This adapts the nginx configuration according to [Mozilla recommendations](https://ssl-config.mozilla.org/#server=nginx&version=1.17.7&config=intermediate&openssl=1.1.1d&guideline=5.6):

* updated default cipher suite
* TLSv1.0 and 1.1 removed from default protocols
* default TLS curves expanded

The http block includes the ssl.conf snippet, which avoids having nginx defaults take precedence over desired config in server blocks preceding the one server block containing explicit config directives.

Clients are allowed to choose ciphers, because clients know best if they have support for hardware-accelerated AES.

No dhparam is set if the only protocol is TLSv1.3, because that protocol uses Ephemeral Diffie-Hellman key exchange protocol, which employs one-time keys for the current network session. At the end of the session, the key is discarded. The hard coded protocol identifier is a bit of concern; one may argue that there's no bad coming from specifying dhparam if TLSv1.3 does not use them (removing the need for TLSv1.3 special casing).

Last, HSTS age is raised to 2 years.