### PR TITLE
[dhcrelay] Add debops.dhcrelay role

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -349,6 +349,15 @@ stages:
     JANE_DIFF_PATTERN: '.*/roles/dhcpd/.*'
     JANE_LOG_PATTERN: '\[dhcpd\]'
 
+'dhcrelay role':
+  <<: *test_role_no_deps
+  variables:
+    JANE_TEST_FACT: 'dhcrelay.fact'
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/dhcrelay.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_dhcrelay'
+    JANE_DIFF_PATTERN: '.*/roles/dhcrelay/.*'
+    JANE_LOG_PATTERN: '\[dhcrelay\]'
+
 'dhparam role':
   <<: *test_role_no_deps
   variables:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,10 @@ Added
 New DebOps roles
 ''''''''''''''''
 
+- The :ref:`debops.dhcrelay` role can be used to manage the ISC DHCP Relay
+  Agent, which forwards DHCP traffic between networks. This role replaces the
+  dhcrelay functionality in :ref:`debops.dhcpd`.
+
 - The :ref:`debops.global_handlers` Ansible role provides a central place to
   maintain handlers for other Ansible roles. Keeping them centralized allows
   Ansible roles to use handlers from different roles without including them

--- a/ansible/playbooks/net/all.yml
+++ b/ansible/playbooks/net/all.yml
@@ -15,6 +15,8 @@
 
 - import_playbook: tinc.yml
 
+- import_playbook: dhcrelay.yml
+
 - import_playbook: dhcp_probe.yml
 
 - import_playbook: stunnel.yml

--- a/ansible/playbooks/net/dhcrelay.yml
+++ b/ansible/playbooks/net/dhcrelay.yml
@@ -1,0 +1,1 @@
+../service/dhcrelay.yml

--- a/ansible/playbooks/service/dhcrelay.yml
+++ b/ansible/playbooks/service/dhcrelay.yml
@@ -1,0 +1,19 @@
+---
+# Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+# Copyright (C) 2020 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Manage ISC DHCP relay
+  collections: [ 'debops.debops', 'debops.roles01',
+                 'debops.roles02', 'debops.roles03' ]
+  hosts: [ 'debops_service_dhcrelay' ]
+  become: True
+
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
+
+  roles:
+
+    - role: dhcrelay
+      tags: [ 'role::dhcrelay', 'skip::dhcrelay' ]

--- a/ansible/roles/dhcrelay/COPYRIGHT
+++ b/ansible/roles/dhcrelay/COPYRIGHT
@@ -1,0 +1,19 @@
+debops.dhcrelay - Manage ISC DHCP Relay Agent using Ansible
+
+Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+Copyright (C) 2020 DebOps <https://debops.org/>
+SPDX-License-Identifier: GPL-3.0-or-later
+
+This Ansible role is part of DebOps.
+
+DebOps is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 3, as
+published by the Free Software Foundation.
+
+DebOps is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with DebOps. If not, see https://www.gnu.org/licenses/.

--- a/ansible/roles/dhcrelay/defaults/main.yml
+++ b/ansible/roles/dhcrelay/defaults/main.yml
@@ -1,0 +1,57 @@
+---
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+
+# .. Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+# .. Copyright (C) 2020 DebOps <https://debops.org/>
+# .. SPDX-License-Identifier: GPL-3.0-or-later
+
+# .. _dhcrelay__ref_defaults:
+
+# Default variables
+# =================
+
+# .. contents:: Sections
+#    :local:
+#
+# .. include:: ../../../../includes/global.rst
+
+# APT packages [[[
+# ----------------
+
+# .. envvar:: dhcrelay__base_packages [[[
+#
+# List of base packages to install for DHCP server support.
+dhcrelay__base_packages: [ 'isc-dhcp-relay' ]
+
+                                                                   # ]]]
+# .. envvar:: dhcrelay__packages [[[
+#
+# List of additional packages to install with this role.
+dhcrelay__packages: []
+                                                                   # ]]]
+                                                                   # ]]]
+# ISC DHCP relay options [[[
+# --------------------------
+
+# .. envvar:: dhcrelay__servers [[[
+#
+# List of DHCP servers that should receive the relayed packets.
+dhcrelay__servers: [ '{{ ansible_default_ipv4.gateway
+                         if ansible_default_ipv4.gateway|d()
+                         else [] }}' ]
+
+                                                                   # ]]]
+# .. envvar:: dhcrelay__interfaces [[[
+#
+# List of network interfaces that dhcrelay should listen on.
+dhcrelay__interfaces: [ '{{ ansible_local.ifupdown.internal_interface
+                            if ansible_local.ifupdown.internal_interface|d()
+                            else ansible_default_ipv4.interface }}' ]
+
+                                                                   # ]]]
+# .. envvar:: dhcrelay__options [[[
+#
+# Additional dhcrelay options.
+dhcrelay__options: ''
+                                                                   # ]]]
+                                                                   # ]]]

--- a/ansible/roles/dhcrelay/meta/main.yml
+++ b/ansible/roles/dhcrelay/meta/main.yml
@@ -1,0 +1,25 @@
+---
+# Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+# Copyright (C) 2020 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Ensure that custom Ansible plugins and modules included in the main DebOps
+# collection are available to roles in other collections.
+collections: [ 'debops.debops' ]
+
+dependencies: []
+
+galaxy_info:
+
+  author: 'Imre Jonk'
+  description: 'Install and configure ISC DHCP Relay Agent'
+  company: 'DebOps'
+  license: 'GPL-3.0-or-later'
+  min_ansible_version: '2.9.0'
+  platforms:
+    - name: Debian
+      versions:
+        - buster
+  galaxy_tags:
+    - networking
+    - dhcp

--- a/ansible/roles/dhcrelay/tasks/main.yml
+++ b/ansible/roles/dhcrelay/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+# Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+# Copyright (C) 2020 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- import_role:
+    name: 'global_handlers'
+
+- name: Install ISC DHCP relay packages
+  package:
+    name: '{{ (dhcrelay__base_packages + dhcrelay__packages)|flatten }}'
+    state: 'present'
+  register: dhcrelay__register_packages
+  until: dhcrelay__register_packages is succeeded
+
+- name: Divert ISC DHCP relay defaults
+  dpkg_divert:
+    path: '/etc/default/isc-dhcp-relay'
+
+- name: Configure ISC DHCP relay defaults
+  template:
+    src: 'etc/default/isc-dhcp-relay.j2'
+    dest: '/etc/default/isc-dhcp-relay'
+  notify: [ 'Restart isc-dhcp-relay' ]
+
+- name: Make sure that Ansible local facts directory exists
+  file:
+    path: '/etc/ansible/facts.d'
+    state: 'directory'
+
+- name: Save local facts
+  template:
+    src: 'etc/ansible/facts.d/dhcrelay.fact.j2'
+    dest: '/etc/ansible/facts.d/dhcrelay.fact'
+    mode: '0755'
+  register: dhcrelay__register_facts
+
+- name: Update Ansible facts if they were modified
+  action: setup
+  when: dhcrelay__register_facts is changed

--- a/ansible/roles/dhcrelay/templates/etc/ansible/facts.d/dhcrelay.fact.j2
+++ b/ansible/roles/dhcrelay/templates/etc/ansible/facts.d/dhcrelay.fact.j2
@@ -1,0 +1,28 @@
+#!{{ ansible_python['executable'] }}
+
+# Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+# Copyright (C) 2020 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# {{ ansible_managed }}
+
+from json import dumps
+import os
+import subprocess
+
+
+def cmd_exists(cmd):
+    return any(
+        os.access(os.path.join(path, cmd), os.X_OK)
+        for path in os.environ['PATH'].split(os.pathsep)
+    )
+
+
+output = {'installed': cmd_exists('dhcrelay')}
+
+if output['installed']:
+    output['version'] = subprocess.check_output(
+        ['dhcrelay', '--version'], stderr=subprocess.STDOUT
+    ).decode('utf-8').split('-')[2].replace('\n', '')
+
+print(dumps(output, sort_keys=True, indent=4))

--- a/ansible/roles/dhcrelay/templates/etc/default/isc-dhcp-relay.j2
+++ b/ansible/roles/dhcrelay/templates/etc/default/isc-dhcp-relay.j2
@@ -1,0 +1,14 @@
+{# Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+ # Copyright (C) 2020 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-or-later
+ #}
+# {{ ansible_managed }}
+
+# What servers should the DHCP relay forward requests to?
+SERVERS="{{ dhcrelay__servers|join(" ") }}"
+
+# On what interfaces should the DHCP relay (dhrelay) serve DHCP requests?
+INTERFACES="{{ dhcrelay__interfaces|join(" ") }}"
+
+# Additional options that are passed to the DHCP relay daemon?
+OPTIONS="{{ dhcrelay__options }}"

--- a/ansible/roles/global_handlers/handlers/dhcrelay.yml
+++ b/ansible/roles/global_handlers/handlers/dhcrelay.yml
@@ -1,0 +1,9 @@
+---
+# Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+# Copyright (C) 2020 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Restart isc-dhcp-relay
+  service:
+    name: 'isc-dhcp-relay'
+    state: 'restarted'

--- a/ansible/roles/global_handlers/handlers/main.yml
+++ b/ansible/roles/global_handlers/handlers/main.yml
@@ -13,6 +13,8 @@
 
 - import_tasks: 'dhcp_probe.yml'
 
+- import_tasks: 'dhcrelay.yml'
+
 - import_tasks: 'dnsmasq.yml'
 
 - import_tasks: 'docker_gen.yml'

--- a/docs/ansible/role-index.rst
+++ b/docs/ansible/role-index.rst
@@ -249,6 +249,7 @@ Networking
 - :ref:`debops.avahi`
 - :ref:`debops.dhcp_probe`
 - :ref:`debops.dhcpd`
+- :ref:`debops.dhcrelay`
 - :ref:`debops.dnsmasq`
 - :ref:`debops.freeradius`
 - :ref:`debops.ifupdown`

--- a/docs/ansible/roles/dhcrelay/getting-started.rst
+++ b/docs/ansible/roles/dhcrelay/getting-started.rst
@@ -1,0 +1,26 @@
+.. Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+.. Copyright (C) 2020 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-or-later
+
+Getting started
+===============
+
+The default configuration of this role will install isc-dhcp-relay, configure
+it to listen on the internal network interface and forward requests to the
+default IPv4 gateway. A DHCP server should be running on the default IPv4
+gateway; if not, you should change the :envvar:`dhcrelay__servers` variable.
+
+Example playbook
+----------------
+
+If you are using this role without DebOps, here's an example Ansible playbook
+that uses the ``debops.dhcrelay`` role:
+
+.. literalinclude:: ../../../../ansible/playbooks/service/dhcrelay.yml
+   :language: yaml
+   :lines: 1,6-
+
+Other resources
+---------------
+
+It is worth checking out the dhcrelay manpage: :man:`dhcrelay(8)`.

--- a/docs/ansible/roles/dhcrelay/index.rst
+++ b/docs/ansible/roles/dhcrelay/index.rst
@@ -1,0 +1,28 @@
+.. Copyright (C) 2014-2018 Maciej Delmanowski <drybjed@gmail.com>
+.. Copyright (C) 2014-2018 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+.. _debops.dhcrelay:
+
+debops.dhcrelay
+===============
+
+.. include:: man_description.rst
+   :start-line: 7
+
+.. toctree::
+   :maxdepth: 3
+
+   getting-started
+   defaults/main
+
+Copyright
+---------
+
+.. literalinclude:: ../../../../ansible/roles/dhcrelay/COPYRIGHT
+
+..
+ Local Variables:
+ mode: rst
+ ispell-local-dictionary: "american"
+ End:

--- a/docs/ansible/roles/dhcrelay/man_description.rst
+++ b/docs/ansible/roles/dhcrelay/man_description.rst
@@ -1,0 +1,14 @@
+.. Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+.. Copyright (C) 2020 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-or-later
+
+Description
+===========
+
+The ``debops.dhcrelay`` role can be used to configure dhcrelay, the Internet
+Systems Consortium DHCP Relay Agent. dhcrelay can be used to relay DHCPv4
+messages between hosts on one network, and a DHCPv4 server on another network.
+
+This role does not support DHCPv6, as DHCPv6 is currently not supported by the
+init script provided by the isc-dhcp-relay package in Debian Stable. A
+workaround for this can be implemented if there is demand for it.

--- a/docs/ansible/roles/dhcrelay/man_index.rst
+++ b/docs/ansible/roles/dhcrelay/man_index.rst
@@ -1,0 +1,21 @@
+:orphan:
+
+.. Copyright (C) 2014-2018 Maciej Delmanowski <drybjed@gmail.com>
+.. Copyright (C) 2014-2018 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+debops.dhcrelay
+===============
+
+.. toctree::
+   :maxdepth: 3
+
+   man_synopsis
+   man_description
+   getting-started
+
+..
+ Local Variables:
+ mode: rst
+ ispell-local-dictionary: "american"
+ End:

--- a/docs/ansible/roles/dhcrelay/man_synopsis.rst
+++ b/docs/ansible/roles/dhcrelay/man_synopsis.rst
@@ -1,0 +1,8 @@
+.. Copyright (C) 2014-2018 Maciej Delmanowski <drybjed@gmail.com>
+.. Copyright (C) 2014-2018 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+Synopsis
+========
+
+``debops service/dhcrelay`` [**--limit** `group,host,`...] [**--diff**] [**--check**] [**--tags** `tag1,tag2,`...] [**--skip-tags** `tag1,tag2,`...] [<``ansible-playbook`` options>] ...

--- a/docs/news/upgrades.rst
+++ b/docs/news/upgrades.rst
@@ -15,6 +15,25 @@ perform the upgrades between different stable releases.
 Unreleased
 ----------
 
+Splitting up debops.dhcpd
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- A new role has been written for the ISC DHCP Relay Agent:
+  :ref:`debops.dhcrelay`. dhcrelay was originally part of the
+  :ref:`debops.dhcpd` role but will be removed on the next role update. You will
+  need to update your Ansible inventory by adding your dhcrelay hosts to the new
+  ``debops_service_dhcrelay`` group. Inventory variable changes are as follows:
+
+  +----------------------------+--------------------------------+---------------+
+  | Old variable name          | New variable name              | Changed value |
+  +============================+================================+===============+
+  | ``dhcpd_relay_servers``    | :envvar:`dhcrelay__servers`    | No            |
+  +----------------------------+--------------------------------+---------------+
+  | ``dhcpd_relay_interfaces`` | :envvar:`dhcrelay__interfaces` | No            |
+  +----------------------------+--------------------------------+---------------+
+  | ``dhcpd_relay_options``    | :envvar:`dhcrelay__options`    | Yes           |
+  +----------------------------+--------------------------------+---------------+
+
 Changes in the OpenLDAP support
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
`debops.dhcrelay` manages the ISC DHCP Relay Agent on Debian Stable for
forwarding of DHCPv4 messages between networks. The init script for
the isc-dhcp-relay package in Buster (and Bullseye, for that matter)
currently does not support DHCPv6, so this role currently only supports
managing dhcrelay for DHCPv4 relaying. A workaround for this can be
implemented in DebOps if there is demand for it.

This role replaces the dhcrelay functionality in `debops.dhcpd`. The
dhcrelay functionality in `debops.dhcpd` will be removed in the next
role update.