### PR TITLE
[gitlab] Some fixes for Gitlab pages and add access control

### DIFF
--- a/ansible/roles/gitlab/defaults/main.yml
+++ b/ansible/roles/gitlab/defaults/main.yml
@@ -197,6 +197,45 @@ gitlab_pages_domain: ''
 # Port the ``gitlab-pages`` HTTP server listens to.
 gitlab_pages_port: '8090'
                                                                    # ]]]
+
+# .. envvar:: gitlab_pages_access_control_enabled [[[
+#
+# GitLab Pages access control can be configured per-project, and allows access to
+# a Pages site to be controlled based on a user’s membership to that project.
+# You need set also ``gitlab_pages_auth_client_id`` and ``gitlab_pages_auth_client_secret``
+# Available in Gitlab 12.10 and newer.
+# https://docs.gitlab.com/12.10/ee/administration/pages/source.html#access-control
+gitlab_pages_access_control_enabled: False
+                                                                   # ]]]
+
+# .. envvar:: gitlab_pages_auth_client_id [[[
+#
+# GitLab application Client ID
+gitlab_pages_auth_client_id: ''
+                                                                   # ]]]
+
+# .. envvar:: gitlab_pages_auth_client_secret [[[
+#
+# GitLab application Client Secret
+gitlab_pages_auth_client_secret: ''
+                                                                   # ]]]
+
+
+# .. envvar:: gitlab_pages_auth_secret_path [[[
+#
+# Path to auth secret file located on the Ansible Controller. See the
+# :ref:`debops.secret` role for more details.
+gitlab_pages_auth_secret_path: '{{ secret + "/credentials/" + inventory_hostname +
+                                   "/gitlab-pages/auth/secret" }}'
+
+                                                                   # ]]]
+
+# .. envvar:: gitlab_pages_auth_secret [[[
+#
+# Cookie store hash key, should be at least 32 bytes long.
+gitlab_pages_auth_secret: "{{ lookup('password', gitlab_pages_auth_secret_path
+                              + ' length=40 chars=hexdigits') }}"
+                                                                   # ]]]
                                                                    # ]]]
 # nginx webserver options [[[
 # ---------------------------
@@ -493,11 +532,9 @@ gitlab_group: 'git'
 # If the LDAP support was enabled after the system groups have been created,
 # the role will keep the current prefix value to not duplicate the UNIX groups.
 gitlab_system_groups_prefix: '{{ ansible_local.system_groups.local_prefix
-                                 if (ansible_local|d() and ansible_local.system_groups|d() and
-                                     ansible_local.system_groups.local_prefix is defined)
+                                 if ansible_local.system_groups.local_prefix|d()
                                  else ("_"
-                                       if (ansible_local|d() and ansible_local.ldap|d() and
-                                           (ansible_local.ldap.posix_enabled|d())|bool)
+                                       if (ansible_local.ldap.posix_enabled|d())|bool)
                                        else "") }}'
 
                                                                    # ]]]

--- a/ansible/roles/gitlab/tasks/configure_gitlab-pages.yml
+++ b/ansible/roles/gitlab/tasks/configure_gitlab-pages.yml
@@ -110,3 +110,13 @@
   become: True
   become_user: '{{ gitlab_user }}'
   when: gitlab_register_pages_checkout is changed
+
+- name: Setup GitLab Pages default variables
+  template:
+    src: 'etc/default/gitlab-pages.j2'
+    dest: '/etc/default/gitlab-pages'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  when: gitlab_version is version_compare("12.8", operator="ge", strict=True)
+  notify: [ 'Restart gitlab', 'Restart gitlab.slice' ]

--- a/ansible/roles/gitlab/tasks/configure_gitlab-pages.yml
+++ b/ansible/roles/gitlab/tasks/configure_gitlab-pages.yml
@@ -116,7 +116,7 @@
     src: 'etc/default/gitlab-pages.j2'
     dest: '/etc/default/gitlab-pages'
     owner: 'root'
-    group: 'root'
-    mode: '0644'
+    group: '{{ gitlab_group }}'
+    mode: '0640'
   when: gitlab_version is version_compare("12.8", operator="ge", strict=True)
   notify: [ 'Restart gitlab', 'Restart gitlab.slice' ]

