### PR TITLE
[pki] Install 'acme-tiny' from OS repositories

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -268,6 +268,19 @@ LDAP
   the ``libapache2-mod-php*`` APT packages to ensure that the selected
   repository is the same as the ``php*`` APT packages.
 
+:ref:`debops.pki` role
+''''''''''''''''''''''
+
+- The :command:`acme-tiny` script will be installed from Debian/Ubuntu
+  repositories on Debian Buster, Ubuntu Focal and newer OS releases. This
+  solves the issue with ``acme-tiny`` script in upstream having
+  ``#!/usr/bin/env python`` shebang hard-coded which makes the script unusable
+  on hosts without Python 2.7 installed.
+
+  The installation location of the script from upstream is changed from
+  :file:`/usr/local/lib/pki/` to :file:`/usr/local/bin/` to leverage the
+  ``$PATH`` variable so that the OS version is used without issues.
+
 :ref:`debops.rsnapshot` role
 ''''''''''''''''''''''''''''
 

--- a/ansible/roles/pki/defaults/main.yml
+++ b/ansible/roles/pki/defaults/main.yml
@@ -196,7 +196,7 @@ pki_acme_tiny_src: '{{ (ansible_local.fhs.src | d("/usr/local/src"))
 # .. envvar:: pki_acme_tiny_bin [[[
 #
 # Path where the :program:`acme-tiny` script will be installed.
-pki_acme_tiny_bin: '/usr/local/lib/pki/acme-tiny'
+pki_acme_tiny_bin: '/usr/local/bin/acme-tiny'
 
                                                                    # ]]]
 # .. envvar:: pki_acme_ca [[[
@@ -258,9 +258,13 @@ pki_base_packages: [ 'ssl-cert', 'make', 'ca-certificates',
 # .. envvar:: pki_acme_packages [[[
 #
 # List of APT packages required by ACME support.
-# :program:`acme-tiny` itself is not yet available in Debian Stable.
-# Ref: https://packages.debian.org/source/stretch/acme-tiny
-pki_acme_packages: [ 'curl', 'git' ]
+pki_acme_packages:
+  - 'curl'
+  - 'git'
+  - '{{ [] if (ansible_distribution_release in
+               [ "wheezy", "jessie", "stretch",
+                 "precise", "trusty", "xenial", "bionic" ])
+           else "acme-tiny" }}'
 
                                                                    # ]]]
 # .. envvar:: pki_packages [[[

--- a/ansible/roles/pki/files/usr/local/lib/pki/pki-realm
+++ b/ansible/roles/pki/files/usr/local/lib/pki/pki-realm
@@ -165,7 +165,7 @@ initialize_environment () {
 
     local -A acme_client_script_map
     acme_client_script_map=(
-        ["acme_tiny"]="/usr/local/lib/pki/acme-tiny"
+        ["acme_tiny"]="$(command -v acme-tiny || true)"
     )
 
     config["acme_client_script"]="${acme_client_script_map[${config['acme_client']}]}"

--- a/ansible/roles/pki/tasks/acme_tiny.yml
+++ b/ansible/roles/pki/tasks/acme_tiny.yml
@@ -20,32 +20,38 @@
     createhome: False
     shell: '/bin/false'
 
-- name: Create source directory
-  file:
-    path: '{{ pki_acme_tiny_src }}'
-    state: 'directory'
-    owner: 'root'
-    group: 'root'
-    mode: '0755'
+- name: Install acme-tiny from source
+  when: ansible_distribution_release in
+        [ "wheezy", "jessie", "stretch",
+          "precise", "trusty", "xenial", "bionic" ]
+  block:
 
-- name: Clone acme-tiny source code
-  git:
-    repo: '{{ pki_acme_tiny_repo }}'
-    dest: '{{ pki_acme_tiny_src + "/acme-tiny" }}'
-    version: '{{ pki_acme_tiny_version }}'
-  register: pki_register_acme_tiny_src
+    - name: Create source directory
+      file:
+        path: '{{ pki_acme_tiny_src }}'
+        state: 'directory'
+        owner: 'root'
+        group: 'root'
+        mode: '0755'
 
-- name: Install acme-tiny script
-  command: cp -f {{ pki_acme_tiny_src }}/acme-tiny/acme_tiny.py {{ pki_acme_tiny_bin }}
-  when: pki_register_acme_tiny_src is changed
+    - name: Clone acme-tiny source code
+      git:
+        repo: '{{ pki_acme_tiny_repo }}'
+        dest: '{{ pki_acme_tiny_src + "/acme-tiny" }}'
+        version: '{{ pki_acme_tiny_version }}'
+      register: pki_register_acme_tiny_src
 
-- name: Ensure that acme-tiny is executable
-  file:
-    path: '{{ pki_acme_tiny_bin }}'
-    state: 'file'
-    owner: 'root'
-    group: 'root'
-    mode: '0755'
+    - name: Install acme-tiny script
+      command: cp -f {{ pki_acme_tiny_src }}/acme-tiny/acme_tiny.py {{ pki_acme_tiny_bin }}
+      when: pki_register_acme_tiny_src is changed
+
+    - name: Ensure that acme-tiny is executable
+      file:
+        path: '{{ pki_acme_tiny_bin }}'
+        state: 'file'
+        owner: 'root'
+        group: 'root'
+        mode: '0755'
 
 - name: Create ACME challenge path
   file:


### PR DESCRIPTION
This patch fixes the usage of the 'acme-tiny' script on hosts without
Python 2.7 installed by default.