### PR TITLE
[gitlab] Bugfix: Set redis-server.service in Wants section

### DIFF
--- a/ansible/roles/gitlab/templates/etc/systemd/system/gitlab-gitaly.service.j2
+++ b/ansible/roles/gitlab/templates/etc/systemd/system/gitlab-gitaly.service.j2
@@ -17,6 +17,7 @@
 
 [Unit]
 Description=GitLab Gitaly Server
+Wants=redis-server.service
 After=redis-server.service
 PartOf=gitlab.slice
 

--- a/ansible/roles/gitlab/templates/etc/systemd/system/gitlab-sidekiq.service.j2
+++ b/ansible/roles/gitlab/templates/etc/systemd/system/gitlab-sidekiq.service.j2
@@ -18,8 +18,7 @@
 
 [Unit]
 Description=GitLab Sidekiq Worker
-Requires=redis-server.service
-Wants=postgresql.service
+Wants=redis-server.service postgresql.service
 After=redis-server.service postgresql.service
 PartOf=gitlab.slice
 

--- a/ansible/roles/gitlab/templates/etc/systemd/system/gitlab-unicorn.service.j2
+++ b/ansible/roles/gitlab/templates/etc/systemd/system/gitlab-unicorn.service.j2
@@ -18,8 +18,7 @@
 
 [Unit]
 Description=GitLab Unicorn Server
-Requires=redis-server.service
-Wants=postgresql.service
+Wants=redis-server.service postgresql.service
 After=redis-server.service postgresql.service
 PartOf=gitlab.slice
 

--- a/ansible/roles/gitlab/templates/etc/systemd/system/gitlab.slice.j2
+++ b/ansible/roles/gitlab/templates/etc/systemd/system/gitlab.slice.j2
@@ -9,8 +9,7 @@
 
 [Unit]
 Description=GitLab Slice
-Requires=redis-server.service
-Wants=postgresql.service gitlab-gitaly.service gitlab-unicorn.service gitlab-sidekiq.service gitlab-workhorse.service gitlab-mailroom.service
+Wants=redis-server.service postgresql.service gitlab-gitaly.service gitlab-unicorn.service gitlab-sidekiq.service gitlab-workhorse.service gitlab-mailroom.service
 {% if gitlab_enable_pages|bool %}
 Wants=gitlab-pages.service
 {% endif %}


### PR DESCRIPTION
Bugfix: Set redis-server.service in Wants section in systemd files. Redis server could be installed in other host

Signed-off-by: Pedro Luis López Sánchez <plopez@neuromobilemarketing.com>