### PR TITLE
Fix the error: 'dict object' has no attribute 'hirsute'

### DIFF
--- a/ansible/roles/php/defaults/main.yml
+++ b/ansible/roles/php/defaults/main.yml
@@ -187,6 +187,7 @@ php__release_included_map:
   bionic:   '{{ php__php_included_packages }}'
   focal:    '{{ php__php_included_packages }}'
   groovy:    '{{ php__php_included_packages }}'
+  hirsute:  '{{ php__php_included_packages }}'
 
                                                                    # ]]]
 # .. envvar:: php__php5_included_packages [[[


### PR DESCRIPTION
Just added 'hirsute' (ubuntu 21.04) on debops.php 

The same happened for 'groovy' and solved by pr [#1657](https://github.com/debops/debops/pull/1657)


TASK [debops.roles01.php : Get available PHP packages for selected version] ********************************************************************************
FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: {{ (lookup(\"flattened\", php__server_api_packages + php__base_packages + php__packages + php__group_packages + php__host_packages + php__dependent_packages).split(\",\") | difference(php__included_packages)) | join(\" \") }}: {{ php__php_included_packages if php__sury else php__release_included_map[ansible_distribution_release] }}: **'dict object' has no attribute 'hirsute'**