### PR TITLE
Update debops/ansible/roles/logrotate/tasks/main.yml

### DIFF
--- a/ansible/roles/logrotate/tasks/main.yml
+++ b/ansible/roles/logrotate/tasks/main.yml
@@ -17,8 +17,8 @@
     {% if logrotate__cron_period in [ 'hourly', 'weekly', 'monthly' ] %}
     test -z "$(dpkg-divert --list /etc/cron.daily/logrotate)" \
       || dpkg-divert --quiet --local --rename --remove /etc/cron.daily/logrotate ;
-    dpkg-divert --quiet --local
-                --divert /etc/cron.{{ logrotate__cron_period }}/logrotate
+    dpkg-divert --quiet --local \
+                --divert /etc/cron.{{ logrotate__cron_period }}/logrotate \
                 --rename /etc/cron.daily/logrotate
     {% else %}
     dpkg-divert --quiet --local --rename --remove /etc/cron.daily/logrotate


### PR DESCRIPTION
Otherwise this task fails with an error below


```
cat group_vars/all/logrotate.yml
---
logrotate__cron_period: 'hourly'
logrotate__default_period: 'daily'


------

TASK [logrotate : Manage the log rotation period in cron] **********************************************************************************************************************************************************************
task path: /opt/ansible/lib/python3.7/site-packages/debops/ansible/roles/logrotate/tasks/main.yml:14                                                                                                                           
fatal: [aio1-iev3-srv.local]: FAILED! => {"changed": true, "cmd": "set -o nounset -o pipefail -o errexit &&\ntest -z \"$(dpkg-divert --list /etc/cron.daily/logrotate)\"  || dpkg-divert --quiet --local --rename --remove /etc/
cron.daily/logrotate ;\ndpkg-divert --quiet --local\n            --divert /etc/cron.hourly/logrotate\n            --rename /etc/cron.daily/logrotate\n", "delta": "0:00:00.045689", "end": "2020-09-06 04:12:39.165452", "msg": 
"non-zero return code", "rc": 2, "start": "2020-09-06 04:12:39.119763", "stderr": "dpkg-divert: warning: please specify --no-rename explicitly, the default will change to --rename in 1.20.x\ndpkg-divert: error: --add needs a
 single argument\n\nUse --help for help about diverting files.", "stderr_lines": ["dpkg-divert: warning: please specify --no-rename explicitly, the default will change to --rename in 1.20.x", "dpkg-divert: error: --add needs
 a single argument", "", "Use --help for help about diverting files."], "stdout": "", "stdout_lines": []}
```