### PR TITLE
[reprepro] Add missing architectures

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -362,6 +362,12 @@ Fixed
 - Fixed an issue with facts not showing Redis instances correctly when password
   is empty.
 
+debops.reprepro role
+''''''''''''''''''''
+
+- Added missing architectures (all expected architectures for Bookworm, and
+  some missing architectures for older releases).
+
 :ref:`debops.resolvconf` role
 '''''''''''''''''''''''''''''
 

--- a/ansible/roles/reprepro/defaults/main.yml
+++ b/ansible/roles/reprepro/defaults/main.yml
@@ -874,12 +874,28 @@ reprepro_debian_suites:
 #
 # List of Debian architectures by release
 reprepro_debian_architectures:
-  'squeeze': [ 'source', 'amd64', 'armel', 'i386' ]
-  'wheezy': [ 'source', 'amd64', 'armel', 'armhf', 'i386' ]
-  'jessie': [ 'source', 'amd64', 'arm64', 'armel', 'armhf', 'i386' ]
-  'stretch': [ 'source', 'amd64', 'arm64', 'armel', 'armhf', 'i386' ]
-  'buster': [ 'source', 'amd64', 'arm64', 'armel', 'armhf', 'i386' ]
-  'bullseye': [ 'source', 'amd64', 'arm64', 'armel', 'armhf', 'i386' ]
+
+  'squeeze':  [ 'source', 'amd64', 'armel', 'ia64', 'i386', 'kfreebsd-amd64',
+                'kfreebsd-i386', 'mips', 'mipsel', 'powerpc', 's390', 'sparc' ]
+
+  'wheezy':   [ 'source', 'amd64', 'armel', 'armhf', 'ia64', 'i386',
+                'kfreebsd-amd64', 'kfreebsd-i386', 'mips', 'mipsel', 'powerpc',
+                's390', 's390x', 'sparc' ]
+
+  'jessie':   [ 'source', 'amd64', 'arm64', 'armel', 'armhf', 'i386', 'mips',
+                'mipsel', 'powerpc', 'ppc64el', 's390x' ]
+
+  'stretch':  [ 'source', 'amd64', 'arm64', 'armel', 'armhf', 'i386', 'mips',
+                'mips64el', 'mipsel', 'ppc64el', 's390x' ]
+
+  'buster':   [ 'source', 'amd64', 'arm64', 'armel', 'armhf', 'i386', 'mips',
+                'mips64el', 'mipsel', 'ppc64el', 's390x' ]
+
+  'bullseye': [ 'source', 'amd64', 'arm64', 'armel', 'armhf', 'i386',
+                'mips64el', 'mipsel', 'ppc64el', 's390x' ]
+
+  'bookworm': [ 'source', 'amd64', 'arm64', 'armel', 'armhf', 'i386',
+                'mips64el', 'mipsel', 'ppc64el', 's390x' ]
 
                                                                    # ]]]
 # Configuration for other Ansible roles [[[


### PR DESCRIPTION
This adds the expected architectures for Bookworm, and adds the missing
architectures for older releases. The lists of official architectures
were obtained from the release notes. The list of architectures for
Bookworm was obtained from the current Bookworm Release file (which is
subject to change).

Adding the Bookworm architectures is necessary in order to make reprepro
work on Debian 11. This is because Bookworm is configured as the 'next'
release, and if that release doesn't have architecture information the
reprepro commands will fail.