### PR TITLE
[rsnapshot] rrsync is not compressed

### DIFF
--- a/docs/ansible/roles/rsnapshot/guides.rst
+++ b/docs/ansible/roles/rsnapshot/guides.rst
@@ -97,7 +97,7 @@ provided script to a convenient directory:
 .. code-block:: console
 
    sudo apt install rsync
-   sudo gzip -d -c /usr/share/doc/rsync/scripts/rrsync.gz > /usr/local/bin/rrsync
+   sudo cp -v /usr/share/doc/rsync/scripts/rrsync /usr/local/bin/rrsync
    sudo chmod +x /usr/local/bin/rrsync
 
 When the :command:`rrsync` script is set up, you will have to add one of the


### PR DESCRIPTION
Hello,

I noticed that `rrsync` is not compressed anymore when trying to prepare two Buster hosts (not managed by Ansible) to be backup. See [file list of package rsync in buster](https://packages.debian.org/buster/amd64/rsync/filelist).

It looks this logic is already in place when provisioning Ansible managed hosts:

https://github.com/debops/debops/blob/c250b0d015d724c5b3f32fccda8ede34af456601/ansible/roles/rsnapshot/tasks/main.yml#L121-L131

According to [file list of package rsync in stretch](https://packages.debian.org/stretch/amd64/rsync/filelist), `rrsync` was compressed under Stretch.

Let me know if Stretch case should be taken into account.

On top of that, I would open a separate issue because `rrsync` is packaged directly as binary starting from version 3.1.3-8, see [Debian changelog.](https://metadata.ftp-master.debian.org/changelogs//main/r/rsync/rsync_3.1.3~bpo10+1_changelog)