### PR TITLE
Minidlna

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1409,6 +1409,18 @@ stages:
     JANE_DIFF_PATTERN: '.*/roles/memcached/.*'
     JANE_LOG_PATTERN: '\[memcached\]'
 
+'minidlna role':
+  <<: *test_role_1st_deps
+  needs:
+    - 'etc_services role'
+    - 'ferm role'
+  variables:
+    JANE_TEST_FACT: 'mariadb.fact minidlna.fact'
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/minidlna.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_minidlna'
+    JANE_DIFF_PATTERN: '.*/roles/minidlna/.*'
+    JANE_LOG_PATTERN: '\[minidlna\]'
+
 'minio role':
   <<: *test_role_2nd_deps
   needs:

--- a/ansible/playbooks/service/minidlna.yml
+++ b/ansible/playbooks/service/minidlna.yml
@@ -1,0 +1,29 @@
+---
+# Copyright (C) 2021-2021 Julien Lecomte <julien@lecomte.at>
+# Copyright (C) 2021-2021 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+- name: Install and manage MiniDLNA
+  collections: [ 'debops.debops', 'debops.roles01',
+                 'debops.roles02', 'debops.roles03' ]
+  hosts: [ 'debops_service_minidlna' ]
+  become: True
+
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
+
+  roles:
+
+    - role: etc_services
+      tags: [ 'role::etc_services', 'skip::etc_services' ]
+      etc_services__dependent_list:
+        - '{{ minidlna_server__etc_services__dependent_list }}'
+
+    - role: ferm
+      tags: [ 'role::ferm', 'skip::ferm' ]
+      ferm__dependent_rules:
+        - '{{ minidlna__ferm__dependent_rules }}'
+
+    - role: minidlna
+      tags: [ 'role::minidlna', 'skip::minidlna' ]

--- a/ansible/playbooks/srv/all.yml
+++ b/ansible/playbooks/srv/all.yml
@@ -104,3 +104,5 @@
 - import_playbook: tinyproxy.yml
 
 - import_playbook: libuser.yml
+
+- import_playbook: minidlna.yml

--- a/ansible/playbooks/srv/minidlna.yml
+++ b/ansible/playbooks/srv/minidlna.yml
@@ -1,0 +1,1 @@
+../service/minidlna.yml

--- a/ansible/roles/minidlna/COPYRIGHT
+++ b/ansible/roles/minidlna/COPYRIGHT
@@ -1,0 +1,17 @@
+debops.minidlna - Manage DLNA with Ansible
+
+Copyright (C) 2021 Julien Lecomte <julien@lecomte.at>
+Copyright (C) 2021 DebOps <https://debops.org/>
+SPDX-License-Identifier: GPL-3.0-only
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 3, as
+published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see https://www.gnu.org/licenses/

