### PR TITLE
- Telegraf role arrives to DebOps.

### DIFF
--- a/ansible/playbooks/service/telegraf.yml
+++ b/ansible/playbooks/service/telegraf.yml
@@ -1,5 +1,6 @@
 ---
-# Copyright (C) 2020 DebOps <https://debops.org/>
+# Copyright (C) 2021 Dr. Serge Victor <https://dr.sergevictor.eu/>
+# Copyright (C) 2021 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Manage Telegraf instance

--- a/ansible/playbooks/service/telegraf.yml
+++ b/ansible/playbooks/service/telegraf.yml
@@ -1,0 +1,27 @@
+---
+# Copyright (C) 2020 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Manage Telegraf instance
+  collections: [ 'debops.debops' ]
+  hosts: [ 'debops_service_telegraf' ]
+  become: True
+
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
+
+  roles:
+
+    - role: keyring
+      tags: [ 'role::keyring', 'skip::keyring', 'role::influxdata' ]
+      keyring__dependent_apt_keys:
+        - '{{ influxdata__keyring__dependent_apt_keys }}'
+
+    - role: influxdata
+      tags: [ 'role::influxdata', 'skip::influxdata' ]
+      influxdata__dependent_packages:
+        - '{{ telegraf__influxdata__dependent_packages }}'
+
+    - role: telegraf
+      tags: [ 'role::telegraf', 'skip::telegraf' ]

--- a/ansible/roles/telegraf/COPYRIGHT
+++ b/ansible/roles/telegraf/COPYRIGHT
@@ -1,0 +1,18 @@
+debops.telegraf - Manage Telegraf instance using Ansible
+
+Copyright (C) 2020 DebOps <https://debops.org/>
+SPDX-License-Identifier: GPL-3.0-or-later
+
+This repository is part of DebOps.
+
+DebOps is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 3, as
+published by the Free Software Foundation.
+
+DebOps is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with DebOps. If not, see https://www.gnu.org/licenses/.

--- a/ansible/roles/telegraf/COPYRIGHT
+++ b/ansible/roles/telegraf/COPYRIGHT
@@ -1,6 +1,7 @@
 debops.telegraf - Manage Telegraf instance using Ansible
 
-Copyright (C) 2020 DebOps <https://debops.org/>
+Copyright (C) 2021 Dr. Serge Victor <https://dr.sergevictor.eu/>
+Copyright (C) 2021 DebOps <https://debops.org/>
 SPDX-License-Identifier: GPL-3.0-or-later
 
 This repository is part of DebOps.

--- a/ansible/roles/telegraf/defaults/main.yml
+++ b/ansible/roles/telegraf/defaults/main.yml
@@ -2,13 +2,13 @@
 # .. vim: foldmarker=[[[,]]]:foldmethod=marker
 
 # .. Copyright (C) 2021 Dr. Serge Victor <https://dr.sergevictor.eu/>
-# .. Copyright (C) 2021 DebOps <https://debops.org/>
+# .. Copyright (C) 2020 DebOps <https://debops.org/>
 # .. SPDX-License-Identifier: GPL-3.0-or-later
 
 # .. _telegraf__ref_defaults:
 
 # debops.telegraf default variables
-# ========================================
+# =================================
 
 # .. contents:: Sections
 #    :local:
@@ -17,7 +17,7 @@
 
 
 # APT packages [[[
-# -------------------------------
+# ------------
 
 # .. envvar:: telegraf__base_packages [[[
 #
@@ -40,70 +40,50 @@ telegraf__packages: []
 # :file:`/etc/telegraf/telegraf.d` configuration directory.
 # Definition of minimum one input and one output is mandatory.
 
-# .. envvar:: telegraf__plugins_input [[[
+# .. envvar:: telegraf__configuration [[[
 #
-# Input plugins list
-telegraf__plugins_input:
-  - '{{ telegraf__input_proxy_default }}'
+# All plugins you want to run on all hosts
+telegraf__configuration:
+
+  - name: 'input_influxdb_local'
+    config: |
+      [[inputs.influxdb_v2_listener]]
+        service_address = "127.0.0.1:38086"
+    state: 'present'
+
+  - name: 'output_discard'
+    config: |
+      [[outputs.discard]]
+    state: 'present'
                                                                    # ]]]
 
-# .. envvar:: telegraf__plugins_output [[[
+# .. envvar:: telegraf__group_configuration [[[
 #
