### PR TITLE
[dovecot] Don't hardcode mailbox definitions

### DIFF
--- a/ansible/roles/dovecot/defaults/main.yml
+++ b/ansible/roles/dovecot/defaults/main.yml
@@ -585,6 +585,42 @@ dovecot_auth_config_map:
         mode: '0600'
 
                                                                    # ]]]
+# .. envvar:: dovecot_mailbox_definitions [[[
+#
+# Custom mailbox definitions. For more details, see
+# :ref:`dovecot_mailbox_definitions`.
+dovecot_mailbox_definitions:
+  - name: 'Drafts'
+    comment: 'These mailboxes are widely used and could perhaps be created automatically:'
+    special_use: '\Drafts'
+  - name: 'Junk'
+    special_use: '\Junk'
+  - name: 'Trash'
+    special_use: '\Trash'
+  - name: 'Sent'
+    comment: |
+      For \Sent mailboxes there are two widely used names. We'll mark both of
+      them as \Sent. User typically deletes one of them if duplicates are created.
+    special_use: '\Sent'
+  - name: 'Sent Messages'
+    special_use: '\Sent'
+  - name: 'virtual/All'
+    comment: 'If you have a virtual "All messages" mailbox:'
+    special_use: '\All'
+    imap_comment: 'All my messages'
+    state: 'comment'
+  - name: 'virtual/Flagged'
+    comment: 'If you have a virtual "Flagged" mailbox:'
+    special_use: '\Flagged'
+    imap_comment: 'All my flagged messages'
+    state: 'comment'
+  - name: 'virtual/Important'
+    comment: 'If you have a virtual "Important" mailbox:'
+    special_use: '\Important'
+    imap_comment: 'All my important messages'
+    state: 'comment'
+
+                                                                   # ]]]
 # .. envvar:: dovecot_custom_localconf [[[
 #
 # Dovecot custom configuration added at the end of ``/etc/dovecot/local.conf``

--- a/ansible/roles/dovecot/tasks/main.yml
+++ b/ansible/roles/dovecot/tasks/main.yml
@@ -67,7 +67,7 @@
            --rename /etc/dovecot/conf.d/{{ item }}
            creates=/etc/dovecot/conf.d/{{ item }}.dpkg-divert
   with_flattened:
-    - [ '10-auth.conf', '10-mail.conf', '10-master.conf', '10-ssl.conf', '15-lda.conf' ]
+    - [ '10-auth.conf', '10-mail.conf', '10-master.conf', '10-ssl.conf', '15-lda.conf', '15-mailboxes.conf' ]
     - [ '{{ "20-imap.conf" if "imap" in dovecot_protocols else [] }}' ]
     - [ '{{ "20-pop3.conf" if "pop3" in dovecot_protocols else [] }}' ]
     - [ '{{ "20-lmtp.conf" if "lmtp" in dovecot_protocols else [] }}' ]
@@ -138,7 +138,7 @@
     group: 'root'
     mode: '0644'
   with_flattened:
-    - [ '10-auth.conf', '10-mail.conf', '10-master.conf', '10-ssl.conf', '15-lda.conf' ]
+    - [ '10-auth.conf', '10-mail.conf', '10-master.conf', '10-ssl.conf', '15-lda.conf', '15-mailboxes.conf' ]
     - [ '{{ "20-imap.conf" if "imap" in dovecot_protocols else [] }}' ]
     - [ '{{ "20-pop3.conf" if "pop3" in dovecot_protocols else [] }}' ]
     - [ '{{ "20-lmtp.conf" if "lmtp" in dovecot_protocols else [] }}' ]

