### PR TITLE
[filebeat] How can Filebeat be part of ELK? It is not -> Elastic Stack

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,7 +34,7 @@ New DebOps roles
   entirely in the playbook.
 
 - The :ref:`debops.filebeat` role can be used to install and configure
-  `Filebeat`__, a log shipping agent from Elastic, part of the ELK stack.
+  `Filebeat`__, a log shipping agent from Elastic, part of the Elastic Stack.
 
   .. __: https://www.elastic.co/beats/filebeat
 

--- a/ansible/roles/kibana/meta/main.yml
+++ b/ansible/roles/kibana/meta/main.yml
@@ -30,6 +30,6 @@ galaxy_info:
     - database
     - nosql
     - elasticsearch
-    - elk
+    - elastic
     - dashboard
     - visualization

--- a/docs/ansible/roles/filebeat/defaults-detailed.rst
+++ b/docs/ansible/roles/filebeat/defaults-detailed.rst
@@ -220,8 +220,8 @@ Controller, managed by the :ref:`debops.secret` Ansible role:
 
    filebeat__keys:
 
-     - ELASTIC_PASSWORD: '{{ lookup("file", secret + "/elk-stack/elastic/password") }}'
-     - KIBANA_PASSWORD:  '{{ lookup("file", secret + "/elk-stack/kibana/password") }}'
+     - ELASTIC_PASSWORD: '{{ lookup("file", secret + "/elastic-stack/elastic/password") }}'
+     - KIBANA_PASSWORD:  '{{ lookup("file", secret + "/elastic-stack/kibana/password") }}'
 
 Update an existing key with new content (presence of the ``force`` parameter
 will update the key on each Ansible run):

--- a/docs/ansible/roles/filebeat/man_description.rst
+++ b/docs/ansible/roles/filebeat/man_description.rst
@@ -5,8 +5,8 @@
 Description
 ===========
 
-`Filebeat`__, from `Elastic`__ is part of the Elasticsearch-Logstash-Kibana
-(ELK) stack. Filebeat can be used to parse and "ingest" logs from files,
+`Filebeat`__, from `Elastic`__ is part of the Elastic Stack.
+Filebeat can be used to parse and "ingest" logs from files,
 syslog, and various other sources, parse them and send them off to
 Elasticsearch, Logstash or other destinations.
 


### PR DESCRIPTION
@drybjed You wrote it yourself in the changelog. ELK means "Elasticsearch-Logstash-Kibana". But how can the Beats agents be part of ELK :) ? They are not (which is not nice). That is why Elastic changed the name for good. ELK is legacy for some time now. We should not use such legacy names. They are not precise. https://www.elastic.co/elastic-stack

Other than that, nice work. I will probably look into the role in more detail at some point in time. For now, I only peeked at the diff.

Fixes: #1445