### PR TITLE
[sssd] sudo support fixes

### DIFF
--- a/ansible/roles/sssd/defaults/main.yml
+++ b/ansible/roles/sssd/defaults/main.yml
@@ -24,7 +24,7 @@
 #
 # List of APT packages required for LDAP lookups via NSS and PAM.
 sssd__base_packages:
-  - [ 'sssd', 'libnss-sss' ]
+  - [ 'sssd', 'libnss-sss', 'libsss-sudo' ]
 
                                                                    # ]]]
 # .. envvar:: sssd__packages [[[

--- a/ansible/roles/sudo/defaults/main.yml
+++ b/ansible/roles/sudo/defaults/main.yml
@@ -30,7 +30,8 @@ sudo__enabled: True
 # List of base APT packages to install for :command:`sudo` support.
 sudo__base_packages: '{{ [ "sudo-ldap" ]
                          if (ansible_local|d() and ansible_local.ldap|d() and
-                             (ansible_local.ldap.posix_enabled|d())|bool)
+                             (ansible_local.ldap.posix_enabled|d())|bool and not
+                             (ansible_local.sssd|d() and ansible_local.sssd.installed|d())|bool)
                          else [ "sudo" ] }}'
 
                                                                    # ]]]
@@ -169,7 +170,8 @@ sudo__combined_sudoers: '{{ sudo__sudoers
 # not be changed or removed.
 sudo__ldap_enabled: '{{ True
                         if (ansible_local|d() and ansible_local.ldap|d() and
-                            (ansible_local.ldap.posix_enabled|d())|bool)
+                            (ansible_local.ldap.posix_enabled|d())|bool and not
+                            (ansible_local.sssd|d() and ansible_local.sssd.installed|d())|bool)
                         else False }}'
 
                                                                    # ]]]


### PR DESCRIPTION
sssd needs libsss-sudo to be installed and does not require the
separate functionality of sudo-ldap.