### PR TITLE
[owncloud] Make Nextcloud 18.0 the default release

### DIFF
--- a/ansible/roles/owncloud/defaults/main.yml
+++ b/ansible/roles/owncloud/defaults/main.yml
@@ -425,7 +425,7 @@ owncloud__variant_name_map:
 # and the `package index <https://download.owncloud.org/download/repositories/>`_ for more details.
 owncloud__release: '{{ "10.4"
                        if (owncloud__variant == "owncloud")
-                       else "17.0" }}'
+                       else "18.0" }}'
 
 
 # .. envvar:: owncloud__distribution

--- a/ansible/roles/owncloud/meta/watch-nextcloud
+++ b/ansible/roles/owncloud/meta/watch-nextcloud
@@ -6,7 +6,7 @@
 
 # Role: owncloud
 # Package: nextcloud
-# Version: 17.0
+# Version: 18.0
 
 version=4
 https://download.nextcloud.com/server/releases/ nextcloud-(.+)\.tar\.bz2


### PR DESCRIPTION
Nextcloud 17.0 will become end of life in 2020-09, this PR sets 18.0 as the default release. There's no change as 18.0 was already supported.