### PR TITLE
[debops] Fix PKI hook uninstallation

### DIFF
--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -253,7 +253,7 @@
 
 - name: Ensure the PKI nginx hook is absent
   file:
-    path: '{{ nginx_pki_hook_path }}'
+    path: '{{ nginx_pki_hook_path + "/" + nginx_pki_hook_name }}'
     state: 'absent'
   when: (nginx__deploy_state in [ 'absent' ])
 

--- a/ansible/roles/postfix/tasks/main.yml
+++ b/ansible/roles/postfix/tasks/main.yml
@@ -153,6 +153,6 @@
 
 - name: Ensure the PKI postfix hook is absent
   file:
-    path: '{{ postfix__pki_hook_path }}'
+    path: '{{ postfix__pki_hook_path + "/" + postfix__pki_hook_name }}'
     state: 'absent'
   when: not (postfix__pki|bool)

--- a/ansible/roles/prosody/tasks/main.yml
+++ b/ansible/roles/prosody/tasks/main.yml
@@ -50,6 +50,6 @@
 
 - name: Ensure the PKI prosody hook is absent
   file:
-    path: '{{ prosody__pki_hook_path }}'
+    path: '{{ prosody__pki_hook_path + "/" + prosody__pki_hook_name }}'
     state: 'absent'
   when: (prosody__deploy_state in [ 'absent' ])


### PR DESCRIPTION
The *_pki_hook_path variables point at the PKI hook directory,
not the actual pki hook files. Unless I'm mistaken, setting
a directory to "absent" would mean that Ansible would recursively
delete the whole directory.

The dovecot role has the same issue, but I didn't touch it for now,
already fixed in my separate dovecot rewrite branch.