### PR TITLE
[pki] Perform multiple ACME request attempts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -203,6 +203,18 @@ General
   just "Internal Server Error". The service as a whole survives this.
   The bug in the configuration template has been fixed.
 
+:ref:`debops.pki` role
+''''''''''''''''''''''
+
+- The pki-realm script will now attempt another ACME certificate request in case
+  the previous attempt failed and was more than two days ago. The previous
+  situation was that the script would not perform any ACME requests if the
+  acme/error.log file was present in the PKI realm, because performing multiple
+  certificate issuance requests could easily trigger a rate limit. The downside
+  of this was that the script would also completely give up on renewal attempts
+  if the first attempt happened to fail (e.g. due to some issue at Let's
+  Encrypt).
+
 :ref:`debops.python` role
 '''''''''''''''''''''''''
 

--- a/ansible/roles/pki/files/usr/local/lib/pki/pki-realm
+++ b/ansible/roles/pki/files/usr/local/lib/pki/pki-realm
@@ -1078,6 +1078,14 @@ convert_der_to_pem () {
 
 request_acme_tiny_certificate () {
 
+    # Rotate acme/error.log if it was modified more than two days ago. This
+    # allows another renewal attempt, but still prevents hitting rate limits.
+    # Let's Encrypt limits duplicate certificate requests to five per week
+    # (https://letsencrypt.org/docs/rate-limits/).
+    if [[ -e acme/error.log ]] && [[ $(find acme/error.log -mtime +1) ]]; then
+        mv acme/error.log "acme/error-$(date +%s).log"
+    fi
+
     if [ "${config['pki_acme']}" = "true" ] && [ -x "${config['acme_client_script']}" ] && [ -d "${config['acme_challenge_dir']}" ] && [ ! -e acme/error.log ] && [ -r acme/request.pem ] ; then
 
         if ! ( check_expiration_time acme/cert.pem "${config['acme_expiration_seconds']}" && check_openssl_key_crt_match private/key.pem acme/cert.pem ) ; then

--- a/docs/ansible/roles/pki/acme-integration.rst
+++ b/docs/ansible/roles/pki/acme-integration.rst
@@ -59,11 +59,14 @@ The Let's Encrypt ACME Certificate Authority has
 related to the number of certificate requests and the number of domains permitted per
 certificate.
 
-To avoid triggering the limits too quickly due to a mistake, ``debops.pki``
-disables the requests when the :file:`acme/error.log` file is present in the PKI
-realm directory. You can check contents of this file to find out what might be
-the issue, and after fixing it you need to remove the file to let the
-:program:`pki-realm` script make the request again.
+When a certificate request fails, useful error output will be written to
+:file:`acme/error.log`. This file will also prevent the :program:`pki-realm`
+script from quickly retrying the request and potentially hitting a rate limit.
+If this file exists and it was modified less than two days ago, the
+:program:`pki-realm` script will not perform the request. If the file is older
+than two days, it will move the file out of the way and perform the request as
+usual. If you want to retry the request straightaway, you can just move
+:file:`acme/error.log` out of the way yourself.
 
 How ACME certificates are managed
 ---------------------------------


### PR DESCRIPTION
The pki-realm script did not perform ACME certificate requests if the
acme/error.log file was present. This change moves the acme/error.log file out
of the way if it is older than two days, ensuring that certificate renewals are
still attempted later if the first attempt failed (e.g. due to some issue at
Let's Encrypt). The two-day wait should prevent the script from hitting any rate
limits.

Closes: #774