### PR TITLE
[icinga_db] feat remote database access

### DIFF
--- a/ansible/playbooks/service/icinga_db.yml
+++ b/ansible/playbooks/service/icinga_db.yml
@@ -15,5 +15,17 @@
 
   roles:
 
+    - role: mariadb
+      tags: [ 'role::mariadb', 'skip::mariadb' ]
+      mariadb__dependent_databases: '{{ icinga_db__mariadb__dependent_databases }}'
+      mariadb__dependent_users: '{{ icinga_db__mariadb__dependent_users }}'
+      when: (icinga_db__type == 'mariadb')
+
+    - role: postgresql
+      tags: [ 'role::postgresql', 'skip::postgresql' ]
+      postgresql__dependent_roles: '{{ icinga_db__postgresql__dependent_roles }}'
+      postgresql__dependent_databases: '{{ icinga_db__postgresql__dependent_databases }}'
+      when: (icinga_db__type == 'postgresql')
+
     - role: icinga_db
       tags: [ 'role::icinga_db', 'skip::icinga_db' ]

--- a/ansible/roles/icinga_db/defaults/main.yml
+++ b/ansible/roles/icinga_db/defaults/main.yml
@@ -55,6 +55,130 @@ icinga_db__feature: '{{ "ido-pgsql"
                         else ("ido-mysql"
                               if (icinga_db__type == "mariadb")
                               else "unknown") }}'
