### PR TITLE
[minidlna] First working version

### DIFF
--- a/ansible/playbooks/service/minidlna.yml
+++ b/ansible/playbooks/service/minidlna.yml
@@ -1,0 +1,29 @@
+---
+# Copyright (C) 2021-2021 Julien Lecomte <julien@lecomte.at>
+# Copyright (C) 2021-2021 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+- name: Install and manage MiniDLNA
+  collections: [ 'debops.debops', 'debops.roles01',
+                 'debops.roles02', 'debops.roles03' ]
+  hosts: [ 'debops_service_minidlna' ]
+  become: True
+
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
+
+  roles:
+
+    - role: etc_services
+      tags: [ 'role::etc_services', 'skip::etc_services' ]
+      etc_services__dependent_list:
+        - '{{ minidlna_server__etc_services__dependent_list }}'
+
+    - role: ferm
+      tags: [ 'role::ferm', 'skip::ferm' ]
+      ferm__dependent_rules:
+        - '{{ minidlna__ferm__dependent_rules }}'
+
+    - role: minidlna
+      tags: [ 'role::minidlna', 'skip::minidlna' ]

--- a/ansible/playbooks/srv/all.yml
+++ b/ansible/playbooks/srv/all.yml
@@ -104,3 +104,5 @@
 - import_playbook: tinyproxy.yml
 
 - import_playbook: libuser.yml
+
+- import_playbook: minidlna.yml

--- a/ansible/playbooks/srv/minidlna.yml
+++ b/ansible/playbooks/srv/minidlna.yml
@@ -1,0 +1,29 @@
+---
+# Copyright (C) 2021-2021 Julien Lecomte <julien@lecomte.at>
+# Copyright (C) 2021-2021 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+- name: Install and manage MiniDLNA
+  collections: [ 'debops.debops', 'debops.roles01',
+                 'debops.roles02', 'debops.roles03' ]
+  hosts: [ 'debops_service_minidlna' ]
+  become: True
+
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
+
+  roles:
+
+    - role: etc_services
+      tags: [ 'role::etc_services', 'skip::etc_services' ]
+      etc_services__dependent_list:
+        - '{{ minidlna_server__etc_services__dependent_list }}'
+
+    - role: ferm
+      tags: [ 'role::ferm', 'skip::ferm' ]
+      ferm__dependent_rules:
+        - '{{ minidlna__ferm__dependent_rules }}'
+
+    - role: minidlna
+      tags: [ 'role::minidlna', 'skip::minidlna' ]

--- a/ansible/roles/minidlna/COPYRIGHT
+++ b/ansible/roles/minidlna/COPYRIGHT
@@ -1,4 +1,4 @@
-debops.dlna - Manage DLNA with Ansible
+debops.minidlna - Manage DLNA with Ansible
 
 Copyright (C) 2021 Julien Lecomte <julien@lecomte.at>
 Copyright (C) 2021 DebOps <https://debops.org/>

--- a/ansible/roles/minidlna/COPYRIGHT
+++ b/ansible/roles/minidlna/COPYRIGHT
@@ -1,0 +1,17 @@
+debops.dlna - Manage DLNA with Ansible
+
+Copyright (C) 2021 Julien Lecomte <julien@lecomte.at>
+Copyright (C) 2021 DebOps <https://debops.org/>
+SPDX-License-Identifier: GPL-3.0-only
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 3, as
+published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see https://www.gnu.org/licenses/

