### PR TITLE
[postldap] Use last mailservice schema

### DIFF
--- a/ansible/roles/postldap/defaults/main.yml
+++ b/ansible/roles/postldap/defaults/main.yml
@@ -332,7 +332,7 @@ postldap__postfix__dependent_lookup_tables:
       (and are responsible for them), the virtual_mailbox_maps configuration is used.
     no_log: '{{ postldap__no_log|d(True) }}'
     connection: '{{ postldap__postfix_ldap_connection }}'
-    search_base: '{{ postldap__ldap_people_dn|join(",") }}'
+    search_base: '{{ postldap__ldap_base_dn|join(",") }}'
     query_filter: '(&
                     (objectClass=mailRecipient)
                     (|

--- a/ansible/roles/postldap/defaults/main.yml
+++ b/ansible/roles/postldap/defaults/main.yml
@@ -139,6 +139,7 @@ postldap__mailbox_base: '/var/vmail'
 # Note: these lookups are recursive.
 postldap__virtual_alias_maps:
   - '$alias_maps'
+  - 'ldap:/etc/postfix/ldap_virtual_groups_maps.cf'
   - 'ldap:/etc/postfix/ldap_virtual_alias_maps.cf'
                                                                    # ]]]
                                                                    # ]]]
@@ -308,6 +309,24 @@ postldap__postfix__dependent_lookup_tables:
                     )
                   )'
     result_attribute: 'mailAddress'
+
+  - name: 'ldap_virtual_groups_maps.cf'
+    state: 'present'
+    comment: |
+      The virtual_groups_maps setting is used to find the delivery addresses of
+      the members of a group (mailAlias or mailDistributionList) (configured in
+      the attribute mailForwardTo).
+    no_log: '{{ postldap__no_log|d(True) }}'
+    connection: '{{ postldap__postfix_ldap_connection }}'
+    search_base: '{{ postldap__ldap_groups_dn|join(",") }}'
+    query_filter: '(&
+                     (|
+                       (objectClass=mailAlias)
+                       (objectClass=mailDistributionList)
+                     )
+                     (mailAddress=%s)
+                   )'
+    result_attribute: 'mailForwardTo'
 
   - name: 'ldap_virtual_mailbox_maps.cf'
     state: 'present'

--- a/ansible/roles/postldap/defaults/main.yml
+++ b/ansible/roles/postldap/defaults/main.yml
@@ -326,7 +326,7 @@ postldap__postfix__dependent_lookup_tables:
     connection: '{{ postldap__postfix_ldap_connection }}'
     search_base: '{{ postldap__ldap_people_dn|join(",") }}'
     query_filter: '(&
