### PR TITLE
Add imre@ciphermail.com to .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -44,7 +44,8 @@ Patrick Heeney <patrickheeney@gmail.com>
 Mariska Hoogenboom <tallandtree@gmail.com> <m.hoogenboom@nl.ccv.eu>
 Mariska Hoogenboom <tallandtree@gmail.com> tallandtree <tallandtree@gmail.com>
 Sandro Jäckel <sandro.jaeckel@gmail.com> Sandro <sandro.jaeckel@gmail.com>
-Imre Jonk <imre@imrejonk.nl> Imre Jonk <mail@imrejonk.nl>
+Imre Jonk <imre@imrejonk.nl> <mail@imrejonk.nl>
+Imre Jonk <imre@imrejonk.nl> <imre@ciphermail.com>
 Werner M. Krauß <werner.krauss@netwerkstatt.at> wernerkrauss <werner.krauss@netwerkstatt.at>
 Nilesh Londhe <nilesh@cloudgeni.us> Nilesh Londhe <lvnilesh@users.noreply.github.com>
 lk <lk@openmailbox.org> lk <lk-minot@users.noreply.github.com>


### PR DESCRIPTION
I've recently changed my Git setup at work. I'm now using a separate PGP
key for work-related stuff (0x7A0BF17EF5AB0D90) and the commits from my
work machine are now authored by Imre Jonk <imre@ciphermail.com>. There
are two reasons for this:

1. Security. I've been using my personal PGP key at work, which can be
   considered a vulnerability. Even though the key resides on a Yubikey,
   I'd like to keep work and personal stuff separated. My work key is
   also on a Yubikey and is signed with my personal key.
2. Copyright/authorship issues. It is much clearer who owns the code I
   write for DebOps when I properly set the commit email address.

I will not use my work email address or PGP key on the mailing list, I
image that might be confusing considering that I'm already subscribed
with my personal address.