### PR TITLE
Allow user override via envvar

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,9 +4,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS   ?=
 SPHINXBUILD   = sphinx-build
-PAPER         =
+PAPER        ?=
 BUILDDIR      = _build
 
 # User-friendly check for sphinx-build


### PR DESCRIPTION
Allows a user to `export SPHINXOPTS=-j4` for example.