### PR TITLE
[owncloud] add variable for release channel

### DIFF
--- a/ansible/roles/owncloud/defaults/main.yml
+++ b/ansible/roles/owncloud/defaults/main.yml
@@ -819,6 +819,12 @@ owncloud__role_config:
     state: '{{ "present" if (owncloud__temp_path != "") else "absent" }}'
     value: '{{ owncloud__temp_path }}'
 
+# .. envvar:: owncloud__release_channel
+#
+# Release channel
+owncloud__release_channel: '{{ "stable" if (owncloud__variant == "nextcloud" and
+                                owncloud__release is version("17.0", ">="))
+                            else "production" }}'
 
 # .. envvar:: owncloud__role_recommended_config
 #
@@ -848,8 +854,7 @@ owncloud__role_recommended_config:
   ## Default is "stable" as of Nextcloud 11.
   ## "production" is the most conservative channel which is preferred by the role maintainers.
   ## https://owncloud.org/release-channels/
-  'updater.release.channel': 'production'
-
+  'updater.release.channel': '{{ owncloud__release_channel }}'
 
 # .. envvar:: owncloud__config
 #

--- a/ansible/roles/owncloud/defaults/main.yml
+++ b/ansible/roles/owncloud/defaults/main.yml
@@ -821,10 +821,12 @@ owncloud__role_config:
 
 # .. envvar:: owncloud__release_channel
 #
-# Release channel
-owncloud__release_channel: '{{ "stable" if (owncloud__variant == "nextcloud" and
-                                owncloud__release is version("17.0", ">="))
-                            else "production" }}'
+# The channel for tracking Nextcloud upstream releases.
+# Refer to the `official Nextcloud documentation <https://nextcloud.com/release-channels/>`__ for details.
+owncloud__release_channel: '{{ "stable"
+                               if (owncloud__variant == "nextcloud" and
+                                   owncloud__release is version("17.0", ">="))
+                               else "production" }}'
 
 # .. envvar:: owncloud__role_recommended_config
 #
@@ -851,9 +853,7 @@ owncloud__role_recommended_config:
   ## ISO 8601 datetime: 2004-02-12T15:19:21+00:00
   logdateformat: 'Y-m-d H:i:s.u'
 
-  ## Default is "stable" as of Nextcloud 11.
-  ## "production" is the most conservative channel which is preferred by the role maintainers.
-  ## https://owncloud.org/release-channels/
+  ## Release channel
   'updater.release.channel': '{{ owncloud__release_channel }}'
 
 # .. envvar:: owncloud__config


### PR DESCRIPTION
Since Nexcloud 17 we should change the default channel to stable ([default channel for CE](https://nextcloud.com/release-channels/)) . This PR add a variable to set the channel outside the role and define this variable to stable for nexcloud > 17.0.