### PR TITLE
[nginx] Always allow access to ACME challenge dir

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,14 @@ Fixed
   IP address using DNS and the host does not have an entry in the DNS or in
   :file:`/etc/hosts` database.
 
+:ref:`debops.nginx` role
+''''''''''''''''''''''''
+
+- Access to the ACME challenge directories is now always allowed, even if a
+  server-wide allowlist configuration or HTTP basic authentication enforcement
+  has been applied. This ensures that it is always possible to request and renew
+  certificates through the ACME protocol.
+
 
 `debops v2.3.0`_ - 2021-06-04
 -----------------------------

--- a/ansible/roles/nginx/templates/etc/nginx/snippets/acme-challenge.conf.j2
+++ b/ansible/roles/nginx/templates/etc/nginx/snippets/acme-challenge.conf.j2
@@ -13,6 +13,7 @@
 # Return the ACME challenge present in the server public root.
 # If not found, switch to global web server root.
 location ^~ /.well-known/acme-challenge/ {
+        allow all;
         default_type "text/plain";
         try_files $uri @well-known-acme-challenge;
 }
@@ -20,6 +21,7 @@ location ^~ /.well-known/acme-challenge/ {
 # Return the ACME challenge present in the global server public root.
 # If not present, redirect request to a specified domain.
 location @well-known-acme-challenge {
+        allow all;
         root {{ nginx_acme_root }};
         default_type "text/plain";
 {% if nginx_acme_domain %}


### PR DESCRIPTION
This change ensures that NGINX always allows access to ACME challenge
files, even when the server is configured with restrictive access
controls.