### PR TITLE
[journald] Create secret directories after facts

### DIFF
--- a/ansible/roles/journald/tasks/main.yml
+++ b/ansible/roles/journald/tasks/main.yml
@@ -6,14 +6,6 @@
 - import_role:
     name: 'ansible_plugins'
 
-- import_role:
-    name: 'secret'
-  vars:
-    secret__directories:
-      - '{{ (journald__fss_verify_key_path | dirname)
-            if journald__fss_enabled|bool
-            else [] }}'
-
 - name: Make sure that Ansible local facts directory exists
   file:
     path: '/etc/ansible/facts.d'
@@ -30,6 +22,14 @@
 - name: Update Ansible facts if they were modified
   action: setup
   when: journald__register_facts is changed
+
+- import_role:
+    name: 'secret'
+  vars:
+    secret__directories:
+      - '{{ (journald__fss_verify_key_path | dirname)
+            if journald__fss_enabled|bool
+            else [] }}'
 
 - name: Move persistent journal to volatile storage if requested
   command: 'journalctl --relinquish-var'


### PR DESCRIPTION
The task that creates the directories on the Ansible Controller using
the 'secret' role depends on the Ansible local facts on the remote host.
This patch changes the order of the tasks in the 'journald' role to
ensure that all facts are known and up to date when the 'secret' role is
invoked.

Fixes #1558 