### PR TITLE
[debops] support security key SSH keys

### DIFF
--- a/ansible/playbooks/ldap/init-directory.yml
+++ b/ansible/playbooks/ldap/init-directory.yml
@@ -29,7 +29,7 @@
     admin_gecos: '{{ getent_passwd[admin_user][3] }}'
 
     # SSH public keys in the 'ssh-agent'
-    admin_sshkeys: "{{ lookup('pipe','ssh-add -L | grep ^ssh || cat ~/.ssh/*.pub || true').split('\n') }}"
+    admin_sshkeys: '{{ lookup("pipe", "ssh-add -L | grep ^\\\(sk-\\\)\\\?ssh || cat ~/.ssh/*.pub || true").split("\n") }}'
 
     # Password of the administrator account, stored in the Password Store on
     # the Ansible Controller

--- a/ansible/roles/preseed/defaults/main.yml
+++ b/ansible/roles/preseed/defaults/main.yml
@@ -234,7 +234,7 @@ preseed__sudo_group: '{{ preseed__admin_groups[0] }}'
 #
 # List of SSH public keys installed on administrator account, as well as the
 # ``root`` account.
-preseed__admin_sshkeys: [ '{{ lookup("pipe", "ssh-add -L | grep ^ssh || cat ~/.ssh/id_rsa.pub || true") }}' ]
+preseed__admin_sshkeys: [ '{{ lookup("pipe", "ssh-add -L | grep ^\\\(sk-\\\)\\\?ssh || cat ~/.ssh/id_rsa.pub || true") }}' ]
 
 
 # .. Debian Preseed configuration [[[1

--- a/ansible/roles/system_users/defaults/main.yml
+++ b/ansible/roles/system_users/defaults/main.yml
@@ -249,7 +249,7 @@ system_users__default_accounts:
                    in system_users__shell_package_map.keys())
                else omit }}'
     admin: True
-    sshkeys: '{{ lookup("pipe","ssh-add -L | grep ^ssh || cat ~/.ssh/*.pub || true") }}'
+    sshkeys: '{{ lookup("pipe", "ssh-add -L | grep ^\\\(sk-\\\)\\\?ssh || cat ~/.ssh/*.pub || true") }}'
     state: '{{ "present"
                if system_users__self|bool
                else "ignore" }}'


### PR DESCRIPTION
OpenSSH supports FIDO U2F security keys via the ed25519-sk and ecdsa-sk
key types. They are denoted as "sk-ssh-*" keys in the output from
"ssh-add".

Example:
sk-ssh-ed25519@openssh.com <gibberish>
instead of:
ssh-ed25519 <gibberish> <comment>