### PR TITLE
[roundcube] Update Roundcube version to 1.4.10

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -152,7 +152,7 @@ Updates of upstream application versions
   10.7 respectively.
 
 - In the :ref:`debops.roundcube` role, the Roundcube version installed by
-  default has been updated to ``1.4.9``.
+  default has been updated to ``1.4.10``.
 
 - In the :ref:`debops.owncloud` role, the Nextcloud version installed by
   default has been updated to ``v18.0``.

--- a/ansible/roles/roundcube/defaults/main.yml
+++ b/ansible/roles/roundcube/defaults/main.yml
@@ -163,7 +163,7 @@ roundcube__git_dir: '{{ roundcube__src + "/"
 # .. envvar:: roundcube__git_version [[[
 #
 # Roundcube release tag to deploy.
-roundcube__git_version: '1.4.9'
+roundcube__git_version: '1.4.10'
 
                                                                    # ]]]
 # .. envvar:: roundcube__git_dest [[[

--- a/ansible/roles/roundcube/meta/watch-roundcubemail
+++ b/ansible/roles/roundcube/meta/watch-roundcubemail
@@ -4,7 +4,7 @@
 
 # Role: roundcube
 # Package: roundcubemail
-# Version: 1.4.9
+# Version: 1.4.10
 
 version=4
 https://github.com/roundcube/roundcubemail/tags .*/v?(.*\S+)\.tar\.gz


### PR DESCRIPTION
Roundcube 1.4.10 contains a fix for a stored XSS vulnerability
(CVE-2020-35730) as well as some general improvements.

https://github.com/roundcube/roundcubemail/releases/tag/1.4.10