### PR TITLE
[freeradius] minor changes related to install-eapol_test script

### DIFF
--- a/docs/ansible/roles/freeradius/examples/eduroam/resources.yml
+++ b/docs/ansible/roles/freeradius/examples/eduroam/resources.yml
@@ -42,7 +42,7 @@ resources__host_files:
 
       git clone --depth 1 --no-single-branch https://github.com/FreeRADIUS/freeradius-server.git
 
-      cd freeradius-server/scripts/travis/
+      cd freeradius-server/scripts/ci/
 
       ./eapol_test-build.sh
 


### PR DESCRIPTION
Hello,

`travis` directory has been renamed to `ci` (see https://github.com/FreeRADIUS/freeradius-server/pull/3728).

This PR reflects that change.