### PR TITLE
Bugfix: missing parantheses in when-condition of tinc modprobe tasks

### DIFF
--- a/ansible/roles/tinc/tasks/main.yml
+++ b/ansible/roles/tinc/tasks/main.yml
@@ -43,9 +43,9 @@
     state: 'present'
   with_items: '{{ tinc__modprobe_modules }}'
   when: (tinc__modprobe|bool and
-         ((ansible_system_capabilities_enforced|d())|bool and
+         (((ansible_system_capabilities_enforced|d())|bool and
           "cap_sys_admin" in ansible_system_capabilities) or
-         not (ansible_system_capabilities_enforced|d(True))|bool)
+         not (ansible_system_capabilities_enforced|d(True))|bool))
 
 - name: Make sure that required modules are loaded on boot
   lineinfile:
@@ -56,9 +56,9 @@
     mode: '0644'
   with_items: '{{ tinc__modprobe_modules }}'
   when: (tinc__modprobe|bool and
-         ((ansible_system_capabilities_enforced|d())|bool and
+         (((ansible_system_capabilities_enforced|d())|bool and
           "cap_sys_admin" in ansible_system_capabilities) or
-         not (ansible_system_capabilities_enforced|d(True))|bool)
+         not (ansible_system_capabilities_enforced|d(True))|bool))
 
 # Tinc configuration [[[1
 - name: Set tincd default environment


### PR DESCRIPTION
Setting tinc__modprobe to False had no effect and leads to a fatal error when running in lxc container.