### PR TITLE
[ci] Install Cryptography from Debian in Vagrant

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,6 +47,12 @@ Updates of upstream application versions
 - In the :ref:`debops.roundcube` role, the Roundcube version installed by
   default has been updated to ``1.4.11``.
 
+Continuous Integration
+''''''''''''''''''''''
+
+- The Vagrant provisioning script now installs Cryptography from the Debian
+  archive instead of from PyPI.
+
 :ref:`debops.roundcube` role
 ''''''''''''''''''''''''''''
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -372,6 +372,7 @@ EOF
         jq \
         make \
         python-apt \
+        python-cryptography \
         python-distro \
         python-dnspython \
         python-future \
@@ -393,6 +394,7 @@ EOF
         python-yaml \
         python3 \
         python3-apt \
+        python3-cryptography \
         python3-distro \
         python3-dnspython \
         python3-future \


### PR DESCRIPTION
Cryptography is an Ansible dependency and was previously installed as a
Python package. I think we all prefer installing it from the Debian
archive. There's another reason for this since the release of
Cryptography 3.4, because it now requires Rust toolchain 1.45.0+ in
order to build. The Rust toolchain version in Debian 10 is too old for
that.