--- a/ansible/roles/minidlna/defaults/main.yml
+++ b/ansible/roles/minidlna/defaults/main.yml
@@ -1,0 +1,147 @@
+---
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+
+# .. Copyright (C) 2021 Julien Lecomte <julien@lecomte.at>
+# .. Copyright (C) 2021 DebOps <https://debops.org/>
+# .. SPDX-License-Identifier: GPL-3.0-only
+
+# .. _minidlna__ref_defaults:
+
+# .. contents:: Sections
+#    :local:
+#
+# .. include:: ../../../../includes/global.rst
+
+# Packages and installation [[[
+# -------------------------
+
+# .. envvar:: minidlna__base_packages [[[
+#
+# List of APT packages to install for :command:`minidlna` support.
+minidlna__base_packages: [ 'minidlna' ]
+
+                                                                   # ]]]
+# .. envvar:: minidlna__packages [[[
+#
+# List of additional APT packages to install during :command:`minidlna`
+# configuration.
+minidlna__packages: []
+
+                                                                   # ]]]
+                                                                   # ]]]
+# MiniDLNA configuration [[[
+# ----------------------
+
+# .. envvar:: minidlna__http_port [[[
+#
+# Port for HTTP traffic. Defaults to 8200.
+minidlna__http_port: 8200
+
+                                                                   # ]]]
+# .. envvar:: minidlna__media_dirs [[[
+#
+# List of media directories to scan and present to end user.
+#
+# If you want to restrict a media_dir to a specific content type, you can
+# prepend the directory name with a letter representing the type (A, P or V),
+# followed by a comma, as so:
+#
+# * "A" for audio    (eg. "A,/var/lib/minidlna/music")
+# * "P" for pictures (eg. "P,/var/lib/minidlna/pictures")
+# * "V" for video    (eg. "V,/var/lib/minidlna/videos")
+# * "PV" for pictures and video (eg. "PV,/var/lib/minidlna/digital_camera")
+#
+minidlna__media_dirs: []
+
+                                                                   # ]]]
+# .. envvar:: minidlna__default_configuration [[[
+#
+# YAML dictionary of {name, value} for configuration file.
+minidlna__default_configuration:
+  - name: "inotify"
+    value: "yes"
+                                                                   # ]]]
+# .. envvar:: minidlna__configuration [[[
+#
+# YAML dictionary of {name, value} for configuration file.
+minidlna__configuration: []
+
+                                                                   # ]]]
+# .. envvar:: minidlna__default_album_art_names [[[
+#
+# List of file names to look for when searching for album art.
+# Names should be delimited with a forward slash ("/").
+minidlna__default_album_art_names:
+  - "Cover.jpg/cover.jpg/AlbumArtSmall.jpg/albumartsmall.jpg"
+  - "AlbumArt.jpg/albumart.jpg/Album.jpg/album.jpg"
+  - "Folder.jpg/folder.jpg/Thumb.jpg/thumb.jpg"
+                                                                   # ]]]
+# .. envvar:: minidlna__album_art_names [[[
+#
+# List of file names to look for when searching for album art.
+# Names should be delimited with a forward slash ("/").
+minidlna__album_art_names: []
+
+                                                                   # ]]]
+# .. envvar:: minidlna__allow [[[
+#
+# List of IP addresses or CIDR subnets which are allowed to connect to the
+# MiniDLNA instances over the network, on all hosts in the Ansible
+# inventory. This variable configures the firewall for all instances at the
+# same time, for individual instance configuration you should modify the
+# :envvar:`minidlna__ferm__dependent_rules` variable directly.
+minidlna__allow: []
+
+                                                                   # ]]]
+                                                                   # ]]]
+# Configuration for other Ansible roles [[[
+# -------------------------------------
+
+# .. envvar:: minidlna__ferm__dependent_rules [[[
+#
+# Configuration for the :ref:`debops.ferm` Ansible role.
+minidlna__ferm__dependent_rules:
+
+  - name: 'minidlna_allow_tcp'
+    type: 'accept'
+    dport: [ "{{ minidlna__http_port }}" ]
+    protocol: [ 'tcp' ]
+    saddr: '{{ minidlna__allow }}'
+    weight: '50'
+    by_role: 'debops.minidlna'
+
+  - name: 'minidlna_allow_udp'
+    type: 'accept'
+    dport: [ 1900 ]
+    protocol: [ 'udp' ]
+    saddr: '{{ minidlna__allow }}'
+    weight: '50'
+    by_role: 'debops.minidlna'
+                                                                   # ]]]
+# .. envvar:: minidlna_server__etc_services__dependent_list [[[
+#
+# Configuration for the :ref:`debops.etc_services` Ansible role.
+minidlna_server__etc_services__dependent_list:
+
+  - name: 'ssdp'
+    port: '1900'
+    comment: 'Simple Service Discovery Protocol'
+
+  - name: 'minidlna'
+    port: '{{ minidlna__http_port }}'
+    comment: 'MiniDLNA Server'
+
+                                                                   # ]]]
+# .. envvar:: minidlna__combined_configuration [[[
+#
+# Cofiguration merged into one.
+minidlna__combined_configuration: '{{ minidlna__default_configuration
+                                      + minidlna__configuration }}'
+                                                                   # ]]]
+# .. envvar:: minidlna__combined_album_art_names [[[
+#
+# Album art configuration merged into one.
+minidlna__combined_album_art_names: '{{ minidlna__default_album_art_names
+                                      + minidlna__album_art_names }}'
+                                                                   # ]]]
+                                                                   # ]]]

