### PR TITLE
add lxc__default_container_backing_store variable

### DIFF
--- a/ansible/roles/lxc/defaults/main.yml
+++ b/ansible/roles/lxc/defaults/main.yml
@@ -644,6 +644,11 @@ lxc__default_container_architecture: '{{ "amd64"
                                          if (ansible_architecture == "x86_64")
                                          else ansible_architecture }}'
                                                                    # ]]]
+# .. envvar:: lxc__default_container_backing_store [[[
+#
+# Specify the default backing store used during container creation
+lxc__default_container_backing_store: 'dir'
+                                                                   # ]]]
                                                                    # ]]]
 # LXC container instances [[[
 # ---------------------------

--- a/ansible/roles/lxc/tasks/main.yml
+++ b/ansible/roles/lxc/tasks/main.yml
@@ -292,7 +292,7 @@
     archive:             '{{ item.archive             | d(omit) }}'
     archive_compression: '{{ item.archive_compression | d(omit) }}'
     archive_path:        '{{ item.archive_path        | d(omit) }}'
-    backing_store:       '{{ item.backing_store       | d(omit) }}'
+    backing_store:       '{{ item.backing_store       | d(lxc__default_container_backing_store) }}'
     clone_name:          '{{ item.clone_name          | d(omit) }}'
     clone_snapshot:      '{{ item.clone_snapshot      | d(omit) }}'
     config:              '{{ item.config              | d(lxc__default_container_config) }}'


### PR DESCRIPTION
The backing store is a parameter that is used only on the lxc-create CLI
As such it is not possible to set a default value via lxc.conf or
any other mechanism on the LXC side

This provides a new role-global variable to set a default for the backing
store