### PR TITLE
[resolvconf] Fix resolving upstream nameservers

### DIFF
--- a/ansible/roles/resolvconf/templates/etc/ansible/facts.d/resolvconf.fact.j2
+++ b/ansible/roles/resolvconf/templates/etc/ansible/facts.d/resolvconf.fact.j2
@@ -60,9 +60,7 @@ if os.path.isfile(systemdresolved_path):
 
 for element in resolvconf_files:
     try:
-        nameservers = read_resolv_file(element)
-
-        for server in nameservers:
+        for server in read_resolv_file(element):
             if not server.startswith('127.'):
                 upstream_nameservers.append(server)
 


### PR DESCRIPTION
This patch prevents override variable `nameservers` and lost information from the primary resolver configuration.

Related to #1478

Currently (at least at versions 2.3.0, 2.3.1) upstream nameservers may not be included in the fact, because value of the `nameservers` is not relevant.

```py
if (('127.0.0.1' in nameservers or
        '127.0.0.53' in nameservers) and
        upstream_nameservers):
    output['upstream_nameservers'] = upstream_nameservers
```