### PR TITLE
[docker_registry] Turn off Nginx buffering to improve docker push speed; RFC

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -194,6 +194,14 @@ LDAP
 
 - The DHCP Relay Agent functionality has been moved to :ref:`debops.dhcrelay`.
 
+:ref:`debops.docker_registry` role
+''''''''''''''''''''''''''''''''''
+
+- Turn off Nginx request body buffering. Nginx now "streams" large files
+  instead of first having to write them to temporary files before they get
+  forwarded to docker-registry for again writing them to disk.
+  This speeds up :command:`docker push` on systems with slower storage.
+
 :ref:`debops.fhs` role
 ''''''''''''''''''''''
 

--- a/ansible/roles/docker_registry/defaults/main.yml
+++ b/ansible/roles/docker_registry/defaults/main.yml
@@ -610,6 +610,11 @@ docker_registry__nginx__dependent_servers:
 
     options: |
       client_max_body_size {{ docker_registry__max_upload_size }};
+      # Disable buffering.
+      # https://serverfault.com/questions/768693/nginx-how-to-completely-disable-request-body-buffering/818090#818090
+      proxy_http_version 1.1;
+      proxy_request_buffering off;
+      proxy_buffering off;
 
       # required to avoid error HTTP 411: see Issue #1486 (https://github.com/moby/moby/issues/1486)
       chunked_transfer_encoding on;


### PR DESCRIPTION
Feel free to test this change. What do you think if we turn of `proxy_buffering` in more roles? Specially for self hosting, you will not always have the fastest storage and I would argue that for applications handling bigger request bodies like docker-registry does, this Nginx default is bad.