### PR TITLE
[lvm] Fix check mode bug in fs creation task

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -334,6 +334,13 @@ LDAP
 - Fixed multiple issues with adding and updating hosts to the LDAP directory
   when these hosts were configured for network bonding.
 
+:ref:`debops.lvm` role
+''''''''''''''''''''''
+
+- Fixed an issue where the role would fail in check mode. The role tries to
+  simulate creating a filesystem, but this failed when the underlying LVM volume
+  did not actually exist (which is to be expected when running in check mode).
+
 :ref:`debops.nslcd` role
 ''''''''''''''''''''''''
 

--- a/ansible/roles/lvm/tasks/manage_lvm.yml
+++ b/ansible/roles/lvm/tasks/manage_lvm.yml
@@ -55,6 +55,7 @@
   when: lvm__logical_volumes|d(False) and
         item.vg|d() and item.lv|d() and item.size|d() and
         item.state|d('present') != 'absent'
+  register: lvm__register_logical_volumes
 
 - name: Manage filesystems
   filesystem:
@@ -67,7 +68,9 @@
   when: lvm__logical_volumes|d(False) and
         item.vg|d() and item.lv|d() and item.size|d() and
         item.state|d('present') != 'absent' and
-        ((item.mount|d() and item.fs|d(True)) or item.fs|d())
+        ((item.mount|d() and item.fs|d(True)) or item.fs|d()) and
+        (not ansible_check_mode or
+         (ansible_check_mode and lvm__register_logical_volumes is not changed))
 
 - name: Manage mount points
   mount:


### PR DESCRIPTION
This fixes an issue where the role would fail in check mode. The role
tries to simulate creating a filesystem, but this failed when the
underlying LVM volume did not actually exist (which is to be expected
when running in check mode).