### PR TITLE
Fix expected token err '','', got ''integer''.

### DIFF
--- a/ansible/roles/ifupdown/tasks/main.yml
+++ b/ansible/roles/ifupdown/tasks/main.yml
@@ -86,7 +86,7 @@
                                                                                                | d(item.key) }}'
     owner: 'root'
     group: 'root'
-    mode: '{{ item.value.mode | d(0644) }}'
+    mode: '{{ item.value.mode | d("0644") }}'
   with_dict: '{{ ifupdown__combined_interfaces }}'
   register: ifupdown__register_interfaces_created
   when: item.value.state|d('present') not in [ 'absent', 'ignore' ]


### PR DESCRIPTION
When running `debops service/ifupdown -K -l host.xyz.example.com`, I get the following error:

```
TASK [ifupdown : Generate network interface configuration] 
fatal: [host.xyz.example.com]: FAILED! => 
  msg: 'template error while templating string: expected token '','', got ''integer''. String: {{ item.value.mode | d(0644) }}'
```

The only ifupdown config in my inventory is `ifupdown__external_interface: "eth0"` for said host.