--- a/ansible/roles/minidlna/defaults/main.yml
+++ b/ansible/roles/minidlna/defaults/main.yml
@@ -1,0 +1,118 @@
+---
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+
+# .. Copyright (C) 2021 Julien Lecomte <julien@lecomte.at>
+# .. Copyright (C) 2021 DebOps <https://debops.org/>
+# .. SPDX-License-Identifier: GPL-3.0-only
+
+# .. _minidlna__ref_defaults:
+
+# .. contents:: Sections
+#    :local:
+#
+# .. include:: ../../../../includes/global.rst
+
+# Packages and installation [[[
+# -----------------------------
+
+# .. envvar:: minidlna__base_packages [[[
+#
+# List of APT packages to install for :command:`dlna` support.
+minidlna__base_packages: [ 'minidlna' ]
+
+                                                                   # ]]]
+# .. envvar:: minidlna__packages [[[
+#
+# List of additional APT packages to install during :command:`dlna`
+# configuration.
+minidlna__packages: []
+
+                                                                   # ]]]
+                                                                   # ]]]
+# MiniDLNA configuration [[[
+# ---------------------------
+
+# .. envvar:: minidlna__http_port [[[
+#
+# Port for HTTP traffic. Defaults to 8200.
+minidlna__http_port: 8200 
+
+                                                                   # ]]]
+
+# .. envvar:: minidlna__allow [[[
+#
+# YAML dictionary that contains the configuration of the Tinc mesh networks
+# configured on all hosts in the Ansible inventory.
+minidlna__config: {}
+
+# .. envvar:: media_dirs [[[
+#
+# List of media directories to scan and present to end user.
+# 
+# If you want to restrict a media_dir to a specific content type, you can
+# prepend the directory name with a letter representing the type (A, P or V),
+# followed by a comma, as so:
+#   * "A" for audio    (eg. media_dir=A,/var/lib/minidlna/music)
+#   * "P" for pictures (eg. media_dir=P,/var/lib/minidlna/pictures)
+#   * "V" for video    (eg. media_dir=V,/var/lib/minidlna/videos)
+#   * "PV" for pictures and video (eg. media_dir=PV,/var/lib/minidlna/digital_camera)
+minidlna__media_dirs: []
+
+                                                                   # ]]]
+# .. envvar:: minidlna__conf [[[
+#
+# YAML dictionary of {name, value} for configuration file.
+minidlna__configuration: []
+
+                                                                   # ]]]
+# .. envvar:: minidlna__allow [[[
+#
+# List of IP addresses or CIDR subnets which are allowed to connect to the
+# MiniDLNA instances over the network, on all hosts in the Ansible
+# inventory. This variable configures the firewall for all instances at the
+# same time, for individual instance configuration you should modify the
+# :envvar:`minidlna_server__ferm__dependent_rules` variable directly.
+minidlna__allow: {}
+
+                                                                   # ]]]
+                                                                   # ]]]
+# Configuration for other Ansible roles [[[
+# -----------------------------------------
+
+# .. envvar:: minidlna__ferm__dependent_rules [[[
+#
+# Configuration for the :ref:`debops.ferm` Ansible role.
+minidlna__ferm__dependent_rules:
+
+  - name: 'minidlna_allow_tcp'
+    type: 'accept'
+    dport: [ "{{ minidlna__http_port }}" ]
+    protocol: [ 'tcp' ]
+    saddr: '{{ minidlna__allow }}'
+    weight: '50'
+    by_role: 'debops.minidlna'
+
+  - name: 'minidlna_allow_udp'
+    type: 'accept'
+    dport: [ 1900 ]
+    protocol: [ 'udp' ]
+    saddr: '{{ minidlna__allow }}'
+    weight: '50'
+    by_role: 'debops.minidlna'
+                                                                   # ]]]
+
+# .. envvar:: minidlna_server__etc_services__dependent_list [[[
+#
+# Configuration for the :ref:`debops.etc_services` Ansible role.
+minidlna_server__etc_services__dependent_list:
+
+  - name: 'ssdp'
+    port: '1900'
+    comment: 'Simple Service Discovery Protocol'
+
+  - name: 'minidlna'
+    port: '8200'
+    comment: 'MiniDLNA Server'
+
+                                                                   # ]]]
+                                                                   # ]]]

--- a/ansible/roles/minidlna/defaults/main.yml
+++ b/ansible/roles/minidlna/defaults/main.yml
@@ -35,7 +35,7 @@ minidlna__packages: []
 # .. envvar:: minidlna__http_port [[[
 #
 # Port for HTTP traffic. Defaults to 8200.
