### PR TITLE
[postfix] [bugfix] /etc/postfix/lookup_table.j2 and postfix facts

### DIFF
--- a/ansible/roles/postfix/templates/etc/ansible/facts.d/postfix.fact.j2
+++ b/ansible/roles/postfix/templates/etc/ansible/facts.d/postfix.fact.j2
@@ -19,7 +19,7 @@ output = {'installed': True}
 try:
     with open(os.devnull, 'w') as devnull:
         postconf_stdout = subprocess.check_output(
-            ["LC_MESSAGES=C dpkg-query -W -f='${Version}\n' 'postfix'"],
+            ["LC_MESSAGES=C dpkg-query -W -f='${Version}' 'postfix'"],
             shell=True, stderr=devnull)
 
 except subprocess.CalledProcessError:

--- a/ansible/roles/postfix/templates/etc/postfix/lookup_table.j2
+++ b/ansible/roles/postfix/templates/etc/postfix/lookup_table.j2
@@ -59,7 +59,7 @@
 {%       if element.comment|d() %}
 {{ element.comment | regex_replace('\n$','') | comment(prefix='\n', postfix='') -}}
 {%       endif %}
-{{ ('{}{:<' + (margin + auto_margin['length'])|string + '} {}').format(option_commented, element.key | d(element.name | d(element)), element.action | d(element.value | d(default_action))) }}
+{{ ('{}{:<' + (margin + auto_margin['length'])|string + '} {}').format(option_commented, element.key | d(element.name | d(element)), element.action | d(element.value | d(default_action))).rstrip() }}
 {%     endif %}
 {%   endfor %}
 {% endif %}


### PR DESCRIPTION
This PR addresses two bugfixes in the postfix role. I didn't found any issues regarding this bugs. But for me this was critical to fix.

1. ansible/roles/postfix/templates/etc/postfix/lookup_table.j2

We use postfix lookup tables to store our mynetworks and relaydomains lists. These lookup tables don't have a key value pair. It's a simple list with networks or domains.
Currently the template would add unnessesary trailing whitespaces. (trough margin)
I've added the `rstrip` function to remove all trailing whitespaces.
Now the following is possible without annoying whitespaces at the end:
```
postfix__lookup_tables:
  - name: 'mynetworks'
    default_action: ''
    options:
      - 127.0.0.1/32
      - 9.9.9.9/32
```

2. ansible/roles/postfix/templates/etc/ansible/facts.d/postfix.fact.j2

If you manually uninstall postfix on the target server (`apt remove --purge postfix`) and execute the postfix.fact script, it will return a newline character "\n" for the version. This lead to multiple problems...
I removed the newline character inside the script because is't not needed.
Now the script would return a empty string "" for version.