### PR TITLE
[apt] Update security suite name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -68,6 +68,13 @@ Updates of upstream application versions
 Fixed
 ~~~~~
 
+:ref:`debops.apt` role
+''''''''''''''''''''''
+
+- The role configured the Debian Bullseye security repository with the
+  'bullseye/updates' suite name. This is incorrect, the Bullseye security suite
+  is called 'bullseye-security'.
+
 :ref:`debops.netbox` role
 '''''''''''''''''''''''''
 

--- a/ansible/roles/apt/defaults/main.yml
+++ b/ansible/roles/apt/defaults/main.yml
@@ -500,7 +500,11 @@ apt__security_sources:
   - uri:          'http://security.debian.org/'
     comment:      'Debian Security repository'
     type:         '{{ apt__source_types }}'
-    suite:        '{{ apt__distribution_release + "/updates" }}'
+    suite:        '{{ apt__distribution_release
+                      + ("/updates"
+                         if apt__distribution_release in
+                            [ "jessie", "stretch", "buster" ]
+                         else "-security") }}'
     components:   '{{ apt__distribution_components }}'
     distribution: 'Debian'
     state:        '{{ apt__security_sources_state


### PR DESCRIPTION
Debian uses the suffix '-security' instead of '/updates' for its
security repository suites since Debian Bullseye.

Ref: https://www.debian.org/releases/bullseye/errata