### PR TITLE
[nullmailer] Prevent unnecessary installation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -355,6 +355,14 @@ LDAP
   alternative NTP service implementation and ``systemd-timesyncd`` is not
   available.
 
+:ref:`debops.nullmailer` role
+'''''''''''''''''''''''''''''
+
+- The role will no longer install nullmailer if the host is also configured to
+  install Postfix. This prevents a situation where nullmailer will get installed
+  as part of the common playbook, only to be removed later on in the playbook
+  run.
+
 :ref:`debops.owncloud` role
 ''''''''''''''''''''''''''''
 

--- a/ansible/roles/nullmailer/defaults/main.yml
+++ b/ansible/roles/nullmailer/defaults/main.yml
@@ -23,17 +23,10 @@
 #
 # Enable or disable support for ``nullmailer`` service. The role will check for
 # presence of other Mail Transport Agents on a host and disable itself
-# automatically if needed.
+# automatically if needed. The role will also disable itself if Ansible detects
+# that another MTA should be installed (e.g. when the host is part of the
+# ``debops_service_postfix`` inventory group).
 nullmailer__enabled: True
-
-                                                                   # ]]]
-# .. envvar:: nullmailer__skip_mta [[[
-#
-# The ``debops.nullmailer`` role avoids replacing the currently configured SMTP
-# server if it's detected. To disable this functionality and force the
-# ``nullmailer`` service to replace an existing MTA, set this variable to
-# ``False``.
-nullmailer__skip_mta: True
 
                                                                    # ]]]
 # .. envvar:: nullmailer__skip_mta_packages [[[
@@ -41,6 +34,14 @@ nullmailer__skip_mta: True
 # List of APT packages which, if present, will disable configuration of
 # ``nullmailer`` service.
 nullmailer__skip_mta_packages: [ 'postfix' ]
+
+                                                                   # ]]]
+# .. envvar:: nullmailer__skip_inventory_groups [[[
+#
+# List of inventory groups to skip deployment for. If the host is a member of
+# one or more of these groups, the ``nullmailer`` configuration will be
+# disabled.
+nullmailer__skip_inventory_groups: [ 'debops_service_postfix' ]
 
                                                                    # ]]]
 # .. envvar:: nullmailer__purge_mta_packages [[[

--- a/ansible/roles/nullmailer/tasks/main_env.yml
+++ b/ansible/roles/nullmailer/tasks/main_env.yml
@@ -21,5 +21,6 @@
   set_fact:
     nullmailer__deploy_state: '{{ "present"
                                   if (nullmailer__enabled|bool and
-                                      (not nullmailer__skip_mta|bool or not nullmailer__register_mta.stdout|d()))
+                                      not nullmailer__register_mta.stdout|d() and
+                                      not nullmailer__skip_inventory_groups|intersect(group_names))
                                   else "absent" }}'

--- a/docs/news/upgrades.rst
+++ b/docs/news/upgrades.rst
@@ -15,6 +15,14 @@ perform the upgrades between different stable releases.
 Unreleased
 ----------
 
+Role configuration changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- The :ref:`debops.nullmailer` role has dropped the ``nullmailer__skip_mta``
+  variable. The role now decides whether or not to install nullmailer based on
+  :envvar:`nullmailer__skip_mta_packages` and
+  :envvar:`nullmailer__skip_inventory_groups`.
+
 Changes to debops.resolvconf facts
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This change prevents `debops.nullmailer` from installing nullmailer when
the host is part of the `debops_service_postfix` group.

Closes #652