### PR TITLE
[icinga_web] add LDAP support for authentication and groups

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -239,6 +239,11 @@ LDAP
 - The role will now activate both the serial console and the (previously
   disabled) native platform console when ``grub__serial_console`` is ``True``.
 
+:ref:`debops.icinga_web` role
+'''''''''''''''''''''''''''''
+
+- The role now automatically configures LDAP user and group support.
+
 :ref:`debops.lvm` role
 ''''''''''''''''''''''
 

--- a/ansible/playbooks/service/icinga_web.yml
+++ b/ansible/playbooks/service/icinga_web.yml
@@ -76,6 +76,11 @@
       nginx__dependent_upstreams:
         - '{{ icinga_web__nginx__dependent_upstreams }}'
 
+    - role: ldap
+      tags: [ 'role::ldap', 'skip::ldap' ]
+      ldap__dependent_tasks:
+        - '{{ icinga_web__ldap__dependent_tasks }}'
+
     - role: postgresql
       tags: [ 'role::postgresql', 'skip::postgresql' ]
       postgresql__dependent_roles:

--- a/ansible/roles/icinga_web/defaults/main.yml
+++ b/ansible/roles/icinga_web/defaults/main.yml
@@ -583,13 +583,10 @@ icinga_web__default_account_password: '{{ lookup("password", secret + "/icinga_w
 #
 # Enable LDAP support
 icinga_web__ldap_enabled: '{{ True
-                            if (ansible_local|d() and ansible_local.ldap|d() and
-                                (ansible_local.ldap.enabled|d())|bool)
-                            else False }}'
+                              if ansible_local.ldap.enabled|d()|bool
+                              else False }}'
 
                                                                    # ]]]
-
-
 # .. envvar:: icinga_web__ldap_base_dn [[[
 #
 # The base Distinguished Name which should be used to create Distinguished
@@ -597,16 +594,36 @@ icinga_web__ldap_enabled: '{{ True
 icinga_web__ldap_base_dn: '{{ ansible_local.ldap.base_dn|d([]) }}'
 
                                                                    # ]]]
-# .. envvar:: icinga_web__ldap_group_base_dn [[[
+# .. envvar:: icinga_web__ldap_groups_rdn [[[
 #
-# The base Distinguished Name where Icinga Web will look for groups.
-icinga_web__ldap_group_base_dn: '{{ icinga_web__ldap_base_dn | join(",") }}'
+# The Relative Distinguished Name of the object which contains the groups stored
+# in LDAP.
+icinga_web__ldap_groups_rdn: '{{ ansible_local.ldap.groups_rdn
+                                 |d("ou=Groups") }}'
 
                                                                    # ]]]
-# .. envvar:: icinga_web__user_base_dn [[[
+# .. envvar:: icinga_web__ldap_groups_dn [[[
 #
