### PR TITLE
[lxd] Add GitHub GPG key to trusted keys

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -308,6 +308,13 @@ LDAP
 
 - Linux Software RAID devices are now scanned by default.
 
+:ref:`debops.lxd` role
+''''''''''''''''''''''
+
+- During installation, the role will enable trust for the GitHub's GPG signing
+  key to allow for verification of the LXD source code. Check the
+  :ref:`lxd__ref_install_details` for more information.
+
 :ref:`debops.nginx` role
 ''''''''''''''''''''''''
 

--- a/ansible/roles/lxd/defaults/main.yml
+++ b/ansible/roles/lxd/defaults/main.yml
@@ -41,7 +41,9 @@ lxd__upstream_type: '{{ "apt"
 #
 # The GPG key used to sign LXD release tags in the repository, required for
 # signature verification.
-lxd__upstream_gpg_key: '602F 5676 63E5 93BC BD14  F338 C638 974D 6479 2D67'
+lxd__upstream_gpg_key:
+  - '602F 5676 63E5 93BC BD14  F338 C638 974D 6479 2D67'
+  - '5DE3 E050 9C47 EA3C F04A  42D3 4AEE 18F8 3AFD EB23'
 
                                                                    # ]]]
 # .. envvar:: lxd__upstream_git_repository [[[

--- a/docs/ansible/roles/lxd/getting-started.rst
+++ b/docs/ansible/roles/lxd/getting-started.rst
@@ -11,6 +11,8 @@ Getting started
       :local:
 
 
+.. _lxd__ref_install_details:
+
 LXD installation details
 ------------------------
 
@@ -38,6 +40,19 @@ Due to the build dependency on the ``lxc-dev`` APT package, which pulls the
 ``lxc`` APT package automatically, the :ref:`debops.lxc` role and its
 dependencies will be used to configure the LXC environment. The ``lxcbr0``
 network brige will be automatically disabled in this case.
+
+.. warning:: Merge commits in the `lxc/lxd`__ GitHub repository might be signed
+   with the `GPG key issued by GitHub`__, used for `signing commits done in the web
+   interface`__. It has to be done, because tagged LXD releases `have problems
+   with their dependency chains`__ and due to that the :ref:`debops.lxd` role
+   relies on stable branches in the LXD repository. The trust is limited to the
+   ``_golang`` UNIX account and might have an impact for any Go applications
+   built in that specific environment.
+
+   .. __: https://github.com/lxc/lxd
+   .. __: https://help.github.com/articles/about-gpg/
+   .. __: https://security.stackexchange.com/a/173494
+   .. __: https://github.com/lxc/lxd/issues/8293
 
 
 Example inventory


### PR DESCRIPTION
I tried to find a way to install LXD without trusting the GitHub GPG key, but the tagged releases have issues with dependencies, and release tarballs would require a more invasive fix. For now, I think that trusting the GitHub's GPG key in a restricted environment seems to be a good middle ground, however I'm aware that using this for LXD will mean that this trust will be enabled on a container host itself although in a limited capacity... Any objections for this solution?