### PR TITLE
[ldap] Update device iface regex to support systemd-nspawn veth

### DIFF
--- a/ansible/roles/ldap/defaults/main.yml
+++ b/ansible/roles/ldap/defaults/main.yml
@@ -301,7 +301,7 @@ ldap__device_ip_addresses: '{{ q("template",
 #
 # Regex used to determine which network interfaces to consider for inclusion
 # in the LDAP device object ``ipHostNumber`` attributes.
-ldap__device_ip_iface_regex: '^(bond|en|eth|vlan|mv-)'
+ldap__device_ip_iface_regex: '^(bond|en|eth|vlan|mv-|host)'
 
                                                                    # ]]]
 # .. envvar:: ldap__device_mac_addresses [[[


### PR DESCRIPTION
Systemd-nspawn containers which use virtual ethernet (veth) networking
will by default have interfaces named host0 (see
/lib/systemd/network/80-container-host0.network on a normal Debian
installation).