-# Output plugins list
-telegraf__plugins_output:
-  - '{{ telegraf__output_proxy_default }}'
-
-                                                                   # ]]]
-
-# .. envvar:: telegraf__plugins_aggregator [[[
-#
-# Aggregator plugins list
-telegraf__plugins_aggregator: []
-
-                                                                   # ]]]
-
-# .. envvar:: telegraf__plugins_processor [[[
-#
-# Processor plugins list
-telegraf__plugins_processor: []
+# All plugins you want to run in group.
+telegraf__group_configuration: []
 
                                                                    # ]]]
 
-# .. envvar:: telegraf__input_proxy_default [[[
+# .. envvar:: telegraf_host_configuration [[[
 #
-# Default dummy proxy input
-telegraf__input_proxy_default:
-  name: 'input_proxy_default'
-  content: |
-    [[inputs.influxdb_v2_listener]]
-      service_address = ":38086"
-  state: 'present'
+# All plugins you want to run in a particulr host.
+telegraf__host_configuration: []
 
                                                                    # ]]]
 
-# .. envvar:: telegraf__output_proxy_default [[[
 #
-# Default dummy proxy output
-telegraf__output_proxy_default:
-  name: 'output_proxy_default'
-  content: |
-    [[outputs.influxdb_v2]]
-  state: 'present'
-                                                                   # ]]]
-
 # .. envvar:: telegraf__combined_configuration [[[
 #
 # Full list of Telegraf configuration options passed to the
 # configuration template dir.
-telegraf__plugins_combined: '{{ telegraf__plugins_input +
-                                  telegraf__plugins_output +
-                                  telegraf__plugins_aggregator +
-                                  telegraf__plugins_processor }}'
+telegraf__configuration_combined: '{{ telegraf__configuration
+                                      + telegraf__group_configuration
+                                      + telegraf__host_configuration }}'
 
                                                                    # ]]]
                                                                    # ]]]
 # Configuration for other Ansible roles [[[
-# -----------------------------------------
+# -------------------------------------
 
 # .. envvar:: telegraf__influxdata__dependent_packages [[[
 #

--- a/ansible/roles/telegraf/defaults/main.yml
+++ b/ansible/roles/telegraf/defaults/main.yml
@@ -1,7 +1,8 @@
 ---
 # .. vim: foldmarker=[[[,]]]:foldmethod=marker
 
-# .. Copyright (C) 2020 DebOps <https://debops.org/>
+# .. Copyright (C) 2021 Dr. Serge Victor <https://dr.sergevictor.eu/>
+# .. Copyright (C) 2021 DebOps <https://debops.org/>
 # .. SPDX-License-Identifier: GPL-3.0-or-later
 
 # .. _telegraf__ref_defaults:

--- a/ansible/roles/telegraf/defaults/main.yml
+++ b/ansible/roles/telegraf/defaults/main.yml
@@ -1,0 +1,115 @@
+---
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+
+# .. Copyright (C) 2020 DebOps <https://debops.org/>
+# .. SPDX-License-Identifier: GPL-3.0-or-later
+
+# .. _telegraf__ref_defaults:
+
+# debops.telegraf default variables
+# ========================================
+
+# .. contents:: Sections
+#    :local:
+#
+# .. include:: ../../../../includes/global.rst
+
+
+# APT packages [[[
+# -------------------------------
+
+# .. envvar:: telegraf__base_packages [[[
+#
+# List of the default APT packages to install Telegraf.
+telegraf__base_packages: [ 'telegraf' ]
+
+                                                                   # ]]]
+# .. envvar:: telegraf__packages [[[
+#
+# List of additional APT packages ta install with Telegraf.
+telegraf__packages: []
+
+                                                                   # ]]]
+                                                                   # ]]]
+
+# Telegraf configuration directory [[[
+# --------------------------------
+
+# The variable below defines the contents of the
+# :file:`/etc/telegraf/telegraf.d` configuration directory.
+# Definition of minimum one input and one output is mandatory.
+
+# .. envvar:: telegraf__plugins_input [[[
+#
+# Input plugins list
+telegraf__plugins_input:
+  - '{{ telegraf__input_proxy_default }}'
+                                                                   # ]]]
+
+# .. envvar:: telegraf__plugins_output [[[
+#
+# Output plugins list
+telegraf__plugins_output:
+  - '{{ telegraf__output_proxy_default }}'
+
+                                                                   # ]]]
+
+# .. envvar:: telegraf__plugins_aggregator [[[
+#
+# Aggregator plugins list
+telegraf__plugins_aggregator: []
+
+                                                                   # ]]]
+
+# .. envvar:: telegraf__plugins_processor [[[
+#
+# Processor plugins list
+telegraf__plugins_processor: []
+
+                                                                   # ]]]
+
+# .. envvar:: telegraf__input_proxy_default [[[
+#
+# Default dummy proxy input
+telegraf__input_proxy_default:
+  name: 'input_proxy_default'
+  content: |
+    [[inputs.influxdb_v2_listener]]
+      service_address = ":38086"
+  state: 'present'
+
+                                                                   # ]]]
+
+# .. envvar:: telegraf__output_proxy_default [[[
+#
+# Default dummy proxy output
+telegraf__output_proxy_default:
+  name: 'output_proxy_default'
+  content: |
+    [[outputs.influxdb_v2]]
+  state: 'present'
+                                                                   # ]]]
+
+# .. envvar:: telegraf__combined_configuration [[[
+#
+# Full list of Telegraf configuration options passed to the
+# configuration template dir.
+telegraf__plugins_combined: '{{ telegraf__plugins_input +
+                                  telegraf__plugins_output +
+                                  telegraf__plugins_aggregator +
+                                  telegraf__plugins_processor }}'
+
+                                                                   # ]]]
+                                                                   # ]]]
+# Configuration for other Ansible roles [[[
+# -----------------------------------------
+
+# .. envvar:: telegraf__influxdata__dependent_packages [[[
+#
+# Configuration for the :ref:`debops.influxdata` Ansible role.
+telegraf__influxdata__dependent_packages:
+  - '{{ telegraf__base_packages }}'
+  - '{{ telegraf__packages }}'
+
+                                                                   # ]]]
+                                                                   # ]]]

