### PR TITLE
[postfix] Disable rarely-used DSN and ETRN

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -351,6 +351,22 @@ LDAP
   since Postfix 3.0. This allows specifying parameter values that contain
   whitespace.
 
+- The `DSN command`__ is now disabled by default. DSN (:rfc:`3464`) gives
+  senders control over successful and failed delivery status notifications. This
+  allows spammers to learn about an organization's internal mail infrastructure,
+  and gives them the ability to confirm that an address is in use. When DSN
+  support is disabled, Postfix will still let the SMTP client know that their
+  message has been received as part of the SMTP transaction; they just will not
+  get successful delivery notices from your internal systems.
+
+  .. __: http://www.postfix.org/DSN_README.html
+
+- The `ETRN command`__ is now disabled by default. ETRN, also known as Remote
+  Message Queue Starting (:rfc:`1985`), was designed for sites that have
+  intermittent Internet connectivity, but is rarely used nowadays.
+
+  .. __: http://www.postfix.org/ETRN_README.html
+
 :ref:`debops.resolvconf` role
 '''''''''''''''''''''''''''''
 

--- a/ansible/roles/postfix/defaults/main.yml
+++ b/ansible/roles/postfix/defaults/main.yml
@@ -699,6 +699,12 @@ postfix__restrictions_maincf:
       - name: 'reject_multi_recipient_bounce'
         weight: -100
 
+  - name: 'smtpd_discard_ehlo_keywords'
+    section: 'restrictions'
+    value:
+      - 'dsn'  # Disallow Delivery Status Notification requests
+      - 'etrn'  # Disallow Remote Message Queue Starting
+
                                                                    # ]]]
 # .. envvar:: postfix__maincf [[[
 #


### PR DESCRIPTION
This disables the rarely-used DSN and ETRN commands, which are used for
Delivery Status Notifications (RFC 3464) and Remote Message Queue
Starting (RFC 1985), respectively. Both commands are optional SMTP
service extensions. Disabling them should improve security and
spam-resistance, and should not have noticeable side effects. GMail has
both commands disabled, for example.

A DebOps user can enable these commands again if needed.