### PR TITLE
[gitlab-runner] Move S3 cache settings to dedicated section in config.toml

### DIFF
--- a/ansible/roles/gitlab_runner/templates/etc/gitlab-runner/config.toml.j2
+++ b/ansible/roles/gitlab_runner/templates/etc/gitlab-runner/config.toml.j2
@@ -460,13 +460,14 @@ metrics_server = "{{ gitlab_runner__metrics_server }}"
 {%     if ((runner.cache|d() and runner.cache|bool) or gitlab_runner__cache|bool) %}
   [runners.cache]
     Type = "{{ runner.cache_type | d(gitlab_runner__cache_type) }}"
-    ServerAddress = "{{ runner.cache_server_address | d(gitlab_runner__cache_server_address) }}"
-    AccessKey = "{{ runner.cache_access_key | d(gitlab_runner__cache_access_key) }}"
-    SecretKey = "{{ runner.cache_secret_key | d(gitlab_runner__cache_secret_key) }}"
-    BucketName = "{{ runner.cache_bucket_name | d(gitlab_runner__cache_bucket_name) }}"
-    BucketLocation = "{{ runner.cache_bucket_location | d(gitlab_runner__cache_bucket_location) }}"
-    Insecure = {{ (runner.cache_insecure | d(gitlab_runner__cache_insecure)) | bool | lower }}
     Shared = {{ (runner.cache_shared | d(gitlab_runner__cache_shared)) | bool | lower }}
+    [runners.cache.s3]
+      ServerAddress = "{{ runner.cache_server_address | d(gitlab_runner__cache_server_address) }}"
+      AccessKey = "{{ runner.cache_access_key | d(gitlab_runner__cache_access_key) }}"
+      SecretKey = "{{ runner.cache_secret_key | d(gitlab_runner__cache_secret_key) }}"
+      BucketName = "{{ runner.cache_bucket_name | d(gitlab_runner__cache_bucket_name) }}"
+      BucketLocation = "{{ runner.cache_bucket_location | d(gitlab_runner__cache_bucket_location) }}"
+      Insecure = {{ (runner.cache_insecure | d(gitlab_runner__cache_insecure)) | bool | lower }}
 {%     endif %}
 
 {%   endif %}


### PR DESCRIPTION
S3 settings were moved to dedicated section in version 11.3.0. For more information see: https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-runnerscache-section

This PR doesn't improve support for other types of cache (`gcs` and `azure`).