### PR TITLE
Correctly react to various ways python files are reported by "file"

### DIFF
--- a/lib/tests/check-pep8
+++ b/lib/tests/check-pep8
@@ -21,7 +21,7 @@ printf "%s " "Searching for Python scripts"
 counter=0
 
 while read -r in ; do
-    if file -i "${in}" | grep -q x-python ; then
+    if file -i "${in}" | grep -q x-python\\\|x-script\.python ; then
         file_list+=("${in}")
         counter=$(( counter + 1 ))
         counter_state=$(( counter % 5 ))


### PR DESCRIPTION
Under debian/testing, python files are reported as text/x-script.python instead of test/x-python

this breaks check-pep8. this fixes allows both mime types to work

related debian bug : https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=985209