### PR TITLE
[owncloud] Add support for NC 19 and drop NC 18

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -87,9 +87,9 @@ LDAP
 :ref:`debops.owncloud` role
 '''''''''''''''''''''''''''
 
-- Drop Nextcloud 16 and 17 support because it is EOL. You need to upgrade Nextcloud
-  manually if you are running version 17 or below. The role now defaults to
-  Nextcloud 18 for new installations.
+- Drop Nextcloud 16, 17 and 18 support because it is EOL. You need to upgrade Nextcloud
+  manually if you are running version 18 or below. The role now defaults to
+  Nextcloud 19 for new installations.
 
 :ref:`debops.postgresql` role
 '''''''''''''''''''''''''''''

--- a/ansible/roles/owncloud/COPYRIGHT
+++ b/ansible/roles/owncloud/COPYRIGHT
@@ -2,8 +2,8 @@ debops.owncloud - Install and manage ownCloud instances
 
 Copyright (C) 2015-2016 Maciej Delmanowski <drybjed@gmail.com>
 Copyright (C) 2015      Hartmut Goebel <h.goebel@crazy-compilers.com>
-Copyright (C) 2015-2019 Robin Schneider <ypid@riseup.net>
-Copyright (C) 2015-2019 DebOps <https://debops.org/>
+Copyright (C) 2015-2021 Robin Schneider <ypid@riseup.net>
+Copyright (C) 2015-2021 DebOps <https://debops.org/>
 SPDX-License-Identifier: GPL-3.0-only
 
 This Ansible role is part of DebOps.

--- a/ansible/roles/owncloud/defaults/main.yml
+++ b/ansible/roles/owncloud/defaults/main.yml
@@ -3,8 +3,8 @@
 
 # .. Copyright (C) 2015-2016 Maciej Delmanowski <drybjed@gmail.com>
 # .. Copyright (C) 2015      Hartmut Goebel <h.goebel@crazy-compilers.com>
-# .. Copyright (C) 2015-2020 Robin Schneider <ypid@riseup.net>
-# .. Copyright (C) 2015-2020 DebOps <https://debops.org/>
+# .. Copyright (C) 2015-2021 Robin Schneider <ypid@riseup.net>
+# .. Copyright (C) 2015-2021 DebOps <https://debops.org/>
 # .. SPDX-License-Identifier: GPL-3.0-only
 
 # .. _owncloud__ref_defaults:
@@ -76,6 +76,8 @@ owncloud__required_php_packages:
   # - 'posix'
   # - 'zlib'
 
+  - 'bcmath'
+  - 'gmp'
 
 # .. envvar:: owncloud__recommended_php_packages
 #
@@ -414,8 +416,7 @@ owncloud__variant_name_map:
 #
 # * ownCloud ``10.4``
 #
-# * Nextcloud ``18.0``
-# * Nextcloud ``19.0`` (untested)
+# * Nextcloud ``19.0``
 #
 # For Nextcloud refer to the `Nextcloud Maintenance and Release Schedule <https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule>`_.
 # and the `Nextcloud Server Changelog <https://nextcloud.com/changelog/>`_.
@@ -424,7 +425,7 @@ owncloud__variant_name_map:
 # and the `package index <https://download.owncloud.org/download/repositories/>`_ for more details.
 owncloud__release: '{{ "10.4"
                        if (owncloud__variant == "owncloud")
-                       else "18.0" }}'
+                       else "19.0" }}'
 
 
 # .. envvar:: owncloud__distribution
@@ -2192,6 +2193,9 @@ owncloud__nginx__dependent_servers:
       error_page            403             /core/templates/403.php;
       error_page            404             /core/templates/404.php;
       {% endif %}
+
+      # Default Cache-Control policy
+      expires 1m;
 
 
       # Avoid to send the security headers twice as ownCloud

--- a/ansible/roles/owncloud/meta/watch-nextcloud
+++ b/ansible/roles/owncloud/meta/watch-nextcloud
@@ -6,7 +6,7 @@
 
 # Role: owncloud
 # Package: nextcloud
-# Version: 18.0
+# Version: 19.0
 
 version=4
 https://download.nextcloud.com/server/releases/ nextcloud-(.+)\.tar\.bz2


### PR DESCRIPTION
NC 18 will get EOL at the end of the month. Ref: https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule

I am still testing a bit but you can already review. Not much is needed. NC 20 will need a bit more Nginx changes that is why I did not add support for it yet.