### PR TITLE
Fix 'python-pip-whl' package situation

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -382,7 +382,7 @@ EOF
         python-nose2-cov \
         python-openssl \
         python-passlib \
-        python-pip-whl \
+        python-pip \
         python-pycodestyle \
         python-pytest \
         python-pytest-cov \

--- a/ansible/roles/docker_server/defaults/main.yml
+++ b/ansible/roles/docker_server/defaults/main.yml
@@ -474,7 +474,6 @@ docker_server__keyring__dependent_apt_keys:
 # Configuration for the :ref:`debops.python` Ansible role.
 docker_server__python__dependent_packages3:
 
-  - 'python3-pip'
   - 'python3-setuptools'
   - 'python3-virtualenv'
   - 'python3-dev'
@@ -485,7 +484,6 @@ docker_server__python__dependent_packages3:
 # Configuration for the :ref:`debops.python` Ansible role.
 docker_server__python__dependent_packages2:
 
-  - 'python-pip-whl'
   - 'python-setuptools'
   - 'python-virtualenv'
   - 'python-dev'

--- a/ansible/roles/preseed/defaults/main.yml
+++ b/ansible/roles/preseed/defaults/main.yml
@@ -495,7 +495,6 @@ preseed__python__dependent_packages3:
   - 'python3-apt'
   - 'python3-pycurl'
   - 'python3-httplib2'
-  - 'python3-pip'
 
                                                                    # ]]]
 # .. envvar:: preseed__python__dependent_packages2 [[[
@@ -507,7 +506,6 @@ preseed__python__dependent_packages2:
   - 'python-apt'
   - 'python-pycurl'
   - 'python-httplib2'
-  - 'python-pip-whl'
 
                                                                    # ]]]
                                                                    # ]]]

--- a/ansible/roles/python/defaults/main.yml
+++ b/ansible/roles/python/defaults/main.yml
@@ -150,7 +150,7 @@ python__core_packages2:
 # opration on the remote host.
 python__base_packages2:
   - 'python-httplib2'
-  - 'python-pip-whl'
+  - 'python-pip'
   - 'python-setuptools'
   - 'python-pycurl'
   - 'python-virtualenv'


### PR DESCRIPTION
The 'python-pip-whl' Debian package does not contain full 'pip'
application, so the 'python-pip' package needs to be installed.

This patch removes the 'python-pip' package installation from all roles
but 'python', which is a dependency of the aformentioned roles.