### PR TITLE
[ldap] Fix issues related to network bonding

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -116,7 +116,7 @@ LDAP
 :ref:`debops.ldap` role
 '''''''''''''''''''''''
 
-- Fixed multiple issues with adding and updating hosts to the LDAP directory,
+- Fixed multiple issues with adding and updating hosts to the LDAP directory
   when these hosts were configured for network bonding.
 
 :ref:`debops.owncloud` role

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -113,6 +113,12 @@ LDAP
 - Fixed an issue where the role would attempt to add APT keys from a PGP
   keyserver without installing the :command:`gnupg` package first.
 
+:ref:`debops.ldap` role
+'''''''''''''''''''''''
+
+- Fixed multiple issues with adding and updating hosts to the LDAP directory,
+  when these hosts were configured for network bonding.
+
 :ref:`debops.owncloud` role
 ''''''''''''''''''''''''''''
 

--- a/ansible/roles/ldap/defaults/main.yml
+++ b/ansible/roles/ldap/defaults/main.yml
@@ -284,7 +284,7 @@ ldap__device_aliases: [ '{{ ansible_hostname }}' ]
 # attributes, if they are configured to be reachable from outside of the host.
 ldap__device_ip_addresses: '{{ q("template",
                                  "lookup/ldap__device_ip_addresses.j2")
-                                 | from_yaml }}'
+                                 | from_yaml | flatten }}'
 
                                                                    # ]]]
 # .. envvar:: ldap__device_mac_addresses [[[
@@ -295,9 +295,14 @@ ldap__device_ip_addresses: '{{ q("template",
 # Only the Ethernet network interfaces, or their equivalents in the virtual
 # machines or containers, will be included in the list. Any other types of
 # network devices will be skipped.
+#
+# The 'unique' filter is used here to prevent adding duplicate MAC addresses to
+# the device object. This could otherwise cause problems when the host employs
+# network bonding (where the MAC addresses of the physical interfaces can become
+# the same).
 ldap__device_mac_addresses: '{{ q("template",
                                   "lookup/ldap__device_mac_addresses.j2")
-                                  | from_yaml }}'
+                                  | from_yaml | flatten | unique }}'
 
                                                                    # ]]]
 # .. envvar:: ldap__device_self_rdn [[[
@@ -383,8 +388,8 @@ ldap__device_object_classes: '{{ [ "device", "ieee802Device", "ipHost" ]
 # well on any changes.
 ldap__device_attributes:
   cn: '{{ ([ ldap__device_self_rdn.split("=")[1] ] + ldap__device_aliases) | unique }}'
-  ipHostNumber: '{{ ldap__device_ip_addresses  | flatten }}'
-  macAddress:   '{{ ldap__device_mac_addresses | flatten }}'
+  ipHostNumber: '{{ ldap__device_ip_addresses }}'
+  macAddress:   '{{ ldap__device_mac_addresses }}'
   manager:      '{{ ldap__device_managers }}'
                                                                    # ]]]
                                                                    # ]]]

--- a/ansible/roles/ldap/templates/lookup/ldap__device_ip_addresses.j2
+++ b/ansible/roles/ldap/templates/lookup/ldap__device_ip_addresses.j2
@@ -7,7 +7,7 @@
 {% set ldap__tpl_device_ip_addresses = [] %}
 {% for item in ansible_interfaces %}
 {%   set iface = (item | replace('-','_') | regex_replace('^(.*)$', 'ansible_\\1')) %}
-{%   if iface.startswith(('ansible_en', 'ansible_eth', 'ansible_vlan')) %}
+{%   if iface.startswith(('ansible_bond', 'ansible_en', 'ansible_eth', 'ansible_vlan')) %}
 {%     set _ = ldap__tpl_device_interfaces.append(item) %}
 {%   elif hostvars[inventory_hostname][iface].type|d('ether') == 'bridge' %}
 {%     set _ = ldap__tpl_device_masters.append(item) %}


### PR DESCRIPTION
These changes fix the following issues related to creating and updating
host entries in the LDAP database, when the host to be added/updated is
configured with network bonding:

- ldap__device_ip_addresses and ldap__device_mac_addresses were not
  lists, but lists of lists. Flattening happened in another variable.
- ldap__device_ip_addresses did not contain IP addresses of bond*
  interfaces.
- ldap__device_mac_addresses can, when the host is configured for
  network bonding, contain duplicate MAC addresses. This is because
  the Linux Ethernet Bonding Driver changes the MAC address of the
  secondary physical interface so that it uses the same MAC address as
  the primary interface (at least in active-backup setups). This causes
  an ldap.TYPE_OR_VALUE_EXISTS error.