### PR TITLE
[docs] Add note to pki-realms.rst about DH params

### DIFF
--- a/docs/ansible/roles/pki/pki-realms.rst
+++ b/docs/ansible/roles/pki/pki-realms.rst
@@ -86,8 +86,13 @@ the next section). The contents of these files are:
 
 :file:`default.crt`
   This is the server certificate with optionally bundled Intermediate
-  Certificate Authorities. It is sent to the clients during connection
-  establishment by the application. This file is publicly readable.
+  Certificate Authorities and Diffie-Hellman parameters. It is sent to the
+  clients during connection establishment by the application. This file is
+  publicly readable. Note that not all software appreciates embedded DH
+  parameters in this file. Some Java-based applications, or at least `Graylog`_
+  4.1 and other software using recent versions of the Bouncy Castle library,
+  throw exceptions when trying to parse this file. Consider using
+  ``public/cert_intermediate.pem`` when that happens.
 
 :file:`default.key`
   This is the server private key. It's readable only by the ``root`` account

--- a/docs/includes/global.rst
+++ b/docs/includes/global.rst
@@ -1178,6 +1178,7 @@
 .. _YAML Syntax: https://docs.ansible.com/ansible/YAMLSyntax.html
 .. _reStructuredText: http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html
 .. _Sphinx: https://www.sphinx-doc.org/
+.. _Graylog: https://www.graylog.org/
 
 .. ]]]
 


### PR DESCRIPTION
Related to `debops.pki`
Some Java-based applications don't like the DH params at the end of
default.crt. I figured this out when debugging a failed update to
Graylog 4.1: https://github.com/Graylog2/graylog2-server/issues/10997