### PR TITLE
[nginx] Default template preserve support < 1.7.5

### DIFF
--- a/ansible/roles/nginx/templates/etc/nginx/sites-available/default.conf.j2
+++ b/ansible/roles/nginx/templates/etc/nginx/sites-available/default.conf.j2
@@ -667,7 +667,7 @@ server {
 {%         endif                                                %}
 {%     endif                                                    %}
 {%     if item.hsts_enabled|d(True) | bool                      %}
-        add_header                Strict-Transport-Security "max-age={{ nginx_hsts_age }}{{ "; includeSubDomains" if nginx_hsts_subdomains|bool else "" }}{{ "; preload" if ((item.hsts_preload | d(nginx_hsts_preload)) | bool) else "" }}" always;
+        add_header                Strict-Transport-Security "max-age={{ nginx_hsts_age }}{{ "; includeSubDomains" if nginx_hsts_subdomains|bool else "" }}{{ "; preload" if ((item.hsts_preload | d(nginx_hsts_preload)) | bool) else "" }}"{% if nginx_version is version_compare('1.7.5','>=') %} always{% endif %};
 {% endif                                                    %}
 {% if item.csp_enabled|d(False) | bool %}
         add_header                Content-Security-Policy "{{ item.csp|d("default-src https: ;") + (" " + item.csp_append|d(nginx__http_csp_append) if (item.csp_append|d(nginx__http_csp_append)) else "") }}";


### PR DESCRIPTION
Currently the default template will fail nginx `checkconfig` due to new syntax being used without condition.

This PR is small update to first check the nginx version (as we do elsewhere in the template) before using new syntax.