### PR TITLE
[nslcd] Configure idle_timelimit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -201,6 +201,14 @@ LDAP
 - Fixed multiple issues with adding and updating hosts to the LDAP directory
   when these hosts were configured for network bonding.
 
+:ref:`debops.nslcd` role
+''''''''''''''''''''''''
+
+- Enabled idle_timelimit to make sure that connections to the LDAP server are
+  properly closed. A disabled or too high idle_timelimit causes the LDAP server
+  to time out, resulting in nslcd errors like "ldap_result() failed: Can't
+  contact LDAP server".
+
 :ref:`debops.ntp` role
 ''''''''''''''''''''''
 

--- a/ansible/roles/nslcd/defaults/main.yml
+++ b/ansible/roles/nslcd/defaults/main.yml
@@ -153,6 +153,14 @@ nslcd__ldap_host_filter: '(|
 # configuration file. See :ref:`nslcd__ref_configuration` for more details, and
 # :man:`nslcd.conf(5)` for possible configuration parameters.
 
+# .. envvar:: nslcd__idle_timelimit [[[
+#
+# The idle timelimit for connections with the LDAP server. This must be lower
+# than the server's olcIdleTimeout, otherwise nslcd will log error messages like
+# "ldap_result() failed: Can't contact LDAP server".
+nslcd__idle_timelimit: '600'
+
+                                                                   # ]]]
 # .. envvar:: nslcd__default_configuration [[[
 #
 # The default :command:`nslcd` configuration options defined by the role.
@@ -168,6 +176,10 @@ nslcd__default_configuration:
   - name: 'uri'
     comment: 'The location at which the LDAP server(s) should be reachable.'
     value: '{{ ansible_local.ldap.uri|d("") }}'
+
+  - name: 'idle_timelimit'
+    comment: 'The idle timelimit for connections with the LDAP server.'
+    value: '{{ nslcd__idle_timelimit }}'
 
   - name: 'base'
     comment: 'The search base that will be used for all queries.'


### PR DESCRIPTION
idle_timelimit used to be disabled by default, which meant that nslcd
would never close a connection. The LDAP server however would (after 900
seconds as configured by olcIdleTimeout). This caused nslcd to log lots
of error messages like "ldap_result() failed: Can't contact LDAP server"

This change sets the default idle_timelimit to 600 seconds.