### PR TITLE
[redis_server] Add a way to overwrite save option

### DIFF
--- a/ansible/roles/redis_server/templates/etc/redis/instance/ansible-redis-dynamic.conf.j2
+++ b/ansible/roles/redis_server/templates/etc/redis/instance/ansible-redis-dynamic.conf.j2
@@ -37,7 +37,7 @@ readarray -t redis_dynamic_config_map << EOF
 {%           endif %}
 {%         endif %}
 {%       elif element.value is iterable and element.value is not string and element.value is not mapping %}
-{{ '{}={}'.format(element.name, element.value | map(attribute='name') | list | join(' ')) }}
+{{ '{}={}'.format(element.name, element.value | selectattr("state", "equalto", "present") | map(attribute='name') | list | join(' ')) }}
 {%       endif %}
 {%     endif %}
 {%   endfor %}

--- a/docs/ansible/roles/redis_server/defaults-detailed.rst
+++ b/docs/ansible/roles/redis_server/defaults-detailed.rst
@@ -144,6 +144,18 @@ Define additional instance configuration:
    :language: yaml
    :lines: 1,5-
 
+To replace options which are lists you have to reset them first:
+
+.. literalinclude:: examples/instance_configuration_reset_list.yml
+   :language: yaml
+   :lines: 1,5-
+
+You can also remove some items from the list:
+
+.. literalinclude:: examples/instance_configuration_remove_list_item.yml
+   :language: yaml
+   :lines: 1,5-
+
 Syntax
 ~~~~~~
 

--- a/docs/ansible/roles/redis_server/examples/instance_configuration_remove_list_item.yml
+++ b/docs/ansible/roles/redis_server/examples/instance_configuration_remove_list_item.yml
@@ -1,0 +1,17 @@
+---
+# Copyright (C) 2018 Maciej Delmanowski <drybjed@gmail.com>
+# Copyright (C) 2018 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+# Remove single save command and add another one.
+redis_server__configuration:
+
+  - name: 'main'
+    options:
+
+      - name: 'save'
+        value:
+          - '90 1000'
+          - name: '60 10000'
+            state: 'absent'
+        dynamic: True

--- a/docs/ansible/roles/redis_server/examples/instance_configuration_reset_list.yml
+++ b/docs/ansible/roles/redis_server/examples/instance_configuration_reset_list.yml
@@ -1,0 +1,19 @@
+---
+# Copyright (C) 2018 Maciej Delmanowski <drybjed@gmail.com>
+# Copyright (C) 2018 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+# Overwrite default snapshoting configuration.
+redis_server__configuration:
+
+  - name: 'main'
+    options:
+
+      - name: 'save'
+        value: ''
+        dynamic: True
+
+      - name: 'save'
+        value:
+          - '1200 1'
+        dynamic: True


### PR DESCRIPTION
By default there are 3 values of `save` option:

```yaml
redis_server__default_base_options:
  - name: 'save'
    value: [ '900 1', '300 10', '60 10000' ]
    dynamic: True
```

I need to overwrite it but using something like this doesn't work - new values are appended:

```yaml
redis_server__group_configuration:
  - name: 'main'
    options:
      - name: 'save'
        value:
          - '1200 1'
        dynamic: True
```

This PR makes it possible to disable default values:

```yaml
redis_server__group_configuration:
  - name: 'main'
    options:
      - name: 'save'
        value:
          - '1200 1'
          - name: '900 1'
            state: 'absent'
          - name: '300 10'
            state: 'absent'
          - name: '60 10000'
            state: 'absent'
        dynamic: True
```

Let me know if there is a better way to do it ;)