### PR TITLE
[LDAP] Fix 'nextuidgid.schema' OID number

### DIFF
--- a/ansible/roles/slapd/files/etc/ldap/schema/debops/nextuidgid.schema
+++ b/ansible/roles/slapd/files/etc/ldap/schema/debops/nextuidgid.schema
@@ -31,7 +31,7 @@
 
 
 # The nextuidgid.schema namespace
-objectIdentifier nextUidGid DebOpsLDAP:2
+objectIdentifier nextUidGid DebOpsLDAP:3
 
 # The nextuidgid.schema object namespace
 objectIdentifier nextUidGidObject nextUidGid:1

--- a/docs/meta/debops-oid-registry.rst
+++ b/docs/meta/debops-oid-registry.rst
@@ -57,13 +57,15 @@ enterprise.DebOps.DebOpsLDAP / 1.3.6.1.4.1.53622.42
 The Object identifiers for LDAP objects managed by DebOps are defined in the
 ``42`` namespace.
 
-===== ==================================================== ====================
- OID   LDAP schema                                          Ansible role
------ ---------------------------------------------------- --------------------
-1     :ref:`posixgroupid.schema <slapd__ref_posixgroupid>`  :ref:`debops.slapd`
------ ---------------------------------------------------- --------------------
-2     :ref:`mailservice.schema <slapd__ref_mailservice>`    :ref:`debops.slapd`
-===== ==================================================== ====================
+===== ======================================================= ====================
+ OID   LDAP schema                                            Ansible role
+----- ------------------------------------------------------- --------------------
+1     :ref:`posixgroupid.schema <slapd__ref_posixgroupid>`    :ref:`debops.slapd`
+----- ------------------------------------------------------- --------------------
+2     :ref:`mailservice.schema <slapd__ref_mailservice>`      :ref:`debops.slapd`
+----- ------------------------------------------------------- --------------------
+3     :ref:`nextuidgid.schema <slapd__ref_nextuidgid_schema>` :ref:`debops.slapd`
+===== ======================================================= ====================
 
 References
 ----------


### PR DESCRIPTION
The schema used the base OID from the 'mailservice.schema' LDAP schema.
By sheer luck that schema uses .3 suffix for attributes and .4 suffix
for objects, so the collision was not detected by OpenLDAP.

This patch changes the 'nextuidgid.schema' base OID to be unique and
adds a corresponding entry in the DebOps OID Registry.