### PR TITLE
[icinga_web] add support for x509 module

### DIFF
--- a/ansible/playbooks/service/icinga_web.yml
+++ b/ansible/playbooks/service/icinga_web.yml
@@ -22,7 +22,9 @@
           - '{{ php__keyring__dependent_apt_keys }}'
           - '{{ nginx__keyring__dependent_apt_keys }}'
           - '{{ postgresql__keyring__dependent_apt_keys if (icinga_web__database_type == "postgresql") else [] }}'
-          - '{{ mariadb__keyring__dependent_apt_keys if (icinga_web__database_type == "mariadb") else [] }}'
+          - '{{ mariadb__keyring__dependent_apt_keys
+                if (icinga_web__database_type == "mariadb" or icinga_web__x509_enabled)
+                else [] }}'
       tags: [ 'role::keyring', 'skip::keyring',
               'role::php', 'role::nginx', 'role::postgresql', 'role::mariadb' ]
 
@@ -55,11 +57,15 @@
       tags: [ 'role::python', 'skip::python', 'role::mariadb', 'role::postgresql' ]
       python__dependent_packages3:
         - '{{ postgresql__python__dependent_packages3 if icinga_web__database_type == "postgresql" else [] }}'
-        - '{{ mariadb__python__dependent_packages3 if icinga_web__database_type == "mariadb" else [] }}'
+        - '{{ mariadb__python__dependent_packages3
+              if (icinga_web__database_type == "mariadb" or icinga_web__x509_enabled)
+              else [] }}'
         - '{{ nginx__python__dependent_packages3 }}'
       python__dependent_packages2:
         - '{{ postgresql__python__dependent_packages2 if icinga_web__database_type == "postgresql" else [] }}'
-        - '{{ mariadb__python__dependent_packages2 if icinga_web__database_type == "mariadb" else [] }}'
+        - '{{ mariadb__python__dependent_packages2
+              if (icinga_web__database_type == "mariadb" or icinga_web__x509_enabled)
+              else [] }}'
         - '{{ nginx__python__dependent_packages2 }}'
 
     - role: php
@@ -94,7 +100,8 @@
         - '{{ icinga_web__mariadb__dependent_databases }}'
       mariadb__dependent_users:
         - '{{ icinga_web__mariadb__dependent_users }}'
-      when: icinga_web__database_type == 'mariadb'
+      when: icinga_web__database_type == 'mariadb' or
+            icinga_web__x509_enabled|bool
 
     - role: icinga_web
       tags: [ 'role::icinga_web', 'skip::icinga_web' ]

--- a/ansible/roles/icinga_web/defaults/main.yml
+++ b/ansible/roles/icinga_web/defaults/main.yml
@@ -171,6 +171,11 @@ icinga_web__default_modules:
     git_version: 'v0.5.0'
     state: 'present'
 
+  - name: 'x509'
+    git_repo: 'https://github.com/icinga/icingaweb2-module-x509'
+    git_version: 'v1.0.0'
+    state: '{{ "present" if icinga_web__x509_enabled|bool else "ignore" }}'
+
                                                                    # ]]]
 # .. envvar:: icinga_web__modules [[[
 #
@@ -493,6 +498,64 @@ icinga_web__director_kickstart_enabled: '{{ True
                                             if (ansible_local|d() and ansible_local.icinga|d() and
                                                 (ansible_local.icinga.installed|d())|bool)
                                             else False }}'
