### PR TITLE
[gitlab_runner] add runner pre/post scripts in config.toml

### DIFF
--- a/ansible/roles/gitlab_runner/templates/etc/gitlab-runner/config.toml.j2
+++ b/ansible/roles/gitlab_runner/templates/etc/gitlab-runner/config.toml.j2
@@ -83,6 +83,21 @@ metrics_server = "{{ gitlab_runner__metrics_server }}"
 {%     if runner.output_limit|d() %}
   output_limit = {{ runner.output_limit }}
 {%     endif %}
+{%     if runner.pre_clone_script|d() %}
+  pre_clone_script = '''
+{{ runner.pre_clone_script | indent(4, true) | regex_replace("((?m)^\s*$|\n$)", "") }}
+  '''
+{%     endif %}
+{%     if runner.pre_build_script|d() %}
+  pre_build_script = '''
+{{ runner.pre_build_script | indent(4, true) | regex_replace("((?m)^\s*$|\n$)", "") }}
+  '''
+{%     endif %}
+{%     if runner.post_build_script|d() %}
+  post_build_script = '''
+{{ runner.post_build_script | indent(4, true) | regex_replace("((?m)^\s*$|\n$)", "") }}
+  '''
+{%     endif %}
 {%     if runner.builds_dir|d() %}
   builds_dir = "{{ runner.builds_dir }}"
 {%     endif %}


### PR DESCRIPTION
This PR adds optional pre_clone_script, pre_build_script and post_build_script in config.toml.

The script must be provided as a (multiline) string in the pre_clone_script (resp pre_build_script,...) key of any gitlab_runner__*_instances variable, ex:

```
gitlab_runner__group_instances:

  - name: '{{ ansible_hostname + "-docker" }}'
    executor: 'docker'
    pre_build_script: |
      sudo chown my_user:my_user -R "$CI_PROJECT_DIR" && \
      echo "done"
```

results in: 

```
[[runners]]
  name = "foo-docker"
  url = "https://code.example.com"
  token = "xxxx"
  executor = "docker"
  pre_build_script = '''
      sudo chown my_user:my_user -R "$CI_PROJECT_DIR" && \
      echo "done"
  '''
```
