### PR TITLE
mount role: restart remote-fs.target if automount option

### DIFF
--- a/ansible/roles/mount/tasks/main.yml
+++ b/ansible/roles/mount/tasks/main.yml
@@ -69,6 +69,16 @@
          (((item.opts if (item.opts is string) else item.opts | join(','))
            if item.opts|d() else 'defaults') is match(".*x-systemd.automount.*")))
 
+- name: Restart 'remote-fs.target' systemd unit
+  systemd:
+    name: 'remote-fs.target'
+    state: 'restarted'
+    daemon_reload: True
+  loop: '{{ mount__register_devices.results }}'
+  when: (mount__enabled|bool and ansible_service_mgr == 'systemd' and item is changed and
+         (((item.opts if (item.opts is string) else item.opts | join(','))
+           if item.opts|d() else 'defaults') is match(".*x-systemd.automount.*")))
+
 - name: Manage directories
   file:
     path:    '{{ item.path    | d(item.dest | d(item.name)) }}'


### PR DESCRIPTION
As discussed on IRC with @drybjed, debops.mount can also be used to mount remote share (sshfs,…).
debops.nfs role is dedicated to… NFS.

The role already has a restart for local-fs.target if a device has `x-systemd.automount` option. This is an additionnal task to also restart *remote-fs.target*.

I wasn't able to find an easy way to restart the two targets in one task (the task already has a loop on mount__register_devices.results).

Successfully test with automount option :
```
PLAY [Manage local device and bind mounts] ***********************************************************************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] *******************************************************************************************************************************************************************************************************************************************************************************************************
ok: [myhost]

TASK [mount : Install required packages] *************************************************************************************************************************************************************************************************************************************************************************************
ok: [myhost]

TASK [mount : Ensure that the mount points exist] ****************************************************************************************************************************************************************************************************************************************************************************
ok: [myhost] => (item={'name': '/media/sshfs/shared', 'src': 'USER@nas.example.org:/mnt/shared.sshfs', 'fstype': 'fuse.sshfs', 'opts': 'x-systemd.automount,x-systemd.device-timeout=2,x-systemd.idle-timeout=2min,noatime,noauto,intr,allow_other,_netdev', 'state': 'present'})

TASK [mount : Manage device mounts] ******************************************************************************************************************************************************************************************************************************************************************************************
changed: [myhost] => (item={'name': '/media/sshfs/shared', 'src': 'USER@nas.example.org:/mnt/shared.sshfs', 'fstype': 'fuse.sshfs', 'opts': 'x-systemd.automount,x-systemd.device-timeout=2,x-systemd.idle-timeout=2min,noatime,noauto,intr,allow_other,_netdev', 'state': 'present'})

TASK [mount : Restart 'local-fs.target' systemd unit] ************************************************************************************************************************************************************************************************************************************************************************
changed: [myhost] => (item={'src': 'USER@nas.example.org:/mnt/shared.sshfs', 'changed': True, 'name': '/media/sshfs/shared', 'dump': '0', 'fstab': '/etc/fstab', 'passno': '0', 'fstype': 'fuse.sshfs', 'invocation': {'module_args': {'src': 'USER@nas.example.org:/mnt/shared.sshfs', 'dump': None, 'boot': True, 'fstab': None, 'passno': None, 'fstype': 'fuse.sshfs', 'state': 'present', 'path': '/media/sshfs/shared', 'backup': False, 'opts': 'x-systemd.automount,x-systemd.device-timeout=2,x-systemd.idle-timeout=2min,noatime,noauto,intr,allow_other,_netdev'}}, 'opts': 'x-systemd.automount,x-systemd.device-timeout=2,x-systemd.idle-timeout=2min,noatime,noauto,intr,allow_other,_netdev', 'failed': False, 'item': {'name': '/media/sshfs/shared', 'src': 'USER@nas.example.org:/mnt/shared.sshfs', 'fstype': 'fuse.sshfs', 'opts': 'x-systemd.automount,x-systemd.device-timeout=2,x-systemd.idle-timeout=2min,noatime,noauto,intr,allow_other,_netdev', 'state': 'present'}, 'ansible_loop_var': 'item'})

TASK [mount : Restart 'remote-fs.target' systemd unit] ***********************************************************************************************************************************************************************************************************************************************************************
changed: [myhost] => (item={'src': 'USER@nas.example.org:/mnt/shared.sshfs', 'changed': True, 'name': '/media/sshfs/shared', 'dump': '0', 'fstab': '/etc/fstab', 'passno': '0', 'fstype': 'fuse.sshfs', 'invocation': {'module_args': {'src': 'USER@nas.example.org:/mnt/shared.sshfs', 'dump': None, 'boot': True, 'fstab': None, 'passno': None, 'fstype': 'fuse.sshfs', 'state': 'present', 'path': '/media/sshfs/shared', 'backup': False, 'opts': 'x-systemd.automount,x-systemd.device-timeout=2,x-systemd.idle-timeout=2min,noatime,noauto,intr,allow_other,_netdev'}}, 'opts': 'x-systemd.automount,x-systemd.device-timeout=2,x-systemd.idle-timeout=2min,noatime,noauto,intr,allow_other,_netdev', 'failed': False, 'item': {'name': '/media/sshfs/shared', 'src': 'USER@nas.example.org:/mnt/shared.sshfs', 'fstype': 'fuse.sshfs', 'opts': 'x-systemd.automount,x-systemd.device-timeout=2,x-systemd.idle-timeout=2min,noatime,noauto,intr,allow_other,_netdev', 'state': 'present'}, 'ansible_loop_var': 'item'})

TASK [mount : Make sure that Ansible local facts directory exists] ***********************************************************************************************************************************************************************************************************************************************************
ok: [myhost]

TASK [mount : Save mount local facts] ****************************************************************************************************************************************************************************************************************************************************************************************ok: [myhost]

PLAY RECAP *******************************************************************************************************************************************************************************************************************************************************************************************************************
myhost               : ok=8    changed=3    unreachable=0    failed=0    skipped=4    rescued=0    ignored=0
```

