### PR TITLE
[etckeeper] add automatic email on commit

### DIFF
--- a/ansible/roles/etckeeper/defaults/main.yml
+++ b/ansible/roles/etckeeper/defaults/main.yml
@@ -285,6 +285,19 @@ etckeeper__avoid_commit_before_install: '{{ True
 # "origin" for ``git``). Space-separated lists of multiple remotes also work
 # (eg, "origin gitlab github" for git).
 etckeeper__push_remote: '{{ ansible_local.etckeeper.push_remote|d("") }}'
+
+                                                                   # ]]]
+# .. envvar:: etckeeper__email_on_commit [[[
+#
+# Set this option to ``True`` to allow :program:`etckeeper` send email on every
+# commit.
+etckeeper__email_on_commit: False
+                                                                   # ]]]
+
+# .. envvar:: etckeeper__email_on_commit_email [[[
+#
+# Email address for :program:`etckeeper` to use in email send after commit.
+etckeeper__email_on_commit_email: '{{ etckeeper__vcs_email }}'
                                                                    # ]]]
                                                                    # ]]]
 # Configuration for other Ansible roles [[[

--- a/ansible/roles/etckeeper/tasks/main.yml
+++ b/ansible/roles/etckeeper/tasks/main.yml
@@ -126,6 +126,16 @@
   when: etckeeper__enabled|bool and etckeeper__vcs == 'git' and
         etckeeper__vcs_user|d() and etckeeper__vcs_email|d()
 
+- name: Create etckeeper commit.d 99email
+  template:
+    src: 'etc/etckeeper/commit.d/99email.j2'
+    dest: '/etc/etckeeper/commit.d/99email'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+  notify: [ 'Commit changes in etckeeper' ]
+  when: etckeeper__email_on_commit|bool
+
 - name: Configure other VCS software
   include_tasks: 'other_vcs.yml'
   when: etckeeper__enabled|bool and etckeeper__vcs != 'git' and

--- a/ansible/roles/etckeeper/templates/etc/etckeeper/commit.d/99email.j2
+++ b/ansible/roles/etckeeper/templates/etc/etckeeper/commit.d/99email.j2
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Copyright (C) 2021 Émile <emile@bleuchtang.fr>
+# Copyright (C) 2021 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# {{ ansible_managed }}
+
+EMAIL_ON_COMMIT="{{ etckeeper__email_on_commit_email }}"
+
+if [ "$VCS" = git ] && [ -d .git ]; then
+        git log -p -1 | mail -s "[$(hostname -f)] etckeeper changes" "$EMAIL_ON_COMMIT"
+else
+        echo "EMAIL_ON_COMMIT not yet supported for $VCS" >&2
+fi


### PR DESCRIPTION
This PR add the possibility to send an email on every commit (daily commit or manual commit). It's disable by default so it didn't break anything. Work only on git but can be improve for other vcs in futur.