### PR TITLE
[ferm] Disable mgmt of iptables backend on Stretch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -270,6 +270,12 @@ General
 
 - The EteSync playbook is now included in the default DebOps playbook.
 
+:ref:`debops.ferm` role
+'''''''''''''''''''''''
+
+- The management of the :command:`iptables` backend symlink using the
+  'alternatives' system is disabled on Debian 9, where it is unsupported.
+
 :ref:`debops.iscsi` role
 ''''''''''''''''''''''''
 

--- a/ansible/roles/ferm/defaults/main.yml
+++ b/ansible/roles/ferm/defaults/main.yml
@@ -44,8 +44,10 @@ ferm__flush: '{{ ferm__enabled | bool }}'
 # .. envvar:: ferm__iptables_backend_enabled [[[
 #
 # Enable or disable configuration of the :command:`iptables` backend symlink
-# using the "alternatives" system.
-ferm__iptables_backend_enabled: True
+# using the "alternatives" system, supported on Debian 10 and later.
+ferm__iptables_backend_enabled: '{{ False
+                                    if ansible_distribution_release in [ "wheezy", "jessie", "stretch", "trusty", "xenial" ]
+                                    else True }}'
 
                                                                    # ]]]
 # ..envvar:: ferm__iptables_backend_path [[[


### PR DESCRIPTION
Commit 0909d02f7 introduced management of the iptables backend symlink
using the 'alternatives' system, but this caused an error on Debian 9
systems:

```
TASK [ferm : Manage iptables backend using alternatives]
fatal: [unifi.ciphermail.com]: FAILED! => changed=false
  msg: Specified path /usr/sbin/iptables-nft does not exist
```

This commit restores the old behaviour on Debian 9.