### PR TITLE
[slapd] Make standalone RADIUS objects connectable

### DIFF
--- a/ansible/roles/slapd/files/etc/ldap/schema/debops/freeradius-client.schema
+++ b/ansible/roles/slapd/files/etc/ldap/schema/debops/freeradius-client.schema
@@ -93,4 +93,4 @@ objectClass ( FreeRADIUSldapRADIUSClientObject:2
               SUP top
               STRUCTURAL
               MUST cn
-              MAY ( uid $ userPassword $ description ) )
+              MAY ( uid $ userPassword $ description $ owner $ manager $ seeAlso ) )

--- a/ansible/roles/slapd/files/etc/ldap/schema/debops/freeradius-profile.schema
+++ b/ansible/roles/slapd/files/etc/ldap/schema/debops/freeradius-profile.schema
@@ -448,4 +448,4 @@ objectClass ( FreeRADIUSldapRADIUSProfileObject:2
               SUP top
               STRUCTURAL
               MUST cn
-              MAY ( uid $ userPassword $ description ) )
+              MAY ( uid $ userPassword $ description $ owner $ seeAlso ) )


### PR DESCRIPTION
This patch adds additional LDAP attributes to standalone FreeRADIUS
Client and Profile objects. These attributes allow for creation of
references from the standalone objects to other entries in the LDAP
directory, for example to claim ownership of a RADIUS Profile by
a particular person.