### PR TITLE
Saslauthd uid correction

### DIFF
--- a/ansible/roles/saslauthd/defaults/main.yml
+++ b/ansible/roles/saslauthd/defaults/main.yml
@@ -286,10 +286,11 @@ saslauthd__ldap_default_profiles:
       - name: 'ldap_filter'
         value: '(|
                   (&
-                    (objectClass=inetOrgPerson)
+                    (objectClass=mailRecipient)
                     (|
                       (uid=%u)
-                      (mail=%U@%r)
+                      (mailAddress=%U@%r)
+                      (mailAlternateAddress=%U@%r)
                     )
                     (|
                       (authorizedService=all)

--- a/ansible/roles/saslauthd/defaults/main.yml
+++ b/ansible/roles/saslauthd/defaults/main.yml
@@ -245,7 +245,7 @@ saslauthd__ldap_default_profiles:
                   )
                   (&
                     (objectClass=account)
-                    (uid=%u)
+                    (uid=%U)
                     (host=%r)
                   )
                 )'
@@ -289,7 +289,7 @@ saslauthd__ldap_default_profiles:
                     (objectClass=inetOrgPerson)
                     (|
                       (uid=%u)
-                      (mail=%u@%r)
+                      (mail=%U@%r)
                     )
                     (|
                       (authorizedService=all)
@@ -298,7 +298,7 @@ saslauthd__ldap_default_profiles:
                   )
                   (&
                     (objectClass=account)
-                    (uid=%u)
+                    (uid=%U)
                     (host=%r)
                     (|
                       (authorizedService=all)


### PR DESCRIPTION
A small confusion between the '%u' and '%U' token that was preventing the identification of sender using email addresses.

https://blog.sys4.de/cyrus-sasl-saslauthdconf-man-page-en.html

At the same time I propose to restrict the LDAP lookup for email sender to be closer to the mailservice schema: look only for `mailAddress` and `mailAlternateAddress` of `mailRecipient` object class.