### PR TITLE
[apt_cacher_ng] No longer create NGINX webroot

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,11 @@ Changed
 Fixed
 ~~~~~
 
+:ref:`debops.apt_cacher_ng` role
+''''''''''''''''''''''''''''''''
+
+- The role no longer creates an unnecessary NGINX webroot directory.
+
 :ref:`debops.kmod` role
 '''''''''''''''''''''''
 

--- a/ansible/roles/apt_cacher_ng/defaults/main.yml
+++ b/ansible/roles/apt_cacher_ng/defaults/main.yml
@@ -562,6 +562,7 @@ apt_cacher_ng__nginx__servers:
     enabled: True
     allow: '{{ apt_cacher_ng__allow + apt_cacher_ng__group_allow + apt_cacher_ng__host_allow }}'
     ssl: False
+    webroot_create: False
     type: 'proxy'
     proxy_pass: 'http://apt-cacher-ng'
     proxy_options: |
@@ -582,6 +583,7 @@ apt_cacher_ng__nginx__servers:
     allow: '{{ apt_cacher_ng__allow + apt_cacher_ng__group_allow + apt_cacher_ng__host_allow }}'
     state: '{{ "present" if (ansible_local.pki|d()) else "absent" }}'
     listen: False
+    webroot_create: False
     type: 'proxy'
     proxy_pass: 'http://apt-cacher-ng'
     proxy_options: |


### PR DESCRIPTION
The NGINX server configuration provided by `debops.apt_cacher_ng` only
functions to set up proxies and a redirect, so no webroot is necessary.