### PR TITLE
[lvm] Allow custom lvcreate options

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,9 @@ Added
 
   .. __: https://man7.org/linux/man-pages/man7/lvmthin.7.html
 
+- It is now possible to apply custom options to :ref:`lvm__thin_pools` and
+  :ref:`lvm__logical_volumes`.
+
 :ref:`debops.lxc` role
 ''''''''''''''''''''''
 

--- a/ansible/roles/lvm/defaults/main.yml
+++ b/ansible/roles/lvm/defaults/main.yml
@@ -91,7 +91,7 @@ lvm__volume_groups: []
                                                                    # ]]]
 # .. envvar:: lvm__thin_pools [[[
 #
-# list of LVM thin pools, each one defined as a yaml dict. see
+# List of LVM thin pools, each one defined as a yaml dict. see
 # :ref:`lvm__thin_pools` for more details.
 lvm__thin_pools: []
 

--- a/ansible/roles/lvm/tasks/manage_lvm.yml
+++ b/ansible/roles/lvm/tasks/manage_lvm.yml
@@ -48,6 +48,7 @@
     vg:       '{{ item.vg }}'
     thinpool: '{{ item.thinpool }}'
     size:     '{{ item.size }}'
+    opts:     '{{ item.opts | d(omit) }}'
   with_items: '{{ lvm__thin_pools }}'
   when: lvm__thin_pools|d(False) and
         item.vg|d() and item.thinpool|d() and item.size|d() and
@@ -58,6 +59,7 @@
     lv:         '{{ item.lv }}'
     vg:         '{{ item.vg }}'
     size:       '{{ item.size }}'
+    opts:       '{{ item.opts | d(omit) }}'
     thinpool:   '{{ item.thinpool | d(omit) }}'
     force:      '{{ item.force | d(omit) }}'
     shrink:     '{{ item.force | d(False) }}'

--- a/docs/ansible/roles/lvm/defaults-detailed.rst
+++ b/docs/ansible/roles/lvm/defaults-detailed.rst
@@ -93,6 +93,11 @@ List of required parameters:
   Size of the LVM Thin Pool, use the same format as these supported by
   ``lvol`` Ansible module.
 
+List of optional LVM parameters:
+
+``opts``
+  Free-form options to be passed to the :command:`lvcreate` command.
+
 Create a LVM Thin Pool::
 
     lvm__thin_pools:
@@ -100,6 +105,15 @@ Create a LVM Thin Pool::
       - vg: 'vg_alpha'
         thinpool: 'pool0'
         size: '1T'
+
+Create a LVM Thin Pool with custom size of metadata volume::
+
+    lvm__thin_pools:
+
+      - vg: 'vg_alpha'
+        thinpool: 'pool0'
+        size: '1T'
+        opts: '--poolmetadatasize 16G'
 
 .. _lvm__logical_volumes:
 
@@ -137,6 +151,9 @@ List of optional LVM parameters:
 ``force``
   Boolean. If present and ``True`` allows ``lvol`` module to shrink or remove
   Logical Volumes.
+
+``opts``
+  Free-form options to be passed to the :command:`lvcreate` command.
 
 List of optional filesystem parameters:
 


### PR DESCRIPTION
The _ansible_ [`lvol` modules](https://docs.ansible.com/ansible/latest/collections/community/general/lvol_module.html) supports custom options ([`opts`](https://docs.ansible.com/ansible/latest/collections/community/general/lvol_module.html#parameter-opts)) for the `lvcreate` command. This is really nice to have in DebOps, because I will gave the _LVM_ much more power.

P.S.: In ansible/roles/lvm/defaults/main.yml, I just fixed a very little typo