### PR TITLE
[resolvconf] Remove variables from fact script

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -139,6 +139,14 @@ LDAP
   since Postfix 3.0. This allows specifying parameter values that contain
   whitespace.
 
+:ref:`debops.resolvconf` role
+'''''''''''''''''''''''''''''
+
+- The 'domain', 'nameservers' and 'search' variables have been removed from the
+  resolvconf Ansible local facts script. You are encouraged to use the
+  `ansible_domain`, `ansible_dns.nameservers` and `ansible_dns.search` variables
+  instead.
+
 :ref:`debops.slapd` role
 ''''''''''''''''''''''''
 

--- a/ansible/roles/dnsmasq/defaults/main.yml
+++ b/ansible/roles/dnsmasq/defaults/main.yml
@@ -408,7 +408,7 @@ dnsmasq__default_configuration:
                    if (
                        (ansible_local.lxc.net_domain|d()) or
                        (ansible_local.resolvconf.upstream_nameservers
-                          | d(ansible_local.resolvconf.nameservers) | ipaddr("private"))
+                          | d(ansible_dns.nameservers) | ipaddr("private"))
                       )
                    else "present" }}'
 

--- a/ansible/roles/docker_server/defaults/main.yml
+++ b/ansible/roles/docker_server/defaults/main.yml
@@ -224,8 +224,7 @@ docker_server__fixed_cidr: ''
 # .. envvar:: docker_server__dns_nameserver [[[
 #
 # List of IP addresses of nameservers used by Docker. By default they
-# are gathered by the :ref:`debops.core` role from the :file:`/etc/resolv.conf` file of
-# the remote host.
+# are gathered from the resolvconf configuration using Ansible facts.
 docker_server__dns_nameserver: '{{ ansible_local.resolvconf.upstream_nameservers
                                    if (ansible_local.resolvconf.upstream_nameservers|d())
                                    else (ansible_dns.nameservers
@@ -235,15 +234,8 @@ docker_server__dns_nameserver: '{{ ansible_local.resolvconf.upstream_nameservers
                                                                    # ]]]
 # .. envvar:: docker_server__dns_search [[[
 #
-# List of DNS search domains to use by Docker. By default they are gathered by
-# the :ref:`debops.core` role from the :file:`/etc/resolv.conf` file of the remote host.
-docker_server__dns_search: '{{ ansible_local.resolvconf.search
-                               if (ansible_local.resolvconf.search|d() and
-                                   (ansible_local.resolvconf.upstream_nameservers|d() or
-                                    "127.0.0.1" not in ansible_dns.nameservers))
-                               else (ansible_dns.search|d()
-                                     if ("127.0.0.1" not in ansible_dns.nameservers)
-                               else []) }}'
+# List of DNS search domains to use by Docker.
+docker_server__dns_search: '{{ ansible_dns.search }}'
                                                                    # ]]]
                                                                    # ]]]
 # Remote Docker connection (TCP) [[[

--- a/ansible/roles/resolvconf/templates/etc/ansible/facts.d/resolvconf.fact.j2
+++ b/ansible/roles/resolvconf/templates/etc/ansible/facts.d/resolvconf.fact.j2
@@ -23,18 +23,11 @@ def read_resolv_file(resolv_file):
     try:
         with open(resolv_file, 'r') as f:
             nameservers = []
-            domain = ''
-            search = []
             for line in f:
                 if line.startswith('nameserver'):
                     nameservers.append(line.strip().split()[1])
-                elif line.startswith('domain'):
-                    domain = line.strip().split()[1]
-                elif line.startswith('search'):
-                    for element in line.strip().split()[1:]:
-                        search.append(element.rstrip('.'))
 
-            return nameservers, domain, search
+            return nameservers
 
     except Exception:
         pass
@@ -50,14 +43,7 @@ if not output['installed']:
     output['deploy_state'] = 'absent'
 
 # Get the primary resolver configuration
-nameservers, domain, search = read_resolv_file('/etc/resolv.conf')
-
-if nameservers:
-    output['nameservers'] = nameservers
-if domain:
-    output['domain'] = domain
-if search:
-    output['search'] = search
+nameservers = read_resolv_file('/etc/resolv.conf')
 
 # Get the upstream resolver configuration
 upstream_nameservers = []
@@ -74,7 +60,7 @@ if os.path.isfile(systemdresolved_path):
 
 for element in resolvconf_files:
     try:
-        nameservers, domain, search = read_resolv_file(element)
+        nameservers = read_resolv_file(element)
 
         for server in nameservers:
             if not server.startswith('127.'):
@@ -87,8 +73,8 @@ for element in resolvconf_files:
 # upstream nameservers, then output the upstream nameservers.
 # - 127.0.0.1 is the stub address used by resolvconf
 # - 127.0.0.53 is the stub address used by systemd-resolved
-if (('127.0.0.1' in output['nameservers'] or
-        '127.0.0.53' in output['nameservers']) and
+if (('127.0.0.1' in nameservers or
+        '127.0.0.53' in nameservers) and
         upstream_nameservers):
     output['upstream_nameservers'] = upstream_nameservers
 

--- a/docs/news/upgrades.rst
+++ b/docs/news/upgrades.rst
@@ -15,6 +15,14 @@ perform the upgrades between different stable releases.
 Unreleased
 ----------
 
+Changes to debops.resolvconf facts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- The 'domain', 'nameservers' and 'search' variables have been removed from the
+  resolvconf Ansible local facts script. You are encouraged to use the
+  `ansible_domain`, `ansible_dns.nameservers` and `ansible_dns.search` variables
+  instead.
+
 Splitting up debops.dhcpd
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This commit removes the 'domain', 'nameservers' and 'search' variables
from the resolvconf Ansible local facts script. `ansible_domain`,
`ansible_dns.nameservers` and `ansible_dns.search` can be used instead.
References in `debops.docker_server` and `debops.dnsmasq` have been
updated to reflect this change.

Closes #1469