-                    (objectClass=inetOrgPerson)
+                    (objectClass=mailRecipient)
                     (|
                       (mailAddress=%s)
                       (mailAlternateAddress=%s)
@@ -365,7 +365,7 @@ postldap__postfix__dependent_lookup_tables:
     search_base: '{{ postldap__ldap_base_dn|join(",") }}'
     query_filter: '(|
                     (&
-                      (objectClass=inetOrgPerson)
+                      (objectClass=mailRecipient)
                       (|
                         (mailAddress=%s)
                         (mailAlternateAddress=%s)
@@ -429,7 +429,7 @@ postldap__postfix__dependent_lookup_tables:
     search_base: '{{ postldap__ldap_base_dn|join(",") }}'
     query_filter: '(|
                     (&
-                      (objectClass=inetOrgPerson)
+                      (objectClass=mailRecipient)
                       (|
                         (mailAddress=%s)
                         (mailAlternateAddress=%s)

--- a/ansible/roles/postldap/defaults/main.yml
+++ b/ansible/roles/postldap/defaults/main.yml
@@ -118,13 +118,23 @@ postldap__vmail_posix_gidnumber: '{{ ansible_local.postldap.vmail_posix_gidnumbe
 # All mailboxes are stored directly in the file system of the server.
 #
 # This setting describes the prefix that the virtual delivery agent prepends to all pathname results from
-# `$virtual_mailbox_maps` table lookups.
+# ``ldap_virtual_mailbox_maps`` table lookups.
 # The directories under this base contain the users MailDirs.
 # This directory must be created in advance and must be writeable by all potential mail users.
 # To achieve this, either use the same GID across all mail users and set group ownership to that GID,
 # or make the directory world writable.
 postldap__mailbox_base: '/var/vmail'
 
+                                                                   # ]]]
+# .. envvar:: postldap__virtual_mailbox_maps_attribute [[[
+#
+# The attributes needed to reconstruct the mailbox path use by the ``ldap_virtual_mailbox_maps`` lookup table.
+postldap__virtual_mailbox_maps_attribute: 'uid'
+                                                                   # ]]]
+# .. envvar:: postldap__virtual_mailbox_maps_format [[[
+#
+# The relative path format to the user mailbox use by the ``ldap_virtual_mailbox_maps`` lookup table.
+postldap__virtual_mailbox_maps_format: '/%u/Maildir/'
                                                                    # ]]]
 # .. envvar:: postldap__virtual_alias_maps [[[
 #
@@ -321,7 +331,6 @@ postldap__postfix__dependent_lookup_tables:
     comment: |
       As we only want to accept mail, where we know the recipients
       (and are responsible for them), the virtual_mailbox_maps configuration is used.
-      The path for the mailbox is retrieved from the mailHomeDirectory attribute
     no_log: '{{ postldap__no_log|d(True) }}'
     connection: '{{ postldap__postfix_ldap_connection }}'
     search_base: '{{ postldap__ldap_people_dn|join(",") }}'
@@ -336,7 +345,8 @@ postldap__postfix__dependent_lookup_tables:
                       (authorizedService=mail:receive)
                     )
                   )'
-    result_attribute: 'mailHomeDirectory'
+    result_attribute: '{{ postldap__virtual_mailbox_maps_attribute }}'
+    result_format: '{{ postldap__virtual_mailbox_maps_format }}'
 
   - name: 'ldap_virtual_mailbox_domains.cf'
     state: 'present'

--- a/ansible/roles/postldap/defaults/main.yml
+++ b/ansible/roles/postldap/defaults/main.yml
@@ -312,7 +312,6 @@ postldap__postfix__dependent_lookup_tables:
                        (objectClass=mailDistributionList)
                        (objectClass=mailRecipient)
                      )
-                     (objectClass=mailRecipient)
                      (|
                        (mailAddress=%s)
                        (mailAlternateAddress=%s)
@@ -338,7 +337,6 @@ postldap__postfix__dependent_lookup_tables:
                     (objectClass=mailRecipient)
                     (|
                       (mailAddress=%s)
-                      (mailAlternateAddress=%s)
                     )
                     (|
                       (authorizedService=all)

--- a/ansible/roles/postldap/defaults/main.yml
+++ b/ansible/roles/postldap/defaults/main.yml
@@ -371,28 +371,26 @@ postldap__postfix__dependent_lookup_tables:
     no_log: '{{ postldap__no_log|d(True) }}'
     connection: '{{ postldap__postfix_ldap_connection }}'
     search_base: '{{ postldap__ldap_base_dn|join(",") }}'
-    query_filter: '(|
-                    (&
-                      (objectClass=mailRecipient)
-                      (|
-                        (mailAddress=%s)
-                        (mailAlternateAddress=%s)
-                      )
-                      (|
-                        (authorizedService=all)
-                        (authorizedService=mail:send)
-                      )
-                    )
-                    (&
-                      (objectClass=account)
-                      (uid=%u)
-                      (host=%d)
-                      (|
-                        (authorizedService=all)
-                        (authorizedService=mail:send)
-                      )
-                    )
-                  )'
+    query_filter: '(&
+                     (|
+                       (&
+                         (objectClass=mailRecipient)
+                         (|
+                           (mailAddress=%s)
+                           (mailAlternateAddress=%s)
+                         )
+                       )
+                       (&
+                         (objectClass=account)
+                         (uid=%u)
+                         (host=%d)
+                       )
+                     )
+                     (|
+                       (authorizedService=all)
+                       (authorizedService=mail:send)
+                     )
+                   )'
     result_attribute: ''
     special_result_attribute: 'member'
     leaf_result_attribute: 'uid'

--- a/ansible/roles/postldap/defaults/main.yml
+++ b/ansible/roles/postldap/defaults/main.yml
@@ -344,7 +344,6 @@ postldap__postfix__dependent_lookup_tables:
                        (authorizedService=mail:receive)
                      )
                    )'
