### PR TITLE
unattended_upgrades: Add simplest example

### DIFF
--- a/docs/ansible/roles/unattended_upgrades/defaults-detailed.rst
+++ b/docs/ansible/roles/unattended_upgrades/defaults-detailed.rst
@@ -143,6 +143,8 @@ Include specified origin patterns for all hosts:
 
    unattended_upgrades__origins:
 
+     - 'o=packages.gitlab.com/gitlab/gitlab-ce,n=${distro_codename},l=gitlab-ce'
+
      - origin: 'site=download.owncloud.org'
 
      - origin: [ 'site=download.example.org', 'o=Example Testing Packages' ]


### PR DESCRIPTION
According to #1815, in our case using `- origin: '...'` does not work, while directly `- '...'` does work OK.