### PR TITLE
[rsyslog] Re-enable streamDriverPermittedPeers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,13 @@ Added
 
   .. __: https://wiki.debian.org/Multiarch/HOWTO
 
+:ref:`debops.rsyslog` role
+''''''''''''''''''''''''''
+
+- It is now possible to override the default ``netstream_driver``,
+  ``driver_mode`` and ``driver_authmode`` parameters in every
+  :ref:`rsyslog__ref_forward` forwarding rule.
+
 :ref:`debops.sshd` role
 '''''''''''''''''''''''
 
@@ -63,6 +70,12 @@ Updates of upstream application versions
 - A few changes to the Postfix LDAP lookup tables were made, most notably a
   better split between alias lookups (ldap_virtual_alias_maps.cf) and
   distribution list lookups (ldap_virtual_forward_maps.cf).
+
+:ref:`debops.rsyslog` role
+''''''''''''''''''''''''''
+
+- The default NetStream driver mode and authentication mode are now set based
+  on whether the ``gtls`` driver is enabled.
 
 :ref:`debops.system_users` role
 '''''''''''''''''''''''''''''''
@@ -100,6 +113,12 @@ Fixed
   server-wide allowlist configuration or HTTP basic authentication enforcement
   has been applied. This ensures that it is always possible to request and renew
   certificates through the ACME protocol.
+
+:ref:`debops.rsyslog` role
+''''''''''''''''''''''''''
+
+- The rsyslog role always configured the streamDriverPermittedPeers option,
+  even when the ``anon`` network driver authentication mode was selected.
 
 
 `debops v2.3.0`_ - 2021-06-04

--- a/ansible/roles/rsyslog/defaults/main.yml
+++ b/ansible/roles/rsyslog/defaults/main.yml
@@ -210,7 +210,7 @@ rsyslog__pki_key: '{{ ansible_local.pki.key|d("default.key") }}'
                                                                    # ]]]
 # .. envvar:: rsyslog__default_netstream_driver [[[
 #
-# Specify the default netstrap driver used by the ``imtcp`` module. The
+# Specify the default NetStream driver used by the ``imtcp`` module. The
 # ``gtls`` will be enabled by default if the support for PKI is enabled,
 # otherwise ``ptcp`` will be used.
 rsyslog__default_netstream_driver: '{{ "gtls"
@@ -218,11 +218,25 @@ rsyslog__default_netstream_driver: '{{ "gtls"
                                        else "ptcp" }}'
 
                                                                    # ]]]
+# .. envvar:: rsyslog__default_driver_mode [[[
+#
+# The NetStream driver mode. The ptcp driver only supports mode 0 (unencrypted
+# transmission). The gtls driver supports modes 0 (unencrypted transmission,
+# just like the ptcp driver) and 1 (TLS-protected operation).
+# Ref: https://rsyslog.readthedocs.io/en/latest/concepts/netstrm_drvr.html
+rsyslog__default_driver_mode: '{{ "1"
+                                  if rsyslog__default_netstream_driver == "gtls"
+                                  else "0" }}'
+
+                                                                   # ]]]
 # .. envvar:: rsyslog__default_driver_authmode [[[
 #
 # Specify the default network driver authetication mode. Currently only
 # `x509/name` or `anon` are available:
-rsyslog__default_driver_authmode: "x509/name"
+rsyslog__default_driver_authmode: '{{ "x509/name"
+                                      if rsyslog__default_netstream_driver == "gtls" and
+                                         rsyslog__default_driver_mode == "1"
+                                      else "anon" }}'
 
                                                                    # ]]]
 # .. envvar:: rsyslog__domain [[[
@@ -671,11 +685,10 @@ rsyslog__default_rules:
                 queue.type="{{ element.queue_type | d('linkedList') }}"
                 queue.size="{{ element.queue_size | d('10000') }}"
                 action.resumeRetryCount="{{ element.resume_retry_count | d('100') }}"
-                streamDriver="{{ element.driver | d('gtls') }}"
-                streamDriverMode="{{ element.drivermode | d('1') }}"
-                streamDriverAuthMode="{{ element.driverauthmode | d(rsyslog__default_driver_authmode) }}"
-          {% if rsyslog__default_driver_authmode != "anon"
-             and ( element.driverauthmode is defined and element.driverauthmode != "anon" ) %}
+                streamDriver="{{ element.netstream_driver | d(rsyslog__default_netstream_driver) }}"
+                streamDriverMode="{{ element.driver_mode | d(rsyslog__default_driver_mode) }}"
+                streamDriverAuthMode="{{ element.driver_authmode | d(rsyslog__default_driver_authmode) }}"
+          {% if element.driver_authmode | d(rsyslog__default_driver_authmode) != "anon" %}
           {%   if rsyslog__send_permitted_peers is string %}
                 streamDriverPermittedPeers="{{ rsyslog__send_permitted_peers }}"
           {%   else %}

--- a/docs/ansible/roles/rsyslog/defaults-detailed.rst
+++ b/docs/ansible/roles/rsyslog/defaults-detailed.rst
@@ -57,6 +57,18 @@ specific parameters:
 ``queue_size``
   The size of the message queue, by default ``10000``.
 
+``netstream_driver``
+  The NetStream driver used by the ``imtcp`` module, defaults to the value of
+  :envvar:`rsyslog__default_netstream_driver`.
+
+``driver_mode``
+  The NetStream driver mode, defaults to the value of
+  :envvar:`rsyslog__default_driver_mode`.
+
+``driver_authmode``
+  The NetStream driver authentication mode, defaults to the value of
+  :envvar:`rsyslog__default_driver_authmode`.
+
 
 .. _rsyslog__ref_configuration:
 


### PR DESCRIPTION
Commit 2cadbbbd23900fa093fe63c2131ab04c922eecc6 added a conditional that
resulted in streamDriverPermittedPeers being set only when the
(undocumented) `drivermode` parameter was set in the `rsyslog__forward`
rule entry. As streamDriverPermittedPeers specifies the name of the
remote peer as used in TLS certificate validation, this option should
always be set when securing the syslog traffic with TLS, which is what
this commit takes care of.

This commit also documents the new rsyslog__forward parameters, and adds
one new default variable: `rsyslog__default_driver_mode`. I have taken
the liberty to rename element.driver, element.drivermode and
element.driverauthmode to better match the naming in the
defaults/main.yml file.

/cc @bleuchtang

Ref: https://github.com/debops/debops/pull/1729