### PR TITLE
[dhcpd] Quote host-identifier

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -144,6 +144,13 @@ Fixed
 
 - The role no longer creates an unnecessary NGINX webroot directory.
 
+:ref:`debops.dhcpd` role
+''''''''''''''''''''''''
+
+- host-identifier parameters are now always quoted in dhcpd6.conf. This is
+  needed when the host-identifier contains periods (e.g. fully qualified
+  domain names).
+
 :ref:`debops.kmod` role
 '''''''''''''''''''''''
 

--- a/ansible/roles/dhcpd/templates/etc/dhcp/macro_host.j2
+++ b/ansible/roles/dhcpd/templates/etc/dhcp/macro_host.j2
@@ -18,7 +18,7 @@ host {{ host.hostname }} {
     hardware ethernet {{ host.ethernet }};
     fixed-address {{ host.address4 }};
 {%      elif protocol == 'DHCPv6' %}
-    host-identifier option fqdn.fqdn {{ host.hostname }};
+    host-identifier option fqdn.fqdn "{{ host.hostname }}";
     fixed-address6 {{ host.address6 }};
 {%      endif %}
 }


### PR DESCRIPTION
host-identifier parameters that contain periods (e.g. FQDNs) need to be
quoted to prevent this error:

```
/etc/dhcp/dhcpd6.conf line 50: semicolon expected.
    host-identifier option fqdn.fqdn secure7.
```