--- a/ansible/roles/telegraf/handlers/main.yml
+++ b/ansible/roles/telegraf/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+# Copyright (C) 2021 Dr. Serge Victor <https://dr.sergevictor.eu/>
+# Copyright (C) 2021 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Restart Telegraf
+  service:
+    name: "telegraf"
+    state: "restarted"

--- a/ansible/roles/telegraf/meta/main.yml
+++ b/ansible/roles/telegraf/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 # Copyright (C) 2021 Dr. Serge Victor <https://dr.sergevictor.eu/>
-# Copyright (C) 2020 DebOps <https://debops.org/>
+# Copyright (C) 2021 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 dependencies: []
@@ -10,7 +10,7 @@ galaxy_info:
   author: 'Dr. Serge Victor'
   description: 'Install and manage a Telegraf instance'
   company: 'DebOps'
-  license: 'GPL-3.0-only'
+  license: 'GPL-3.0-or-later'
   min_ansible_version: '2.9.0'
   platforms:
     - name: 'Debian'
@@ -20,6 +20,7 @@ galaxy_info:
     - name: 'Ubuntu'
       versions:
         - 'focal'
+        - 'bionic'
   galaxy_tags:
     - 'monitoring'
     - 'influxdb'

--- a/ansible/roles/telegraf/meta/main.yml
+++ b/ansible/roles/telegraf/meta/main.yml
@@ -1,0 +1,25 @@
+---
+# Copyright (C) 2021 Dr. Serge Victor <https://dr.sergevictor.eu/>
+# Copyright (C) 2020 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+dependencies: []
+
+galaxy_info:
+
+  author: 'Dr. Serge Victor'
+  description: 'Install and manage a Telegraf instance'
+  company: 'DebOps'
+  license: 'GPL-3.0-only'
+  min_ansible_version: '2.9.0'
+  platforms:
+    - name: 'Debian'
+      versions:
+        - 'bullseye'
+        - 'buster'
+    - name: 'Ubuntu'
+      versions:
+        - 'focal'
+  galaxy_tags:
+    - 'monitoring'
+    - 'influxdb'

