### PR TITLE
[lvm] Mount LVM volumes by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -334,6 +334,14 @@ LDAP
 - Fixed multiple issues with adding and updating hosts to the LDAP directory
   when these hosts were configured for network bonding.
 
+:ref:`debops.lvm` role
+''''''''''''''''''''''
+
+- Made default behaviour match the documentation: the role now automatically
+  takes care of mounting a filesystem on an LVM volume if the mount point is
+  specified with ``item.mount``. This previously required setting the
+  ``item.fs`` parameter to ``True`` as well.
+
 :ref:`debops.nslcd` role
 ''''''''''''''''''''''''
 

--- a/ansible/roles/lvm/tasks/manage_lvm.yml
+++ b/ansible/roles/lvm/tasks/manage_lvm.yml
@@ -82,5 +82,5 @@
   with_items: '{{ lvm__logical_volumes }}'
   when: lvm__logical_volumes|d(False) and
         item.vg|d() and item.lv|d() and item.size|d() and
-        item.fs|d() and item.mount|d() and
+        item.fs|d(True) and item.mount|d() and
         item.state|d('present') != 'absent'

--- a/docs/news/upgrades.rst
+++ b/docs/news/upgrades.rst
@@ -99,6 +99,13 @@ ISC DHCP Server role rewrite
   | ``dhcpd_includes``                  | Removed                                                         |               |
   +-------------------------------------+-----------------------------------------------------------------+---------------+
 
+Changes in :ref:`debops.lvm`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Changed default behaviour: the role now mounts LVM volumes even when
+  ``item.fs`` is not defined. This of course still requires setting the mount
+  point with ``item.mount``.
+
 v2.1.0 (2020-06-21)
 -------------------
 


### PR DESCRIPTION
This makes the default behaviour match the documentation: the role now
automatically takes care of mounting a filesystem on an LVM volume if
the mount point is specified with ``item.mount``. This previously
required setting the ``item.fs`` parameter to ``True`` as well.