### PR TITLE
[dhcrelay] Import ansible_plugins for dpkg_divert

### DIFF
--- a/ansible/roles/dhcrelay/tasks/main.yml
+++ b/ansible/roles/dhcrelay/tasks/main.yml
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - import_role:
+    name: 'ansible_plugins'
+
+- import_role:
     name: 'global_handlers'
 
 - name: Install ISC DHCP relay packages


### PR DESCRIPTION
The dpkg_divert module is part of the ansible_plugins role, but it was
not imported in `debops.dhcrelay`, resulting in this error:

`ERROR! couldn't resolve module/action 'dpkg_divert'`