### PR TITLE
[rabbitmq_server] Fix per account vhost creation

### DIFF
--- a/ansible/roles/rabbitmq_server/templates/lookup/rabbitmq_server__accounts_vhosts.j2
+++ b/ansible/roles/rabbitmq_server/templates/lookup/rabbitmq_server__accounts_vhosts.j2
@@ -5,13 +5,11 @@
 {% set rabbitmq_server__tpl_accounts_vhosts = [] %}
 {% for account in lookup("flattened", rabbitmq_server__combined_accounts) %}
 {%   if account.vhost|d() and account.state|d('present') != 'absent' %}
-{%     set _ = rabbitmq_server__tpl_accounts_vhosts.append({ 'name': account.vhost }) %}
-{%   endif %}
-{%   if account.node|d() %}
-{%     set _ = rabbitmq_server__tpl_accounts_vhosts.append({ 'node': account.node }) %}
-{%   endif %}
-{%   if account.tracing|d() %}
-{%     set _ = rabbitmq_server__tpl_accounts_vhosts.append({ 'tracing': account.tracing }) %}
+{%     set _ = rabbitmq_server__tpl_accounts_vhosts.append({
+   'name': account.vhost,
+   'node': account.node|d(omit),
+   'tracing': account.tracing|d(omit)
+}) %}
 {%   endif %}
 {% endfor %}
 {{ rabbitmq_server__tpl_accounts_vhosts }}


### PR DESCRIPTION
The per account vhost lookup template added a vhost for each vhost name,
node name and tracing setting defined on the account. This is fixed to
create single vhost with the correct settings.