--- a/ansible/roles/dovecot/templates/etc/dovecot/conf.d/15-mailboxes.conf.j2
+++ b/ansible/roles/dovecot/templates/etc/dovecot/conf.d/15-mailboxes.conf.j2
@@ -1,0 +1,87 @@
+{# Copyright (C) 2021 David Härdeman <david@hardeman.nu>
+ # Copyright (C) DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-only
+ #}
+# {{ ansible_managed }}
+{#
+
+This file follows the upstream default configuration except for the parts
+that are configurable via DebOps variables. If you need a more customized
+setup, you can provide your own template via the DebOps template_src
+lookup mechanism.
+
+#}
+
+##
+## Mailbox definitions
+##
+
+# Each mailbox is specified in a separate mailbox section. The section name
+# specifies the mailbox name. If it has spaces, you can put the name
+# "in quotes". These sections can contain the following mailbox settings:
+#
+# auto:
+#   Indicates whether the mailbox with this name is automatically created
+#   implicitly when it is first accessed. The user can also be automatically
+#   subscribed to the mailbox after creation. The following values are
+#   defined for this setting:
+# 
+#     no        - Never created automatically.
+#     create    - Automatically created, but no automatic subscription.
+#     subscribe - Automatically created and subscribed.
+#  
+# special_use:
+#   A space-separated list of SPECIAL-USE flags (RFC 6154) to use for the
+#   mailbox. There are no validity checks, so you could specify anything
+#   you want in here, but it's not a good idea to use flags other than the
+#   standard ones specified in the RFC:
+#
+#     \All       - This (virtual) mailbox presents all messages in the
+#                  user's message store.
+#     \Archive   - This mailbox is used to archive messages.
+#     \Drafts    - This mailbox is used to hold draft messages.
+#     \Flagged   - This (virtual) mailbox presents all messages in the
+#                  user's message store marked with the IMAP \Flagged flag.
+#     \Important - This (virtual) mailbox presents all messages in the
+#                  user's message store deemed important to user.
+#     \Junk      - This mailbox is where messages deemed to be junk mail
+#                  are held.
+#     \Sent      - This mailbox is used to hold copies of messages that
+#                  have been sent.
+#     \Trash     - This mailbox is used to hold messages that have been
+#                  deleted.
+#
+# comment:
+#   Defines a default comment or note associated with the mailbox. This
+#   value is accessible through the IMAP METADATA mailbox entries
+#   "/shared/comment" and "/private/comment". Users with sufficient
+#   privileges can override the default value for entries with a custom
+#   value.
+
+# NOTE: Assumes "namespace inbox" has been defined in 10-mail.conf.
+namespace inbox {
+{% for mailbox in dovecot_mailbox_definitions %}
+{%   if 'name' in mailbox and mailbox.state|d('present') in [ 'present', 'comment' ] %}
+{%     if 'comment' in mailbox %}
+{{       '{}'.format(mailbox.comment | regex_replace('\n$', '') | comment(prefix='', decoration='  # ', postfix='')) -}}
+{%     endif %}
+{%     if mailbox.state|d('present') == 'comment' %}
+{%       set comment_prefix = '# ' %}
+{%     else %}
+{%       set comment_prefix = '' %}
+{%     endif %}
+{{     '  {}mailbox "{}" {{'.format(comment_prefix, mailbox.name | regex_replace('\n$', '')) }}
+{%     if 'auto' in mailbox %}
+{{       '  {}  auto = {}'.format(comment_prefix, mailbox.auto | regex_replace('\n$', '')) }}
+{%     endif %}
+{%     if 'special_use' in mailbox %}
+{{       '  {}  special_use = {}'.format(comment_prefix, [ mailbox.special_use ] | flatten | join(' ') | regex_replace('\n$', '')) }}
+{%     endif %}
+{%     if 'imap_comment' in mailbox %}
+{{       '  {}  comment = {}'.format(comment_prefix, mailbox.imap_comment | regex_replace('\n$', '')) }}
+{%     endif %}
+{{     '  {}}}'.format(comment_prefix) }}
+{{     '' }}
+{%   endif %}
+{% endfor %}
+}

--- a/docs/ansible/roles/dovecot/defaults-detailed.rst
+++ b/docs/ansible/roles/dovecot/defaults-detailed.rst
@@ -253,3 +253,59 @@ The LMTP transport target will only be configured in Postfix when 'lmtp'
 is enabled in ``dovecot_protocols``.
 
 For most people the default configuration will be sufficient.
+
+.. _dovecot_mailbox_definitions:
+
+dovecot_mailbox_definitions
+---------------------------
+
+Configuration dictionary for mailbox specific settings. Valid keys are
+``name`` (mandatory), ``comment``, ``special_use``, ``auto``, ``imap_comment``
+and ``state``.
+
+``name`` is the name of the mailbox. ``comment`` includes a comment in the
+generated configuration file. ``state`` can either be ``comment`` (in which
+case the mailbox entry will be included in the generated configuration file
+but commented out) or ``present`` (in which case the mailbox entry will be
+included in the generated configuration, this is also the default if ``state``
+is not set). Other values will lead to the mailbox entry being silently
+ignored.
+
+``auto`` controls whether a mailbox with the given ``name`` will be
+automatically created and whether users will be automatically subscribed.
+Possible values are ``no`` (don't create automatically, the default),
+``create`` (autocreate but don't autosubscribe) and ``subscribe``
+(autocreate and autosubscribe).
+
+``special_use`` marks a mailbox with special-use flags (see 
+`RFC6154`_) which assist mail clients in autoconfiguring
+new mail accounts. A mailbox can be tagged with one or more special-use
+flags (defined as a string or list of strings), but mail clients are unlikely
+to recognize anything else than the standard ones, which are:
+
+\All
+  This (virtual) mailbox presents all messages in the user's message store.
+\Archive
+  This mailbox is used to archive messages.
+\Drafts
+  This mailbox is used to hold draft messages.
+\Flagged
+  This (virtual) mailbox presents all messages in the
+  user's message store marked with the IMAP \Flagged flag.
+\Important
+  This (virtual) mailbox presents all messages in the
+  user's message store deemed important to the user.
+\Junk
+  This mailbox is where messages deemed to be junk mail
+  are held.
+\Sent
+  This mailbox is used to hold copies of messages that
+  have been sent.
+\Trash
+  This mailbox is used to hold messages that have been
+  deleted.
+
+``imap_comment`` adds a comment for a mailbox which is made available to
+mail clients via the IMAP METADATA protocol.
+
+.. _RFC6154: https://datatracker.ietf.org/doc/html/rfc6154#page-4


### PR DESCRIPTION
Currently the values in /etc/dovecot/conf.d/15-mailboxes.conf (from the Debian
packaging) are hardcoded and cannot be changed via the Dovecot role. Since
the mailbox hierarchy (e.g. legacy setups) and naming (e.g. for localization)
is site dependent, it makes sense to allow these settings to be changed easily.