### PR TITLE
[fcgiwrap] Fix AnsibleFilterError in check mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -322,6 +322,11 @@ LDAP
 - Fixed the configuration support on Ubuntu Focal due to bantime feature
   changes in the :command:`fail2ban` v0.11.
 
+:ref:`debops.fcgiwrap` role
+'''''''''''''''''''''''''''
+
+- The role can now be used in check mode without throwing an AnsibleFilterError.
+
 :ref:`debops.ifupdown` role
 '''''''''''''''''''''''''''
 

--- a/ansible/roles/fcgiwrap/tasks/main.yml
+++ b/ansible/roles/fcgiwrap/tasks/main.yml
@@ -17,6 +17,7 @@
   register: fcgiwrap__register_version
   changed_when: False
   failed_when: False
+  check_mode: False
 
 - name: Make sure required system groups exist
   group:


### PR DESCRIPTION
This solves an issue where the 'Generate systemd units' task fails with
this error: `msg: 'AnsibleFilterError: Version comparison: LooseVersion
instance has no attribute ''version'''`

The task tries to template a systemd service file, but the template
needs fcgiwrap__register_version to do a version comparison. This
variable is never initialized in check mode. This commit changes that by
forcing Ansible to run the 'Check the fcgiwrap version' in check mode as
well.