+
+                                                                   # ]]]
+
+# .. envvar:: icinga_db__dbconfigs [[[
+#
+# Debconf questions and answers for the icinga2-ido-pgsql and icinga2-ido-mysql
+# packages, to install these packages without user interaction.
+icinga_db__dbconfigs:
+
+  - question: 'icinga2-{{ icinga_db__feature }}/dbconfig-install'
+    vtype: 'boolean'
+    value: 'false'
+
+  - question: 'icinga2-{{ icinga_db__feature }}/dbconfig-upgrade'
+    vtype: 'boolean'
+    value: '{{ icinga_db__host == "localhost" }}'
+
+  - question: 'icinga2-{{ icinga_db__feature }}/enable'
+    vtype: 'boolean'
+    value: 'true'
+
+  - question: 'icinga2-{{ icinga_db__feature }}/remote/host'
+    vtype: 'string'
+    value: '{{ icinga_db__host }}'
+
+  - question: 'icinga2-{{ icinga_db__feature }}/remote/port'
+    vtype: 'string'
+    value: '{{ icinga_db__port }}'
+
+  - question: 'icinga2-{{ icinga_db__feature }}/db/dbname'
+    vtype: 'string'
+    value: '{{ icinga_db__database }}'
+
+  - question: 'icinga2-{{ icinga_db__feature }}/db/app-user'
+    vtype: 'string'
+    value: '{{ icinga_db__user }}'
+
+  - question: 'icinga2-{{ icinga_db__feature }}/{{ "pgsql"
+                                                   if icinga_db__type == "postgresql"
+                                                   else ("mysql" if icinga_db__type == "mariadb"
+                                                                 else "")}}/app-pass'
+    vtype: 'password'
+    value: '{{ icinga_db__password }}'
+
+                                                                   # ]]]
+                                                                   # ]]]
+
+# Database configuration [[[
+# --------------------------
+# .. envvar:: icinga_db__host [[[
+#
+# The host where the Icinga 2 database will be installed.
+icinga_db__host: '{{ ansible_local.postgresql.server
+                     if (ansible_local.postgresql.server|d() and
+                         icinga_db__type == "postgresql")
+                     else (ansible_local.mariadb.server
+                           if (ansible_local.mariadb.server|d() and
+                               icinga_db__type == "mariadb")
+                           else "localhost") }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_db__port [[[
+#
+# The port used to connect to the Icinga 2 database.
+icinga_db__port: '{{ ansible_local.postgresql.port
+                     if (ansible_local.postgresql.port|d() and
+                         icinga_db__type == "postgresql")
+                     else (ansible_local.mariadb.port
+                           if (ansible_local.mariadb.server|d() and
+                               icinga_db__type == "mariadb")
+                           else "unknown") }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_db__user [[[
+#
+# Name of the database user for Icinga 2.
+icinga_db__user: 'icinga2'
+
+                                                                   # ]]]
+# .. envvar:: icinga_db__database [[[
+#
+# Name of the database for Icinga 2.
+icinga_db__database: 'icinga2'
+
+                                                                   # ]]]
+# .. envvar:: icinga_db__password_path [[[
+#
+# Path to database password file located on the Ansible Controller. See the
+# :ref:`debops.secret` role for more details.
+icinga_db__password_path: '{{ secret + "/" + icinga_db__type + "/" +
+                                        ansible_local[icinga_db__type].delegate_to }}{%
+                                         if icinga_db__type == "postgresql" %}/{{ ansible_local[icinga_db__type].port }}{% endif
+                                        %}{{ "/credentials/" + icinga_db__user +
+                                        "/password" }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_db__password [[[
+#
+# Password of the Icinga 2 database user.
+icinga_db__password: "{{ lookup('password', icinga_db__password_path
+                                   + ' length=48 chars=ascii_letters,digits,.-_') }}"
+
+                                                                   # ]]]
+# .. envvar:: icinga_db__init [[[
+#
+# Should the Icinga 2 database be initialized ? Per default, it should be
+# initialized only the first time this role runs.
+icinga_db__init: '{{ False if ansible_local.icinga_db.configured|d()
+                           else True }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_db__postgresql_schema [[[
+#
+# Path on the host where this role runs of the PostgreSQL schema. This schema
+# is used to populate the database when it is created.
+icinga_db__postgresql_schema: '/usr/share/icinga2-ido-pgsql/schema/pgsql.sql'
+
+                                                                   # ]]]
+# .. envvar:: icinga_db__mariadb_schema [[[
+#
+# Path on the host where this role runs of the MariaDB schema. This schema
+# is used to populate the database when it is created.
+icinga_db__mariadb_schema: '/usr/share/icinga2-ido-mysql/schema/mysql.sql'
+
                                                                    # ]]]
                                                                    # ]]]
 # APT packages [[[
@@ -79,3 +203,40 @@ icinga_db__base_packages:
 icinga_db__packages: []
                                                                    # ]]]
                                                                    # ]]]
+
+# Configuration for other Ansible roles [[[
+# -----------------------------------------
+
+# .. envvar:: icinga_db__postgresql__dependent_roles [[[
+#
+# Configuration of PostgreSQL roles for :ref:`debops.postgresql` Ansible role.
+icinga_db__postgresql__dependent_roles:
+  - name: '{{ icinga_db__user }}'
+    password: '{{ icinga_db__password }}'
+    db: '{{ icinga_db__database }}'
+    priv: ['ALL']
+
+                                                                   # ]]]
+# .. envvar:: icinga_db__postgresql__dependent_databases [[[
+#
+# Configuration of PostgreSQL databases for the :ref:`debops.postgresql` Ansible
+# role.
+icinga_db__postgresql__dependent_databases:
+  - name: '{{ icinga_db__database }}'
+    owner: '{{ icinga_db__user }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_db__mariadb__dependent_users [[[
+#
+# Configuration of MariaDB users for :ref:`debops.mariadb` Ansible role.
+icinga_db__mariadb__dependent_users:
+  - name: '{{ icinga_db__user }}'
+    password: '{{ icinga_db__password }}'
+    database: '{{ icinga_db__database }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_db__mariadb__dependent_databases [[[
+#
+# Configuration of MariaDB databases for :ref:`debops.mariadb` Ansible role.
+icinga_db__mariadb__dependent_databases:
+  - name: '{{ icinga_db__database }}'

--- a/ansible/roles/icinga_db/tasks/main.yml
+++ b/ansible/roles/icinga_db/tasks/main.yml
@@ -6,17 +6,21 @@
 - import_role:
     name: 'global_handlers'
 
+- import_role:
+    name: 'secret'
+
 - name: Set dbconfig configuration for Icinga database
   debconf:
     name: 'icinga2-{{ icinga_db__feature }}'
-    question: '{{ item }}'
-    vtype: 'boolean'
-    value: 'true'
-  with_items:
-    - 'icinga2-{{ icinga_db__feature }}/dbconfig-install'
-    - 'icinga2-{{ icinga_db__feature }}/dbconfig-upgrade'
+    question: '{{ item.question }}'
+    vtype: '{{ item.vtype }}'
+    value: '{{ item.value }}'
+  with_items: '{{ icinga_db__dbconfigs }}'
   when: icinga_db__icinga_installed|bool and
-        icinga_db__type != 'unknown'
+        icinga_db__type != 'unknown' and
+        item.state|d('present') == 'present'
+  no_log: '{{ item.vtype == "password" }}'
+  changed_when: False
 
 - name: Install required packages
   package:
@@ -29,6 +33,28 @@
   notify: [ 'Check icinga2 configuration and restart' ]
   when: icinga_db__icinga_installed|bool and
         icinga_db__type != 'unknown'
+
+- name: Import Icinga IDO database on installation into PostgreSQL
+  postgresql_db:
+    name: '{{ icinga_db__database }}'
+    state: 'restore'
+    login_host: '{{ icinga_db__host }}'
+    login_password: '{{ icinga_db__password }}'
+    login_user: '{{ icinga_db__user }}'
+    target: '{{ icinga_db__postgresql_schema }}'
+  when: icinga_db__type == 'postgresql' and
+        icinga_db__init|bool
+
+- name: Import Icinga IDO database on installation into MariaDB
+  mysql_db:
+    name: '{{ icinga_db__database }}'
+    state: 'import'
+    login_host: '{{ icinga_db__host }}'
+    login_password: '{{ icinga_db__password }}'
+    login_user: '{{ icinga_db__user }}'
+    target: '{{ icinga_db__mariadb_schema }}'
+  when: icinga_db__type == 'mariadb' and
+        icinga_db__init|bool
 
 - name: Ensure that IDO feature is enabled
   file:


### PR DESCRIPTION
Currently, icinga_db role only works with local database access. As it should run on icinga master nodes, it's a problem when the database is not hosted on the icinga masters.

When installed, icinga2-ido-{pgsql,mysql} does the following:
- it creates the database and the user
- it imports the schema to the created database
- it writes the IDO config to /etc/dbconfig-common/ido-{pgsql,mysql}.conf and to /etc/icinga2/features-available/ido-{pgsql,mysql}.conf

For it to work with a remote database, we would need an administrative remote access (role + database creation) which is insecure.

This PR instead does the following:
- it "manually" creates the database and the user (with postgresql and mariadb dependent variables)
- it configures icinga2-ido-{pgsql,mysql} with debconf, so that icinga2-ido-{pgsql,mysql} won't try to install the user and the database
- it installs icinga2-ido-{pgsql,mysql}
- it "manually" imports the schema

In addition to remote database access, we gain icinga database password handled with password lookup. Currently, the password is created by icinga-ido-{pgsql,mysql} and is weaker than with password lookup.

I have tested with postgresql and mariadb databases, both with local and remote access.