-    result_attribute: ''
     special_result_attribute: 'member'
     leaf_result_attribute: 'mailAddress'
 
@@ -438,7 +437,6 @@ postldap__postfix__dependent_lookup_tables:
                        (authorizedService=mail:send)
                      )
                    )'
-    result_attribute: ''
     special_result_attribute: 'member'
     leaf_result_attribute: 'uid, mailAddress, mailAlternateAddress'
     size_limit: 1

--- a/ansible/roles/postldap/defaults/main.yml
+++ b/ansible/roles/postldap/defaults/main.yml
@@ -291,45 +291,45 @@ postldap__postfix__dependent_lookup_tables:
   - name: 'ldap_virtual_alias_maps.cf'
     state: 'present'
     comment: |
-      The virtual_alias_maps setting is used to find the target mailbox
-      (configured in the attribute mail, aka the mailbox or maildrop).
+      The virtual_alias_maps setting is used to find the final delivery address
+      (configured in the attribute mailAddress).
     no_log: '{{ postldap__no_log|d(True) }}'
     connection: '{{ postldap__postfix_ldap_connection }}'
     search_base: '{{ postldap__ldap_people_dn|join(",") }}'
     query_filter: '(&
                     (objectClass=inetOrgPerson)
                     (|
-                      (mail=%s)
-                      (mailAlias=%s)
+                      (mailAddress=%s)
+                      (mailAlternateAddress=%s)
                     )
                     (|
                       (authorizedService=all)
                       (authorizedService=mail:receive)
                     )
                   )'
-    result_attribute: 'mail'
+    result_attribute: 'mailAddress'
 
   - name: 'ldap_virtual_mailbox_maps.cf'
     state: 'present'
     comment: |
       As we only want to accept mail, where we know the recipients
       (and are responsible for them), the virtual_mailbox_maps configuration is used.
+      The path for the mailbox is retrieved from the mailHomeDirectory attribute
     no_log: '{{ postldap__no_log|d(True) }}'
     connection: '{{ postldap__postfix_ldap_connection }}'
     search_base: '{{ postldap__ldap_people_dn|join(",") }}'
     query_filter: '(&
                     (objectClass=inetOrgPerson)
                     (|
-                      (mail=%s)
-                      (mailAlias=%s)
+                      (mailAddress=%s)
+                      (mailAlternateAddress=%s)
                     )
                     (|
                       (authorizedService=all)
                       (authorizedService=mail:receive)
                     )
                   )'
-    result_attribute: 'mail'
-    result_format: '/%d/%u/Maildir/'
+    result_attribute: 'mailHomeDirectory'
 
   - name: 'ldap_virtual_mailbox_domains.cf'
     state: 'present'
@@ -351,7 +351,7 @@ postldap__postfix__dependent_lookup_tables:
       The smtpd_sender_login_maps configurations performs a lookup from an incoming
       email-sender to a username. Postfix first performs a full lookup
       on user@domain, then user and then @domain.
-      The later one is also used for catchalls where the mailAlias
+      The later one is also used for catchalls where the mailAlternateAddress
       is set to e.g. @foobar.com
     no_log: '{{ postldap__no_log|d(True) }}'
     connection: '{{ postldap__postfix_ldap_connection }}'
@@ -360,8 +360,8 @@ postldap__postfix__dependent_lookup_tables:
                     (&
                       (objectClass=inetOrgPerson)
                       (|
-                        (mail=%s)
-                        (mailAlias=%s)
+                        (mailAddress=%s)
+                        (mailAlternateAddress=%s)
                       )
                       (|
                         (authorizedService=all)
@@ -378,7 +378,7 @@ postldap__postfix__dependent_lookup_tables:
                       )
                     )
                   )'