-minidlna__http_port: 8200 
+minidlna__http_port: 8200
 
                                                                    # ]]]
 
@@ -48,7 +48,7 @@ minidlna__config: {}
 # .. envvar:: media_dirs [[[
 #
 # List of media directories to scan and present to end user.
-# 
+#
 # If you want to restrict a media_dir to a specific content type, you can
 # prepend the directory name with a letter representing the type (A, P or V),
 # followed by a comma, as so:

--- a/ansible/roles/minidlna/defaults/main.yml
+++ b/ansible/roles/minidlna/defaults/main.yml
@@ -13,24 +13,24 @@
 # .. include:: ../../../../includes/global.rst
 
 # Packages and installation [[[
-# -----------------------------
+# -------------------------
 
 # .. envvar:: minidlna__base_packages [[[
 #
-# List of APT packages to install for :command:`dlna` support.
+# List of APT packages to install for :command:`minidlna` support.
 minidlna__base_packages: [ 'minidlna' ]
 
                                                                    # ]]]
 # .. envvar:: minidlna__packages [[[
 #
-# List of additional APT packages to install during :command:`dlna`
+# List of additional APT packages to install during :command:`minidlna`
 # configuration.
 minidlna__packages: []
 
                                                                    # ]]]
                                                                    # ]]]
 # MiniDLNA configuration [[[
-# ---------------------------
+# ----------------------
 
 # .. envvar:: minidlna__http_port [[[
 #
@@ -38,17 +38,19 @@ minidlna__packages: []
 minidlna__http_port: 8200
 
                                                                    # ]]]
-# .. envvar:: media_dirs [[[
+# .. envvar:: minidlna__media_dirs [[[
 #
 # List of media directories to scan and present to end user.
 #
 # If you want to restrict a media_dir to a specific content type, you can
 # prepend the directory name with a letter representing the type (A, P or V),
 # followed by a comma, as so:
-#   * "A" for audio    (eg. media_dir=A,/var/lib/minidlna/music)
-#   * "P" for pictures (eg. media_dir=P,/var/lib/minidlna/pictures)
-#   * "V" for video    (eg. media_dir=V,/var/lib/minidlna/videos)
-#   * "PV" for pictures and video (eg. media_dir=PV,/var/lib/minidlna/digital_camera)
+#
+# * "A" for audio    (eg. media_dir=A,/var/lib/minidlna/music)
+# * "P" for pictures (eg. media_dir=P,/var/lib/minidlna/pictures)
+# * "V" for video    (eg. media_dir=V,/var/lib/minidlna/videos)
+# * "PV" for pictures and video (eg. media_dir=PV,/var/lib/minidlna/digital_camera)
+#
 minidlna__media_dirs: []
 
                                                                    # ]]]
@@ -67,7 +69,8 @@ minidlna__configuration: []
                                                                    # ]]]
 # .. envvar:: minidlna__default_album_art_names [[[
 #
-# YAML dictionary of {name, value} for album_art_names file.
+# List of file names to look for when searching for album art.
+# Names should be delimited with a forward slash ("/").
 minidlna__default_album_art_names:
   - "Cover.jpg/cover.jpg/AlbumArtSmall.jpg/albumartsmall.jpg"
   - "AlbumArt.jpg/albumart.jpg/Album.jpg/album.jpg"
@@ -77,7 +80,6 @@ minidlna__default_album_art_names:
 #
 # List of file names to look for when searching for album art.
 # Names should be delimited with a forward slash ("/").
-# This option can be specified more than once.
 minidlna__album_art_names: []
 
                                                                    # ]]]
@@ -87,13 +89,13 @@ minidlna__album_art_names: []
 # MiniDLNA instances over the network, on all hosts in the Ansible
 # inventory. This variable configures the firewall for all instances at the
 # same time, for individual instance configuration you should modify the
