### PR TITLE
[sudo] Use @includedir with sudo 1.9.1+

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -81,6 +81,15 @@ Fixed
 
 - Fixed a typo that caused the iSCSI target discovery task to fail.
 
+:ref:`debops.sudo` role
+'''''''''''''''''''''''
+
+- The role no longer adds a duplicate includedir line to /etc/sudoers. This was
+  an issue with sudo 1.9.1 (and later), which `changed`__ the includedir syntax
+  from '#includedir' to '\@includedir'.
+
+  .. __: https://www.sudo.ws/stable.html#1.9.1
+
 :ref:`debops.system_users` role
 '''''''''''''''''''''''''''''''
 

--- a/ansible/roles/sudo/tasks/main.yml
+++ b/ansible/roles/sudo/tasks/main.yml
@@ -27,11 +27,34 @@
   until: sudo__register_packages is succeeded
   when: sudo__enabled|bool
 
+- name: Make sure that Ansible local facts directory exists
+  file:
+    path: '/etc/ansible/facts.d'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+
+- name: Save sudo local facts
+  template:
+    src: 'etc/ansible/facts.d/sudo.fact.j2'
+    dest: '/etc/ansible/facts.d/sudo.fact'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+  register: sudo__register_facts
+
+- name: Update Ansible facts if they were modified
+  action: setup
+  when: sudo__register_facts is changed
+
 - name: Ensure that '/etc/sudoers' includes '/etc/sudoers.d'
   lineinfile:
     dest: '/etc/sudoers'
-    regexp: '^#includedir\s+/etc/sudoers.d$'
-    line: '#includedir /etc/sudoers.d'
+    regexp: '^(?:@|#)includedir\s+\/etc\/sudoers.d$'
+    line: '{{ ("#"
+               if ansible_local.sudo.version|d("0.0.0") is version("1.9.1", "<")
+               else "@") + "includedir /etc/sudoers.d" }}'
     insertafter: 'EOF'
     state: 'present'
     validate: 'visudo -cf "%s"'
@@ -69,25 +92,7 @@
     mode: '0644'
   when: sudo__enabled|bool and sudo__logind_session|bool
 
-- name: Make sure that Ansible local facts directory exists
-  file:
-    path: '/etc/ansible/facts.d'
-    state: 'directory'
-    owner: 'root'
-    group: 'root'
-    mode: '0755'
-
-- name: Save sudo local facts
-  template:
-    src: 'etc/ansible/facts.d/sudo.fact.j2'
-    dest: '/etc/ansible/facts.d/sudo.fact'
-    owner: 'root'
-    group: 'root'
-    mode: '0755'
-  register: sudo__register_facts
-
 - name: Update Ansible facts if they were modified
   action: setup
-  when: sudo__register_facts is changed or
-        sudo__register_sudoers_removed is changed or
+  when: sudo__register_sudoers_removed is changed or
         sudo__register_sudoers_created is changed

--- a/ansible/roles/sudo/templates/etc/ansible/facts.d/sudo.fact.j2
+++ b/ansible/roles/sudo/templates/etc/ansible/facts.d/sudo.fact.j2
@@ -9,8 +9,8 @@
 
 from __future__ import print_function
 from json import dumps
-from sys import exit
 import os
+import subprocess
 
 
 def cmd_exists(cmd):
@@ -22,5 +22,10 @@ def cmd_exists(cmd):
 
 output = {'configured': True,
           'installed': cmd_exists('sudo')}
+
+if output['installed']:
+    output['version'] = subprocess.check_output(
+        ['sudo', '--version'], stderr=subprocess.STDOUT
+    ).decode('utf-8').replace('\n', ' ').split(' ')[2]
 
 print(dumps(output, sort_keys=True, indent=4))


### PR DESCRIPTION
Sudo 1.9.1 changed the includedir syntax from #includedir to
@includedir. This resulted in a duplicate line in /etc/sudoers after
running the debops.sudo role. The fix is to conditionally add the line
with '#' or '@' based on the version of sudo.