-    result_attribute: 'uid, mail, mailAlias'
+    result_attribute: 'uid, mailAddress, mailAlternateAddress'
     size_limit: 1
 
   - name: 'ldap_known_sender_relays.cf'
@@ -424,8 +424,8 @@ postldap__postfix__dependent_lookup_tables:
                     (&
                       (objectClass=inetOrgPerson)
                       (|
-                        (mail=%s)
-                        (mailAlias=%s)
+                        (mailAddress=%s)
+                        (mailAlternateAddress=%s)
                       )
                     )
                     (&
@@ -434,7 +434,7 @@ postldap__postfix__dependent_lookup_tables:
                       (host=%d)
                     )
                   )'
-    result_attribute: 'uid, mail, mailAlias'
+    result_attribute: 'uid, mailAddress, mailAlternateAddress'
     result_format: '550 Authentication Required'
 
   - name: 'ldap_unauth_domain_access.cf'

--- a/ansible/roles/postldap/defaults/main.yml
+++ b/ansible/roles/postldap/defaults/main.yml
@@ -416,7 +416,7 @@ postldap__postfix__dependent_lookup_tables:
                    )'
     result_attribute: ''
     special_result_attribute: 'member'
-    leaf_result_attribute: 'uid'
+    leaf_result_attribute: 'uid, mail'
     size_limit: 1
 
   - name: 'ldap_known_sender_relays.cf'

--- a/ansible/roles/postldap/defaults/main.yml
+++ b/ansible/roles/postldap/defaults/main.yml
@@ -118,7 +118,7 @@ postldap__vmail_posix_gidnumber: '{{ ansible_local.postldap.vmail_posix_gidnumbe
 # All mailboxes are stored directly in the file system of the server.
 #
 # This setting describes the prefix that the virtual delivery agent prepends to all pathname results from
-# ``ldap_virtual_mailbox_maps`` table lookups.
+# ``$virtual_mailbox_maps`` table lookups.
 # The directories under this base contain the users MailDirs.
 # This directory must be created in advance and must be writeable by all potential mail users.
 # To achieve this, either use the same GID across all mail users and set group ownership to that GID,

--- a/ansible/roles/postldap/defaults/main.yml
+++ b/ansible/roles/postldap/defaults/main.yml
@@ -298,16 +298,16 @@ postldap__postfix__dependent_lookup_tables:
     connection: '{{ postldap__postfix_ldap_connection }}'
     search_base: '{{ postldap__ldap_people_dn|join(",") }}'
     query_filter: '(&
-                    (objectClass=inetOrgPerson)
-                    (|
-                      (mailAddress=%s)
-                      (mailAlternateAddress=%s)
-                    )
-                    (|
-                      (authorizedService=all)
-                      (authorizedService=mail:receive)
-                    )
-                  )'
+                     (objectClass=inetOrgPerson)
+                     (|
+                       (mailAddress=%s)
+                       (mailAlternateAddress=%s)
+                     )
+                     (|
+                       (authorizedService=all)
+                       (authorizedService=mail:receive)
+                     )
+                   )'
     result_attribute: 'mailAddress'
 
   - name: 'ldap_virtual_groups_maps.cf'

--- a/ansible/roles/postldap/defaults/main.yml
+++ b/ansible/roles/postldap/defaults/main.yml
@@ -149,6 +149,7 @@ postldap__virtual_mailbox_maps_format: '/%u/Maildir/'
 # Note: these lookups are recursive.
 postldap__virtual_alias_maps:
   - '$alias_maps'
+  - 'ldap:/etc/postfix/ldap_virtual_forward_maps.cf'
   - 'ldap:/etc/postfix/ldap_virtual_alias_maps.cf'
                                                                    # ]]]
                                                                    # ]]]
@@ -302,14 +303,12 @@ postldap__postfix__dependent_lookup_tables:
     state: 'present'
     comment: |
       The virtual_alias_maps setting is used to find the final delivery address,