--- a/ansible/roles/telegraf/tasks/main.yml
+++ b/ansible/roles/telegraf/tasks/main.yml
@@ -1,0 +1,80 @@
+---
+# Copyright (C) 2020 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Import custom Ansible plugins
+  import_role:
+    name: 'ansible_plugins'
+
+- name: Import DebOps global handlers
+  import_role:
+    name: 'global_handlers'
+
+- name: Stop Telegraf instance on first install
+  service:
+    name: 'telegraf'
+    state: 'stopped'
+  when: not (ansible_local.telegraf.installed|d(false)|bool)
+
+- name: Divert the original telegraf main configuration file
+  dpkg_divert:
+    path: '/etc/telegraf/telegraf.conf'
+    state: 'present'
+    delete: True
+  tags: [ 'role::telegraf:config' ]
+
+- name: Configure Telegraf instance leading file
+  template:
+    src: 'etc/telegraf/telegraf.conf.j2'
+    dest: '/etc/telegraf/telegraf.conf'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  tags: [ 'role::telegraf:config' ]
+
+- name: Remove plugins configuration if requested
+  file:
+    path: '/etc/telegraf/telegraf.d/{{ item.name }}.conf'
+    state: 'absent'
+  with_flattened:
+    - '{{ telegraf__plugins_combined }}'
+  when: (item.name|d() and
+         ((item.state|d() and item.state == 'absent') or
+          (item.delete|d() and item.delete|bool)))
+  tags: [ 'role::telegraf:config' ]
+
+- name: Configure plugins
+  template:
+    src: 'etc/telegraf.d/plugin.conf.j2'
+    dest: '/etc/telegraf/telegraf.d/{{ item.name }}.conf'
+    owner: 'root'
+    group: 'telegraf'
+    mode: '0640'
+  with_flattened:
+    - '{{ telegraf__plugins_combined }}'
+  when: (item.name|d() and item.state|d('present') != 'absent' and
+         (item.delete is undefined or not item.delete|bool))
+  tags: [ 'role::telegraf:config' ]
+
+- name: Start or restart Telegraf
+  service:
+    name: 'telegraf'
+    state: 'restarted'
+
+- name: Make sure that Ansible local facts directory exists
+  file:
+    path: '/etc/ansible/facts.d'
+    state: 'directory'
+    mode: '0755'
+
+- name: Save Telegraf instance local facts
+  template:
+    src: 'etc/ansible/facts.d/telegraf.fact.j2'
+    dest: '/etc/ansible/facts.d/telegraf.fact'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+  notify: [ 'Refresh host facts' ]
+
+- name: Re-read local facts if they have been modified
+  meta: 'flush_handlers'

--- a/ansible/roles/telegraf/tasks/main.yml
+++ b/ansible/roles/telegraf/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
-# Copyright (C) 2020 DebOps <https://debops.org/>
+# Copyright (C) 2021 Dr. Serge Victor <https://dr.sergevictor.eu/>
+# Copyright (C) 2021 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Import custom Ansible plugins
@@ -45,7 +46,7 @@
 
 - name: Configure plugins
   template:
-    src: 'etc/telegraf.d/plugin.conf.j2'
+    src: 'etc/telegraf/telegraf.d/plugin.conf.j2'
     dest: '/etc/telegraf/telegraf.d/{{ item.name }}.conf'
     owner: 'root'
     group: 'telegraf'

--- a/ansible/roles/telegraf/tasks/main.yml
+++ b/ansible/roles/telegraf/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # Copyright (C) 2021 Dr. Serge Victor <https://dr.sergevictor.eu/>
-# Copyright (C) 2021 DebOps <https://debops.org/>
+# Copyright (C) 2020 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Import custom Ansible plugins
@@ -11,18 +11,12 @@
   import_role:
     name: 'global_handlers'
 
-- name: Stop Telegraf instance on first install
-  service:
-    name: 'telegraf'
-    state: 'stopped'
-  when: not (ansible_local.telegraf.installed|d(false)|bool)
-
 - name: Divert the original telegraf main configuration file
   dpkg_divert:
     path: '/etc/telegraf/telegraf.conf'
     state: 'present'
-    delete: True
-  tags: [ 'role::telegraf:config' ]
+    delete: true
+  notify: [ 'Restart Telegraf' ]
 
 - name: Configure Telegraf instance leading file
   template:
@@ -31,18 +25,29 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  tags: [ 'role::telegraf:config' ]
+  notify: [ 'Restart Telegraf' ]
 
 - name: Remove plugins configuration if requested
   file:
     path: '/etc/telegraf/telegraf.d/{{ item.name }}.conf'
     state: 'absent'
-  with_flattened:
-    - '{{ telegraf__plugins_combined }}'
-  when: (item.name|d() and
-         ((item.state|d() and item.state == 'absent') or
-          (item.delete|d() and item.delete|bool)))
-  tags: [ 'role::telegraf:config' ]
+  loop: '{{ telegraf__configuration_combined | parse_kv_items }}'
+  when: item.state|d('present') == 'absent' and item.config|d()
+  notify: [ 'Restart Telegraf' ]
+
+- name: Find plugins which are in filesystem
+  find:
+    paths: /etc/telegraf/telegraf.d
+    patterns: '*.conf'
+  register: telegraf_existing_plugins_filenames
+
+- name: Backup and disactivate plugins unexisting in desired configuration
+  command:
+    cmd: mv -f '{{ item.path | quote }}' '{{ item.path | quote }}.inactive'
+    removes: item.path
+  loop: '{{ telegraf_existing_plugins_filenames.files }}'
+  when: item.path | basename | splitext | first not in telegraf__configuration_combined | parse_kv_items | map(attribute="name")
+  notify: [ 'Restart Telegraf' ]
 
 - name: Configure plugins
   template:
@@ -51,16 +56,10 @@
     owner: 'root'
     group: 'telegraf'
     mode: '0640'
