### PR TITLE
[system_users] fix python version check

### DIFF
--- a/ansible/roles/system_users/tasks/main.yml
+++ b/ansible/roles/system_users/tasks/main.yml
@@ -9,8 +9,18 @@
 - import_role:
     name: 'secret'
 
+- name: Gather local facts
+  setup:
+    filter: ansible_python_version
+    gather_subset: '!all'
+  delegate_to: 'localhost'
+  delegate_facts: True
+  become: False
+  run_once: True
+
 - name: Gather local Ansible user details
-  script: 'script/getent_passwd.py{{ "2" if (ansible_python_version is version_compare("3.5", "<"))
+  script: 'script/getent_passwd.py{{ "2" if (hostvars["localhost"]["ansible_python_version"]
+                                             is version_compare("3.5", "<"))
                                      else "3" }} {{ system_users__self_name }}'
   register: system_users__register_passwd
   delegate_to: 'localhost'


### PR DESCRIPTION
When running the system_users role on a controller with only python3
against a host with python2, the wrong getent_passwd.py script
will be exeucted.

The reason is that the "Gather local Ansible user details" task is
delegated to localhost, but the ansible_python_version variable
comes from the host, not the controller.