### PR TITLE
[apt] allow to add foreign architectures

### DIFF
--- a/ansible/roles/apt/defaults/main.yml
+++ b/ansible/roles/apt/defaults/main.yml
@@ -26,6 +26,31 @@
 apt__enabled: True
 
                                                                    # ]]]
+# Extra architectures [[[
+# -----------------------
+
+# These lists define extra architectures to be enabled on the host.
+# The main architecture does not need to be defined that way
+
+# .. envvar:: apt__extra_architectures [[[
+#
+# List of extra architectures to configure on all hosts in Ansible inventory.
+apt__extra_architectures: []
+
+                                                                   # ]]]
+# .. envvar:: apt__group_extra_architectures [[[
+#
+# List of extra architectures to configure on hosts in specific Ansible inventory
+# group.
+apt__group_extra_architectures: []
+
+                                                                   # ]]]
+# .. envvar:: apt__host_extra_architectures [[[
+#
+# List of extra architectures to configure on specific hosts in Ansible inventory.
+apt__host_extra_architectures: []
+                                                                   # ]]]
+                                                                   # ]]]
 # .. envvar:: apt__sources_deploy_state [[[
 #
 # Enable (if ``present``) or disable (if ``absent``) management of

--- a/ansible/roles/apt/tasks/main.yml
+++ b/ansible/roles/apt/tasks/main.yml
@@ -56,6 +56,15 @@
     - 'etc/apt/apt.conf.d/25no-recommends.conf'
   when: apt__enabled|bool
 
+- name: Enable extra architectures
+  command: dpkg --add-architecture {{ item }}
+  with_flattened:
+    - '{{ apt__extra_architectures }}'
+    - '{{ apt__group_extra_architectures }}'
+    - '{{ apt__host_extra_architectures }}'
+  when: item not in ansible_facts.ansible_local.apt.foreign_architectures|d()
+  notify: [ 'Refresh host facts' ]
+
 - name: Check current APT diversions
   environment:
     LC_ALL: 'C'


### PR DESCRIPTION
This adds a new set of variables apt__*_extra_architectures that will
be added to the machine, allowing the configuration of multi-architecture
machines

Note that this has only been tested on 2.2 

Signed-off-by: Jérémy Rosen <jeremy.rosen@smile.fr>