-  with_flattened:
-    - '{{ telegraf__plugins_combined }}'
-  when: (item.name|d() and item.state|d('present') != 'absent' and
-         (item.delete is undefined or not item.delete|bool))
-  tags: [ 'role::telegraf:config' ]
-
-- name: Start or restart Telegraf
-  service:
-    name: 'telegraf'
-    state: 'restarted'
+  loop: '{{ telegraf__configuration_combined | parse_kv_items }}'
+  when: item.state|d('present') not in [ 'absent', 'ignore' ] and item.config|d()
+  no_log: '{{ debops__no_log | d(True) }}'
+  notify: [ 'Restart Telegraf' ]
 
 - name: Make sure that Ansible local facts directory exists
   file:

--- a/ansible/roles/telegraf/templates/etc/ansible/facts.d/telegraf.fact.j2
+++ b/ansible/roles/telegraf/templates/etc/ansible/facts.d/telegraf.fact.j2
@@ -1,7 +1,8 @@
 #!{{ ansible_python['executable'] }}
 # -*- coding: utf-8 -*-
 
-# Copyright (C) 2020 DebOps <https://debops.org/>
+# Copyright (C) 2021 Dr. Serge Victor <https://dr.sergevictor.eu/>
+# Copyright (C) 2021 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 # {{ ansible_managed }}

--- a/ansible/roles/telegraf/templates/etc/ansible/facts.d/telegraf.fact.j2
+++ b/ansible/roles/telegraf/templates/etc/ansible/facts.d/telegraf.fact.j2
@@ -1,0 +1,24 @@
+#!{{ ansible_python['executable'] }}
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2020 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# {{ ansible_managed }}
+
+from __future__ import print_function
+from json import dumps, loads
+import os
+
+
+def cmd_exists(cmd):
+    return any(
+        os.access(os.path.join(path, cmd), os.X_OK)
+        for path in os.environ["PATH"].split(os.pathsep)
+    )
+
+
+output = {}
+output['installed'] = cmd_exists('telegraf')
+
+print(dumps(output, sort_keys=True, indent=4))

--- a/ansible/roles/telegraf/templates/etc/telegraf.d/plugin.conf.j2
+++ b/ansible/roles/telegraf/templates/etc/telegraf.d/plugin.conf.j2
@@ -1,0 +1,6 @@
+ # Copyright (C) 2020 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-or-later
+ #}
+# {{ ansible_managed }}
+#
+{{ item.content }}

--- a/ansible/roles/telegraf/templates/etc/telegraf.d/plugin.conf.j2
+++ b/ansible/roles/telegraf/templates/etc/telegraf.d/plugin.conf.j2
@@ -1,6 +1,0 @@
- # Copyright (C) 2020 DebOps <https://debops.org/>
- # SPDX-License-Identifier: GPL-3.0-or-later
- #}
-# {{ ansible_managed }}
-#
-{{ item.content }}

--- a/ansible/roles/telegraf/templates/etc/telegraf/telegraf.conf.j2
+++ b/ansible/roles/telegraf/templates/etc/telegraf/telegraf.conf.j2
@@ -1,0 +1,7 @@
+ # Copyright (C) 2020 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-or-later
+ #}
+# {{ ansible_managed }}
+#
+# This Telegraf instance is configured in /etc/telegraf/telegraf.d directory
+# only.

--- a/ansible/roles/telegraf/templates/etc/telegraf/telegraf.conf.j2
+++ b/ansible/roles/telegraf/templates/etc/telegraf/telegraf.conf.j2
@@ -1,4 +1,5 @@
- # Copyright (C) 2020 DebOps <https://debops.org/>
+# Copyright (C) 2021 Dr. Serge Victor <https://dr.sergevictor.eu/>
+# Copyright (C) 2021 DebOps <https://debops.org/>
  # SPDX-License-Identifier: GPL-3.0-or-later
  #}
 # {{ ansible_managed }}

--- a/ansible/roles/telegraf/templates/etc/telegraf/telegraf.conf.j2
+++ b/ansible/roles/telegraf/templates/etc/telegraf/telegraf.conf.j2
@@ -4,5 +4,8 @@
  #}
 # {{ ansible_managed }}
 #
-# This Telegraf instance is configured in /etc/telegraf/telegraf.d directory
-# only.
+# This Telegraf instance is configured in:
+# 
+# /etc/telegraf/telegraf.d
+#
+# directory only.

