### PR TITLE
[nginx] Do not gzip text/vcard MIME types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -395,6 +395,13 @@ LDAP
   specified with ``item.mount``. This previously required setting the
   ``item.fs`` parameter to ``True`` as well.
 
+:ref:`debops.nginx` role
+''''''''''''''''''''''''
+
+- Disabled gzip compression of text/vcard MIME types. Vcards contain, by nature,
+  sensitive information and should not be gzipped to prevent successful BREACH
+  attacks.
+
 :ref:`debops.nslcd` role
 ''''''''''''''''''''''''
 

--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -309,7 +309,6 @@ nginx_http_options: |
     text/cache-manifest
     text/css
     text/plain
-    text/vcard
     text/vnd.rim.location.xloc
     text/vtt
     text/x-component


### PR DESCRIPTION
Vcards contain sensitive information. It's best to disable gzip
compression for them to prevent successful BREACH attacks.

Ref: http://www.breachattack.com/