### PR TITLE
[postldap] Change LDAP lookup tables

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,13 @@ You can read information about required changes between releases in the
 Changed
 ~~~~~~~
 
+:ref:`debops.postldap` role
+'''''''''''''''''''''''''''
+
+- A few changes to the Postfix LDAP lookup tables were made, most notably a
+  better split between alias lookups (ldap_virtual_alias_maps.cf) and
+  distribution list lookups (ldap_virtual_forward_maps.cf).
+
 :ref:`debops.system_users` role
 '''''''''''''''''''''''''''''''
 

--- a/ansible/roles/postldap/defaults/main.yml
+++ b/ansible/roles/postldap/defaults/main.yml
@@ -448,7 +448,7 @@ postldap__postfix__dependent_lookup_tables:
                    )'
     result_attribute: ''
     special_result_attribute: 'member'
-    leaf_result_attribute: 'uid, mailAddress, mailAlternateAddress'
+    leaf_result_attribute: '{{ postldap__virtual_mailbox_maps_attribute }}'
     size_limit: 1
 
   - name: 'ldap_known_sender_relays.cf'

--- a/ansible/roles/postldap/defaults/main.yml
+++ b/ansible/roles/postldap/defaults/main.yml
@@ -341,20 +341,14 @@ postldap__postfix__dependent_lookup_tables:
     connection: '{{ postldap__postfix_ldap_connection }}'
     search_base: '{{ postldap__ldap_base_dn|join(",") }}'
     query_filter: '(&
-                     (|
-                       (objectClass=mailRecipient)
-                     )
-                     (|
-                       (mailAddress=%s)
-                       (mailAlternateAddress=%s)
-                     )
+                     (objectClass=mailRecipient)
+                     (mailAlternateAddress=%s)
                      (|
                        (authorizedService=all)
                        (authorizedService=mail:receive)
                      )
                    )'
-    special_result_attribute: 'member'
-    leaf_result_attribute: 'mailAddress'
+    result_attribute: 'mailAddress'
 
   - name: 'ldap_virtual_forward_maps.cf'
     state: 'present'

--- a/ansible/roles/postldap/defaults/main.yml
+++ b/ansible/roles/postldap/defaults/main.yml
@@ -363,16 +363,15 @@ postldap__postfix__dependent_lookup_tables:
                        (objectClass=mailAlias)
                        (objectClass=mailDistributionList)
                      )
-                     (|
-                       (mailAddress=%s)
-                       (mailAlternateAddress=%s)
-                     )
+                     (mailAddress=%s)
                      (|
                        (authorizedService=all)
                        (authorizedService=mail:receive)
                      )
                    )'
     result_attribute: 'mailForwardTo'
+    special_result_attribute: 'member'
+    leaf_result_attribute: 'mailAddress'
 
   - name: 'ldap_virtual_mailbox_maps.cf'
     state: 'present'

--- a/ansible/roles/postldap/defaults/main.yml
+++ b/ansible/roles/postldap/defaults/main.yml
@@ -446,6 +446,7 @@ postldap__postfix__dependent_lookup_tables:
                        (authorizedService=mail:send)
                      )
                    )'
+    result_attribute: ''
     special_result_attribute: 'member'
     leaf_result_attribute: 'uid, mailAddress, mailAlternateAddress'
     size_limit: 1


### PR DESCRIPTION
This PR contains fixes for minor issues we discovered in `debops.postldap` while updating to stable-2.3. They should be backwards-compatible. See the commit messages for details about each change.