+                                                                   # ]]]
+                                                                   # ]]]
+# Icinga 2 x509 module support [[[
+# -----------------------------
+
+# .. envvar:: icinga_web__x509_enabled [[[
+#
+# Enable or disable support for Icinga 2 Web x509 module. It requires
+# MariaDB/MySQL.
+# See https://github.com/icinga/icingaweb2-module-x509 for more details
+icinga_web__x509_enabled: '{{ ansible_local.mariadb is defined }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__x509_database_name [[[
+#
+# Name of the Icinga 2 Web database used for the X509 module
+icinga_web__x509_database_name: 'icingaweb2_x509'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__x509_database_user [[[
+#
+# Name of the Icinga 2 Web x509 database user.
+icinga_web__x509_database_user: 'icingaweb2_x509'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__x509_database_password [[[
+#
+# Password for Icinga 2 Web x509 database.
+icinga_web__x509_database_password: '{{ lookup("password", secret + "/mariadb/" + ansible_local.mariadb.delegate_to +
+                                   "/credentials/" + icinga_web__x509_database_user + "/password" +
+                                   " length=48 chars=ascii_letters,digits,.-_") }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__x509_database_host [[[
+#
+# Address of the Icinga 2 X509 database server.
+icinga_web__x509_database_host: '{{ ansible_local.mariadb.server }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__x509_database_port [[[
+#
+# The port on which the Icinga 2 x509 database server listens for
+# connections.
+icinga_web__x509_database_port: '{{ ansible_local.mariadb.port }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__x5609_database_schema [[[
+#
+# Absolute path to the Icinga 2 Web internal database schema which will be
+# imported during initialization.
+icinga_web__x509_database_schema: '/usr/share/icingaweb2/modules/x509/etc/schema/mysql.schema.sql'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__x509_database_init [[[
+#
+# Enable or disable initialization of the Icinga 2 Web x509 database.
+icinga_web__x509_database_init: '{{ not ansible_local.icinga_web.x509_installed | d(False) }}'
+
                                                                    # ]]]
                                                                    # ]]]
 # Icinga 2 REST API [[[
@@ -861,6 +924,35 @@ icinga_web__default_resources:
 
     state: '{{ "present" if icinga_web__director_enabled|bool else "ignore" }}'
 
+  - name: 'icingaweb2_x509'
+    options:
+
+      - name: 'type'
+        value: 'db'
+
+      - name: 'db'
+        value: 'mysql'
+
+      - name: 'host'
+        value: '{{ icinga_web__x509_database_host }}'
+
+      - name: 'port'
+        value: '{{ icinga_web__x509_database_port }}'
+
+      - name: 'dbname'
+        value: '{{ icinga_web__x509_database_name }}'
+
+      - name: 'username'
+        value: '{{ icinga_web__x509_database_user }}'
+
+      - name: 'password'
+        value: '{{ icinga_web__x509_database_password }}'
+
+      - name: 'charset'
+        value: 'utf8'
+
+    state: '{{ "present" if icinga_web__x509_enabled|bool else "ignore" }}'
+
                                                                    # ]]]
 # .. envvar:: icinga_web__resources [[[
 #
@@ -1134,6 +1226,44 @@ icinga_web__combined_director_kickstart_cfg: '{{ icinga_web__current_director_ki
                                                  + icinga_web__director_kickstart_cfg }}'
                                                                    # ]]]
                                                                    # ]]]
+# The :file:`modules/x509/config.ini` configuration file [[[
+# --------------------------------------------------------------
+
+# These variables manage the contents of the
+# :file:`/etc/icingaweb2/modules/x509/config.ini` configuration file.
+# See :ref:`icinga_web__ref_ini_configuration` for more details.
+
+# .. envvar:: icinga_web__current_x509_cfg [[[
+#
+# The current contents of the config file, gathered during runtime.
+icinga_web__current_x509_cfg: '{{ (icinga_web__register_config.stdout
+                                       | from_json)["modules/x509/config.ini"] | d([]) }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__default_x509_cfg [[[
+#
+# The default Icinga 2 509 configuration appled by the role.
+icinga_web__default_x509_cfg:
+
+  - name: 'backend'
+    options:
+
+      - name: 'resource'
+        value: 'icingaweb2_x509'
+
+    state: '{{ "present" if icinga_web__x509_enabled|bool else "ignore" }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__combined_x509_cfg [[[
+#
+# The variable which combines the Icinga 2 x509 configuration from
+# different source variables and is used by the role task to generate the
+# actual file.
+icinga_web__combined_x509_cfg: '{{ icinga_web__current_x509_cfg
+                                       + icinga_web__default_x509_cfg }}'
+
+                                                                   # ]]]
+                                                                   # ]]]
 # Configuration for other Ansible roles [[[
 # -----------------------------------------
 
@@ -1219,9 +1349,15 @@ icinga_web__postgresql__dependent_extensions:
 icinga_web__mariadb__dependent_databases:
 
   - name: '{{ icinga_web__database_name }}'
+    state: '{{ "present" if icinga_web__database_type == "mariadb" else "ignore" }}'
 
   - name: '{{ icinga_web__director_database_name }}'
-    state: '{{ "present" if icinga_web__director_enabled|bool else "ignore" }}'
+    state: '{{ "present"
+                if (icinga_web__director_enabled|bool and icinga_web__director_database_type == "mariadb")
+                else "ignore" }}'
+
+  - name: '{{ icinga_web__x509_database_name }}'
+    state: '{{ "present" if icinga_web__x509_enabled|bool else "ignore" }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__mariadb__dependent_users [[[
@@ -1231,10 +1367,17 @@ icinga_web__mariadb__dependent_users:
 
   - database: '{{ icinga_web__database_name }}'
     user: '{{ icinga_web__database_user }}'
+    state: '{{ "present" if icinga_web__database_type == "mariadb" else "ignore" }}'
 
   - database: '{{ icinga_web__director_database_name }}'
     user: '{{ icinga_web__director_database_user }}'
-    state: '{{ "present" if icinga_web__director_enabled|bool else "ignore" }}'
+    state: '{{ "present"
+                if (icinga_web__director_enabled|bool and icinga_web__director_database_type == "mariadb")
+                else "ignore" }}'
+
+  - database: '{{ icinga_web__x509_database_name }}'
+    user: '{{ icinga_web__x509_database_user }}'
+    state: '{{ "present" if icinga_web__x509_enabled|bool else "ignore" }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__php__dependent_packages [[[
@@ -1249,6 +1392,7 @@ icinga_web__php__dependent_packages:
   - 'pgsql'
   - 'curl'
   - 'yaml'
+  - 'gmp'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__php__dependent_pools [[[

--- a/ansible/roles/icinga_web/tasks/main.yml
+++ b/ansible/roles/icinga_web/tasks/main.yml
@@ -40,6 +40,8 @@
 
     - name: 'modules/director'
 
+    - name: 'modules/x509'
+
   when: item.state|d('present') not in [ 'absent', 'ignore', 'init' ]
 
 - name: Download and install Icinga upstream modules
@@ -111,6 +113,9 @@
     - filename: 'modules/director/kickstart.ini'
       config: '{{ icinga_web__combined_director_kickstart_cfg }}'
 
+    - filename: 'modules/x509/config.ini'
+      config: '{{ icinga_web__combined_x509_cfg }}'
+
   when: item.state|d('present') not in [ 'absent', 'ignore', 'init' ]
 
 - name: Generate initial data file
@@ -162,6 +167,18 @@
   when: icinga_web__database_type == 'mariadb' and
         icinga_web__database_host == 'localhost' and
         icinga_web__database_init|bool
+
+- name: Import Icinga Web x509 database on installation into MariaDB
+  mysql_db:
+    name: '{{ icinga_web__x509_database_name }}'
+    state: 'import'
+    target: '{{ icinga_web__x509_database_schema }}'
+    login_host: '{{ icinga_web__x509_database_host }}'
+    login_port: '{{ icinga_web__x509_database_port }}'
+    login_user: '{{ icinga_web__x509_database_user }}'
+    login_password: '{{ icinga_web__x509_database_password }}'
+  when: icinga_web__x509_enabled|bool and
+        icinga_web__x509_database_init|bool
 
 - name: Ensure that initial data schema is removed
   file:
@@ -235,6 +252,11 @@
     enabled: False
     state: 'stopped'
   when: not icinga_web__director_enabled|bool
+
+- name: Import CA certificates to Icinga Web x509 truststore
+  command: 'icingacli x509 import --file /etc/ssl/certs/ca-certificates.crt'
+  when: icinga_web__x509_enabled|bool and
+        icinga_web__x509_database_init|bool
 
 - name: Make sure that Ansible local facts directory exists
   file:

--- a/ansible/roles/icinga_web/templates/etc/ansible/facts.d/icinga_web.fact.j2
+++ b/ansible/roles/icinga_web/templates/etc/ansible/facts.d/icinga_web.fact.j2
@@ -21,6 +21,7 @@ def cmd_exists(cmd):
 
 
 output = loads('''{{ {"installed": False,
+                      "x509_installed": icinga_web__x509_enabled,
                       "database_type": icinga_web__database_type}
                      | to_nice_json }}''')
 


### PR DESCRIPTION
This PR adds support for Icinga Certificate Monitoring (https://icinga.com/docs/icinga-certificate-monitoring/latest/)

It requires a MySQL/MariaDB database (currently not compatible with PostgreSQL)

It installs the module from the git repo, setup the mysql database and creates the needed icingaweb resources, so that the user is able to monitor his certificates in Icinga Web.

The monitoring configuration (https://icinga.com/docs/icinga-certificate-monitoring/latest/doc/10-Monitoring/) is left to the user with Icinga Director, although another PR could probably automatically create needed objects/services in Icinga Director.