### PR TITLE
[apache] Use 'dont-create' to not upload template.

### DIFF
--- a/ansible/roles/apache/tasks/main.yml
+++ b/ansible/roles/apache/tasks/main.yml
@@ -149,7 +149,7 @@
     group: 'root'
     mode: '0644'
   notify: [ 'Test apache and reload' ]
-  when: (item.state|d("present") != "absent" and item.type|d(apache__vhost_type) not in ["divert"])
+  when: (item.state|d("present") != "absent" and item.type|d(apache__vhost_type) not in ["divert", "dont-create"])
   with_flattened: '{{ apache__combined_vhosts }}'
   tags: [ 'role::apache:vhosts' ]
 


### PR DESCRIPTION
According to documentation of "dont-create", the snippet already exists on host. To quote documentation: "This special type assumes the snippet file is already present and does not try to create it."

Yet, the "Create sites-available configuration" task from the apache role will create a vhost file.

