### PR TITLE
Fix the error: 'dict object' has no attribute 'groovy'.

### DIFF
--- a/ansible/roles/php/defaults/main.yml
+++ b/ansible/roles/php/defaults/main.yml
@@ -186,6 +186,7 @@ php__release_included_map:
   zesty:    '{{ php__php_included_packages }}'
   bionic:   '{{ php__php_included_packages }}'
   focal:    '{{ php__php_included_packages }}'
+  groovy:    '{{ php__php_included_packages }}'
 
                                                                    # ]]]
 # .. envvar:: php__php5_included_packages [[[


### PR DESCRIPTION
Closes issue #1654.