### PR TITLE
[opendkim] Remove dependency on pyOpenSSL

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -177,6 +177,15 @@ General
   :command:`ansible-lint` linter. These roles are not yet cleaned up and
   integrated with the main playbook.
 
+- The dependency on ``pyOpenSSL`` has been removed. This dependency was required
+  in Ansible < 2.8.0 because these versions were unable to use the
+  ``cryptography`` module, but DebOps is nowadays developed against Ansible 2.9.
+  pyOpenSSL was used only to generate private RSA keys for the
+  :ref:`debops.opendkim` role. Switching to ``cryptography`` is also a security
+  precaution and the Python Cryptographic Authority
+  [recommends](https://github.com/pyca/cryptography/blob/master/docs/faq.rst#why-use-cryptography)
+  doing so.
+
 LDAP
 ''''
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ RUN apt-get -q update \
        python3-dnspython \
        python3-future \
        python3-ldap \
-       python3-openssl \
        python3-pip \
        python3-wheel \
        python3-setuptools \

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -113,21 +113,13 @@ Ansible:
 
 .. __: https://bitbucket.org/ecollins/passlib/wiki/Home
 
-`pyOpenSSL`__
-  This is a Python wrapper for the OpenSSL library, available in the
-  ``python-openssl`` package. It's a requirement for :ref:`debops.opendkim` and
-  other roles that generate X.509 certificates or private keys on the Ansible
-  Controller.
-
-.. __: https://www.pyopenssl.org/
-
 You can install them using your distribution packages on Debian or
 Ubuntu by running the command:
 
 .. code-block:: console
 
    sudo apt install python3-future python3-ldap python3-netaddr \
-                    python3-dnspython python3-passlib python3-openssl
+                    python3-dnspython python3-passlib
 
 The missing Python dependencies will be automatically installed with the
 ``ansible`` and ``debops`` Python packages, however some of them, like the

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -29,7 +29,6 @@ depends=('python' 'python-distro' 'python-future' 'util-linux' 'encfs' 'gnupg')
 optdepends=(
     'ansible: required to run playbooks and roles'
     'python-dnspython: required by Ansible "dig" module'
-    'python-pyopenssl: required by "openssl_*" Ansible modules'
     'python-netaddr: required by Ansible "ipaddr" filter plugin'
     'python-ldap: required by Ansible "ldap_*" modules'
     'python-passlib: required by Ansible "password" lookup plugin')

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -380,7 +380,6 @@ EOF
         python-netaddr \
         python-nose2 \
         python-nose2-cov \
-        python-openssl \
         python-passlib \
         python-pip \
         python-pycodestyle \
@@ -401,7 +400,6 @@ EOF
         python3-netaddr \
         python3-nose2 \
         python3-nose2-cov \
-        python3-openssl \
         python3-passlib \
         python3-pip \
         python3-pycodestyle \

--- a/docs/ansible/roles/opendkim/defaults-detailed.rst
+++ b/docs/ansible/roles/opendkim/defaults-detailed.rst
@@ -31,12 +31,11 @@ opendkim__keys
 --------------
 
 The ``opendkim__*_keys`` variables define what DomainKeys are created and used
-by OpenDKIM. The private keys are generated on the Ansible Controller (the
-``python-openssl`` package is required), stored in the
-:file:`secret/opendkim/domainkeys/` directory (see :ref:`debops.secret` role for
-details) and copied to the remote hosts.  The role can install the same private
-key on multiple hosts, which can be useful in environments with multiple SMTP
-servers handling the same domains.
+by OpenDKIM. The private keys are generated on the Ansible Controller, stored in
+the :file:`secret/opendkim/domainkeys/` directory (see :ref:`debops.secret` role
+for details) and copied to the remote hosts. The role can install the same
+private key on multiple hosts, which can be useful in environments with multiple
+SMTP servers handling the same domains.
 
 You can use the :file:`secret/opendkim/lib/extract-domainkey-zone` Bash script
 to get the DomainKey public keys which then need to be configured in your DNS

--- a/setup.py
+++ b/setup.py
@@ -80,8 +80,8 @@ try:
         version=unicode(RELEASE),
         install_requires=['distro', 'future'],
         extras_require={
-            'ansible': ['ansible', 'netaddr', 'passlib',
-                        'python-ldap', 'dnspython', 'pyopenssl']
+            'ansible': ['ansible', 'netaddr', 'passlib', 'python-ldap',
+                        'dnspython']
             },
 
         scripts=SCRIPTS,


### PR DESCRIPTION
This dependency was required in Ansible < 2.8.0 because these versions
were unable to use the `cryptography` module, but DebOps is nowadays
developed against Ansible 2.9. pyOpenSSL was used only to generate
private RSA keys for the `debops.opendkim` role. Switching to
`cryptography` is also a security precaution and the Python
Cryptographic Authority [recommends](https://github.com/pyca/cryptography/blob/master/docs/faq.rst#why-use-cryptography)
doing so.

The openssl_privatekey module in `debops.opendkim` will use
`cryptography` when pyOpenSSL is not installed. The Ansible package
depends on this module, so no further changes are required.

Note that this breaks compatibility with the Ansible 2.7 in Debian
Stable, but I believe we aren't trying to maintain compatibility with
that version anymore anyhow.