### PR TITLE
[lvm] Enable thinpool creation

### DIFF
--- a/ansible/roles/lvm/defaults/main.yml
+++ b/ansible/roles/lvm/defaults/main.yml
@@ -89,6 +89,13 @@ lvm__default_mount_options: 'defaults'
 lvm__volume_groups: []
 
                                                                    # ]]]
+# .. envvar:: lvm__thin_pools [[[
+#
+# list of LVM thin pools, each one defined as a yaml dict. see
+# :ref:`lvm__thin_pools` for more details.
+lvm__thin_pools: []
+
+                                                                   # ]]]
 # .. envvar:: lvm__logical_volumes [[[
 #
 # List of Logical Volumes, each one defined as a YAML dict. See

--- a/ansible/roles/lvm/tasks/manage_lvm.yml
+++ b/ansible/roles/lvm/tasks/manage_lvm.yml
@@ -43,14 +43,25 @@
   with_items: '{{ lvm__volume_groups }}'
   when: item.vg|d(False) and item.pvs|d(False)
 
+- name: Manage LVM Thin Pools
+  lvol:
+    vg:       '{{ item.vg }}'
+    thinpool: '{{ item.thinpool }}'
+    size:     '{{ item.size }}'
+  with_items: '{{ lvm__thin_pools }}'
+  when: lvm__thin_pools|d(False) and
+        item.vg|d() and item.thinpool|d() and item.size|d() and
+        item.state|d('present') != 'absent'
+
 - name: Manage LVM Logical Volumes
   lvol:
-    lv:     '{{ item.lv }}'
-    vg:     '{{ item.vg }}'
-    size:   '{{ item.size }}'
-    force:  '{{ item.force | d(omit) }}'
-    shrink: '{{ item.force | d(False) }}'
-    state:  'present'
+    lv:         '{{ item.lv }}'
+    vg:         '{{ item.vg }}'
+    size:       '{{ item.size }}'
+    thinpool:   '{{ item.thinpool | d(omit) }}'
+    force:      '{{ item.force | d(omit) }}'
+    shrink:     '{{ item.force | d(False) }}'
+    state:      'present'
   with_items: '{{ lvm__logical_volumes }}'
   when: lvm__logical_volumes|d(False) and
         item.vg|d() and item.lv|d() and item.size|d() and

--- a/docs/ansible/roles/lvm/defaults-detailed.rst
+++ b/docs/ansible/roles/lvm/defaults-detailed.rst
@@ -70,6 +70,37 @@ Create a Volume Group with multiple Physical Volumes::
       - vg: 'vg_multi'
         pvs: [ '/dev/sdb', '/dev/sdc' ]
 
+.. _lvm__thin_pools:
+
+lvm__thin_pools
+------------------
+
+This is a list of LVM Thin Pools, each one defined as a YAML dict. A LVM Thin Pool
+is related with LVM Thin Logical Volumes. Each LVM Thin Pool LV contains blocks of
+physical storage, which will be referenced by LVM Thin Logical Volumes. Dict
+parameters are mapped to ``lvol`` Ansible module options.
+
+List of required parameters:
+
+``vg``
+  Name of a Volume Group which should be used to create a given Logical Volume.
+
+``thinpool``
+  Name of a LVM Thin Pool, should only have alphanumeric characters and
+  underscores. Do not use hyphens (``-``) in the name.
+
+``size``
+  Size of the LVM Thin Pool, use the same format as these supported by
+  ``lvol`` Ansible module.
+
+Create a LVM Thin Pool::
+
+    lvm__thin_pools:
+
+      - vg: 'vg_alpha'
+        thinpool: 'pool0'
+        size: '1T'
+
 .. _lvm__logical_volumes:
 
 lvm__logical_volumes
@@ -91,9 +122,14 @@ List of required parameters:
 
 ``size``
   Size of the Logical Volume, use the same format as these supported by
-  ``lvol`` Ansible module.
+  ``lvol`` Ansible module. Relative values like ``100%FREE`` are not supported,
+  if a LVM Thin Logical Volume should be created.
 
 List of optional LVM parameters:
+
+``thinpool``
+  Specifies the underlying LVM Thin Pool. Using this option, the Logical Volume
+  will be created as a LVM Thin Logical Volume.
 
 ``state``
   Specifies if a Logical Volume should exist (``present``) or not (``absent``).
@@ -195,3 +231,11 @@ Resize a mounted Logical Volume::
         fs_type: 'ext4'
         fs_resizefs: True
 
+Create a Thin Logical Volume::
+
+    lvm__logical_volumes:
+
+      - lv: 'not_formatted_volume'
+        vg: 'vg_alpha'
+        thinpool: 'pool0'
+        size: '50G'


### PR DESCRIPTION
With _ansible 2.5_ the possibility to create LVM thin volumes was added to the [`lvol`-module](https://docs.ansible.com/ansible/latest/collections/community/general/lvol_module.html).
