### PR TITLE
[sshd]: change defaults so port doesn't have to be specified twice

### DIFF
--- a/ansible/roles/sshd/defaults/main.yml
+++ b/ansible/roles/sshd/defaults/main.yml
@@ -167,7 +167,7 @@ sshd__ferm_limit_target: 'REJECT'
 #
 # List of TCP ports to open in the firewall for SSH connections. You can use
 # port numbers or service names from :file:`/etc/services`.
-sshd__ferm_ports: [ 'ssh' ]
+sshd__ferm_ports: '{{ sshd__ports }}'
                                                                    # ]]]
                                                                    # ]]]
 # OpenSSH server configuration [[[


### PR DESCRIPTION
I wanted to change the default sshd port of a host, so I set sshd_ports
in the ansible inventory and ran debops. Promptly locked myself out
of the host. Turns out the port needs to be specified twice (in
sshd__ports and sshd__ferm_ports.

This changes the default in keeping with DRY and is (IMHO) a lot
more user-friendly. The only loss is that ferm will by default
use a port number rather than a name.