### PR TITLE
Use HTTPS everywhere (mechanical edit using util from https-everywhere)

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -10,12 +10,12 @@
 # Project Homepage: https://github.com/adrienverge/yamllint
 #
 # How to override rules in files:
-# http://yamllint.readthedocs.io/en/latest/disable_with_comments.html
+# https://yamllint.readthedocs.io/en/latest/disable_with_comments.html
 
 ---
 extends: default
 
-# Rules documentation: http://yamllint.readthedocs.io/en/latest/rules.html
+# Rules documentation: https://yamllint.readthedocs.io/en/latest/rules.html
 rules:
 
   braces:

--- a/ansible/plugins/connection_plugins/lxc_ssh.py
+++ b/ansible/plugins/connection_plugins/lxc_ssh.py
@@ -18,7 +18,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
 #
 import errno
 import fcntl

--- a/ansible/roles/apt_cacher_ng/defaults/main.yml
+++ b/ansible/roles/apt_cacher_ng/defaults/main.yml
@@ -363,7 +363,7 @@ apt_cacher_ng__verbose_log: True
 # request, i.e. all downloads must be processed by the preconfigured remapping
 # backends.
 # Set to ``False`` by default to allow to download other repositories via the proxy like
-# `download.owncloud.org <http://download.owncloud.org/download/repositories/>`_.
+# `download.owncloud.org <https://download.owncloud.org/download/repositories/>`_.
 apt_cacher_ng__force_managed: False
 
                                                                    # ]]]

--- a/ansible/roles/apt_cacher_ng/templates/etc/apt-cacher-ng/userinfo.html.j2
+++ b/ansible/roles/apt_cacher_ng/templates/etc/apt-cacher-ng/userinfo.html.j2
@@ -59,7 +59,7 @@
                   <h3>Related links</h3>
                   <ul>
                      <li><a href="${cfg:ReportPage}">Statistics report and configuration page</a> for this Apt-Cacher NG installation</li>
-                     <li><a href="http://www.unix-ag.uni-kl.de/~bloch/acng/">Project Homepage</a>
+                     <li><a href="https://www.unix-ag.uni-kl.de/~bloch/acng/">Project Homepage</a>
                   </ul>
 
                   ${footer}

--- a/ansible/roles/backup2l/templates/etc/backup2l.conf.j2
+++ b/ansible/roles/backup2l/templates/etc/backup2l.conf.j2
@@ -413,7 +413,7 @@ DRIVER_TAR_GPG ()
 # NOTES: USE ONLY WITH MULTI CORE CPU
 # REQUIRES YOU TO DOWNLOAD AND COMPILE PIGZ
 # OR INSTALL IT FROM YOUR DISTRO REPOSITORY
