### PR TITLE
[roundcube] Don't unnecessarily create LDAP object

### DIFF
--- a/ansible/roles/roundcube/defaults/main.yml
+++ b/ansible/roles/roundcube/defaults/main.yml
@@ -4593,7 +4593,8 @@ roundcube__ldap__dependent_tasks:
     objectClass: '{{ roundcube__ldap_self_object_classes }}'
     attributes: '{{ roundcube__ldap_self_attributes }}'
     no_log: True
-    state: '{{ "present" if roundcube__ldap_device_dn|d() else "ignore" }}'
+    state: '{{ "present" if roundcube__ldap_password_enabled and
+                            roundcube__ldap_device_dn|d() else "ignore" }}'
 
                                                                    # ]]]
 # .. envvar:: roundcube__nginx__dependent_servers [[[


### PR DESCRIPTION
The role used to create a uid=roundcube object for the host DN, even
when roundcube__ldap_enabled was set to False. This change ensures that
the debops.ldap dependent task is ignored in that case.