--- a/ansible/roles/telegraf/templates/etc/telegraf/telegraf.d/plugin.conf.j2
+++ b/ansible/roles/telegraf/templates/etc/telegraf/telegraf.d/plugin.conf.j2
@@ -1,0 +1,7 @@
+ # Copyright (C) 2021 Dr. Serge Victor <https://dr.sergevictor.eu/>
+ # Copyright (C) 2021 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-or-later
+ #}
+# {{ ansible_managed }}
+#
+{{ item.content }}

--- a/ansible/roles/telegraf/templates/etc/telegraf/telegraf.d/plugin.conf.j2
+++ b/ansible/roles/telegraf/templates/etc/telegraf/telegraf.d/plugin.conf.j2
@@ -4,4 +4,4 @@
  #}
 # {{ ansible_managed }}
 #
-{{ item.content }}
+{{ item.config }}

--- a/docs/ansible/roles/telegraf/getting-started.rst
+++ b/docs/ansible/roles/telegraf/getting-started.rst
@@ -1,0 +1,34 @@
+.. Copyright (C) 2020 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-or-later
+
+Getting started
+===============
+
+.. only:: html
+
+   .. contents::
+      :local:
+
+Example inventory
+-----------------
+
+To install a Telegraf agent on a host, you need to add it to
+``[debops_service_telegraf]`` Ansible group:
+
+.. code-block:: none
+
+   [debops_service_telegraf]
+   agent-host
+
+This will install ``telegraf`` package and configure a dummy input and output
+plugins which are required to run the service.
+
+Example playbook
+----------------
+
+Here's an example Ansible playbook that uses the ``debops.telegraf``
+role:
+
+.. literalinclude:: ../../../../ansible/playbooks/service/telegraf.yml
+   :language: yaml
+   :lines: 1,7-

--- a/docs/ansible/roles/telegraf/getting-started.rst
+++ b/docs/ansible/roles/telegraf/getting-started.rst
@@ -1,4 +1,5 @@
-.. Copyright (C) 2020 DebOps <https://debops.org/>
+.. Copyright (C) 2021 Dr. Serge Victor <https://dr.sergevictor.eu/>
+.. Copyright (C) 2021 DebOps <https://debops.org/>
 .. SPDX-License-Identifier: GPL-3.0-or-later
 
 Getting started

--- a/docs/ansible/roles/telegraf/index.rst
+++ b/docs/ansible/roles/telegraf/index.rst
@@ -1,4 +1,5 @@
-.. Copyright (C) 2020 DebOps <https://debops.org/>
+.. Copyright (C) 2021 Dr. Serge Victor <https://dr.sergevictor.eu/>
+.. Copyright (C) 2021 DebOps <https://debops.org/>
 .. SPDX-License-Identifier: GPL-3.0-or-later
 
 .. _debops.telegraf:
@@ -7,7 +8,7 @@ debops.telegraf
 ===============
 
 .. include:: man_description.rst
-   :start-line: 6
+   :start-line: 7
 
 .. toctree::
    :maxdepth: 2

--- a/docs/ansible/roles/telegraf/index.rst
+++ b/docs/ansible/roles/telegraf/index.rst
@@ -1,0 +1,28 @@
+.. Copyright (C) 2020 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-or-later
+
+.. _debops.telegraf:
+
+debops.telegraf
+===============
+
+.. include:: man_description.rst
+   :start-line: 6
+
+.. toctree::
+   :maxdepth: 2
+
+   getting-started
+   defaults/main
+   real-world-example
+
+Copyright
+---------
+
+.. literalinclude:: ../../../../ansible/roles/telegraf/COPYRIGHT
+
+..
+ Local Variables:
+ mode: rst
+ ispell-local-dictionary: "american"
+ End:

--- a/docs/ansible/roles/telegraf/man_description.rst
+++ b/docs/ansible/roles/telegraf/man_description.rst
@@ -1,0 +1,12 @@
+.. Copyright (C) 2020 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-or-later
+
+Description
+===========
+
+Use `Telegraf`__ to collect and write metrics into InfluxDB and other supported outputs.
+Telegraf is the open source server agent to help you collect metrics from your stacks, sensors and systems.
+
+The ``debops.telegraf`` role installs and configures Telegraf.
+
+.. __: https://www.influxdata.com/time-series-platform/telegraf/ 

--- a/docs/ansible/roles/telegraf/man_description.rst
+++ b/docs/ansible/roles/telegraf/man_description.rst
@@ -1,4 +1,5 @@
-.. Copyright (C) 2020 DebOps <https://debops.org/>
+.. Copyright (C) 2021 Dr. Serge Victor <https://dr.sergevictor.eu/>
+.. Copyright (C) 2021 DebOps <https://debops.org/>
 .. SPDX-License-Identifier: GPL-3.0-or-later
 
 Description