-# http://www.zlib.net/pigz/
+# https://www.zlib.net/pigz/
 #
 DRIVER_TAR_GZ_PIGZ () {
     case $1 in

--- a/ansible/roles/btrfs/library/btrfs_subvolume.py
+++ b/ansible/roles/btrfs/library/btrfs_subvolume.py
@@ -17,7 +17,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
 
 # import module snippets
 from ansible.module_utils.basic import *

--- a/ansible/roles/dokuwiki/files/srv/www/dokuwiki/farm/animal/README
+++ b/ansible/roles/dokuwiki/files/srv/www/dokuwiki/farm/animal/README
@@ -1,1 +1,1 @@
-This is an animal template for a DokuWiki Farm [http://www.dokuwiki.org/farms].
+This is an animal template for a DokuWiki Farm [https://www.dokuwiki.org/farms].

--- a/ansible/roles/dokuwiki/templates/srv/www/dokuwiki/sites/public/inc/preload.php.j2
+++ b/ansible/roles/dokuwiki/templates/srv/www/dokuwiki/sites/public/inc/preload.php.j2
@@ -7,7 +7,7 @@
  * {{ ansible_managed }}
  *
  * This is an example for a farm setup. Simply copy this file to preload.php and
- * uncomment what you need. See http://www.dokuwiki.org/farms for more information.
+ * uncomment what you need. See https://www.dokuwiki.org/farms for more information.
  * You can also use preload.php for other things than farming, e.g. for moving
  * local configuration files out of the main ./conf directory.
  */

--- a/ansible/roles/dovecot/defaults/main.yml
+++ b/ansible/roles/dovecot/defaults/main.yml
@@ -161,7 +161,7 @@ dovecot_sql_password: ''
 #
 # Default passwort scheme for passwords, stored in a SQL database.
 # For more information about the supported schemes, check `Authentication /
-# PasswordSchemes <http://wiki2.dovecot.org/Authentication/PasswordSchemes>`_
+# PasswordSchemes <https://doc.dovecot.org/configuration_manual/authentication/password_schemes/>`_
 dovecot_sql_default_pass_scheme: 'SSHA512'
 
                                                                    # ]]]
@@ -179,7 +179,7 @@ dovecot_sql_password_query: "SELECT userid AS username, domain, password FROM us
 #
 # Optional the mail_location can be defined with the option ``mail``.
 # For more information about the mail_location, check `MailLocation
-# <http://wiki2.dovecot.org/MailLocation>`_
+# <https://doc.dovecot.org/configuration_manual/mail_location/>`_
 dovecot_sql_user_query: "SELECT home, uid, gid FROM users WHERE userid = '%n' AND domain = '%d'"
 
                                                                    # ]]]
@@ -299,7 +299,7 @@ dovecot__tls_ca_cert_dir: '/etc/ssl/certs/'
 #
 # Requires SSL/TLS also for non-plaintext authentication. For more
 # information check ``ssl_required`` in `Dovecot SSL Configuration
-# <http://wiki2.dovecot.org/SSL/DovecotConfiguration>`_
+# <https://wiki.dovecot.org/SSL/DovecotConfiguration>`_
 dovecot_ssl_required: True
 
                                                                    # ]]]

--- a/ansible/roles/dovecot/templates/etc/dovecot/dovecot-sql.conf.ext.j2
+++ b/ansible/roles/dovecot/templates/etc/dovecot/dovecot-sql.conf.ext.j2
@@ -37,7 +37,7 @@ setup, you can provide your own template via lookup mechanism.
 
 # This file is opened as root, so it should be owned by root and mode 0600.
 #
-# http://wiki2.dovecot.org/AuthDatabase/SQL
+# https://wiki2.dovecot.org/AuthDatabase/SQL
 #
 # For the sql passdb module, you'll need a database with a table that
 # contains fields for at least the username and password. If you want to
@@ -111,7 +111,7 @@ connect ={{ dovecot_tpl_sql_host }}{{ dovecot_tpl_sql_dbname }}{{ dovecot_tpl_sq
 # Default password scheme.
 #
 # List of supported schemes is in
-# http://wiki2.dovecot.org/Authentication/PasswordSchemes
+# https://wiki2.dovecot.org/Authentication/PasswordSchemes
 #
 #default_pass_scheme = MD5
 {% if dovecot_sql_default_pass_scheme is defined and dovecot_sql_default_pass_scheme %}
@@ -129,9 +129,9 @@ default_pass_scheme = {{ dovecot_sql_default_pass_scheme }}
 # and "domain" fields instead of "user".
 #
 # The query can also return other fields which have a special meaning, see
-# http://wiki2.dovecot.org/PasswordDatabase/ExtraFields
+# https://wiki2.dovecot.org/PasswordDatabase/ExtraFields
 #
-# Commonly used available substitutions (see http://wiki2.dovecot.org/Variables
+# Commonly used available substitutions (see https://wiki2.dovecot.org/Variables
 # for full list):
 #   %u = entire user@domain
 #   %n = user part of user@domain
@@ -161,7 +161,7 @@ password_query = {{ dovecot_sql_password_query }}
 # None of these are strictly required. If you use a single UID and GID, and
 # home or mail directory fits to a template string, you could use userdb static
 # instead. For a list of all fields that can be returned, see
-# http://wiki2.dovecot.org/UserDatabase/ExtraFields
+# https://wiki2.dovecot.org/UserDatabase/ExtraFields
 #
 # Examples:
 #   user_query = SELECT home, uid, gid FROM users WHERE userid = '%u'

--- a/ansible/roles/environment/COPYRIGHT
+++ b/ansible/roles/environment/COPYRIGHT
@@ -16,4 +16,4 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with DebOps. If not, see http://www.gnu.org/licenses/.
+along with DebOps. If not, see https://www.gnu.org/licenses/.

--- a/ansible/roles/gitlab/templates/var/local/git/gitlab/config/unicorn.rb.j2
+++ b/ansible/roles/gitlab/templates/var/local/git/gitlab/config/unicorn.rb.j2
@@ -20,7 +20,7 @@
 # ENV['RAILS_RELATIVE_URL_ROOT'] = "/gitlab"
 
 # Read about unicorn workers here:
-# http://doc.gitlab.com/ee/install/requirements.html#unicorn-workers
+# https://docs.gitlab.com/ee/install/requirements.html#unicorn-workers
 #
 # Always have at least two worker processes (https://gitlab.com/gitlab-org/gitlab-ce/issues/13947)
 worker_processes {{ ansible_processor_cores|int + 1 }}

--- a/ansible/roles/influxdb_server/files/usr/sbin/autoinfluxdbbackup
+++ b/ansible/roles/influxdb_server/files/usr/sbin/autoinfluxdbbackup
@@ -14,7 +14,7 @@ set -o pipefail -o errexit
 # VER. 0.1
 
 # Note, this is a lobotomized port of AutoMySQLBackup
-# (http://sourceforge.net/projects/automysqlbackup/) for use with
+# (https://sourceforge.net/projects/automysqlbackup/) for use with
 # InfluxDB.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/ansible/roles/influxdb_server/templates/etc/default/autoinfluxdbbackup.j2
+++ b/ansible/roles/influxdb_server/templates/etc/default/autoinfluxdbbackup.j2
@@ -11,7 +11,7 @@
 # VER. 0.1
 
 # Note, this is a lobotomized port of AutoMySQLBackup
-# (http://sourceforge.net/projects/automysqlbackup/) for use with
+# (https://sourceforge.net/projects/automysqlbackup/) for use with
 # InfluxDB.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/ansible/roles/kmod/COPYRIGHT
+++ b/ansible/roles/kmod/COPYRIGHT
@@ -17,4 +17,4 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with DebOps. If not, see http://www.gnu.org/licenses/.
+along with DebOps. If not, see https://www.gnu.org/licenses/.

--- a/ansible/roles/ldap/COPYRIGHT
+++ b/ansible/roles/ldap/COPYRIGHT
@@ -16,4 +16,4 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with DebOps. If not, see http://www.gnu.org/licenses/.
+along with DebOps. If not, see https://www.gnu.org/licenses/.

--- a/ansible/roles/librenms/COPYRIGHT
+++ b/ansible/roles/librenms/COPYRIGHT
@@ -16,4 +16,4 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with DebOps. If not, see http://www.gnu.org/licenses/.
+along with DebOps. If not, see https://www.gnu.org/licenses/.

--- a/ansible/roles/libvirt/COPYRIGHT
+++ b/ansible/roles/libvirt/COPYRIGHT
@@ -17,4 +17,4 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with DebOps. If not, see http://www.gnu.org/licenses/.
+along with DebOps. If not, see https://www.gnu.org/licenses/.

--- a/ansible/roles/mailman/defaults/main/web_configuration.yml
+++ b/ansible/roles/mailman/defaults/main/web_configuration.yml
@@ -265,7 +265,7 @@ mailman__web_original_configuration:
         'SERVERS':
           - id: 'yahoo'
             name: 'Yahoo'
-            openid_url: 'http://me.yahoo.com/'
+            openid_url: 'https://me.yahoo.com/'
       'google':
         'SCOPE': [ 'profile', 'email' ]
         'AUTH_PARAMS':
@@ -288,7 +288,7 @@ mailman__web_original_configuration:
       significant performance improvement, as CSS files will not need to be
       recompiled on each requests. It means running an additional "compress"
       management command after each code upgrade.
-      http://django-compressor.readthedocs.io/en/latest/usage/#offline-compression
+      https://django-compressor.readthedocs.io/en/latest/usage/#offline-compression
     value: True
 
   - name: 'postorius_template_base_url'

--- a/ansible/roles/mailman/templates/etc/mailman3/mailman.cfg.j2
+++ b/ansible/roles/mailman/templates/etc/mailman3/mailman.cfg.j2
@@ -19,7 +19,7 @@
 # more details.
 #
 # You should have received a copy of the GNU General Public License along with
-# GNU Mailman.  If not, see <http://www.gnu.org/licenses/>.
+# GNU Mailman.  If not, see <https://www.gnu.org/licenses/>.
 
 # This file contains the Debian configuration for mailman.  It uses ini-style
 # formats under the lazr.config regime to define all system configuration

--- a/ansible/roles/netbox/templates/usr/local/lib/netbox/configuration.py.j2
+++ b/ansible/roles/netbox/templates/usr/local/lib/netbox/configuration.py.j2
@@ -168,7 +168,7 @@ NAPALM_PASSWORD = '{{ netbox__config_napalm_password }}'
 # NAPALM timeout (in seconds). (Default: 30)
 NAPALM_TIMEOUT = {{ netbox__config_napalm_timeout }}
 
-# NAPALM optional arguments (see http://napalm.readthedocs.io/en/latest/support/#optional-arguments). Arguments must
+# NAPALM optional arguments (see https://napalm.readthedocs.io/en/latest/support/#optional-arguments). Arguments must
 # be provided as a dictionary.
 NAPALM_ARGS = {{ netbox__config_napalm_args | to_nice_json }}
 

--- a/ansible/roles/nfs/templates/etc/default/nfs-common.j2
+++ b/ansible/roles/nfs/templates/etc/default/nfs-common.j2
@@ -15,7 +15,7 @@ NEED_STATD="no"
 #   Should rpc.statd listen on a specific port? This is especially useful
 #   when you have a port-based firewall. To use a fixed port, set this
 #   this variable to a statd argument like: "--port 4000 --outgoing-port 4001".
-#   For more information, see rpc.statd(8) or http://wiki.debian.org/SecuringNFS
+#   For more information, see rpc.statd(8) or https://wiki.debian.org/SecuringNFS
 STATDOPTS=""
 
 # Do you want to start the idmapd daemon? It is only needed for NFSv4.

--- a/ansible/roles/nfs_server/templates/etc/default/nfs-common.j2
+++ b/ansible/roles/nfs_server/templates/etc/default/nfs-common.j2
@@ -15,7 +15,7 @@ NEED_STATD="{{ 'yes' if nfs_server__v3|bool else 'no' }}"
 #   Should rpc.statd listen on a specific port? This is especially useful
 #   when you have a port-based firewall. To use a fixed port, set this
 #   this variable to a statd argument like: "--port 4000 --outgoing-port 4001".
-#   For more information, see rpc.statd(8) or http://wiki.debian.org/SecuringNFS
+#   For more information, see rpc.statd(8) or https://wiki.debian.org/SecuringNFS
 STATDOPTS="--port {{ nfs_server__service_ports['rpc.statd'] }} --outgoing-port {{ nfs_server__service_ports['rpc.statd-bc'] }}"
 
 # Do you want to start the idmapd daemon? It is only needed for NFSv4.

--- a/ansible/roles/nfs_server/templates/etc/default/nfs-kernel-server.j2
+++ b/ansible/roles/nfs_server/templates/etc/default/nfs-kernel-server.j2
@@ -13,7 +13,7 @@ RPCNFSDPRIORITY={{ nfs_server__priority }}
 # Options for rpc.mountd.
 # If you have a port-based firewall, you might want to set up
 # a fixed port here using the --port option. For more information,
-# see rpc.mountd(8) or http://wiki.debian.org/SecuringNFS
+# see rpc.mountd(8) or https://wiki.debian.org/SecuringNFS
 # To disable NFSv4 on the server, specify '--no-nfs-version 4' here
 RPCMOUNTDOPTS="{{ nfs_server__mountd_options if nfs_server__mountd_options is string else nfs_server__mountd_options | join(' ') }}"
 

--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -258,7 +258,7 @@ nginx__http_auth_htpasswd:
 # become necessary.
 # More information can be found at:
 #
-# - http://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_bucket_size
+# - https://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_bucket_size
 #
 nginx_http_server_names_hash_bucket_size: 64
 
@@ -268,7 +268,7 @@ nginx_http_server_names_hash_bucket_size: 64
 # Sets the maximum size of the server names hash tables.
 # More information can be found at:
 #
-# - http://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_max_size
+# - https://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_max_size
 #
 nginx_http_server_names_hash_max_size: 512
 
@@ -979,7 +979,7 @@ nginx_server_acme:
 #
 # Checks for the existence of files in order, and returns the
 # first file that is found for location /.
-# http://wiki.nginx.org/NginxHttpCoreModule#try_files
+# https://wiki.nginx.org/NginxHttpCoreModule#try_files
 nginx_default_try_files:
   - '$uri'
   - '$uri/'

--- a/ansible/roles/nscd/COPYRIGHT
+++ b/ansible/roles/nscd/COPYRIGHT
@@ -16,4 +16,4 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with DebOps. If not, see http://www.gnu.org/licenses/.
+along with DebOps. If not, see https://www.gnu.org/licenses/.

--- a/ansible/roles/nslcd/COPYRIGHT
+++ b/ansible/roles/nslcd/COPYRIGHT
@@ -16,4 +16,4 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with DebOps. If not, see http://www.gnu.org/licenses/.
+along with DebOps. If not, see https://www.gnu.org/licenses/.

--- a/ansible/roles/opendkim/defaults/main.yml
+++ b/ansible/roles/opendkim/defaults/main.yml
@@ -330,7 +330,7 @@ opendkim__original_config:
 
       Specifies a configuration file to be passed to the Unbound library that
       performs DNS queries applying the DNSSEC protocol.  See the Unbound
-      documentation at http://unbound.net for the expected content of this file.
+      documentation at https://unbound.net/ for the expected content of this file.
       The results of using this and the TrustAnchorFile setting at the same
       time are undefined.
       In Debian, /etc/unbound/unbound.conf is shipped as part of the Suggested
@@ -347,7 +347,7 @@ opendkim__original_config:
 
       Specifies a file from which trust anchor data should be read when doing
       DNS queries and applying the DNSSEC protocol.  See the Unbound documentation
-      at http://unbound.net for the expected format of this file.
+      at https://unbound.net/ for the expected format of this file.
     value: '/usr/share/dns/root.key'
     state: '{{ "absent"
                if (ansible_distribution_release in [ "wheezy", "jessie" ])

--- a/ansible/roles/pam_access/COPYRIGHT
+++ b/ansible/roles/pam_access/COPYRIGHT
@@ -16,4 +16,4 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with DebOps. If not, see http://www.gnu.org/licenses/.
+along with DebOps. If not, see https://www.gnu.org/licenses/.

--- a/ansible/roles/postgresql_server/templates/usr/sbin/autopostgresqlbackup.j2
+++ b/ansible/roles/postgresql_server/templates/usr/sbin/autopostgresqlbackup.j2
@@ -8,7 +8,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # This script is based of the AutoMySQLBackup Script Ver 2.2
-# It can be found at http://sourceforge.net/projects/automysqlbackup/
+# It can be found at https://sourceforge.net/projects/automysqlbackup/
 #
 # The PostgreSQL changes are based on a patch agaisnt AutoMySQLBackup 1.9
 # created by Friedrich Lobenstock <fl@fl.priv.at>

--- a/ansible/roles/rabbitmq_server/templates/etc/rabbitmq/rabbitmq.config.j2
+++ b/ansible/roles/rabbitmq_server/templates/etc/rabbitmq/rabbitmq.config.j2
@@ -9,7 +9,7 @@
 %% ---------------------------------------------------------------------
 %% RabbitMQ Configuration File.
 %%
-%% See http://www.rabbitmq.com/configure.html for details.
+%% See https://www.rabbitmq.com/configure.html for details.
 %% ---------------------------------------------------------------------
 
 {% set rabbitmq_server__tpl_config = {} %}

--- a/ansible/roles/rails_deploy/defaults/main.yml
+++ b/ansible/roles/rails_deploy/defaults/main.yml
@@ -253,7 +253,7 @@ rails_deploy_mysql_super_username: 'mysql'
 # .. envvar:: rails_deploy_database_user_role_attrs [[[
 #
 # What are the roles that should be applied to the app postgres user?
-# See http://docs.ansible.com/postgresql_user_module.html for available options
+# See https://docs.ansible.com/postgresql_user_module.html for available options
 rails_deploy_database_user_role_attrs: ''
 
                                                                    # ]]]

--- a/ansible/roles/roundcube/defaults/main.yml
+++ b/ansible/roles/roundcube/defaults/main.yml
@@ -818,7 +818,7 @@ roundcube__original_configuration:
       Database connection string (DSN) for read+write operations
       Format (compatible with PEAR MDB2): db_provider://user:password@host/database
       Currently supported db_providers: mysql, pgsql, sqlite, mssql, sqlsrv, oracle
-      For examples see http://pear.php.net/manual/en/package.database.mdb2.intro-dsn.php
+      For examples see https://pear.php.net/manual/en/package.database.mdb2.intro-dsn.php
       Note: for SQLite use absolute path (Linux): 'sqlite:////full/path/to/sqlite.db?mode=0646'
             or (Windows): 'sqlite:///C:/full/path/to/sqlite.db'
       Note: Various drivers support various additional arguments for connection,
@@ -892,7 +892,7 @@ roundcube__original_configuration:
   - name: 'log_date_format'
     comment: |
       Date format for log entries
-      (read http://php.net/manual/en/function.date.php for all format characters)
+      (read https://php.net/manual/en/function.date.php for all format characters)
     value: 'd-M-Y H:i:s O'
     section: 'logging'
     state: 'init'
@@ -920,7 +920,7 @@ roundcube__original_configuration:
   - name: 'syslog_facility'
     comment: |
       Syslog facility to use, if using the 'syslog' log driver.
-      For possible values see installer or http://php.net/manual/en/function.openlog.php
+      For possible values see installer or https://php.net/manual/en/function.openlog.php
     value: 'LOG_USER'
     quotes: False
     section: 'logging'
@@ -1031,7 +1031,7 @@ roundcube__original_configuration:
   - name: 'imap_conn_options'
     comment: |
       IMAP socket context options
-      See http://php.net/manual/en/context.ssl.php
+      See https://php.net/manual/en/context.ssl.php
       The example below enables server certificate validation
       Note: These can be also specified as an array of options indexed by hostname
     array:
@@ -1283,7 +1283,7 @@ roundcube__original_configuration:
   - name: 'smtp_conn_options'
     comment: |
       SMTP socket context options
-      See http://php.net/manual/en/context.ssl.php
+      See https://php.net/manual/en/context.ssl.php
       The example below enables server certificate validation, and
       requires 'smtp_timeout' to be non zero.
       Note: These can be also specified as an array of options indexed by hostname
@@ -1322,7 +1322,7 @@ roundcube__original_configuration:
   - name: 'memcache_pconnect'
     comment: |
       Controls the use of a persistent connections to memcache servers
-      See http://php.net/manual/en/memcache.addserver.php
+      See https://php.net/manual/en/memcache.addserver.php
     value: True
     section: 'cache'
     state: 'init'
@@ -1330,7 +1330,7 @@ roundcube__original_configuration:
   - name: 'memcache_timeout'
     comment: |
       Value in seconds which will be used for connecting to the daemon
-      See http://php.net/manual/en/memcache.addserver.php
+      See https://php.net/manual/en/memcache.addserver.php
     value: 1
     section: 'cache'
     state: 'init'
@@ -1339,7 +1339,7 @@ roundcube__original_configuration:
     comment: |
       Controls how often a failed server will be retried (value in seconds).
       Setting this parameter to -1 disables automatic retry.
-      See http://php.net/manual/en/memcache.addserver.php
+      See https://php.net/manual/en/memcache.addserver.php
     value: 15
     section: 'cache'
     state: 'init'
@@ -1881,7 +1881,7 @@ roundcube__original_configuration:
       Absolute path to a local mime.types mapping table file.
       This is used to derive mime-types from the filename extension or vice versa.
       Such a file is usually part of the apache webserver. If you don't find a file named mime.types on your system,
-      download it from http://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types
+      download it from https://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types
     value: null
     section: 'system'
     state: 'init'
@@ -2120,7 +2120,7 @@ roundcube__original_configuration:
       - 'atd'     - install your own After the Deadline server or check with
                     the people at http://www.afterthedeadline.com before using their API
       Since Google shut down their public spell checking service, the default settings
-      connect to http://spell.roundcube.net which is a hosted service provided by Roundcube.
+      connect to https://spell.roundcube.net/ which is a hosted service provided by Roundcube.
       You can connect to any other googie-compliant service by setting 'spellcheck_uri' accordingly.
     value: 'googie'
     section: 'ui'
@@ -3727,7 +3727,7 @@ roundcube__default_plugins:
         comment: |
           LDAP password force replace
           Force LDAP replace in cases where ACL allows only replace not read
-          See http://pear.php.net/package/Net_LDAP2/docs/latest/Net_LDAP2/Net_LDAP2_Entry.html#methodreplace
+          See https://pear.php.net/package/Net_LDAP2/docs/latest/Net_LDAP2/Net_LDAP2_Entry.html#methodreplace
           Default: true
         value: True
 
@@ -4359,7 +4359,7 @@ roundcube__default_plugins:
       - name: 'managesieve_conn_options'
         comment: |
           Connection scket context options
-          See http://php.net/manual/en/context.ssl.php
+          See https://php.net/manual/en/context.ssl.php
           The example below enables server certificate validation
         array:
           - ssl:

--- a/ansible/roles/slapd/files/etc/ldap/schema/debops/dyngroup.schema
+++ b/ansible/roles/slapd/files/etc/ldap/schema/debops/dyngroup.schema
@@ -1,6 +1,6 @@
 # dyngroup.schema -- Dynamic Group schema
 # $OpenLDAP$
-## This work is part of OpenLDAP Software <http://www.openldap.org/>.
+## This work is part of OpenLDAP Software <https://www.openldap.org/>.
 ##
 ## Copyright (C) 1998-2018 The OpenLDAP Foundation.
 ## Copyright (C) 2020      Maciej Delmanowski <drybjed@gmail.com>
@@ -15,14 +15,14 @@
 ##
 ## A copy of this license is available in the file LICENSE in the
 ## top-level directory of the distribution or, alternatively, at
-## <http://www.OpenLDAP.org/license.html>.
+## <https://www.openldap.org/license.html>.
 #
 # Dynamic Group schema (experimental), as defined by Netscape.  See
-# http://www.redhat.com/docs/manuals/ent-server/pdf/esadmin611.pdf
+# https://www.redhat.com/docs/manuals/ent-server/pdf/esadmin611.pdf
 # page 70 for details on how these groups were used.
 #
 # A description of the objectclass definition is available here:
-# http://www.redhat.com/docs/manuals/dir-server/schema/7.1/oc_dir.html#1303745
+# https://www.redhat.com/docs/manuals/dir-server/schema/7.1/oc_dir.html#1303745
 #
 # depends upon:
 #	core.schema
@@ -48,7 +48,7 @@
 # is not guaranteed.
 #
 # Also see the new DynGroup proposed spec at
-# http://tools.ietf.org/html/draft-haripriya-dynamicgroup-02
+# https://tools.ietf.org/html/draft-haripriya-dynamicgroup-02
 #
 # This schema is modified to support the 'autogroup' overlay by adding a MAY
 # 'member' attribute to the 'groupOfURLs' LDAP object.

--- a/ansible/roles/slapd/files/usr/local/sbin/slapd-config
+++ b/ansible/roles/slapd/files/usr/local/sbin/slapd-config
@@ -24,7 +24,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
 # use SASL/EXTERNAL authentication by default

--- a/ansible/roles/sshd/tasks/main.yml
+++ b/ansible/roles/sshd/tasks/main.yml
@@ -45,7 +45,7 @@
 - name: Block OpenSSH server from starting immediately when installed
   #
   # SSH server must not start, until security options are configured!
-  # http://unix.stackexchange.com/questions/321621/configuring-my-sshd-securely-with-automation
+  # https://unix.stackexchange.com/questions/321621/configuring-my-sshd-securely-with-automation
   #
   # However, SSH might already be configured, started, and in use.
   # In this case we should not block it.  Something could try to restart

--- a/ansible/roles/tcpwrappers/COPYRIGHT
+++ b/ansible/roles/tcpwrappers/COPYRIGHT
@@ -16,4 +16,4 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with DebOps. If not, see http://www.gnu.org/licenses/.
+along with DebOps. If not, see https://www.gnu.org/licenses/.

--- a/ansible/roles/tftpd/COPYRIGHT
+++ b/ansible/roles/tftpd/COPYRIGHT
@@ -16,4 +16,4 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with DebOps. If not, see http://www.gnu.org/licenses/.
+along with DebOps. If not, see https://www.gnu.org/licenses/.

--- a/ansible/roles/tgt/COPYRIGHT
+++ b/ansible/roles/tgt/COPYRIGHT
@@ -16,4 +16,4 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with DebOps. If not, see http://www.gnu.org/licenses/.
+along with DebOps. If not, see https://www.gnu.org/licenses/.

--- a/ansible/roles/tinc/templates/etc/systemd/system/tinc.service.j2
+++ b/ansible/roles/tinc/templates/etc/systemd/system/tinc.service.j2
@@ -11,7 +11,7 @@
 [Unit]
 Description=Tinc VPN
 Documentation=man:tinc(8) man:tinc.conf(5)
-Documentation=http://tinc-vpn.org/docs/
+Documentation=https://tinc-vpn.org/docs/
 Wants=network-online.target
 After=local-fs.target network-pre.target apparmor.service systemd-sysctl.service systemd-modules-load.service networking.service ifup-allow-all-auto.service ifup-allow-boot.service
 Conflicts=shutdown.target

--- a/ansible/roles/tinc/templates/etc/systemd/system/tinc@.service.j2
+++ b/ansible/roles/tinc/templates/etc/systemd/system/tinc@.service.j2
@@ -8,7 +8,7 @@
 [Unit]
 Description=Tinc VPN for %i network
 Documentation=man:tincd(8) man:tinc.conf(5)
-Documentation=http://tinc-vpn.org/docs/
+Documentation=https://tinc-vpn.org/docs/
 PartOf=tinc.service
 ReloadPropagatedFrom=tinc.service
 After=network-online.target

--- a/ansible/roles/tinyproxy/defaults/main.yml
+++ b/ansible/roles/tinyproxy/defaults/main.yml
@@ -453,8 +453,8 @@ tinyproxy__default_configuration:
           http://localhost:8888/wired/news/. Neither will actually work
           until you uncomment ReverseMagic as they use absolute linking.
         raw: |
-          ReversePath "/google/" "http://www.google.com/"
-          ReversePath "/wired/"  "http://www.wired.com/"
+          ReversePath "/google/" "https://www.google.com/"
+          ReversePath "/wired/"  "https://www.wired.com/"
         state: 'comment'
 
       - name: 'ReverseOnly'

--- a/ansible/roles/unattended_upgrades/defaults/main.yml
+++ b/ansible/roles/unattended_upgrades/defaults/main.yml
@@ -125,7 +125,7 @@ unattended_upgrades__security_origins:
     - 'o=Devuan,n=${distro_codename}-security,l=Devuan-Security'
     - 'o=Devuan,n=${distro_codename}-updates'
 
-  # http://www.ubuntu.com/usn/
+  # https://www.ubuntu.com/usn/
   'Ubuntu':
     - 'o=Ubuntu,n=${distro_codename},a=${distro_codename}-security'
     - 'o=Ubuntu,n=${distro_codename},a=${distro_codename}-updates'

--- a/bin/debops-optimize-old
+++ b/bin/debops-optimize-old
@@ -13,7 +13,7 @@ set -o nounset -o pipefail -o errexit
 # * does not support `:?` …
 
 # Convert repetitively used programs and commands to Sphinx inline syntax.
-# http://www.sphinx-doc.org/en/stable/markup/inline.html
+# https://www.sphinx-doc.org/en/stable/markup/inline.html
 #
 # Note you should review the changes made by this script and try to build the
 # documentation as this script can not handle all cases. You might need to

--- a/debops/config.py
+++ b/debops/config.py
@@ -74,7 +74,7 @@ elif sys.platform == 'darwin':  # Mac OS X
 def _set_xdg_defaults():
     """
     Set default values for XDG variables according to XDG specification
-    http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
+    https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
     """
     for name, default in (
             ('XDG_CONFIG_HOME', os.path.expanduser('~/.config')),

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -11,7 +11,7 @@ BUILDDIR      = _build
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
-$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
+$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from https://www.sphinx-doc.org/)
 endif
 
 # Internal variables.

--- a/docs/_lib/yaml2rst/func.py
+++ b/docs/_lib/yaml2rst/func.py
@@ -17,7 +17,7 @@ yaml2rst – A Simple Tool for Documenting YAML Files
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
 from __future__ import print_function

--- a/docs/ansible/roles/dovecot/defaults-detailed.rst
+++ b/docs/ansible/roles/dovecot/defaults-detailed.rst
@@ -88,9 +88,9 @@ waiting for more connections, restrict maximal number of IMAP processes to
         mail_max_userip_connections: 15
 
 
-.. _Dovecot Login Process: http://wiki2.dovecot.org/LoginProcess
-.. _Dovecot inet_listeners: http://wiki2.dovecot.org/Services#inet_listeners
-.. _Dovecot unix_listeners: http://wiki2.dovecot.org/Services#unix_listeners_and_fifo_listeners
+.. _Dovecot Login Process: https://wiki2.dovecot.org/LoginProcess
+.. _Dovecot inet_listeners: https://wiki2.dovecot.org/Services#inet_listeners
+.. _Dovecot unix_listeners: https://wiki2.dovecot.org/Services#unix_listeners_and_fifo_listeners
 .. _Dovecot IMAP Service: https://wiki2.dovecot.org/Services#imap.2C_pop3.2C_submission.2C_managesieve
 
 .. _dovecot_imap_listeners:

--- a/docs/ansible/roles/dovecot/guides.rst
+++ b/docs/ansible/roles/dovecot/guides.rst
@@ -41,7 +41,7 @@ statement in the dovecot configuration file, so you can also set much more
 advanced values. Check the dovecot `mail_location`_ documentation for more
 examples.
 
-.. _mail_location: http://wiki2.dovecot.org/MailLocation/
+.. _mail_location: https://wiki2.dovecot.org/MailLocation/
 
 
 Enable server-side mail filtering with sieve
@@ -52,8 +52,8 @@ rules are stored as text files on the mail server and can be managed by
 a client via `ManageSieve`_ network protocol. Dovecot provides sieve support
 via Pigeonhole sieve interpreter.
 
-.. _Sieve: http://wiki2.dovecot.org/Pigeonhole/Sieve/
-.. _ManageSieve: http://wiki2.dovecot.org/Pigeonhole/ManageSieve/
+.. _Sieve: https://wiki2.dovecot.org/Pigeonhole/Sieve/
+.. _ManageSieve: https://wiki2.dovecot.org/Pigeonhole/ManageSieve/
 
 To enable the ManageSieve protocol in your Dovecot role you have to add
 it to the ``dovecot_protocols`` list::
@@ -150,5 +150,5 @@ Postfix independently by setting e.g.::
       virtual_transport = lmtp:inet:192.168.1.123:24
 
 
-.. _LMTP: http://wiki2.dovecot.org/LMTP
+.. _LMTP: https://wiki2.dovecot.org/LMTP
 .. _ansible-ferm: https://github.com/debops/ansible-ferm

--- a/docs/ansible/roles/dovecot/man_description.rst
+++ b/docs/ansible/roles/dovecot/man_description.rst
@@ -14,7 +14,7 @@ secure TLS connection.
 Additionally it allows you to configure a `sieve`_ service which allows you
 to store server-side rules for mail filtering.
 
-.. _Ansible: http://ansible.com/
-.. _Dovecot: http://dovecot.org/
+.. _Ansible: https://www.ansible.com/
+.. _Dovecot: https://dovecot.org/
 .. _ansible-pki: https://github.com/debops/ansible-pki/
 .. _sieve: http://sieve.info/

--- a/docs/ansible/roles/fail2ban/defaults-detailed.rst
+++ b/docs/ansible/roles/fail2ban/defaults-detailed.rst
@@ -131,7 +131,7 @@ Other options are the same as normal ``fail2ban`` jail configuration options.
 Refer to default ``/etc/fail2ban/jail.conf`` or `fail2ban wiki`_ for possible
 options.
 
-.. _fail2ban wiki: http://www.fail2ban.org/wiki/index.php/MANUAL_0_8#Jails
+.. _fail2ban wiki: https://www.fail2ban.org/wiki/index.php/MANUAL_0_8#Jails
 
 .. _examples:
 

--- a/docs/ansible/roles/fail2ban/man_description.rst
+++ b/docs/ansible/roles/fail2ban/man_description.rst
@@ -10,5 +10,5 @@ configured actions when a given regexp_ is found. It's usually used to ban
 offending IP addresses using ``iptables`` rules (only IPv4 connections are
 supported at the moment).
 
-.. _fail2ban: http://www.fail2ban.org/
+.. _fail2ban: https://www.fail2ban.org/
 .. _regexp: https://en.wikipedia.org/wiki/Regular_expression

--- a/docs/ansible/roles/mailman/man_description.rst
+++ b/docs/ansible/roles/mailman/man_description.rst
@@ -6,7 +6,7 @@ Description
 ===========
 
 The :ref:`debops.mailman` Ansible role can be used to create and manage mailing
-lists using `GNU Mailman <http://list.org/>`_ service. The role is designed to
+lists using `GNU Mailman <https://list.org/>`_ service. The role is designed to
 install and configure Mailman 3 using Debian packages, and will automatically
 integrate with PostgreSQL or MariaDB database for configuration storage and
 Postfix for SMTP services.

--- a/docs/ansible/roles/postgresql/man_description.rst
+++ b/docs/ansible/roles/postgresql/man_description.rst
@@ -12,4 +12,4 @@ and databases on local or remote PostgreSQL servers.
 To manage the PostgreSQL server itself, you will need to use
 ``debops.postgresql_server`` role.
 
-.. __: http://www.postgresql.org/
+.. __: https://www.postgresql.org/

--- a/docs/ansible/roles/postgresql_server/defaults-detailed.rst
+++ b/docs/ansible/roles/postgresql_server/defaults-detailed.rst
@@ -70,7 +70,7 @@ documentation for details.
 postgresql_server__hba_*
 ------------------------
 
-`Host-Based Authentication <http://www.postgresql.org/docs/9.4/static/auth-pg-hba-conf.html>`_
+`Host-Based Authentication <https://www.postgresql.org/docs/9.4/static/auth-pg-hba-conf.html>`_
 configuration in ``debops.postgresql_server`` Ansible role is specified in
 a set of lists:
 
@@ -203,7 +203,7 @@ postgresql_server__ident_*
 --------------------------
 
 `Ident maps
-<http://www.postgresql.org/docs/9.4/static/auth-username-maps.html>`_ stored in
+<https://www.postgresql.org/docs/9.4/static/auth-username-maps.html>`_ stored in
 :file:`pg_ident.conf` configuration file is used to map local UNIX accounts to
 PostgreSQL roles. This can be used to control what UNIX accounts can login to
 the PostgreSQL server as a given role.

--- a/docs/ansible/roles/postgresql_server/man_description.rst
+++ b/docs/ansible/roles/postgresql_server/man_description.rst
@@ -10,4 +10,4 @@ used to install and manage a set of PostgreSQL clusters on Debian-based
 systems. You can use :ref:`debops.postgresql` role to configure roles and
 databases on local or remote PostgreSQL servers.
 
-.. __: http://www.postgresql.org/
+.. __: https://www.postgresql.org/

--- a/docs/ansible/roles/rabbitmq_server/defaults-detailed.rst
+++ b/docs/ansible/roles/rabbitmq_server/defaults-detailed.rst
@@ -73,7 +73,7 @@ RabbitMQ configuration options
 RabbitMQ is written in the `Erlang <https://en.wikipedia.org/wiki/Erlang_(programming_language)>`_
 programming language, which is also used for its configuration. YAML, used by
 Ansible, does not provide enough data types to directly map them to the
-`Erlang data types <http://erlang.org/doc/reference_manual/data_types.html>`_
+`Erlang data types <https://erlang.org/doc/reference_manual/data_types.html>`_
 used in the RabbitMQ configuration file, therefore the configuration used by
 ``debops.rabbitmq_server`` focuses on description of the desired data types and
 conditional activation of the configuration sections. This means that simple
@@ -131,7 +131,7 @@ will switch to a more verbose option interpretation, using known parameters:
   - ``boolean``: a boolean ``true``/``false`` value, selected automatically if
     a YAML boolean is used as the value;
 
-  - ``bit-string``: a `bit string <http://erlang.org/doc/reference_manual/data_types.html#bit-strings-and-binaries>`_
+  - ``bit-string``: a `bit string <https://erlang.org/doc/reference_manual/data_types.html#bit-strings-and-binaries>`_
     value with special quotation marks. Only YAML strings are supported at this
     time;
 

--- a/docs/ansible/roles/rabbitmq_server/examples/example-config-sections.yml
+++ b/docs/ansible/roles/rabbitmq_server/examples/example-config-sections.yml
@@ -15,7 +15,7 @@ rabbitmq_server__config:
     comment: |
       RabbitMQ Management Plugin
 
-      See http://www.rabbitmq.com/management.html for details
+      See https://www.rabbitmq.com/management.html for details
     options: []
     weight: 2
 

--- a/docs/ansible/roles/rsyslog/defaults-detailed.rst
+++ b/docs/ansible/roles/rsyslog/defaults-detailed.rst
@@ -27,7 +27,7 @@ daemon configuration is ordered, the forward statements should be set in
 a specific place in the configuration. You can of course define your own
 forwarding rules instead of using these specific variables, if you wish.
 
-You can check `the rsyslog remote forward documentation <http://www.rsyslog.com/sending-messages-to-a-remote-syslog-server/>`_ to see
+You can check `the rsyslog remote forward documentation <https://www.rsyslog.com/sending-messages-to-a-remote-syslog-server/>`_ to see
 how to forward logs to other hosts. Each configuration entry should be
 specified in a separate YAML list element. The entries can be simple FQDN
 hostnames which will be configured to use TCP connections over TLS and port

--- a/docs/ansible/roles/rsyslog/man_description.rst
+++ b/docs/ansible/roles/rsyslog/man_description.rst
@@ -5,7 +5,7 @@
 Description
 ===========
 
-The `rsyslog <http://rsyslog.com/>`_ package is used to read, process, store
+The `rsyslog <https://www.rsyslog.com/>`_ package is used to read, process, store
 and forward system logs in different ways, on local or remote systems. The
 ``debops.rsyslog`` role can be used to easily configure log forwarding to
 a central log server, as well as store logs on the filesystem or other storage

--- a/docs/ansible/roles/sshd/man_description.rst
+++ b/docs/ansible/roles/sshd/man_description.rst
@@ -11,4 +11,4 @@ programs. It allows you to connect to remote hosts over a encrypted communicatio
 channel and to perform a variety of tasks. It's also the primary communication channel
 used by Ansible.
 
-.. _OpenSSH: http://www.openssh.com/
+.. _OpenSSH: https://www.openssh.com/

--- a/docs/ansible/roles/stunnel/man_description.rst
+++ b/docs/ansible/roles/stunnel/man_description.rst
@@ -11,4 +11,4 @@ ports, either on the same host or on separate hosts.
 Encryption is done using SSL certificates. This Ansible role can be used to
 create tunnels between two or more hosts, using Ansible inventory groups.
 
-.. _stunnel: http://stunnel.org/
+.. _stunnel: https://stunnel.org/

--- a/docs/debops-api/_static/api/license
+++ b/docs/debops-api/_static/api/license
@@ -23,7 +23,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -667,7 +667,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -686,11 +686,11 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
+<https://www.gnu.org/licenses/>.
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+<https://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/docs/includes/global.rst
+++ b/docs/includes/global.rst
@@ -1113,7 +1113,7 @@
 .. _groups.io: https://groups.io/
 .. _HWRaid: http://hwraid.le-vert.net/
 .. _Nginx: https://en.wikipedia.org/wiki/Nginx
-.. _nginx map module: http://nginx.org/en/docs/http/ngx_http_map_module.html
+.. _nginx map module: https://nginx.org/en/docs/http/ngx_http_map_module.html
 .. _MariaDB: https://en.wikipedia.org/wiki/Mariadb
 .. _PHP: https://en.wikipedia.org/wiki/PHP
 .. _Redis: https://en.wikipedia.org/wiki/Redis
@@ -1123,7 +1123,7 @@
 .. _Raspbian: https://en.wikipedia.org/wiki/Raspbian
 .. _RedRampage: https://github.com/redrampage/
 .. _Salt: https://en.wikipedia.org/wiki/SaltStack
-.. _Ubuntu 12.04 LTS (Precise Pangolin): http://releases.ubuntu.com/12.04/
+.. _Ubuntu 12.04 LTS (Precise Pangolin): https://releases.ubuntu.com/12.04/
 
 .. _sks-keyservers.net: https://sks-keyservers.net/
 .. _SKS OpenPGP keyserver pool: https://sks-keyservers.net/
@@ -1151,7 +1151,7 @@
 .. _xkcd 1205: https://xkcd.com/1205/
 .. _xkcd 1319: https://xkcd.com/1319/
 
-.. Use http://www.sphinx-doc.org/en/stable/markup/inline.html#role-rfc :) !!!
+.. Use https://www.sphinx-doc.org/en/stable/markup/inline.html#role-rfc :) !!!
    Needs to be fixed first before it can be disabled here.
    debops-optimize can fix it for you ;)
 .. _RFC2119: https://tools.ietf.org/html/rfc2119
@@ -1181,7 +1181,7 @@
 .. _Ansible module: https://docs.ansible.com/ansible/modules.html
 .. _YAML Syntax: https://docs.ansible.com/ansible/YAMLSyntax.html
 .. _reStructuredText: http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html
-.. _Sphinx: http://www.sphinx-doc.org/
+.. _Sphinx: https://www.sphinx-doc.org/
 
 .. ]]]
 

--- a/docs/introduction/getting-started.rst
+++ b/docs/introduction/getting-started.rst
@@ -384,7 +384,7 @@ Each host configured by `DebOps common playbook`_ should have the same set of ba
 services. After a host is configured, you can enable additional Ansible roles
 to install and configure software and applications of your choice.
 
-We will use `DokuWiki <http://dokuwiki.org/>`_ as an example application. The
+We will use `DokuWiki <https://dokuwiki.org/>`_ as an example application. The
 role that manages the installation is called :ref:`debops.dokuwiki` it uses
 :ref:`debops.nginx` and :ref:`debops.php` roles to configure a webserver and
 PHP5 environment. The :ref:`debops.nginx` role calls some additional roles,

--- a/docs/meta/references.rst
+++ b/docs/meta/references.rst
@@ -103,7 +103,7 @@ available.
 `Research Computing at Imperial College London`__
 -------------------------------------------------
 
-.. __: http://www.imperial.ac.uk/mathematics/for-staff/research-computing-support/
+.. __: https://www.imperial.ac.uk/mathematics/for-staff/research-computing-support/
 
 This is a homepage of the Department of Mathematics at ICL. They have their own
 HPC infrastructure `with extensive documentation`__, aimed mostly at their


### PR DESCRIPTION
Mechanical edit which replaces `http://` by `https://` for URLs where it is known that the web server supports HTTPS.

```Shell
node ~/src/EFForg/https-everywhere/utils/rewriter/rewriter.js .
```

A few changes were reset manually before the commit.

Ref: https://github.com/EFForg/https-everywhere/tree/master/utils/rewriter