### PR TITLE
[Roundcube] Update Roundcube version to 1.4.11

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,9 @@ Updates of upstream application versions
 - In the :ref:`debops.ipxe` role, the Debian Buster netboot installer version
   has been updated to the next point release, 10.8.
 
+- In the :ref:`debops.roundcube` role, the Roundcube version installed by
+  default has been updated to ``1.4.11``.
+
 Fixed
 ~~~~~
 

--- a/ansible/roles/roundcube/defaults/main.yml
+++ b/ansible/roles/roundcube/defaults/main.yml
@@ -163,7 +163,7 @@ roundcube__git_dir: '{{ roundcube__src + "/"
 # .. envvar:: roundcube__git_version [[[
 #
 # Roundcube release tag to deploy.
-roundcube__git_version: '1.4.10'
+roundcube__git_version: '1.4.11'
 
                                                                    # ]]]
 # .. envvar:: roundcube__git_dest [[[

--- a/ansible/roles/roundcube/meta/watch-roundcubemail
+++ b/ansible/roles/roundcube/meta/watch-roundcubemail
@@ -4,7 +4,7 @@
 
 # Role: roundcube
 # Package: roundcubemail
-# Version: 1.4.10
+# Version: 1.4.11
 
 version=4
 https://github.com/roundcube/roundcubemail/tags .*/v?(.*\S+)\.tar\.gz


### PR DESCRIPTION
This release fixes a Cross-Site Scripting issue and brings other small
improvements.

Ref: https://github.com/roundcube/roundcubemail/releases/tag/1.4.11