-# :envvar:`minidlna_server__ferm__dependent_rules` variable directly.
+# :envvar:`minidlna__ferm__dependent_rules` variable directly.
 minidlna__allow: {}
 
                                                                    # ]]]
                                                                    # ]]]
 # Configuration for other Ansible roles [[[
-# -----------------------------------------
+# -------------------------------------
 
 # .. envvar:: minidlna__ferm__dependent_rules [[[
 #
@@ -138,7 +140,7 @@ minidlna__combined_configuration: '{{ minidlna__default_configuration
                                                                    # ]]]
 # .. envvar:: minidlna__combined_album_art_names [[[
 #
-# Cofiguration merged into one.
+# Album art configuration merged into one.
 minidlna__combined_album_art_names: '{{ minidlna__default_album_art_names
                                       + minidlna__album_art_names }}'
                                                                    # ]]]

--- a/ansible/roles/minidlna/defaults/main.yml
+++ b/ansible/roles/minidlna/defaults/main.yml
@@ -38,13 +38,6 @@ minidlna__packages: []
 minidlna__http_port: 8200
 
                                                                    # ]]]
-
-# .. envvar:: minidlna__allow [[[
-#
-# YAML dictionary that contains the configuration of the Tinc mesh networks
-# configured on all hosts in the Ansible inventory.
-minidlna__config: {}
-
 # .. envvar:: media_dirs [[[
 #
 # List of media directories to scan and present to end user.
@@ -59,10 +52,33 @@ minidlna__config: {}
 minidlna__media_dirs: []
 
                                                                    # ]]]
-# .. envvar:: minidlna__conf [[[
+# .. envvar:: minidlna__default_configuration [[[
+#
+# YAML dictionary of {name, value} for configuration file.
+minidlna__default_configuration:
+  - name: "inotify"
+    value: "yes"
+                                                                   # ]]]
+# .. envvar:: minidlna__configuration [[[
 #
 # YAML dictionary of {name, value} for configuration file.
 minidlna__configuration: []
+
+                                                                   # ]]]
+# .. envvar:: minidlna__default_album_art_names [[[
+#
+# YAML dictionary of {name, value} for album_art_names file.
+minidlna__default_album_art_names:
+  - "Cover.jpg/cover.jpg/AlbumArtSmall.jpg/albumartsmall.jpg"
+  - "AlbumArt.jpg/albumart.jpg/Album.jpg/album.jpg"
+  - "Folder.jpg/folder.jpg/Thumb.jpg/thumb.jpg"
+                                                                   # ]]]
+# .. envvar:: minidlna__album_art_names [[[
+#
+# List of file names to look for when searching for album art.
+# Names should be delimited with a forward slash ("/").
+# This option can be specified more than once.
+minidlna__album_art_names: []
 
                                                                    # ]]]
 # .. envvar:: minidlna__allow [[[
@@ -100,7 +116,6 @@ minidlna__ferm__dependent_rules:
     weight: '50'
     by_role: 'debops.minidlna'
                                                                    # ]]]
-
 # .. envvar:: minidlna_server__etc_services__dependent_list [[[
 #
 # Configuration for the :ref:`debops.etc_services` Ansible role.
@@ -114,5 +129,17 @@ minidlna_server__etc_services__dependent_list:
     port: '8200'
     comment: 'MiniDLNA Server'
 
+                                                                   # ]]]
+# .. envvar:: minidlna__combined_configuration [[[
+#
+# Cofiguration merged into one.
+minidlna__combined_configuration: '{{ minidlna__default_configuration
+                                      + minidlna__configuration }}'
+                                                                   # ]]]
+# .. envvar:: minidlna__combined_album_art_names [[[
+#
+# Cofiguration merged into one.
+minidlna__combined_album_art_names: '{{ minidlna__default_album_art_names
+                                      + minidlna__album_art_names }}'
                                                                    # ]]]
                                                                    # ]]]

