### PR TITLE
+ custom_log and error_log for fullly customization of CustomLog and ErrorLog Directive

### DIFF
--- a/ansible/roles/apache/templates/etc/apache2/conf-available/local-debops_apache.conf.j2
+++ b/ansible/roles/apache/templates/etc/apache2/conf-available/local-debops_apache.conf.j2
@@ -141,8 +141,8 @@ ServerAlias {{ apache__tpl_names[1:] | map("quote") | join(" ") }}
 {{ get_server_name_aliases(item.name|d([])) }}
 {% endif %}
 ServerAdmin {{ item.server_admin|d(apache__server_admin) | quote }}
-CustomLog ${APACHE_LOG_DIR}/{{ sanitized_name }}_access.log {{ apache__access_log_format }}
-ErrorLog ${APACHE_LOG_DIR}/{{ sanitized_name }}_error.log
+CustomLog {{ item.custom_log|d('${APACHE_LOG_DIR}/' + sanitized_name + '_access.log' + ' ' + apache__access_log_format + ' ' + item.custom_log_condition|d()) }}
+ErrorLog {{ item.error_log|d('${APACHE_LOG_DIR}/' + sanitized_name + '_error.log') }}
 {% endmacro %}
 {% macro get_server_status_directives(item, enabled) %}{# [[[ #}
 {% if enabled|bool %}

--- a/ansible/roles/apache/templates/etc/apache2/sites-available/default.conf.j2
+++ b/ansible/roles/apache/templates/etc/apache2/sites-available/default.conf.j2
@@ -141,8 +141,8 @@ ServerAlias {{ apache__tpl_names[1:] | map("quote") | join(" ") }}
 {{ get_server_name_aliases(item.name|d([])) }}
 {% endif %}
 ServerAdmin {{ item.server_admin|d(apache__server_admin) | quote }}
-CustomLog ${APACHE_LOG_DIR}/{{ sanitized_name }}_access.log {{ apache__access_log_format }} {{ item.custom_log_condition|d() }}
-ErrorLog ${APACHE_LOG_DIR}/{{ sanitized_name }}_error.log
+CustomLog {{ item.custom_log|d('${APACHE_LOG_DIR}/' + sanitized_name + '_access.log' + ' ' + apache__access_log_format + ' ' + item.custom_log_condition|d()) }}
+ErrorLog {{ item.error_log|d('${APACHE_LOG_DIR}/' + sanitized_name + '_error.log') }}
 {% endmacro %}
 {% macro get_server_status_directives(item, enabled) %}{# [[[ #}
 {% if enabled|bool %}


### PR DESCRIPTION
Hello,

We should have fully customization for `CustomLog` and `ErrorLog` Directive of `apache` role.
This allows us to save log to different path, different filename...