### PR TITLE
do not create home dir for snmpd

### DIFF
--- a/ansible/roles/snmpd/tasks/main.yml
+++ b/ansible/roles/snmpd/tasks/main.yml
@@ -68,6 +68,7 @@
     name: '{{ snmpd_user }}'
     groups: '{{ snmpd_proc_hidepid_group }}'
     append: True
+    create_home: False
   when: snmpd_proc_hidepid | bool
   notify: [ 'Restart snmpd' ]
 


### PR DESCRIPTION
this change allow deployment on Ubuntu 20.04