### PR TITLE
etherpad: log to file by default

### DIFF
--- a/ansible/roles/etherpad/defaults/main.yml
+++ b/ansible/roles/etherpad/defaults/main.yml
@@ -87,6 +87,12 @@ etherpad_src_dir: '{{ (ansible_local.fhs.src | d("/usr/local/src"))
 etherpad_log_dir: '{{ (ansible_local.fhs.log | d("/var/log"))
                       + "/" + etherpad_system_name }}'
                                                                    # ]]]
+# .. envvar:: etherpad_log_to_file [[[
+#
+# By default Etherpad log into syslog, set to true if you whant to log into a
+# file instead of syslog.
+etherpad_log_to_file: False
+                                                                   # ]]]
                                                                    # ]]]
 # Basic configuration [[[
 # -----------------------

--- a/ansible/roles/etherpad/templates/etc/systemd/system/etherpad-lite.service.j2
+++ b/ansible/roles/etherpad/templates/etc/systemd/system/etherpad-lite.service.j2
@@ -20,8 +20,10 @@ Group={{ etherpad_group }}
 WorkingDirectory={{ etherpad_home + "/" + etherpad_repository }}
 ExecStart=/usr/bin/nodejs {{ etherpad_home + "/" + etherpad_repository }}/node_modules/ep_etherpad-lite/node/server.js
 Restart=always
+{% if etherpad_log_to_file is defined and etherpad_log_to_file %}
 StandardOutput=append:{{ etherpad_log_dir }}/production.log
 StandardError=inherit
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/roles/etherpad/templates/etc/systemd/system/etherpad-lite.service.j2
+++ b/ansible/roles/etherpad/templates/etc/systemd/system/etherpad-lite.service.j2
@@ -20,6 +20,8 @@ Group={{ etherpad_group }}
 WorkingDirectory={{ etherpad_home + "/" + etherpad_repository }}
 ExecStart=/usr/bin/nodejs {{ etherpad_home + "/" + etherpad_repository }}/node_modules/ep_etherpad-lite/node/server.js
 Restart=always
+StandardOutput=append:{{ etherpad_log_dir }}/production.log
+StandardError=inherit
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Etherpad role prepare everything to allow etherpad to log into /var/log/etherpad-server/ ([dir creation](https://github.com/debops/debops/blob/master/ansible/roles/etherpad/tasks/main.yml#L129), [logrotate](debops/debops/blob/master/ansible/roles/etherpad/defaults/main.yml#L457) ) but by default the service log into syslog. This PR tel to systemd to log into /var/log/etherpad-server/production.log

This can break things if people parse syslog to extract etherpad log. I can add a variable to make this PR not enabled by default.