--- a/docs/ansible/roles/telegraf/man_index.rst
+++ b/docs/ansible/roles/telegraf/man_index.rst
@@ -1,0 +1,21 @@
+:orphan:
+
+.. Copyright (C) 2020 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-or-later
+
+debops.telegraf
+======================
+
+.. toctree::
+   :maxdepth: 2
+
+   man_synopsis
+   man_description
+   getting-started
+   real-world-example
+
+..
+ Local Variables:
+ mode: rst
+ ispell-local-dictionary: "american"
+ End:

--- a/docs/ansible/roles/telegraf/man_synopsis.rst
+++ b/docs/ansible/roles/telegraf/man_synopsis.rst
@@ -1,0 +1,7 @@
+.. Copyright (C) 2020 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-or-later
+
+Synopsis
+========
+
+``debops service/telegraf`` [**--limit** `group,host,`...] [**--diff**] [**--check**] [**--tags** `tag1,tag2,`...] [**--skip-tags** `tag1,tag2,`...] [<``ansible-playbook`` options>] ...

--- a/docs/ansible/roles/telegraf/real-world-example.rst
+++ b/docs/ansible/roles/telegraf/real-world-example.rst
@@ -1,0 +1,90 @@
+.. Copyright (C) 2020 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-or-later
+
+Real world use
+==============
+
+Telegraf requires at least one input and output defined. 
+Default ``debops.telegraf`` role variables create two plugins with nearly zero
+practical use, these are dummy input and output plugins only to fullfill minimal
+Telegraf configuration requirements. 
+
+In next few paragraphs it will be shown real world use example.
+
+.. only:: html
+
+   .. contents::
+      :local:
+      :depth: 1
+
+.. _telegraf__ref_options:
+
+Plugins
+-------
+
+Telegraf instance consists of four types of plugins: ``input``, ``output``,
+``aggregator`` and ``processor`` ones. Only one input and one output is mandatory,
+but you are able to define unlimited amount of plugins in one instance. 
+
+Syntax
+~~~~~~
+
+The variables are YAML lists, each list entry is a YAML dictionary that uses
+specific parameters:
+
+``name``
+    Required. This parameter defines the option name, and it needs to be unique
+    in a given configuration file. This name will represent filename in telegraf
+    configuration directory.
+
+    It is recommended to avoid using whitespaces and other special characters, 
+    use just plain alphabet and numbers and ``_``.
+
+``content``
+    Required. It's a TOML syntax which defines a plugin according to Telegraf
+    documentation. It's just being copied without modifification into
+    configuration directory as a separate file. 
+
+    For more information, refer to the Telegraf documentation at
+    https://docs.influxdata.com/telegraf/
+
+``state``
+    Optional. By default ``present``. If you declare it as ``absent``, this
+    plugin will be removed from your Telegraf instance configuration and
+    disactivated.
+
+Examples
+~~~~~~~~
+
+This example shows real world case of defining an input plugin which receives
+stream of UDP data from Traefik web proxy and forwards it into InfluxDB 2.0 instance.
+
+.. code-block:: yaml
+
+  telegraf__plugins_input:
+    - '{{ telegraf__input_traefik }}'
+
+  telegraf__plugins_output:
+    - '{{ telegraf__output_influxdb2 }}'
+
+  telegraf__input_traefik:
+    name: 'input_udp_traefik'
+    content: |
+      [[inputs.socket_listener]]
+        service_address = "udp4://:12105"
+        data_format = "influx"
+        content_encoding = "identity"
+        [inputs.socket_listener.tags]
+          bucket4itz = "traefik"
+    state: 'present'
+
+  telegraf__output_influxdb2:
+    name: 'output_influx2'
+    content: |
+      [[outputs.influxdb_v2]]
+        urls = ["http://127.0.0.1:8086"]
+        token = "4bwv88XllnYz7KXakKMz173YPsfSOH5_E70FE01PkXf3a7IC-IrzD-zCqjOtU1NGJtZycLguFhuDl8cUpz9QFw=="
+        organization = "DebOps"
+        bucket_tag = "bucket4itz"
+        exclude_bucket_tag = true
+    state: 'present'

--- a/docs/ansible/roles/telegraf/real-world-example.rst
+++ b/docs/ansible/roles/telegraf/real-world-example.rst
@@ -9,18 +9,15 @@ Default ``debops.telegraf`` role variables create two plugins with nearly zero
 practical use, these are dummy input and output plugins only to fullfill minimal
 Telegraf configuration requirements. 
 
+These dummy examples are inactivated automatically if you declare any content
+to variable ``telegraf__configuration``.
+
 In next few paragraphs it will be shown real world use example.
