### PR TITLE
[ldap] Make iface name matching configurable

### DIFF
--- a/ansible/roles/ldap/defaults/main.yml
+++ b/ansible/roles/ldap/defaults/main.yml
@@ -289,12 +289,19 @@ ldap__device_aliases: [ '{{ ansible_hostname }}' ]
 # LDAP device object ``ipHostNumber`` attributes.
 #
 # Only the externally accessible addresses will be added, any internal bridges
-# or other network interfaces not reachable directly from the outise of the
+# or other network interfaces not reachable directly from outside the
 # host will be skipped. The :rfc:`1918` addresses will also be added in the
 # attributes, if they are configured to be reachable from outside of the host.
 ldap__device_ip_addresses: '{{ q("template",
                                  "lookup/ldap__device_ip_addresses.j2")
                                  | from_yaml | flatten }}'
+
+                                                                   # ]]]
+# .. envvar:: ldap__device_ip_iface_regex [[[
+#
+# Regex used to determine which network interfaces to consider for inclusion
+# in the LDAP device object ``ipHostNumber`` attributes.
+ldap__device_ip_iface_regex: '^(bond|en|eth|vlan|mv-)'
 
                                                                    # ]]]
 # .. envvar:: ldap__device_mac_addresses [[[
@@ -313,6 +320,13 @@ ldap__device_ip_addresses: '{{ q("template",
 ldap__device_mac_addresses: '{{ q("template",
                                   "lookup/ldap__device_mac_addresses.j2")
                                   | from_yaml | flatten | unique }}'
+
+                                                                   # ]]]
+# .. envvar:: ldap__device_mac_iface_regex [[[
+#
+# Regex used to determine which network interfaces to consider for inclusion
+# in the LDAP device object ``macAddress`` attributes.
+ldap__device_mac_iface_regex: '^(en|eth|mv-)'
 
                                                                    # ]]]
 # .. envvar:: ldap__device_self_rdn [[[

--- a/ansible/roles/ldap/templates/lookup/ldap__device_ip_addresses.j2
+++ b/ansible/roles/ldap/templates/lookup/ldap__device_ip_addresses.j2
@@ -7,14 +7,13 @@
 {% set ldap__tpl_device_ip_addresses = [] %}
 {% for item in ansible_interfaces %}
 {%   set iface = (item | replace('-','_') | regex_replace('^(.*)$', 'ansible_\\1')) %}
-{%   if iface.startswith(('ansible_bond', 'ansible_en', 'ansible_eth', 'ansible_vlan')) %}
-{%     set _ = ldap__tpl_device_interfaces.append(item) %}
+{%   if item | regex_search(ldap__device_ip_iface_regex) %}
+{%     set _ = ldap__tpl_device_interfaces.append(iface) %}
 {%   elif hostvars[inventory_hostname][iface].type|d('ether') == 'bridge' %}
-{%     set _ = ldap__tpl_device_masters.append(item) %}
+{%     set _ = ldap__tpl_device_masters.append(iface) %}
 {%   endif %}
 {% endfor %}
-{% for item in ldap__tpl_device_interfaces %}
-{%   set iface = (item | replace('-','_') | regex_replace('^(.*)$', 'ansible_\\1')) %}
+{% for iface in ldap__tpl_device_interfaces %}
 {%   if hostvars[inventory_hostname][iface].ipv6|d() %}
 {%     for element in hostvars[inventory_hostname][iface].ipv6 %}
 {%       set address = ((element.address + '/' + element.prefix) | ipaddr('host/prefix')) %}
@@ -34,8 +33,7 @@
 {%     endif %}
 {%   endif %}
 {% endfor %}
-{% for item in ldap__tpl_device_masters %}
-{%   set iface = (item | replace('-','_') | regex_replace('^(.*)$', 'ansible_\\1')) %}
+{% for iface in ldap__tpl_device_masters %}
 {%   if hostvars[inventory_hostname][iface].interfaces|d() %}
 {%     if hostvars[inventory_hostname][iface].interfaces | intersect(ldap__tpl_device_interfaces) %}
 {%       if hostvars[inventory_hostname][iface].ipv6|d() %}

--- a/ansible/roles/ldap/templates/lookup/ldap__device_mac_addresses.j2
+++ b/ansible/roles/ldap/templates/lookup/ldap__device_mac_addresses.j2
@@ -4,8 +4,8 @@
  #}
 {% set ldap__tpl_device_mac_addresses = [] %}
 {% for item in ansible_interfaces %}
-{%   set iface = (item | replace('-','_') | regex_replace('^(.*)$', 'ansible_\\1')) %}
-{%   if iface.startswith(('ansible_en', 'ansible_eth')) %}
+{%   if item | regex_search(ldap__device_mac_iface_regex) %}
+{%     set iface = (item | replace('-','_') | regex_replace('^(.*)$', 'ansible_\\1')) %}
 {%     if hostvars[inventory_hostname][iface].macaddress|d() %}
 {%       set _ = ldap__tpl_device_mac_addresses.append(hostvars[inventory_hostname][iface].macaddress) %}
 {%     endif %}


### PR DESCRIPTION
Right now the interface names are hardcoded in the lookup templates.
I have some nspawn containers with macvlan interfaces (mv-*). They
did not get any IP/MAC addr added to LDAP (which means that no device
entry is created at all since IP/MAC is mandatory in the LDAP schema).

Instead of simply adding "mv-*" interfaces to the lookup scripts, how
about making the lookup configurable, given that there is an everchanging
list of possible interface names.