### PR TITLE
[lvm] Scan Software RAID devices by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -162,6 +162,11 @@ LDAP
   and specific services (user accounts, PAM, :command:`sshd`, :command:`sudo`)
   while leaving higher-level services unaffected.
 
+:ref:`debops.lvm` role
+''''''''''''''''''''''
+
+- Linux Software RAID devices are now scanned by default.
+
 :ref:`debops.nginx` role
 ''''''''''''''''''''''''
 

--- a/ansible/roles/lvm/defaults/main.yml
+++ b/ansible/roles/lvm/defaults/main.yml
@@ -34,7 +34,7 @@ lvm__global_use_lvmetad: True
 # .. envvar:: lvm__devices_filter [[[
 #
 # List of filters that determine what devices are used by ``lvm`` scripts.
-lvm__devices_filter: [ 'a|sd.*|', 'a|vd.*|', 'a|drbd.*|', 'r|.*|' ]
+lvm__devices_filter: [ 'a|sd.*|', 'a|vd.*|', 'a|drbd.*|', 'a|md.*|', 'r|.*|' ]
 
                                                                    # ]]]
 # .. envvar:: lvm__devices_global_filter [[[


### PR DESCRIPTION
This change ensures that LVM scans Linux Software RAID devices
(/dev/md*) for LVM volume groups.