--- a/ansible/roles/gitlab/tasks/configure_gitlab_ce.yml
+++ b/ansible/roles/gitlab/tasks/configure_gitlab_ce.yml
@@ -99,8 +99,7 @@
 - name: Install GitLab SysVinit script
   command: cp -f {{ gitlab_ce_git_checkout + "/lib/support/init.d/gitlab" }} /etc/init.d/gitlab
   register: gitlab__register_sysvinit_script
-  when: (gitlab_register_ce_checkout is changed and
-         (gitlab_use_systemd is defined and not gitlab_use_systemd))
+  when: (gitlab_use_systemd is defined and not gitlab_use_systemd)
 
 - name: Install GitLab systemd service files
   template:
@@ -117,8 +116,7 @@
           if (gitlab_version is version_compare("9.0", operator="gt", strict=True))
           else [] }}'
   register: gitlab__register_systemd_services
-  when: (gitlab_register_ce_checkout is changed and
-         (gitlab_use_systemd is defined and gitlab_use_systemd))
+  when: (gitlab_use_systemd is defined and gitlab_use_systemd)
 
 - name: Install GitLab Pages systemd service file
   template:
@@ -127,7 +125,6 @@
     mode: '0644'
   register: gitlab__register_pages_systemd_services
   when: (gitlab_enable_pages and
-         gitlab_register_ce_checkout is changed and
          (gitlab_use_systemd is defined and gitlab_use_systemd))
 
 - name: Reload systemd daemons
@@ -142,15 +139,13 @@
   service:
     name: 'gitlab'
     enabled: True
-  when: (gitlab_register_ce_checkout is changed and
-         ansible_service_mgr != 'systemd' and not gitlab_use_systemd|bool)
+  when: (ansible_service_mgr != 'systemd' and not gitlab_use_systemd|bool)
 
 - name: Enable GitLab SysVinit service (systemd)
   systemd:
     name: 'gitlab'
     enabled: True
-  when: (gitlab_register_ce_checkout is changed and
-         ansible_service_mgr == 'systemd' and not gitlab_use_systemd|bool)
+  when: (ansible_service_mgr == 'systemd' and not gitlab_use_systemd|bool)
 
 - name: Enable GitLab systemd services
   service:
@@ -165,16 +160,13 @@
     - '{{ "gitlab-gitaly.service"
           if (gitlab_version is version_compare("9.0", operator="gt", strict=True))
           else [] }}'
-  when: (gitlab_register_ce_checkout is changed and
-         gitlab_use_systemd|bool)
+  when: (gitlab_use_systemd|bool)
 
 - name: Enable GitLab Pages systemd service
   service:
     name: 'gitlab-pages.service'
     enabled: True
-  when: (gitlab_enable_pages and
-         gitlab_register_ce_checkout is changed and
-         gitlab_use_systemd|bool)
+  when: (gitlab_enable_pages and gitlab_use_systemd|bool)
 
 
 # ---- GitLab installation / upgrade ----

--- a/ansible/roles/gitlab/templates/etc/default/gitlab-pages.j2
+++ b/ansible/roles/gitlab/templates/etc/default/gitlab-pages.j2
@@ -9,6 +9,7 @@ pages-domain={{ gitlab_pages_domain }}
 pages-root={{ gitlab_pages_path }}
 listen-proxy=127.0.0.1:{{ gitlab_pages_port }}
 gitlab-server=https://{{ gitlab__fqdn }}
+artifacts-server=https://{{ gitlab__fqdn }}/api/v4
 
 {% if gitlab_pages_auth_client_id and gitlab_pages_auth_client_secret %}
 auth-client-id={{ gitlab_pages_auth_client_id }}

