### PR TITLE
[cron] Fix role execution on non-systemd hosts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -116,6 +116,11 @@ General
   'bullseye/updates' suite name. This is incorrect, the Bullseye security suite
   is called 'bullseye-security'.
 
+:ref:`debops.cron` role
+'''''''''''''''''''''''
+
+- Fix role execution on hosts without :command:`systemd` as the service manager.
+
 :ref:`debops.etesync` role
 ''''''''''''''''''''''''''
 

--- a/ansible/roles/cron/defaults/main.yml
+++ b/ansible/roles/cron/defaults/main.yml
@@ -69,7 +69,7 @@ cron__crontab_offset_seeds: '{{ ansible_local.cron.crontab_offset_seeds
                                 else ((ansible_all_ipv4_addresses
                                        + ansible_all_ipv6_addresses
                                        + (ansible_default_ipv4.values() | d([])) | list
-                                       + [ ansible_machine_id, ansible_memtotal_mb ]
+                                       + [ ansible_machine_id|d(), ansible_memtotal_mb ]
                                        + [ ansible_product_name, ansible_product_version ]
                                        + [ ansible_kernel ])
                                       | map("regex_replace", "^(.*)$",


### PR DESCRIPTION
Hosts that don't use 'systemd' as service manager do not have
'ansible_machine_id' fact.