-# The base Distinguished Name where Icinga Web will look for users.
-icinga_web__ldap_user_base_dn: '{{ icinga_web__ldap_base_dn | join(",") }}'
+# The Distinguished Name where Icinga Web will look for groups, defined as a
+# YAML list.
+icinga_web__ldap_groups_dn: '{{ [ icinga_web__ldap_groups_rdn ]
+                                + icinga_web__ldap_base_dn }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__ldap_people_rdn [[[
+#
+# The Relative Distinguished Name of the object which contains the user accounts
+# stored in LDAP.
+icinga_web__ldap_people_rdn: '{{ ansible_local.ldap.people_rdn
+                                 |d("ou=People") }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__ldap_people_dn [[[
+#
+# The base Distinguished Name where Icinga Web will look for users, defined as a
+# YAML list.
+icinga_web__ldap_people_dn: '{{ [ icinga_web__ldap_people_rdn ]
+                                + icinga_web__ldap_base_dn }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__ldap_device_dn [[[
@@ -646,7 +663,8 @@ icinga_web__ldap_self_attributes:
 #
 # The Distinguished Name of the account LDAP object used by the
 # Icinga Web service to bind to the LDAP directory.
-icinga_web__ldap_binddn: '{{ ([ icinga_web__ldap_self_rdn ] + icinga_web__ldap_device_dn) | join(",") }}'
+icinga_web__ldap_binddn: '{{ ([ icinga_web__ldap_self_rdn ]
+                              + icinga_web__ldap_device_dn) | join(",") }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__ldap_bindpw [[[
@@ -654,7 +672,8 @@ icinga_web__ldap_binddn: '{{ ([ icinga_web__ldap_self_rdn ] + icinga_web__ldap_d
 # The password stored in the account LDAP object used by the Icinga Web service
 # to bind to the LDAP directory.
 icinga_web__ldap_bindpw: '{{ lookup("password", secret + "/ldap/credentials/"
-                                  + icinga_web__ldap_binddn | to_uuid + ".password length=48 "
+                                  + icinga_web__ldap_binddn | to_uuid
+                                  + ".password length=48 "
                                   + "chars=ascii_letters,digits,.-_") }}'
 
                                                                    # ]]]
@@ -675,13 +694,21 @@ icinga_web__ldap_encryption: 'starttls'
 # .. envvar:: icinga_web__ldap_port [[[
 #
 # The TCP port to use for LDAP connections.
-icinga_web__ldap_port: '{{ 636 if (icinga_web__ldap_encryption in ["ldaps"]) else 389 }}'
+icinga_web__ldap_port: '{{ 636
+                           if (icinga_web__ldap_encryption in ["ldaps"])
+                           else 389 }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__ldap_user_filter [[[
 #
 # Use this to control which LDAP users are listed as Icinga Web users.
-icinga_web__ldap_user_filter: ''
+icinga_web__ldap_user_filter: '(&
+                                 (objectClass={{ icinga_web__ldap_user_class }})
+                                 (|
+                                   (authorizedService=all)
+                                   (authorizedService=icingaweb)
+                                 )
+                               )'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__ldap_user_class [[[
@@ -699,7 +726,7 @@ icinga_web__ldap_user_name_attribute: 'uid'
 # .. envvar:: icinga_web__ldap_group_filter [[[
 #
 # Use this to control which LDAP groups are listed as Icinga Web groups.
-icinga_web__ldap_group_filter: ''
+icinga_web__ldap_group_filter: 'objectClass={{ icinga_web__ldap_group_class }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__ldap_group_class [[[
@@ -718,10 +745,8 @@ icinga_web__ldap_group_member_attribute: 'member'
 #
 # The LDAP attribute which contains the group name.
 icinga_web__ldap_group_name_attribute: 'cn'
-
                                                                    # ]]]
                                                                    # ]]]
-
 # The :file:`authentication.ini` configuration file [[[
 # -----------------------------------------------------
 
@@ -750,14 +775,14 @@ icinga_web__default_authentication:
       - name: 'resource'
         value: 'icingaweb_db'
 
-  - name: 'auth_ldap'
+  - name: 'ldap_users'
     options:
 
       - name: 'backend'
         value: 'ldap'
 
       - name: 'resource'
-        value: 'ldap'
+        value: 'ldap_db'
 
       - name: 'user_class'
         value: '{{ icinga_web__ldap_user_class }}'
@@ -881,26 +906,20 @@ icinga_web__default_groups:
       - name: 'resource'
         value: 'icingaweb_db'
 
-  - name: 'ldap'
+  - name: 'ldap_groups'
     options:
 
       - name: 'backend'
         value: 'ldap'
 
       - name: 'resource'
-        value: 'ldap'
+        value: 'ldap_db'
 
-      - name: 'user_class'
-        value: '{{ icinga_web__ldap_user_class }}'
-
-      - name: 'user_name_attribute'
-        value: '{{ icinga_web__ldap_user_name_attribute }}'
-
-      - name: 'user_base_dn'
-        value: '{{ icinga_web__ldap_user_base_dn }}'
+      - name: 'user_backend'
+        value: 'ldap_users'
 
       - name: 'base_dn'
-        value: '{{ icinga_web__ldap_group_base_dn }}'
+        value: '{{ icinga_web__ldap_groups_dn | join(",") }}'
 
       - name: 'group_class'
         value: '{{ icinga_web__ldap_group_class }}'
@@ -1070,7 +1089,7 @@ icinga_web__default_resources:
 
     state: '{{ "present" if icinga_web__director_enabled|bool else "ignore" }}'
 
-  - name: 'ldap'
+  - name: 'ldap_db'
     options:
 
       - name: 'type'
@@ -1393,7 +1412,7 @@ icinga_web__ldap__dependent_tasks:
     objectClass: '{{ icinga_web__ldap_self_object_classes }}'
     attributes: '{{ icinga_web__ldap_self_attributes }}'
     no_log: True
-    state: '{{ "present" if icinga_web__ldap_device_dn|d() else "ignore" }}'
+    state: '{{ "present" if icinga_web__ldap_enabled else "ignore" }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__postgresql__dependent_roles [[[

--- a/ansible/roles/icinga_web/defaults/main.yml
+++ b/ansible/roles/icinga_web/defaults/main.yml
@@ -568,6 +568,160 @@ icinga_web__default_account_password: '{{ lookup("password", secret + "/icinga_w
                                           + inventory_hostname + "/default_password") }}'
                                                                    # ]]]
                                                                    # ]]]
+# .. LDAP authentication [[[
+#
+# .. _icinga_web__ref_ldap_defaults:
+#
+# -----------------------
+#   LDAP authentication
+# -----------------------
+#
+# Refer to the `official Icinga web documentation <https://icinga.com/docs/icinga-web-2/latest/doc/05-Authentication/#active-directory-or-ldap-authentication>`__
+# for more details.
+
+# .. envvar:: icinga_web__ldap_enabled [[[
+#
+# Enable LDAP support
+icinga_web__ldap_enabled: '{{ True
+                            if (ansible_local|d() and ansible_local.ldap|d() and
+                                (ansible_local.ldap.enabled|d())|bool)
+                            else False }}'
+
+                                                                   # ]]]
+
+
+# .. envvar:: icinga_web__ldap_base_dn [[[
+#
+# The base Distinguished Name which should be used to create Distinguished
+# Names of the LDAP directory objects, defined as a YAML list.
+icinga_web__ldap_base_dn: '{{ ansible_local.ldap.base_dn|d([]) }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__ldap_group_base_dn [[[
+#
+# The base Distinguished Name where Icinga Web will look for groups.
+icinga_web__ldap_group_base_dn: '{{ icinga_web__ldap_base_dn | join(",") }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__user_base_dn [[[
+#
+# The base Distinguished Name where Icinga Web will look for users.
+icinga_web__ldap_user_base_dn: '{{ icinga_web__ldap_base_dn | join(",") }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__ldap_device_dn [[[
+#
+# The Distinguished Name of the current host LDAP object, defined as a YAML
+# list. It will be used as a base for the Icinga web service account LDAP
+# object. If the list is empty, the role will not create the account LDAP
+# object automatically.
+icinga_web__ldap_device_dn: '{{ ansible_local.ldap.device_dn|d([]) }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__ldap_self_rdn [[[
+#
+# The Relative Distinguished Name of the account LDAP object used by the
+# Icinga Web service to access the LDAP directory.
+icinga_web__ldap_self_rdn: 'uid=icingaweb'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__ldap_self_object_classes [[[
+#
+# List of the LDAP object classes which will be used to create the LDAP object
+# used by the Icinga Web service to access the LDAP directory.
+icinga_web__ldap_self_object_classes: [ 'account', 'simpleSecurityObject' ]
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__ldap_self_attributes [[[
+#
+# YAML dictionary that defines the attributes of the LDAP object used by the
+# Icinga Web service to access the LDAP directory.
+icinga_web__ldap_self_attributes:
+  uid: '{{ icinga_web__ldap_self_rdn.split("=")[1] }}'
+  userPassword: '{{ icinga_web__ldap_bindpw }}'
+  host: '{{ [ ansible_fqdn, ansible_hostname ] | unique }}'
+  description: 'Account used by the "Icinga Web" service to access the LDAP directory'
+
+# .. envvar:: icinga_web__ldap_binddn [[[
+#
+# The Distinguished Name of the account LDAP object used by the
+# Icinga Web service to bind to the LDAP directory.
+icinga_web__ldap_binddn: '{{ ([ icinga_web__ldap_self_rdn ] + icinga_web__ldap_device_dn) | join(",") }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__ldap_bindpw [[[
+#
+# The password stored in the account LDAP object used by the Icinga Web service
+# to bind to the LDAP directory.
+icinga_web__ldap_bindpw: '{{ lookup("password", secret + "/ldap/credentials/"
+                                  + icinga_web__ldap_binddn | to_uuid + ".password length=48 "
+                                  + "chars=ascii_letters,digits,.-_") }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__ldap_hostname [[[
+#
+# The LDAP URI that points to the directory server which should be used by
+# Icinga Web.
+icinga_web__ldap_hostname: '{{ ansible_local.ldap.hosts|d([""]) | first }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__ldap_encryption [[[
+#
+# The LDAP encryption to use, either ``starttls`` (recommended), ``ldaps`` or
+# ``plain`` (discouraged).
+icinga_web__ldap_encryption: 'starttls'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__ldap_port [[[
+#
+# The TCP port to use for LDAP connections.
+icinga_web__ldap_port: '{{ 636 if (icinga_web__ldap_encryption in ["ldaps"]) else 389 }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__ldap_user_filter [[[
+#
+# Use this to control which LDAP users are listed as Icinga Web users.
+icinga_web__ldap_user_filter: ''
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__ldap_user_class [[[
+#
+# The objectClass of LDAP users.
+icinga_web__ldap_user_class: 'inetOrgPerson'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__ldap_user_name_attribute [[[
+#
+# The LDAP attribute which contains the username.
+icinga_web__ldap_user_name_attribute: 'uid'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__ldap_group_filter [[[
+#
+# Use this to control which LDAP groups are listed as Icinga Web groups.
+icinga_web__ldap_group_filter: ''
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__ldap_group_class [[[
+#
+# The objectClass of LDAP groups.
+icinga_web__ldap_group_class: 'groupOfNames'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__ldap_group_member_attribute [[[
+#
+# The LDAP attribute where a group’s members are stored.
+icinga_web__ldap_group_member_attribute: 'member'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__ldap_group_name_attribute [[[
+#
+# The LDAP attribute which contains the group name.
+icinga_web__ldap_group_name_attribute: 'cn'
+
+                                                                   # ]]]
+                                                                   # ]]]
+
 # The :file:`authentication.ini` configuration file [[[
 # -----------------------------------------------------
 
@@ -595,6 +749,26 @@ icinga_web__default_authentication:
 
       - name: 'resource'
         value: 'icingaweb_db'
+
+  - name: 'auth_ldap'
+    options:
+
+      - name: 'backend'
+        value: 'ldap'
+
+      - name: 'resource'
+        value: 'ldap'
+
+      - name: 'user_class'
+        value: '{{ icinga_web__ldap_user_class }}'
+
+      - name: 'user_name_attribute'
+        value: '{{ icinga_web__ldap_user_name_attribute }}'
+
+      - name: 'filter'
+        value: '{{ icinga_web__ldap_user_filter }}'
+
+    state: '{{ "present" if icinga_web__ldap_enabled|bool else "ignore" }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__authentication [[[
@@ -706,6 +880,41 @@ icinga_web__default_groups:
 
       - name: 'resource'
         value: 'icingaweb_db'
+
+  - name: 'ldap'
+    options:
+
+      - name: 'backend'
+        value: 'ldap'
+
+      - name: 'resource'
+        value: 'ldap'
+
+      - name: 'user_class'
+        value: '{{ icinga_web__ldap_user_class }}'
+
+      - name: 'user_name_attribute'
+        value: '{{ icinga_web__ldap_user_name_attribute }}'
+
+      - name: 'user_base_dn'
+        value: '{{ icinga_web__ldap_user_base_dn }}'
+
+      - name: 'base_dn'
+        value: '{{ icinga_web__ldap_group_base_dn }}'
+
+      - name: 'group_class'
+        value: '{{ icinga_web__ldap_group_class }}'
+
+      - name: 'group_member_attribute'
+        value: '{{ icinga_web__ldap_group_member_attribute }}'
+
+      - name: 'group_name_attribute'
+        value: '{{ icinga_web__ldap_group_name_attribute }}'
+
+      - name: 'group_filter'
+        value: '{{ icinga_web__ldap_group_filter }}'
+
+    state: '{{ "present" if icinga_web__ldap_enabled|bool else "ignore" }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__groups [[[
@@ -860,6 +1069,32 @@ icinga_web__default_resources:
         value: '0'
 
     state: '{{ "present" if icinga_web__director_enabled|bool else "ignore" }}'
+
+  - name: 'ldap'
+    options:
+
+      - name: 'type'
+        value: 'ldap'
+
+      - name: 'hostname'
+        value: '{{ icinga_web__ldap_hostname }}'
+
+      - name: 'port'
+        value: '{{ icinga_web__ldap_port }}'
+
+      - name: 'root_dn'
+        value: '{{ icinga_web__ldap_base_dn | join(",") }}'
+
+      - name: 'bind_dn'
+        value: '{{ icinga_web__ldap_binddn }}'
+
+      - name: 'bind_pw'
+        value: '{{ icinga_web__ldap_bindpw }}'
+
+      - name: 'encryption'
+        value: '{{ icinga_web__ldap_encryption }}'
+
+    state: '{{ "present" if icinga_web__ldap_enabled|bool else "ignore" }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__resources [[[
@@ -1146,6 +1381,19 @@ icinga_web__apt_preferences__dependent_list:
     backports: [ 'stretch' ]
     by_role: 'debops.icinga_web'
     reason: 'Incompatibility with PHP 7.3'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__ldap__dependent_tasks [[[
+#
+# Configuration for the :ref:`debops.ldap` Ansible role.
+icinga_web__ldap__dependent_tasks:
+
+  - name: 'Create Icinga Web account for {{ icinga_web__ldap_device_dn | join(",") }}'
+    dn: '{{ icinga_web__ldap_binddn }}'
+    objectClass: '{{ icinga_web__ldap_self_object_classes }}'
+    attributes: '{{ icinga_web__ldap_self_attributes }}'
+    no_log: True
+    state: '{{ "present" if icinga_web__ldap_device_dn|d() else "ignore" }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__postgresql__dependent_roles [[[


### PR DESCRIPTION
This PR adds support for LDAP authentication and groups.

It configures options described here: https://icinga.com/docs/icinga-web-2/latest/doc/05-Authentication/#active-directory-or-ldap-authentication

It was successfully tested on my infra (with manual LDAP management; I don't use debops for that. But I was able to create the uid=icingaweb user with **icinga_web__dependent__ldap_tasks**)   