### PR TITLE
Ensure to add _netdev to choosen options

### DIFF
--- a/ansible/roles/nfs/templates/lookup/mount_options.j2
+++ b/ansible/roles/nfs/templates/lookup/mount_options.j2
@@ -1,5 +1,5 @@
-{# Copyright (C) 2013-2017 Maciej Delmanowski <drybjed@gmail.com>
- # Copyright (C) 2015-2017 DebOps <https://debops.org/>
+{# Copyright (C) 2013-2020 Maciej Delmanowski <drybjed@gmail.com>
+ # Copyright (C) 2015-2020 DebOps <https://debops.org/>
  # SPDX-License-Identifier: GPL-3.0-only
  #}
 {% set nfs__tpl_mount_options = [] %}
@@ -13,5 +13,5 @@
 {% if (item.default_options | d(True)) | bool %}
 {{ (nfs__security_mount_options + nfs__tpl_mount_options + nfs__base_mount_options) | unique | join(',') | to_yaml }}
 {% else %}
-{{ '_netdev' | to_yaml }}
+{{ (nfs__tpl_mount_options + [ '_netdev' ]) | unique | join(',') | to_yaml }}
 {% endif %}


### PR DESCRIPTION
Otherwise, with a config like this : 
``` yml
nfs__group_shares:
  - path: "/media/nfs/shared"
    src: 'nas.example.org:/shared'
    default_options: False
    options: [ 'defaults', '…', 'noatime', 'noauto' ]
```

I only got this entry in `/etc/fstab` : 
```
nas.example.org:/shared /media/nfs/shared nfs4 _netdev 0 0
```

With the modification, i now have : 
```
nas.example.org:/shared /media/nfs/shared nfs4 defaults,…,noatime,noauto,_netdev 0 0
```