-
-.. only:: html
-
-   .. contents::
-      :local:
-      :depth: 1
 
 .. _telegraf__ref_options:
 
-Plugins
--------
+Configuration
+-------------
 
 Telegraf instance consists of four types of plugins: ``input``, ``output``,
 ``aggregator`` and ``processor`` ones. Only one input and one output is mandatory,
@@ -40,7 +37,7 @@ specific parameters:
     It is recommended to avoid using whitespaces and other special characters, 
     use just plain alphabet and numbers and ``_``.
 
-``content``
+``config``
     Required. It's a TOML syntax which defines a plugin according to Telegraf
     documentation. It's just being copied without modifification into
     configuration directory as a separate file. 
@@ -53,38 +50,75 @@ specific parameters:
     plugin will be removed from your Telegraf instance configuration and
     disactivated.
 
+If you configure your instance and later remove one or more of plugins from your
+ansible configuration, it will be automatically disactivated in the host
+and backuped to a filename ending ``.inactive``, for your future reference.  
+
 Examples
 ~~~~~~~~
 
 This example shows real world case of defining an input plugin which receives
-stream of UDP data from Traefik web proxy and forwards it into InfluxDB 2.0 instance.
+stream of UDP data from Collectd and forwards it into InfluxDB 2.0 instance.
 
 .. code-block:: yaml
 
-  telegraf__plugins_input:
-    - '{{ telegraf__input_traefik }}'
+ telegraf__configuration:
+   - name: 'telegraf2influxdb'
+     config: |
+       [[outputs.influxdb_v2]]
+         urls = ["http://127.0.0.1:8086"]
+         token = "4bwv8cXllnYz7KXakKMz173YPSaSOH5_E70FE01PkXf3a7IC-IrzP-zCqjOtU1NGJiZycLguRhuDl8cUpz9QFw=="
+         organization = "DebOps"
+         bucket_tag = "bucket4debops"
+         exclude_bucket_tag = true
+     state: 'present'
 
-  telegraf__plugins_output:
-    - '{{ telegraf__output_influxdb2 }}'
+   - name: 'udp4collectd'
+     config: |
+       [[inputs.socket_listener]]
+         service_address = "udp4://:25826"
+         data_format = "collectd"
+         content_encoding = "identity"
+         ## Authentication file for cryptographic security levels
+         collectd_auth_file = "/etc/collectd/passwd"
+         ## One of none (default), sign, or encrypt
+         collectd_security_level = "encrypt"
+         ## Path of to TypesDB specifications
+         collectd_typesdb = ["/usr/share/collectd/types.db"]
+         collectd_parse_multivalue = "join"
+         [inputs.socket_listener.tags]
+           bucket4debops = "collectd"
+     state: 'present'
 
-  telegraf__input_traefik:
-    name: 'input_udp_traefik'
-    content: |
-      [[inputs.socket_listener]]
-        service_address = "udp4://:12105"
-        data_format = "influx"
-        content_encoding = "identity"
-        [inputs.socket_listener.tags]
-          bucket4itz = "traefik"
-    state: 'present'
+This example defines several system monitoring input plugins which are assigned
+to a particular host only.
 
-  telegraf__output_influxdb2:
-    name: 'output_influx2'
-    content: |
-      [[outputs.influxdb_v2]]
-        urls = ["http://127.0.0.1:8086"]
-        token = "4bwv88XllnYz7KXakKMz173YPsfSOH5_E70FE01PkXf3a7IC-IrzD-zCqjOtU1NGJtZycLguFhuDl8cUpz9QFw=="
-        organization = "DebOps"
-        bucket_tag = "bucket4itz"
-        exclude_bucket_tag = true
-    state: 'present'
+.. code-block:: yaml
+
+  telegraf__configuration: []
+
+  telegraf__host_configuration:
+    - name: 'input_system'
+      config: |
+        [[inputs.system]]
+      state: 'present'
+
+    - name: 'input_diskio'
+      config: |
+        [[inputs.diskio]]
+          devices = ["nvme0n1", "nvme1n1", "md10"]
+      state: 'present'
+
+    - name: 'input_net'
+      config: |
+        [[inputs.net]]
+          interfaces = ["eth0", "bridge0"]
+      state: 'present'
+
+    - name: 'input_zfs'
+      config: |
+        [[inputs.zfs]]
+          poolMetrics = true
+          datasetMetrics = true
+      state: 'present'
+


### PR DESCRIPTION
It's a simple role which helps to maintain Telegraf agent/proxy configuration across servers. It uses ```influxdata``` role to get APT packages from, but is independent from existing InfluxDB roles. It's projected to work with future InfluxDB 2.0 role but can be used with existing InfluxDB 1.x installations as well.