### PR TITLE
[iscsi] Provide default for discovered_portals

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -328,6 +328,11 @@ LDAP
 - Network configuration with bonded interfaces should now be correctly applied
   by the reconfiguration script.
 
+:ref:`debops.iscsi` role
+''''''''''''''''''''''''
+
+- Fixed uninitialized local fact ``ansible_local.iscsi.discovered_portals``.
+
 :ref:`debops.ldap` role
 '''''''''''''''''''''''
 

--- a/ansible/roles/iscsi/tasks/main.yml
+++ b/ansible/roles/iscsi/tasks/main.yml
@@ -62,9 +62,8 @@
     portal:   '{{ item }}'
   with_items: '{{ iscsi__portals }}'
   register: iscsi__register_discover_targets
-  when: (iscsi__portals|d(False) and (ansible_local|d() and ansible_local.iscsi|d() and
-         ansible_local.iscsi.discovered_portals is undefined or
-         (item not in ansible_local.iscsi.discovered_portals)))
+  when: iscsi__portals|d(False) and
+        item not in ansible_local.iscsi.discovered_portals([])
 
 - name: Log in to specified iSCSI targets
   open_iscsi:


### PR DESCRIPTION
This sets an empty list as the default value of
``ansible_local.iscsi.discovered_portals``, preventing an error
condition when the debops.iscsi local facts have not been saved (i.e. on
the first run against a host).