--- a/ansible/roles/minidlna/meta/main.yml
+++ b/ansible/roles/minidlna/meta/main.yml
@@ -28,4 +28,3 @@ galaxy_info:
   galaxy_tags:
     - minidlna
     - dlna
-

--- a/ansible/roles/minidlna/meta/main.yml
+++ b/ansible/roles/minidlna/meta/main.yml
@@ -1,0 +1,31 @@
+---
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+
+# Copyright (C) 2021 Julien Lecomte <julien@lecomte.at>
+# Copyright (C) 2021 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+collections: [ 'debops.debops' ]
+
+dependencies: []
+
+galaxy_info:
+
+  author: 'Julien Lecomte'
+  description: 'Configure MiniDLNA instances'
+  company: 'DebOps'
+  license: 'GPL-3.0-only'
+  min_ansible_version: '2.4.0'
+  platforms:
+    - name: Ubuntu
+      versions:
+        - xenial
+        - bionic
+    - name: Debian
+      versions:
+        - stretch
+        - buster
+  galaxy_tags:
+    - minidlna
+    - dlna
+

--- a/ansible/roles/minidlna/tasks/main.yml
+++ b/ansible/roles/minidlna/tasks/main.yml
@@ -26,7 +26,7 @@
   args:
     creates: '/etc/minidlna.conf.dpkg-divert'
 
-- name: Generate main configuration file
+- name: Generate MiniDLNA configuration file
   template:
     src: 'etc/minidlna.conf.j2'
     dest: '/etc/minidlna.conf'
@@ -34,6 +34,16 @@
     group: 'root'
     mode: '0644'
     unsafe_writes: '{{ True if (core__unsafe_writes|d(ansible_local.core.unsafe_writes|d()) | bool) else omit }}'
+  register: minidlna__register_configuration
+
+- name: Conditionnally restart MiniDLNA service
+  systemd:
+    name: 'minidlna.service'
+    enabled: true
+    daemon_reload: '{{ True if (minidlna__register_configuration is changed) else omit }}'
+    state: '{{ "restarted" if (minidlna__register_configuration is changed) else "started" }}'
+  when: ansible_service_mgr == 'systemd'
+
 # Ansible facts [[[1
 - name: Make sure that Ansible local fact directory exists
   file:
@@ -55,4 +65,3 @@
 
 - name: Reload facts if they were modified
   meta: 'flush_handlers'
-

--- a/ansible/roles/minidlna/tasks/main.yml
+++ b/ansible/roles/minidlna/tasks/main.yml
@@ -1,0 +1,58 @@
+---
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+
+# Copyright (C) 2021 Julien Lecomte <julien@lecomte.at>
+# Copyright (C) 2021 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+- name: Import DebOps global handlers
+  import_role:
+    name: 'global_handlers'
+
+# Package installation [[[1
+- name: Install MiniDLNA packages
+  apt:
+    name: '{{ (minidlna__base_packages
+             + minidlna__packages)
+             | flatten }}'
+    state: 'present'
+  register: minidlna__register_packages
+  until: minidlna__register_packages is succeeded
+
+# MiniDLNA configuration [[[1
+- name: Divert the MiniDLNA configuration file
+  command: dpkg-divert --quiet --local --divert /etc/minidlna.conf.dpkg-divert
+                       --rename /etc/minidlna.conf
+  args:
+    creates: '/etc/minidlna.conf.dpkg-divert'
+
+- name: Generate main configuration file
+  template:
+    src: 'etc/minidlna.conf.j2'
+    dest: '/etc/minidlna.conf'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+    unsafe_writes: '{{ True if (core__unsafe_writes|d(ansible_local.core.unsafe_writes|d()) | bool) else omit }}'
+# Ansible facts [[[1
+- name: Make sure that Ansible local fact directory exists
+  file:
+    path: '/etc/ansible/facts.d'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+
+- name: Create local facts of MiniDLNA
+  template:
+    src: 'etc/ansible/facts.d/minidlna.fact.j2'
+    dest: '/etc/ansible/facts.d/minidlna.fact'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+    unsafe_writes: '{{ True if (core__unsafe_writes|d(ansible_local.core.unsafe_writes|d()) | bool) else omit }}'
+  notify: [ 'Refresh host facts' ]
+
+- name: Reload facts if they were modified
+  meta: 'flush_handlers'
+