-      given an alias or distribution list address.
+      given an alias.
     no_log: '{{ postldap__no_log|d(True) }}'
     connection: '{{ postldap__postfix_ldap_connection }}'
     search_base: '{{ postldap__ldap_base_dn|join(",") }}'
     query_filter: '(&
                      (|
-                       (objectClass=mailAlias)
-                       (objectClass=mailDistributionList)
                        (objectClass=mailRecipient)
                      )
                      (|
@@ -321,9 +320,33 @@ postldap__postfix__dependent_lookup_tables:
                        (authorizedService=mail:receive)
                      )
                    )'
-    result_attribute: 'mailForwardTo'
+    result_attribute: ''
     special_result_attribute: 'member'
     leaf_result_attribute: 'mailAddress'
+
+  - name: 'ldap_virtual_forward_maps.cf'
+    state: 'present'
+    comment: |
+      The virtual_forward_maps setting is used to find the final delivery address,
+      given a distribution list.
+    no_log: '{{ postldap__no_log|d(True) }}'
+    connection: '{{ postldap__postfix_ldap_connection }}'
+    search_base: '{{ postldap__ldap_base_dn|join(",") }}'
+    query_filter: '(&
+                     (|
+                       (objectClass=mailAlias)
+                       (objectClass=mailDistributionList)
+                     )
+                     (|
+                       (mailAddress=%s)
+                       (mailAlternateAddress=%s)
+                     )
+                     (|
+                       (authorizedService=all)
+                       (authorizedService=mail:receive)
+                     )
+                   )'
+    result_attribute: 'mailForwardTo'
 
   - name: 'ldap_virtual_mailbox_maps.cf'
     state: 'present'

--- a/ansible/roles/postldap/defaults/main.yml
+++ b/ansible/roles/postldap/defaults/main.yml
@@ -385,7 +385,9 @@ postldap__postfix__dependent_lookup_tables:
                       )
                     )
                   )'
-    result_attribute: 'uid, mailAddress, mailAlternateAddress'
+    result_attribute: ''
+    special_result_attribute: 'member'
+    leaf_result_attribute: 'uid'
     size_limit: 1
 
   - name: 'ldap_known_sender_relays.cf'

--- a/ansible/roles/postldap/defaults/main.yml
+++ b/ansible/roles/postldap/defaults/main.yml
@@ -440,7 +440,7 @@ postldap__postfix__dependent_lookup_tables:
                    )'
     result_attribute: ''
     special_result_attribute: 'member'
-    leaf_result_attribute: 'uid, mail'
+    leaf_result_attribute: 'uid, mailAddress, mailAlternateAddress'
     size_limit: 1
 
   - name: 'ldap_known_sender_relays.cf'

--- a/ansible/roles/postldap/defaults/main.yml
+++ b/ansible/roles/postldap/defaults/main.yml
@@ -134,8 +134,32 @@ postldap__virtual_mailbox_maps_attribute: 'uid'
 # .. envvar:: postldap__virtual_mailbox_maps_format [[[
 #
 # The relative path format to the user mailbox use by the ``ldap_virtual_mailbox_maps`` lookup table.
+#
+# By default the path to the user mailbox is ``/<uid>/Maildir/``.
+#
 postldap__virtual_mailbox_maps_format: '/%u/Maildir/'
-                                                                   # ]]]
+
+# The path can be easily configured to other values. For example to set it as
+# ``<domain>/<localpart>/Maildir/`` by configuring
+# ``postldap__virtual_mailbox_maps_attribute`` and
+# ``postldap__virtual_mailbox_maps_format`` as follow:
+#
+# ::
+#
+#   postldap__virtual_mailbox_maps_attribute: 'mailAddress'
+#
+#   postldap__virtual_mailbox_maps_format: '/%d/%u/Maildir/'
+#
+# You can also take advantage of the ``mailHomeDirectory`` attribute provided by the
+# mailservice schema to store an arbitrary path for each user. It can be achieve
+# by setting the two variables to the following values:
+#
+# ::
+#
+#   postldap__virtual_mailbox_maps_attribute: 'mailHomeDirectory'
+#
+#   postldap__virtual_mailbox_maps_format: '%s'
+#
 # .. envvar:: postldap__virtual_alias_maps [[[
 #
 # Optional lookup tables that alias specific mail addresses or domains

