### PR TITLE
Fix file permissions for nullmailer configs

### DIFF
--- a/ansible/roles/nullmailer/defaults/main.yml
+++ b/ansible/roles/nullmailer/defaults/main.yml
@@ -346,34 +346,42 @@ nullmailer__configuration_files:
 
   - dest: '/etc/nullmailer/idhost'
     content: '{{ nullmailer__idhost }}'
+    mode: '0644'
     state: '{{ "present" if nullmailer__idhost else "absent" }}'
 
   - dest: '/etc/nullmailer/helohost'
     content: '{{ nullmailer__helohost }}'
+    mode: '0644'
     state: '{{ "present" if nullmailer__helohost else "absent" }}'
 
   - dest: '/etc/nullmailer/defaulthost'
     content: '{{ nullmailer__defaulthost }}'
+    mode: '0644'
     state: '{{ "present" if nullmailer__defaulthost else "absent" }}'
 
   - dest: '/etc/nullmailer/defaultdomain'
     content: '{{ nullmailer__defaultdomain }}'
+    mode: '0644'
     state: '{{ "present" if nullmailer__defaultdomain else "absent" }}'
 
   - dest: '/etc/nullmailer/maxpause'
     content: '{{ nullmailer__maxpause }}'
+    mode: '0644'
     state: '{{ "present" if nullmailer__maxpause else "absent" }}'
 
   - dest: '/etc/nullmailer/pausetime'
     content: '{{ nullmailer__pausetime }}'
+    mode: '0644'
     state: '{{ "present" if nullmailer__pausetime else "absent" }}'
 
   - dest: '/etc/nullmailer/sendtimeout'
     content: '{{ nullmailer__sendtimeout }}'
+    mode: '0644'
     state: '{{ "present" if nullmailer__sendtimeout else "absent" }}'
 
   - dest: '/etc/nullmailer/allmailfrom'
     content: '{{ nullmailer__allmailfrom }}'
+    mode: '0644'
     state: '{{ "present" if nullmailer__allmailfrom else "absent" }}'
 
                                                                    # ]]]


### PR DESCRIPTION
After running DebOps on a clean installation, nullmailer seems to be broken.

Sending a mail returns an error (for Google's sake):
```
echo "test" | sendmail test@example.com
nullmailer-inject: nullmailer-queue failed: 18
```

Looking at nullmailer's logs, it seems that some configuration files have wrong permissions and it can't start:
```
[...]
nullmailer-send: Error: Could not read config file "/etc/nullmailer/defaulthost": Permission denied
[...]
```

During DebOps execution, there are some warnings regarding those configs:
```
[WARNING]: File '/etc/nullmailer/idhost' created with default permissions '600'. The previous default was '666'.
Specify 'mode' to avoid this warning.
[WARNING]: File '/etc/nullmailer/helohost' created with default permissions '600'. The previous default was '666'.
Specify 'mode' to avoid this warning.
[WARNING]: File '/etc/nullmailer/defaulthost' created with default permissions '600'. The previous default was '666'.
Specify 'mode' to avoid this warning.
[WARNING]: File '/etc/nullmailer/maxpause' created with default permissions '600'. The previous default was '666'.
Specify 'mode' to avoid this warning.
[WARNING]: File '/etc/nullmailer/pausetime' created with default permissions '600'. The previous default was '666'.
Specify 'mode' to avoid this warning.
[WARNING]: File '/etc/nullmailer/sendtimeout' created with default permissions '600'. The previous default was '666'.
Specify 'mode' to avoid this warning.
```

Not sure if mode 666 is the appropriate permission here, but I have tested it and it works. The /etc/nullmailer/remotes file [seems to have mode 600](https://github.com/debops/debops/blob/master/ansible/roles/nullmailer/defaults/main.yml#L388). Any ideas regarding the permissions are welcome.