### PR TITLE
automatically upgrade icinga2

### DIFF
--- a/ansible/playbooks/service/icinga.yml
+++ b/ansible/playbooks/service/icinga.yml
@@ -43,6 +43,10 @@
       etc_services__dependent_list:
         - '{{ icinga__etc_services__dependent_list }}'
 
+    - role: unattended_upgrades
+      tags: [ 'role::unattended_upgrades', 'skip::unattended_upgrades' ]
+      unattended_upgrades__dependent_origins: '{{ icinga__unattended_upgrades__dependent_origins }}'
+
     - role: ferm
       tags: [ 'role::ferm', 'skip::ferm' ]
       ferm__dependent_rules:

--- a/ansible/roles/icinga/defaults/main.yml
+++ b/ansible/roles/icinga/defaults/main.yml
@@ -882,4 +882,13 @@ icinga__ferm__dependent_rules:
     by_role: 'icinga'
     name: 'icinga_api'
                                                                    # ]]]
+# .. envvar:: icinga__unattended_upgrades__dependent_origins [[[
+#
+# List of origin patterns managed by the :ref:`debops.unattended_upgrades` role.
+icinga__unattended_upgrades__dependent_origins:
+
+  - origin: 'site=packages.icinga.com'
+    by_role: 'debops.icinga'
+    state: '{{ "present" if icinga__upstream|bool else "absent" }}'
+                                                                   # ]]]
                                                                    # ]]]


### PR DESCRIPTION
This commit enables automatic apt upgrade for icinga2 packages.

It would also automatically upgrade icingaweb2 (installed with debops.icingaweb2 role) since it is installed from the same apt repository. Is it a problem?