### PR TITLE
[system_users] Fix create_home parameter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -141,6 +141,12 @@ Fixed
 - The rsyslog role always configured the streamDriverPermittedPeers option,
   even when the ``anon`` network driver authentication mode was selected.
 
+:ref:`debops.system_users` role
+'''''''''''''''''''''''''''''''
+
+- The ``create_home`` parameter was not functional because of typos in the
+  Ansible task.
+
 
 `debops v2.3.0`_ - 2021-06-04
 -----------------------------

--- a/ansible/roles/system_users/tasks/main.yml
+++ b/ansible/roles/system_users/tasks/main.yml
@@ -80,7 +80,7 @@
     shell:              '{{ item.shell              | d(system_users__default_shell
                                                         if system_users__default_shell|d()
                                                         else omit) }}'
-    createhome:         '{{ item.createhome         | d(omit) }}'
+    create_home:        '{{ item.create_home        | d(omit) }}'
     move_home:          '{{ item.move_home          | d(omit) }}'
     skeleton:           '{{ item.skeleton           | d(omit) }}'
     expires:            '{{ item.expires            | d(omit) }}'


### PR DESCRIPTION
There were typos in the Ansible task causing a `create_home: False`
setting to create the home directory anyway.