--- a/ansible/roles/gitlab/templates/etc/default/gitlab-pages.j2
+++ b/ansible/roles/gitlab/templates/etc/default/gitlab-pages.j2
@@ -1,0 +1,18 @@
+{# Copyright (C) 2011-2015 GitLab B.V. <https://gitlab.com/>
+ # Copyright (C) 2015-2017 Maciej Delmanowski <drybjed@gmail.com>
+ # Copyright (C) 2015-2017 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: MIT
+ #}
+# {{ ansible_managed }}
+
+pages-domain={{ gitlab_pages_domain }}
+pages-root={{ gitlab_pages_path }}
+listen-proxy=127.0.0.1:{{ gitlab_pages_port }}
+gitlab-server=https://{{ gitlab__fqdn }}
+
+{% if gitlab_pages_auth_client_id and gitlab_pages_auth_client_secret %}
+auth-client-id={{ gitlab_pages_auth_client_id }}
+auth-client-secret={{ gitlab_pages_auth_client_secret }}
+auth-redirect-uri=https://{{ gitlab_pages_domain }}/auth
+auth-secret={{ gitlab_pages_auth_secret }}
+{% endif %}

--- a/ansible/roles/gitlab/templates/etc/default/gitlab-pages.j2
+++ b/ansible/roles/gitlab/templates/etc/default/gitlab-pages.j2
@@ -1,6 +1,6 @@
 {# Copyright (C) 2011-2015 GitLab B.V. <https://gitlab.com/>
- # Copyright (C) 2015-2017 Maciej Delmanowski <drybjed@gmail.com>
- # Copyright (C) 2015-2017 DebOps <https://debops.org/>
+ # Copyright (C) 2021 Pedro Luis Lopez <pedroluis.lopezsanchez@gmail.com>
+ # Copyright (C) 2015-2021 DebOps <https://debops.org/>
  # SPDX-License-Identifier: MIT
  #}
 # {{ ansible_managed }}

--- a/ansible/roles/gitlab/templates/etc/systemd/system/gitlab-pages.service.j2
+++ b/ansible/roles/gitlab/templates/etc/systemd/system/gitlab-pages.service.j2
@@ -21,7 +21,11 @@ WorkingDirectory={{ gitlab_pages_path }}
 SyslogIdentifier=gitlab-pages
 PIDFile={{ gitlab_app_root_path }}/gitlab/tmp/pids/gitlab-pages.pid
 
+{% if gitlab_version is version_compare("12.8", operator="ge", strict=True) %}
+ExecStart={{ gitlab_app_root_path }}/gitlab-pages/gitlab-pages -config=/etc/default/gitlab-pages
+{% else %}
 ExecStart={{ gitlab_app_root_path }}/gitlab-pages/gitlab-pages -pages-domain {{ gitlab_pages_domain }} -pages-root {{ gitlab_pages_path }} -listen-proxy 127.0.0.1:{{ gitlab_pages_port }}
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/roles/gitlab/templates/var/local/git/gitlab/config/gitlab.yml.j2
+++ b/ansible/roles/gitlab/templates/var/local/git/gitlab/config/gitlab.yml.j2
@@ -157,6 +157,11 @@ production: &base
     # The location where pages are stored (default: shared/pages).
     path: {{ gitlab_pages_path }}
 
+{% if gitlab_version is version_compare("12.10", operator="ge", strict=True) %}
+    # GitLab Pages access control
+    access_control: {{ gitlab_pages_access_control_enabled }}
+
+{% endif %}
     # The domain under which the pages are served:
     # http://group.example.com/project
     # or project path can be a group page: group.example.com

--- a/ansible/roles/gitlab/templates/var/local/git/gitlab/config/gitlab.yml.j2
+++ b/ansible/roles/gitlab/templates/var/local/git/gitlab/config/gitlab.yml.j2
@@ -161,8 +161,8 @@ production: &base
     # http://group.example.com/project
     # or project path can be a group page: group.example.com
     host: {{ gitlab_pages_domain }}
-    port: {{ gitlab_pages_port }} # Set to 443 if you serve the pages with HTTPS
-    https: false # Set to true if you serve the pages with HTTPS
+    port: 443 # Set to 443 if you serve the pages with HTTPS
+    https: true # Set to true if you serve the pages with HTTPS
     artifacts_server: true
     # external_http: ["1.1.1.1:80", "[2001::1]:80"] # If defined, enables custom domain support in GitLab Pages
     # external_https: ["1.1.1.1:443", "[2001::1]:443"] # If defined, enables custom domain and certificate support in GitLab Pages


### PR DESCRIPTION
- Fix gitlab pages configuration. The configuration in gitlab.yml is only used for compose the URL's in the GitLab front and the role installs nginx with https. So, the correct configuration in gitlab.yml file is to use port 443 and https.
- Fix gitlab systemd services deploy. GitLab Pages could be activated after the first installation. So, it's necessary drop "repository checkout changed" condition in systemd services deploy.
- Improvement GitLab Pages configuration. For version greater or equal than 12.8 it use a default file configuration instead of parameters in systemd service.
- Added support for GitLab Pages access control for version greater or equal than 12.10.