### PR TITLE
[docker_server] Change when virtualenv is created

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -194,6 +194,14 @@ LDAP
 
 - The DHCP Relay Agent functionality has been moved to :ref:`debops.dhcrelay`.
 
+:ref:`debops.docker_server` role
+''''''''''''''''''''''''''''''''
+
+- The role's virtual environment is no longer created by default when
+  :envvar:`docker_server__upstream` is ``False``. This does not impact existing
+  virtualenvs. You can remove ``/usr/local/lib/docker/virtualenv`` yourself if
+  you like.
+
 :ref:`debops.fhs` role
 ''''''''''''''''''''''
 

--- a/ansible/roles/docker_server/defaults/main.yml
+++ b/ansible/roles/docker_server/defaults/main.yml
@@ -120,7 +120,7 @@ docker_server__mandatory_packages:
 # List of base packages to install with Docker.
 docker_server__base_packages:
   - "aufs-tools"
-  - '{{ [ "virtualenv" ] if (ansible_distribution_release not in ["trusty", "wheezy"]) else [] }}'
+  - '{{ [ "virtualenv" ] if docker_server__install_virtualenv else [] }}'
   - "bridge-utils"
   - '{{ [ "cgroup-lite" ] if (ansible_distribution_release in ["trusty"]) else [] }}'
   - '{{ [] if docker_server__upstream|bool else "docker-compose" }}'
@@ -148,7 +148,7 @@ docker_server__version: '{{ ansible_local.docker_server.version|d("0.0.0") }}'
 # .. envvar:: docker_server__install_virtualenv [[[
 #
 # Whether to install Python virtualenv for Docker.
-docker_server__install_virtualenv: True
+docker_server__install_virtualenv: '{{ docker_server__upstream }}'
 
                                                                    # ]]]
 # .. envvar:: docker_server__virtualenv [[[
@@ -179,12 +179,10 @@ docker_server__virtualenv_python_symlink: '/usr/local/bin/docker-python'
 docker_server__default_pip_packages:
 
   - name: 'docker'
-    state: '{{ "present" if docker_server__upstream|bool else "absent" }}'
 
   - name: 'docker-compose'
     path: '/usr/local/bin/docker-compose'
     src:  '{{ docker_server__virtualenv + "/bin/docker-compose" }}'
-    state: '{{ "present" if docker_server__upstream|bool else "absent" }}'
 
                                                                    # ]]]
 # .. envvar:: docker_server__pip_packages [[[


### PR DESCRIPTION
The role always created a virtualenv, by default in
/usr/local/lib/docker/virtualenv. This is however not necessary when
using the docker.io and docker-compose packages from the Debian
repositories.

These changes ensure that the virtualenv is, by default, only created
when Docker is installed from upstream.

Ref. https://github.com/debops/debops/pull/1552