### PR TITLE
[ci] add rust dependency for python cryptography

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get -q update \
        python3-pip \
        python3-wheel \
        python3-setuptools \
+       python3-cryptography \
        procps \
        sudo \
        tree \


### PR DESCRIPTION
Python cryptography [3.4](https://github.com/pyca/cryptography/blob/master/CHANGELOG.rst#34---2021-02-07) need rust toolchain to compile. This PR only fix docker-image part of the CI.