--- a/ansible/roles/postldap/defaults/main.yml
+++ b/ansible/roles/postldap/defaults/main.yml
@@ -139,7 +139,6 @@ postldap__mailbox_base: '/var/vmail'
 # Note: these lookups are recursive.
 postldap__virtual_alias_maps:
   - '$alias_maps'
-  - 'ldap:/etc/postfix/ldap_virtual_groups_maps.cf'
   - 'ldap:/etc/postfix/ldap_virtual_alias_maps.cf'
                                                                    # ]]]
                                                                    # ]]]
@@ -292,13 +291,18 @@ postldap__postfix__dependent_lookup_tables:
   - name: 'ldap_virtual_alias_maps.cf'
     state: 'present'
     comment: |
-      The virtual_alias_maps setting is used to find the final delivery address
-      (configured in the attribute mailAddress).
+      The virtual_alias_maps setting is used to find the final delivery address,
+      given an alias or distribution list address.
     no_log: '{{ postldap__no_log|d(True) }}'
     connection: '{{ postldap__postfix_ldap_connection }}'
-    search_base: '{{ postldap__ldap_people_dn|join(",") }}'
+    search_base: '{{ postldap__ldap_base_dn|join(",") }}'
     query_filter: '(&
-                     (objectClass=inetOrgPerson)
+                     (|
+                       (objectClass=mailAlias)
+                       (objectClass=mailDistributionList)
+                       (objectClass=mailRecipient)
+                     )
+                     (objectClass=mailRecipient)
                      (|
                        (mailAddress=%s)
                        (mailAlternateAddress=%s)
@@ -308,25 +312,9 @@ postldap__postfix__dependent_lookup_tables:
                        (authorizedService=mail:receive)
                      )
                    )'
-    result_attribute: 'mailAddress'
-
-  - name: 'ldap_virtual_groups_maps.cf'
-    state: 'present'
-    comment: |
-      The virtual_groups_maps setting is used to find the delivery addresses of
-      the members of a group (mailAlias or mailDistributionList) (configured in
-      the attribute mailForwardTo).
-    no_log: '{{ postldap__no_log|d(True) }}'
-    connection: '{{ postldap__postfix_ldap_connection }}'
-    search_base: '{{ postldap__ldap_groups_dn|join(",") }}'
-    query_filter: '(&
-                     (|
-                       (objectClass=mailAlias)
-                       (objectClass=mailDistributionList)
-                     )
-                     (mailAddress=%s)
-                   )'
     result_attribute: 'mailForwardTo'
+    special_result_attribute: 'member'
+    leaf_result_attribute: 'mailAddress'
 
   - name: 'ldap_virtual_mailbox_maps.cf'
     state: 'present'

--- a/docs/ansible/roles/postldap/getting-started.rst
+++ b/docs/ansible/roles/postldap/getting-started.rst
@@ -29,7 +29,6 @@ received messages will be distributed into ``/var/vmail/mydomain.net/user1``.
    objectClass: authorizedServiceObject
    authorizedService: all
    mail: user1@mydomain.net
-   mail: alias1@mydomain.net
    mailAddress: user1@mydomain.net
    mailAlternateAddress: alias1@mydomain.net
    mailHomeDirectory: /var/vmail/mydomain.net/user1
@@ -45,6 +44,8 @@ e-mail aliases:
 .. code-block:: none
 
    objectClass: mailAlias
+   objectClass: authorizedServiceObject
+   authorizedService: all
    mail: alias@mydomain.net
    mailAddress: alias@mydomain.net
    mailForwardTo: user1@mydomain.net
@@ -57,6 +58,8 @@ It is also possible to attach an email existing entity using the
 
    objectClass: organizationalUnit
    objectClass: mailDistributionList
+   objectClass: authorizedServiceObject
+   authorizedService: all
    ou: IT Department
    mail: itdept@mydomain.net
    mailAddress: itdept@mydomain.net

--- a/docs/ansible/roles/postldap/getting-started.rst
+++ b/docs/ansible/roles/postldap/getting-started.rst
@@ -13,9 +13,58 @@ support for a ``virtual user mail system``, i.e. where the senders and
 recipients do not correspond to the Linux system users.
 Hence it is possible to host emails for other domains.
 The users, email alias and domains will be managed with LDAP.
