### PR TITLE
[etckeeper] Better control over e-mail hook script

### DIFF
--- a/ansible/roles/etckeeper/defaults/main.yml
+++ b/ansible/roles/etckeeper/defaults/main.yml
@@ -287,11 +287,11 @@ etckeeper__avoid_commit_before_install: '{{ True
 etckeeper__push_remote: '{{ ansible_local.etckeeper.push_remote|d("") }}'
 
                                                                    # ]]]
-# .. envvar:: etckeeper__email_on_commit [[[
+# .. envvar:: etckeeper__email_on_commit_state [[[
 #
 # Set this option to ``True`` to allow :program:`etckeeper` send email on every
 # commit.
-etckeeper__email_on_commit: False
+etckeeper__email_on_commit_state: 'absent'
                                                                    # ]]]
 
 # .. envvar:: etckeeper__email_on_commit_email [[[

--- a/ansible/roles/etckeeper/tasks/main.yml
+++ b/ansible/roles/etckeeper/tasks/main.yml
@@ -127,7 +127,14 @@
   when: etckeeper__enabled|bool and etckeeper__vcs == 'git' and
         etckeeper__vcs_user|d() and etckeeper__vcs_email|d()
 
-- name: Create etckeeper commit.d 99email
+- name: Remove e-mail notification hook script
+  file:
+    path: '/etc/etckeeper/commit.d/99email'
+    state: 'absent'
+  when: etckeeper__enabled|bool and
+        etckeeper__email_on_commit_state == 'absent'
+
+- name: Install e-mail notification hook script
   template:
     src: 'etc/etckeeper/commit.d/99email.j2'
     dest: '/etc/etckeeper/commit.d/99email'
@@ -135,7 +142,8 @@
     group: 'root'
     mode: '0755'
   notify: [ 'Commit changes in etckeeper' ]
-  when: etckeeper__email_on_commit|bool
+  when: etckeeper__enabled|bool and
+        etckeeper__email_on_commit_state == 'present'
 
 - name: Configure other VCS software
   include_tasks: 'other_vcs.yml'


### PR DESCRIPTION
The change fixes small issue with the e-mail hook task which didn't
check if the 'etckeeper' role is enabled and changes the activation
variable to work as a "state" variable to selectively install or remove
the hook script.