### PR TITLE
Add configuration for ansible-lint

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,16 @@
+---
+# Copyright (C) 2021 Maciej Delmanowski <drybjed@gmail.com>
+# Copyright (C) 2021 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Configuration file for ansible-lint
+
+# Ignore these paths during auto-detection
+exclude_paths:
+  - 'docs/ansible/roles/index.rst'
+  - 'docs/debops-api/_static/'
+  - 'lib/debops-api/tests/'
+
+# Add vitual roles for playbook examples
+mock_roles:
+  - 'application'


### PR DESCRIPTION
The configuration file contains fixes for issues found by the
autodetection mode of 'ansible-lint'.