--- a/ansible/roles/minidlna/meta/main.yml
+++ b/ansible/roles/minidlna/meta/main.yml
@@ -1,0 +1,30 @@
+---
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+
+# Copyright (C) 2021 Julien Lecomte <julien@lecomte.at>
+# Copyright (C) 2021 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+collections: [ 'debops.debops' ]
+
+dependencies: []
+
+galaxy_info:
+
+  author: 'Julien Lecomte'
+  description: 'Configure MiniDLNA instances'
+  company: 'DebOps'
+  license: 'GPL-3.0-only'
+  min_ansible_version: '2.4.0'
+  platforms:
+    - name: Ubuntu
+      versions:
+        - xenial
+        - bionic
+    - name: Debian
+      versions:
+        - stretch
+        - buster
+  galaxy_tags:
+    - minidlna
+    - dlna

--- a/ansible/roles/minidlna/tasks/main.yml
+++ b/ansible/roles/minidlna/tasks/main.yml
@@ -1,0 +1,71 @@
+---
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+
+# Copyright (C) 2021 Julien Lecomte <julien@lecomte.at>
+# Copyright (C) 2021 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+- name: Import custom Ansible plugins
+  import_role:
+    name: 'ansible_plugins'
+
+- name: Import DebOps global handlers
+  import_role:
+    name: 'global_handlers'
+
+# Package installation [[[1
+- name: Install MiniDLNA packages
+  apt:
+    name: '{{ (minidlna__base_packages
+             + minidlna__packages)
+             | flatten }}'
+    state: 'present'
+  register: minidlna__register_packages
+  until: minidlna__register_packages is succeeded
+
+# MiniDLNA configuration [[[1
+- name: Divert the MiniDLNA configuration file
+  command: dpkg-divert --quiet --local --divert /etc/minidlna.conf.dpkg-divert
+                       --rename /etc/minidlna.conf
+  args:
+    creates: '/etc/minidlna.conf.dpkg-divert'
+
+- name: Generate MiniDLNA configuration file
+  template:
+    src: 'etc/minidlna.conf.j2'
+    dest: '/etc/minidlna.conf'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+    unsafe_writes: '{{ True if (core__unsafe_writes|d(ansible_local.core.unsafe_writes|d()) | bool) else omit }}'
+  register: minidlna__register_configuration
+
+- name: Conditionnally restart MiniDLNA service
+  systemd:
+    name: 'minidlna.service'
+    enabled: true
+    daemon_reload: '{{ True if (minidlna__register_configuration is changed) else omit }}'
+    state: '{{ "restarted" if (minidlna__register_configuration is changed) else "started" }}'
+  when: ansible_service_mgr == 'systemd'
+
+# Ansible facts [[[1
+- name: Make sure that Ansible local fact directory exists
+  file:
+    path: '/etc/ansible/facts.d'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+
+- name: Create local facts of MiniDLNA
+  template:
+    src: 'etc/ansible/facts.d/minidlna.fact.j2'
+    dest: '/etc/ansible/facts.d/minidlna.fact'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+    unsafe_writes: '{{ True if (core__unsafe_writes|d(ansible_local.core.unsafe_writes|d()) | bool) else omit }}'
+  notify: [ 'Refresh host facts' ]
+
+- name: Reload facts if they were modified
+  meta: 'flush_handlers'

--- a/ansible/roles/minidlna/templates/etc/ansible/facts.d/minidlna.fact.j2
+++ b/ansible/roles/minidlna/templates/etc/ansible/facts.d/minidlna.fact.j2
@@ -1,0 +1,25 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2021 Julien Lecomte <julien@lecomte.at>
+# Copyright (C) 2021 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+# {{ ansible_managed }}
+
+from __future__ import print_function
+from json import loads, dumps
+
+output = {}
+
+try:
+    with open("/etc/minidlna.conf", 'r') as fp:
+        output["configured"] = True
+        for line in fp:
+            if line.startswith("port="):
+                output["http_port"] = line[5:].strip()
+    pass
+except Exception:
+    pass
+
+print(dumps(output, sort_keys=True, indent=4))

