### PR TITLE
Mount reload remote fs

### DIFF
--- a/ansible/roles/nfs/tasks/main.yml
+++ b/ansible/roles/nfs/tasks/main.yml
@@ -30,6 +30,19 @@
         ansible_distribution == 'Debian' and
         ansible_distribution_release in [ 'wheezy', 'jessie' ]
 
+- name: Ensure that the NFS mount points exist
+  file:
+    path:  '{{ item.path }}'
+    owner: '{{ item.owner | d("root") }}'
+    group: '{{ item.group | d("root") }}'
+    mode:  '{{ item.mode  | d("0755") }}'
+    state: 'directory'
+  with_flattened:
+    - '{{ nfs__shares }}'
+    - '{{ nfs__group_shares }}'
+    - '{{ nfs__host_shares }}'
+  when: item.path|d() and item.src|d() and item.state|d('mounted') == 'present'
+
 - name: Manage NFS mount points
   mount:
     name:   '{{ item.path }}'
@@ -55,16 +68,3 @@
   loop: '{{ nfs__register_devices.results }}'
   when: (ansible_service_mgr == 'systemd' and item is changed and
          (lookup("template", "lookup/mount_options.j2") is match(".*x-systemd.automount.*")))
-
-- name: Ensure that the NFS mount points exist
-  file:
-    path:  '{{ item.path }}'
-    owner: '{{ item.owner | d("root") }}'
-    group: '{{ item.group | d("root") }}'
-    mode:  '{{ item.mode  | d("0755") }}'
-    state: 'directory'
-  with_flattened:
-    - '{{ nfs__shares }}'
-    - '{{ nfs__group_shares }}'
-    - '{{ nfs__host_shares }}'
-  when: item.path|d() and item.src|d() and item.state|d('mounted') == 'present'

--- a/ansible/roles/nfs/tasks/main.yml
+++ b/ansible/roles/nfs/tasks/main.yml
@@ -44,7 +44,17 @@
     - '{{ nfs__shares }}'
     - '{{ nfs__group_shares }}'
     - '{{ nfs__host_shares }}'
+  register: nfs__register_devices
   when: item.path|d() and item.src|d()
+
+- name: Restart 'remote-fs.target' systemd unit
+  systemd:
+    name: 'remote-fs.target'
+    state: 'restarted'
+    daemon_reload: True
+  loop: '{{ nfs__register_devices.results }}'
+  when: (ansible_service_mgr == 'systemd' and item is changed and
+         (lookup("template", "lookup/mount_options.j2") is match(".*x-systemd.automount.*")))
 
 - name: Ensure that the NFS mount points exist
   file:

--- a/docs/ansible/roles/nfs/defaults-detailed.rst
+++ b/docs/ansible/roles/nfs/defaults-detailed.rst
@@ -83,3 +83,18 @@ Mount a NFS4 share with automatic configuration:
    nfs__shares:
      - path: '/media/nfs/shared'
        src: 'nas.example.org:/shared'
+
+Create an automount entry for a NFSv4 share using :command:`systemd`
+automount functionality:
+
+.. code-block:: yaml
+
+   nfs__shares:
+
+     - path: '/media/nfs/shared'
+       src: 'nas.example.org:/shared'
+       opts: [ 'defaults',  'x-systemd.automount', 'x-systemd.idle-timeout=2',
+               'x-systemd.device-timeout=2', 'x-systemd.mount-timeout=2' ]
+       # Without this, Ansible tries to mount the share right away which
+       # results in an error
+       state: 'present'


### PR DESCRIPTION
An adaptation of similar code for local-fs.target in [debops.mount role](https://github.com/debops/debops/blob/master/ansible/roles/mount/tasks/main.yml#L62).

It also check options from `lookup/mount_options.j2` cause the user can add the systemd's automount option in several places (nfs__base_mount…, nfs__default_mount…, item.options,…).