### PR TITLE
[elastic_co] Set default version to 7.x

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -160,6 +160,12 @@ Updates of upstream application versions
 - The :file:`lxc_ssh.py` Ansible connection plugin has been updated to include
   latest changes and bugfixes.
 
+- The Elastic APT repository configured on new installations by
+  :ref:`debops.elastic_co` has been updated to version 7.x. Updating the
+  repository configuration on existing hosts requires that you manually update
+  the local facts or to set the ``elastic_co__version`` variable to '7.x' before
+  running the playbook.
+
 General
 '''''''
 

--- a/ansible/roles/elastic_co/defaults/main.yml
+++ b/ansible/roles/elastic_co/defaults/main.yml
@@ -25,7 +25,7 @@
 # The role will remember the selected version using Ansible local facts which
 # should ensure that in the future currently installed version of the APT
 # repository stays the same on a given host.
-elastic_co__version: '{{ ansible_local.elastic_co.version|d("6.x") }}'
+elastic_co__version: '{{ ansible_local.elastic_co.version|d("7.x") }}'
 
                                                                    # ]]]
 # .. envvar:: elastic_co__curator_version [[[


### PR DESCRIPTION
I have tested this with a single-node Elasticsearch installation that we
use for a Graylog system. Upgrading from Elasticsearch 6.8 to 7.10 went
smoothly. No configuration changes were necessary in this case.