--- a/ansible/roles/minidlna/templates/etc/ansible/facts.d/minidlna.fact.j2
+++ b/ansible/roles/minidlna/templates/etc/ansible/facts.d/minidlna.fact.j2
@@ -1,0 +1,9 @@
+{# Copyright (C) 2021 Julien Lecomte <julien@lecomte.at>
+ # Copyright (C) 2021 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-only
+ #}
+{{ ({
+    "enabled": True,
+    "http_port": minidlna__http_port | int
+}) | to_nice_json }}
+

--- a/ansible/roles/minidlna/templates/etc/minidlna.conf.j2
+++ b/ansible/roles/minidlna/templates/etc/minidlna.conf.j2
@@ -1,0 +1,22 @@
+{# Copyright (C) 2021 Julien Lecomte <julien@lecomte.at>
+ # Copyright (C) 2021 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-only
+ #}
+# {{ ansible_managed }}
+#
+# This is the configuration file for the MiniDLNA daemon, a DLNA/UPnP-AV media
+# server.
+
+# Port number for HTTP traffic (descriptions, SOAP, media transfer).
+# This option is mandatory (or it must be specified on the command-line using
+# "-p").
+port={{ minidlna__http_port }}
+
+{% for item in minidlna__media_dirs %}
+media_dir={{item}}
+{% endfor %}
+
+{% for item in minidlna__configuration %}
+{{ item.name }}={{ item.value }}
+{% endfor %}
+

--- a/ansible/roles/minidlna/templates/etc/minidlna.conf.j2
+++ b/ansible/roles/minidlna/templates/etc/minidlna.conf.j2
@@ -16,7 +16,14 @@ port={{ minidlna__http_port }}
 media_dir={{item}}
 {% endfor %}
 
-{% for item in minidlna__configuration %}
+{% for item in minidlna__combined_configuration %}
 {{ item.name }}={{ item.value }}
+{% endfor %}
+
+# List of file names to look for when searching for album art.
+# Names should be delimited with a forward slash ("/").
+# This option can be specified more than once.
+{% for item in minidlna__combined_album_art_names %}
+album_art_names={{ item }}
 {% endfor %}
 

--- a/ansible/roles/sysctl/templates/etc/sysctl.d/parameters.conf.j2
+++ b/ansible/roles/sysctl/templates/etc/sysctl.d/parameters.conf.j2
@@ -20,9 +20,11 @@
 {{ value -}}
 {%   endif %}
 {% endmacro %}
+
 {% if item.comment|d() %}
 {{ item.comment | regex_replace('\n$','') | comment(prefix='', postfix='') }}
 {% endif %}
+
 {% set param_tracker = [] %}
 {% set tracker = {'seen_comment': False} %}
 {% for element in item.options %}

--- a/ansible/roles/sysctl/templates/etc/sysctl.d/parameters.conf.j2
+++ b/ansible/roles/sysctl/templates/etc/sysctl.d/parameters.conf.j2
@@ -24,14 +24,12 @@
 {% if item.comment|d() %}
 {{ item.comment | regex_replace('\n$','') | comment(prefix='', postfix='') }}
 {% endif %}
-
 {% set param_tracker = [] %}
 {% set tracker = {'seen_comment': False} %}
 {% for element in item.options %}
 {%   if element.state|d('present') not in [ 'absent', 'ignore', 'init' ] %}
 {%     if element.comment|d() %}
 {%       if not loop.first and param_tracker and not tracker.seen_comment|bool %}
-
 {%       endif %}
 {%       set _ = tracker.update({'seen_comment': True}) %}
 {{ element.comment | regex_replace('\n$','') | comment(prefix='', postfix='') -}}

--- a/docs/ansible/roles/minidlna/getting-started.rst
+++ b/docs/ansible/roles/minidlna/getting-started.rst
@@ -1,0 +1,34 @@
+.. Copyright (C) 2021 Julien Lecomte <julien@lecomte.at>
+.. Copyright (C) 2021 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+Getting started
+===============
+
+Default configuration
+---------------------
+
+The role does not specify any DLNA media directories by default. You will need
+to configure them using the provided variable :envvar:`minidlna__media_dirs`.
+
+Example inventory
+-----------------
+
+To enable MiniDLNA service on a host it needs to be included in the specific Ansible
+inventory group:
+
+.. code-block:: none
+
+   [debops_service_minidlna]
+   hostname
+
+
+Example playbook
+----------------
+
+If you are using this role without DebOps, here's an example Ansible playbook
+that uses the ``debops.minidlna`` role:
+
+.. literalinclude:: ../../../../ansible/playbooks/service/minidlna.yml
+   :language: yaml
+   :lines: 1,5-

--- a/docs/ansible/roles/minidlna/index.rst
+++ b/docs/ansible/roles/minidlna/index.rst
@@ -1,0 +1,28 @@
+.. Copyright (C) 2021 Julien Lecomte <julien@lecomte.at>
+.. Copyright (C) 2021 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+.. _debops.minidlna:
+
+debops.minidlna
+===============
+
+.. include:: man_description.rst
+   :start-line: 7
+
+.. toctree::
+   :maxdepth: 2
+
+   getting-started
+   defaults/main
+
+Copyright
+---------
+
+.. literalinclude:: ../../../../ansible/roles/minidlna/COPYRIGHT
+
+..
+ Local Variables:
+ mode: rst
+ ispell-local-dictionary: "american"
+ End:

--- a/docs/ansible/roles/minidlna/man_description.rst
+++ b/docs/ansible/roles/minidlna/man_description.rst
@@ -1,0 +1,9 @@
+.. Copyright (C) 2021 Julien Lecomte <julien@lecomte.at>
+.. Copyright (C) 2021 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+Description
+===========
+
+The ``debops.minidlna`` Ansible role can be used to configure a MiniDLNA server on
+Debian/Ubuntu hosts.

--- a/docs/ansible/roles/minidlna/man_index.rst
+++ b/docs/ansible/roles/minidlna/man_index.rst
@@ -1,0 +1,21 @@
+:orphan:
+
+.. Copyright (C) 2021 Julien Lecomte <julien@lecomte.at>
+.. Copyright (C) 2021 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+debops.minidlna
+===============
+
+.. toctree::
+   :maxdepth: 2
+
+   man_synopsis
+   man_description
+   getting-started
+
+..
+ Local Variables:
+ mode: rst
+ ispell-local-dictionary: "american"
+ End:

--- a/docs/ansible/roles/minidlna/man_synopsis.rst
+++ b/docs/ansible/roles/minidlna/man_synopsis.rst
@@ -1,0 +1,8 @@
+.. Copyright (C) 2021 Julien Lecomte <julien@lecomte.at>
+.. Copyright (C) 2021 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+Synopsis
+========
+
+``debops service/minidlna`` [**--limit** `group,host,`...] [**--diff**] [**--check**] [**--tags** `tag1,tag2,`...] [**--skip-tags** `tag1,tag2,`...] [<``ansible-playbook`` options>] ...


### PR DESCRIPTION
Allows user to install and setup a working MiniDLNA server. Registers ports in /etc/services, and setups the ferm firewall.

Issues I'd like to iron out:
- [ ] ferm currently creates two rule files (150_rule_minidlna_allow_tcp.conf, 150_rule_minidlna_allow_udp.conf). I don't know if there would be a method to only have one.
- [x] Also, why is it a 150xyz file and not a 100xyz, or even a 50xyz since I specify 50 as weight.
- [ ] No dependencies are in the meta file; same as all other roles. I guess this is normal.