+This role use the organization defined in the mailservice schema setup by
+:ref:`debops.slapd` by default. The schema is designed to use the 'mail' LDAP
+attribute as an uniqueness constraint for the ``mailAddress``,
+``mailAlternateAddress`` and other attributes across LDAP entries. The 'mail'
+attribute itself is not used in e-mail service operation.
+For example, the following LDAP entry sets the user ``user1`` with
+user1@mydomain.net as main address and alias1@mydomain.net as alias. His
+received messages will be distributed into ``/var/vmail/mydomain.net/user1``.
+
+.. code-block:: none
+
+   objectClass: inetOrgPerson
+   objectClass: mailRecipient
+   objectClass: authorizedServiceObject
+   authorizedService: all
+   mail: user1@mydomain.net
+   mail: alias1@mydomain.net
+   mailAddress: user1@mydomain.net
+   mailAlternateAddress: alias1@mydomain.net
+   mailHomeDirectory: /var/vmail/mydomain.net/user1
+
 Local mail is enabled by default, support for mail aliases is provided by
 the :ref:`debops.etc_aliases` Ansible role and the LDAP user attribute
-``mailAlias``.
+``mailAlternateAddress``.
+
+From a single address it is also possible to deliver the message to several
+recipients by using the ``mailAlias`` structural object to define a standalone
+e-mail aliases:
+
+.. code-block:: none
+
+   objectClass: mailAlias
+   mail: alias@mydomain.net
+   mailAddress: alias@mydomain.net
+   mailForwardTo: user1@mydomain.net
+   mailForwardTo: user2@mydomain.net
+
+It is also possible to attach an email existing entity using the
+'mailDistributionList' auxiliary object:
+
+.. code-block:: none
+
+   objectClass: organizationalUnit
+   objectClass: mailDistributionList
+   ou: IT Department
+   mail: itdept@mydomain.net
+   mailAddress: itdept@mydomain.net
+   mailForwardTo: admin1@mydomain.net
+   mailForwardTo: admin2@mydomain.net
+
+The ``mailAddress`` attribute of the different objects will ensure that the
+addess is unique in the mail system.
 
 This role only works when **LDAP support is explicitly enabled** and the
 environment has a working LDAP infrastructure. See the :ref:`debops.ldap` role

--- a/docs/ansible/roles/postldap/getting-started.rst
+++ b/docs/ansible/roles/postldap/getting-started.rst
@@ -19,8 +19,7 @@ attribute as an uniqueness constraint for the ``mailAddress``,
 ``mailAlternateAddress`` and other attributes across LDAP entries. The 'mail'
 attribute itself is not used in e-mail service operation.
 For example, the following LDAP entry sets the user ``user1`` with
-user1@mydomain.net as main address and alias1@mydomain.net as alias. His
-received messages will be distributed into ``/var/vmail/mydomain.net/user1``.
+user1@mydomain.net as main address and alias1@mydomain.net as alias.
 
 .. code-block:: none
 
@@ -31,7 +30,6 @@ received messages will be distributed into ``/var/vmail/mydomain.net/user1``.
    mail: user1@mydomain.net
    mailAddress: user1@mydomain.net
    mailAlternateAddress: alias1@mydomain.net
-   mailHomeDirectory: /var/vmail/mydomain.net/user1
 
 Local mail is enabled by default, support for mail aliases is provided by
 the :ref:`debops.etc_aliases` Ansible role and the LDAP user attribute


### PR DESCRIPTION
The current postldap role default setup is using filter that are not in accordance with the current mailservice.schema.
This try to correct it. 

For users:
- main address from `mailAddress` attribute
- alias addresses from `mailAlternateAddress` attribute
- delivering of email location from `mailHomeDirectory` attribute

For aliases (expected in `postldap__ldap_groups_dn`):
- standalone alias with the `mailAlias` structural object
- attach to existing organizational unit with the `mailDistributionList` auxiliary object

Sorry for the long time to provide it. I did not found the time to implement it completely until lately.