And without automount option :
```
PLAY [Manage local device and bind mounts] ***********************************************************************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] *******************************************************************************************************************************************************************************************************************************************************************************************************
ok: [myhost]

TASK [mount : Install required packages] *************************************************************************************************************************************************************************************************************************************************************************************
ok: [myhost]

TASK [mount : Ensure that the mount points exist] ****************************************************************************************************************************************************************************************************************************************************************************
ok: [myhost] => (item={'name': '/media/sshfs/shared', 'src': 'USER@nas.example.org:/mnt/shared.sshfs', 'fstype': 'fuse.sshfs', 'state': 'present'})

TASK [mount : Manage device mounts] ******************************************************************************************************************************************************************************************************************************************************************************************
changed: [myhost] => (item={'name': '/media/sshfs/shared', 'src': 'USER@nas.example.org:/mnt/shared.sshfs', 'fstype': 'fuse.sshfs', 'state': 'present'})

TASK [mount : Make sure that Ansible local facts directory exists] ***********************************************************************************************************************************************************************************************************************************************************
ok: [myhost]

TASK [mount : Save mount local facts] ****************************************************************************************************************************************************************************************************************************************************************************************
ok: [myhost]

PLAY RECAP *******************************************************************************************************************************************************************************************************************************************************************************************************************
myhost               : ok=6    changed=1    unreachable=0    failed=0    skipped=6    rescued=0    ignored=0
```

And my configuration : 
```
mount__group_devices:
  - name: /media/sshfs/shared
    src: 'USER@nas.example.org:/mnt/shared.sshfs'
    fstype: "fuse.sshfs"
    opts: "x-systemd.automount,x-systemd.device-timeout=2,x-systemd.idle-timeout=2min,noatime,noauto,intr,allow_other,_netdev"
    state: 'present'
```