### PR TITLE
Filebeat: add optional snippet comment

### DIFF
--- a/ansible/roles/filebeat/templates/etc/filebeat/snippets.d/snippet.yml.j2
+++ b/ansible/roles/filebeat/templates/etc/filebeat/snippets.d/snippet.yml.j2
@@ -5,4 +5,8 @@
 ---
 # {{ ansible_managed }}
 
+{% if item.comment is defined %}
+{{ item.comment | trim | comment}}
+
+{% endif %}
 {{ q("flattened", item.config) | to_nice_yaml(indent=2) }}

--- a/docs/ansible/roles/filebeat/defaults-detailed.rst
+++ b/docs/ansible/roles/filebeat/defaults-detailed.rst
@@ -193,6 +193,9 @@ Each configuration entry is a YAML dictionary with specific parameters:
   an existing file will be removed. If ``ignore``, the entry will not be
   evaluated by Ansible during execution.
 
+``comment``
+  Optional. Comment to be included at the top of the generated file.
+
 ``mode``
   Optional. Specify the filesystem permissions of the generated file. If not
   specified, ``0600`` will be used by default.


### PR DESCRIPTION
Add a way to specify comment to be included at the beginning of the snippet. 