### PR TITLE
[redis_server] Listen on IPv6 as well as IPv4

### DIFF
--- a/ansible/roles/redis_server/defaults/main.yml
+++ b/ansible/roles/redis_server/defaults/main.yml
@@ -148,7 +148,7 @@ redis_server__maxmemory_shared: '{{ (redis_server__maxmemory_total | int
 # interface. To listen for IPv4 and IPv6 connections you can set this variable
 # to ``[ '0.0.0.0', '::' ]``. Ensure that the firewall access is configured
 # properly to avoid security issues.
-redis_server__bind: 'localhost'
+redis_server__bind: [ '127.0.0.1', '::1' ]
 
                                                                    # ]]]
 # .. envvar:: redis_server__allow [[[


### PR DESCRIPTION
redis seems to need an explicit instruction to listen to both
IPv4 and IPv6.

Closes #1800