### PR TITLE
[cryptsetup] Disable checksum computation

### DIFF
--- a/ansible/roles/cryptsetup/tasks/manage_devices.yml
+++ b/ansible/roles/cryptsetup/tasks/manage_devices.yml
@@ -131,6 +131,7 @@
 - name: Check if ciphertext block device exists
   stat:
     path: '{{ item.ciphertext_block_device }}'
+    get_checksum: '{{ item.check_with_checksum|d(True) }}'
   register: cryptsetup__register_ciphertext_device
   when: (item.state|d(cryptsetup__state) in
          [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ])

--- a/ansible/roles/cryptsetup/tasks/manage_devices.yml
+++ b/ansible/roles/cryptsetup/tasks/manage_devices.yml
@@ -131,7 +131,7 @@
 - name: Check if ciphertext block device exists
   stat:
     path: '{{ item.ciphertext_block_device }}'
-    get_checksum: '{{ item.check_with_checksum|d(True) }}'
+    get_checksum: False
   register: cryptsetup__register_ciphertext_device
   when: (item.state|d(cryptsetup__state) in
          [ 'mounted', 'ansible_controller_mounted', 'unmounted', 'present' ])

--- a/docs/ansible/roles/cryptsetup/defaults-detailed.rst
+++ b/docs/ansible/roles/cryptsetup/defaults-detailed.rst
@@ -74,18 +74,6 @@ Each item of those lists is a dictionary with the following documented keys:
 
   Default to :envvar:`cryptsetup__use_uuid`.
 
-.. _cryptsetup__devices_check_with_checksum:
-
-``check_with_checksum``
-  Optional, boolean.
-  Compute checksum of the `ciphertext block device` given by
-  :ref:`item.ciphertext_block_device <cryptsetup__devices_ciphertext_block_device>`.
-
-  Setting this to ``False`` for (very large) regular files used as `ciphertext block device` 
-  avoids long checksum computation times.
-
-  Default to ``True``.
-
 .. _cryptsetup__devices_mode:
 
 ``mode``

--- a/docs/ansible/roles/cryptsetup/defaults-detailed.rst
+++ b/docs/ansible/roles/cryptsetup/defaults-detailed.rst
@@ -74,6 +74,18 @@ Each item of those lists is a dictionary with the following documented keys:
 
   Default to :envvar:`cryptsetup__use_uuid`.
 
+.. _cryptsetup__devices_check_with_checksum:
+
+``check_with_checksum``
+  Optional, boolean.
+  Compute checksum of the `ciphertext block device` given by
+  :ref:`item.ciphertext_block_device <cryptsetup__devices_ciphertext_block_device>`.
+
+  Setting this to ``False`` for (very large) regular files used as `ciphertext block device` 
+  avoids long checksum computation times.
+
+  Default to ``False``.
+
 .. _cryptsetup__devices_mode:
 
 ``mode``

--- a/docs/ansible/roles/cryptsetup/defaults-detailed.rst
+++ b/docs/ansible/roles/cryptsetup/defaults-detailed.rst
@@ -84,7 +84,7 @@ Each item of those lists is a dictionary with the following documented keys:
   Setting this to ``False`` for (very large) regular files used as `ciphertext block device` 
   avoids long checksum computation times.
 
-  Default to ``False``.
+  Default to ``True``.
 
 .. _cryptsetup__devices_mode:
 


### PR DESCRIPTION
Using very large files (hundreds of GB) as _ciphertext block device_ in `cryptsetup` leads to prohibitively long checksum computation times in the existence check of task _Check if ciphertext block device exists_ (which uses the [`stat` module](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/stat_module.html#parameter-get_checksum)). 

This PR adds an optional flag to control the computation of the checksum (defaults to `True`).