### PR TITLE
[debops] Fix version parsing in several facts.d scripts

### DIFF
--- a/ansible/roles/dnsmasq/templates/etc/ansible/facts.d/dnsmasq.fact.j2
+++ b/ansible/roles/dnsmasq/templates/etc/ansible/facts.d/dnsmasq.fact.j2
@@ -28,8 +28,8 @@ output['installed'] = cmd_exists('dnsmasq')
 
 try:
     version_stdout = subprocess.check_output(
-            ["dpkg-query", "-W", "-f=${Version}\n'",
-             "dnsmasq"]).split('-')[0]
+            ["dpkg-query", "-W", "-f=${Version}",
+             "dnsmasq"]).decode('utf-8').split('-')[0]
     output['version'] = version_stdout
 
 except Exception:

--- a/ansible/roles/docker_server/templates/etc/ansible/facts.d/docker_server.fact.j2
+++ b/ansible/roles/docker_server/templates/etc/ansible/facts.d/docker_server.fact.j2
@@ -43,7 +43,7 @@ output = loads('''{{
 output['installed'] = cmd_exists('docker')
 try:
     version_stdout = subprocess.check_output(
-        ["dpkg-query", "-W", "-f=${Version}\n'", docker_pkg]
+        ["dpkg-query", "-W", "-f=${Version}", docker_pkg]
     ).decode('utf-8').split('+')[0]
 
     match = re.search(r'^(?:[^:]:)?(?P<docker_version>[^~]+)', version_stdout)

--- a/ansible/roles/extrepo/templates/etc/ansible/facts.d/extrepo.fact.j2
+++ b/ansible/roles/extrepo/templates/etc/ansible/facts.d/extrepo.fact.j2
@@ -24,7 +24,7 @@ output = {'installed': cmd_exists('extrepo')}
 
 try:
     version_stdout = subprocess.check_output(
-            ["dpkg-query", "-W", "-f=${Version}\n'",
+            ["dpkg-query", "-W", "-f=${Version}",
              "extrepo"]).decode('utf-8').split('~')[0]
     output['version'] = version_stdout
 

--- a/ansible/roles/freeradius/templates/etc/ansible/facts.d/freeradius.fact.j2
+++ b/ansible/roles/freeradius/templates/etc/ansible/facts.d/freeradius.fact.j2
@@ -24,8 +24,8 @@ output = {'installed': cmd_exists('freeradius')}
 
 try:
     version_stdout = subprocess.check_output(
-            ["dpkg-query", "-W", "-f=${Version}\n'",
-             "freeradius"]).split('+')[0]
+            ["dpkg-query", "-W", "-f=${Version}",
+             "freeradius"]).decode('utf-8').split('+')[0]
     output['version'] = version_stdout
 
 except Exception:

--- a/ansible/roles/icinga/templates/etc/ansible/facts.d/icinga.fact.j2
+++ b/ansible/roles/icinga/templates/etc/ansible/facts.d/icinga.fact.j2
@@ -29,7 +29,7 @@ output['installed'] = cmd_exists('icinga2')
 
 try:
     icinga_version_stdout = subprocess.check_output(
-            ["dpkg-query", "-W", "-f=${Version}\n'",
+            ["dpkg-query", "-W", "-f=${Version}",
              "icinga2"]).decode('utf-8').split('-')[0]
     output['version'] = icinga_version_stdout
 

--- a/ansible/roles/redis_sentinel/templates/etc/ansible/facts.d/redis_sentinel.fact.j2
+++ b/ansible/roles/redis_sentinel/templates/etc/ansible/facts.d/redis_sentinel.fact.j2
@@ -43,7 +43,7 @@ output['installed'] = cmd_exists('redis-sentinel')
 if output['installed']:
     try:
         redis_sentinel_version_stdout = subprocess.check_output(
-                ["dpkg-query", "-W", "-f=${Version}\n'",
+                ["dpkg-query", "-W", "-f=${Version}",
                  "redis-sentinel"]).decode('utf-8').split('-')[0]
         output['version'] = redis_sentinel_version_stdout.split(':')[1]
 

--- a/ansible/roles/redis_server/templates/etc/ansible/facts.d/redis_server.fact.j2
+++ b/ansible/roles/redis_server/templates/etc/ansible/facts.d/redis_server.fact.j2
@@ -45,8 +45,8 @@ output['installed'] = cmd_exists('redis-server')
 if output['installed']:
     try:
         redis_server_version_stdout = subprocess.check_output(
-                ["dpkg-query", "-W", "-f=${Version}\n'",
-                 "redis-server"]).split('-')[0]
+                ["dpkg-query", "-W", "-f=${Version}",
+                 "redis-server"]).decode('utf-8').split('-')[0]
         output['version'] = redis_server_version_stdout.split(':')[1]
 
     except Exception:


### PR DESCRIPTION
I noticed that the facts.d output for redis_server was missing the
version information. The same query seemed to be used in several
places so I took the liberty of changing the other uses as well.

Note: only tested with redis_server.