### PR TITLE
[iscsi] Fix typo in target discovery task

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,14 @@ You can read information about required changes between releases in the
 
 .. _debops master: https://github.com/debops/debops/compare/v2.2.0...master
 
+Fixed
+~~~~~
+
+ref:`debops.iscsi` role
+'''''''''''''''''''''''
+
+- Fixed a typo that caused the iSCSI target discovery task to fail.
+
 
 `debops v2.2.0`_ - 2021-01-31
 -----------------------------

--- a/ansible/roles/iscsi/tasks/main.yml
+++ b/ansible/roles/iscsi/tasks/main.yml
@@ -63,7 +63,7 @@
   with_items: '{{ iscsi__portals }}'
   register: iscsi__register_discover_targets
   when: iscsi__portals|d(False) and
-        item not in ansible_local.iscsi.discovered_portals([])
+        item not in ansible_local.iscsi.discovered_portals|d([])
 
 - name: Log in to specified iSCSI targets
   open_iscsi:


### PR DESCRIPTION
This is an errata for the errata.
I only noticed this while upgrading from 2.1.2 to 2.1.3...

Ref: https://github.com/debops/debops/commit/7865301728d8ce283cbe9d8f67f9c9521aa6533e