### PR TITLE
[redis_server] Facts version and passwordless istances

### DIFF
--- a/ansible/roles/redis_server/templates/etc/ansible/facts.d/redis_server.fact.j2
+++ b/ansible/roles/redis_server/templates/etc/ansible/facts.d/redis_server.fact.j2
@@ -45,8 +45,8 @@ output['installed'] = cmd_exists('redis-server')
 if output['installed']:
     try:
         redis_server_version_stdout = subprocess.check_output(
-                ["dpkg-query", "-W", "-f=${Version}\n'",
-                 "redis-server"]).split('-')[0]
+                ["dpkg-query", "-W", "-f=${Version}",
+                 "redis-server"]).decode('utf-8').split('-')[0]
         output['version'] = redis_server_version_stdout.split(':')[1]
 
     except Exception:
@@ -76,6 +76,9 @@ if output['installed']:
 
                                 elif line.startswith('masterauth'):
                                     instance['password'] = unwrap_quotes(line)
+
+                        if 'password' not in instance:
+                            instance['password'] = None
 
                         try:
                             r = redis.StrictRedis(


### PR DESCRIPTION
Fixed version not present in the output.

If no password has been specified in `redis_server__auth_password` no
instances would be presented.