### PR TITLE
[slapd] Add explicit dependency on libldap-common

### DIFF
--- a/ansible/roles/slapd/defaults/main.yml
+++ b/ansible/roles/slapd/defaults/main.yml
@@ -148,7 +148,7 @@ slapd__combined_schemas: '{{ slapd__default_schemas
 # .. envvar:: slapd__base_packages [[[
 #
 # List of required APT packages for OpenLDAP service.
-slapd__base_packages: [ 'slapd', 'ldap-utils', 'ssl-cert' ]
+slapd__base_packages: [ 'slapd', 'ldap-utils', 'ssl-cert', 'libldap-common' ]
 
                                                                    # ]]]
 # .. envvar:: slapd__rfc2307bis_packages [[[


### PR DESCRIPTION
libldap only recommends libldap-common since Bullseye. This is a
backwards compatible fix to make sure libldap-common is installed
together with slapd.

Closes #1793