### PR TITLE
Fix debops-default not finding playbooks in <projectdir>/debops

### DIFF
--- a/debops/__init__.py
+++ b/debops/__init__.py
@@ -155,7 +155,8 @@ def find_playbookpath(config, project_root):
     Search for playbooks in various locations.
     """
     if project_root:
-        places = [os.path.join(project_root, "ansible", "playbooks")]
+        places = [os.path.join(project_root, "ansible", "playbooks"),
+                  os.path.join(project_root, "debops", "ansible", "playbooks")]
     else:
         places = []
     places.extend(config['paths']['playbooks-paths'])


### PR DESCRIPTION
When cloning debops as a subdirectory of a <projectdir> it is expected that all command line tools will search in that
subdirectory.

the find_playbook function did not search for playbooks in that directory, making debops-defaults non functional in that case.