### PR TITLE
[apache] Enable the force keyword for site configuration

### DIFF
--- a/ansible/roles/apache/tasks/main.yml
+++ b/ansible/roles/apache/tasks/main.yml
@@ -164,7 +164,7 @@
                                           else item.name[0] | d("default")) + ".conf")
              if (item.enabled|d(True) | bool)
              else omit }}'
-    force: '{{ ansible_check_mode|d() | bool }}'
+    force: '{{ item.force|d(ansible_check_mode) | bool }}'
     state: '{{ item.enabled|d(True) | bool | ternary("link", "absent")
                if (item.state|d("present") != "absent")
                else "absent" }}'


### PR DESCRIPTION
Enable the `force` keyword in an Apache site configuration. Prevents an edge-case error:

```
failed: [foobar.example.net] (item={'name': '_http_', 'type': 'dont-create', 'force': True, 'enabled': True}) => changed=false 
  ansible_loop_var: item
  item:
    enabled: true
    force: true
    name: _http_
    type: dont-create
  msg: 'src file does not exist, use "force=yes" if you really want to create the link: /etc/apache2/sites-enabled/../sites-available/_http_.conf'
  path: /etc/apache2/sites-enabled/_http_.conf
  src: ../sites-available/_http_.conf
```