--- a/ansible/roles/minidlna/templates/etc/minidlna.conf.j2
+++ b/ansible/roles/minidlna/templates/etc/minidlna.conf.j2
@@ -1,0 +1,31 @@
+{# Copyright (C) 2021 Julien Lecomte <julien@lecomte.at>
+ # Copyright (C) 2021 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-only
+ #}
+# {{ ansible_managed }}
+#
+# This is the configuration file for the MiniDLNA daemon, a DLNA/UPnP-AV media
+# server.
+
+# Port number for HTTP traffic (descriptions, SOAP, media transfer).
+# This option is mandatory (or it must be specified on the command-line using
+# "-p").
+port={{ minidlna__http_port }}
+
+{% for element in minidlna__media_dirs %}
+media_dir={{element}}
+{% endfor %}
+
+{% for element in minidlna__combined_configuration | parse_kv_config %}
+{%   if element.name|d() and element.state|d('present') not in [ 'absent', 'ignore' ] %}
+{{ element.name|d() }}={{ element.value }}
+{%   endif %}
+{% endfor %}
+
+# List of file names to look for when searching for album art.
+# Names should be delimited with a forward slash ("/").
+# This option can be specified more than once.
+{% for element in minidlna__combined_album_art_names %}
+album_art_names={{ element }}
+{% endfor %}
+

--- a/docs/ansible/roles/minidlna/getting-started.rst
+++ b/docs/ansible/roles/minidlna/getting-started.rst
@@ -1,0 +1,34 @@
+.. Copyright (C) 2021 Julien Lecomte <julien@lecomte.at>
+.. Copyright (C) 2021 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+Getting started
+===============
+
+Default configuration
+---------------------
+
+The role does not specify any DLNA media directories by default. You will need
+to configure them using the provided variable :envvar:`minidlna__media_dirs`.
+
+Example inventory
+-----------------
+
+To enable MiniDLNA service on a host it needs to be included in the specific Ansible
+inventory group:
+
+.. code-block:: none
+
+   [debops_service_minidlna]
+   hostname
+
+
+Example playbook
+----------------
+
+If you are using this role without DebOps, here's an example Ansible playbook
+that uses the ``debops.minidlna`` role:
+
+.. literalinclude:: ../../../../ansible/playbooks/service/minidlna.yml
+   :language: yaml
+   :lines: 1,5-

--- a/docs/ansible/roles/minidlna/index.rst
+++ b/docs/ansible/roles/minidlna/index.rst
@@ -1,0 +1,28 @@
+.. Copyright (C) 2021 Julien Lecomte <julien@lecomte.at>
+.. Copyright (C) 2021 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+.. _debops.minidlna:
+
+debops.minidlna
+===============
+
+.. include:: man_description.rst
+   :start-line: 7
+
+.. toctree::
+   :maxdepth: 2
+
+   getting-started
+   defaults/main
+
+Copyright
+---------
+
+.. literalinclude:: ../../../../ansible/roles/minidlna/COPYRIGHT
+
+..
+ Local Variables:
+ mode: rst
+ ispell-local-dictionary: "american"
+ End:

--- a/docs/ansible/roles/minidlna/man_description.rst
+++ b/docs/ansible/roles/minidlna/man_description.rst
@@ -1,0 +1,9 @@
+.. Copyright (C) 2021 Julien Lecomte <julien@lecomte.at>
+.. Copyright (C) 2021 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+Description
+===========
+
+The ``debops.minidlna`` Ansible role can be used to configure a MiniDLNA server on
+Debian/Ubuntu hosts.

--- a/docs/ansible/roles/minidlna/man_index.rst
+++ b/docs/ansible/roles/minidlna/man_index.rst
@@ -1,0 +1,21 @@
+:orphan:
+
+.. Copyright (C) 2021 Julien Lecomte <julien@lecomte.at>
+.. Copyright (C) 2021 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+debops.minidlna
+===============
+
+.. toctree::
+   :maxdepth: 2
+
+   man_synopsis
+   man_description
+   getting-started
+
+..
+ Local Variables:
+ mode: rst
+ ispell-local-dictionary: "american"
+ End:

--- a/docs/ansible/roles/minidlna/man_synopsis.rst
+++ b/docs/ansible/roles/minidlna/man_synopsis.rst
@@ -1,0 +1,8 @@
+.. Copyright (C) 2021 Julien Lecomte <julien@lecomte.at>
+.. Copyright (C) 2021 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+Synopsis
+========
+
+``debops service/minidlna`` [**--limit** `group,host,`...] [**--diff**] [**--check**] [**--tags** `tag1,tag2,`...] [**--skip-tags** `tag1,tag2,`...] [<``ansible-playbook`` options>] ...


### PR DESCRIPTION
Allows user to install and setup a working MiniDLNA server. Registers ports in /etc/services, and setups the ferm firewall.