### PR TITLE
[pki] Symlink acme-tiny instead of copying it over

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -307,7 +307,8 @@ LDAP
 
   The installation location of the script from upstream is changed from
   :file:`/usr/local/lib/pki/` to :file:`/usr/local/bin/` to leverage the
-  ``$PATH`` variable so that the OS version is used without issues.
+  ``$PATH`` variable so that the OS version is used without issues. The script
+  is now also symlinked into place instead of copied over.
 
 :ref:`debops.rsnapshot` role
 ''''''''''''''''''''''''''''

--- a/ansible/roles/pki/tasks/acme_tiny.yml
+++ b/ansible/roles/pki/tasks/acme_tiny.yml
@@ -39,18 +39,13 @@
         repo: '{{ pki_acme_tiny_repo }}'
         dest: '{{ pki_acme_tiny_src + "/acme-tiny" }}'
         version: '{{ pki_acme_tiny_version }}'
-      register: pki_register_acme_tiny_src
 
     - name: Install acme-tiny script
-      command: cp -f {{ pki_acme_tiny_src }}/acme-tiny/acme_tiny.py {{ pki_acme_tiny_bin }}
-      when: pki_register_acme_tiny_src is changed
-
-    - name: Ensure that acme-tiny is executable
       file:
         path: '{{ pki_acme_tiny_bin }}'
-        state: 'file'
-        owner: 'root'
-        group: 'root'
+        src: '{{ pki_acme_tiny_src }}/acme-tiny/acme_tiny.py'
+        state: 'link'
+        force: True  # Overwrite previously copied script
         mode: '0755'
 
 - name: Create ACME challenge path


### PR DESCRIPTION
This replaces the `Install acme-tiny script` task with a task that uses
the file module to symlink `{{ pki_acme_tiny_bin }}` to
`{{ pki_acme_tiny_src }}/acme-tiny/acme_tiny.py`, instead of copying it
over.

Closes #1506