### PR TITLE
[pki] Fix permission issues in /etc/letsencrypt/

### DIFF
--- a/ansible/roles/pki/defaults/main.yml
+++ b/ansible/roles/pki/defaults/main.yml
@@ -247,6 +247,39 @@ pki_create_acme_challenge_dir: '{{ True if (ansible_local.nginx.acme|d() and
                                             ansible_local.nginx.acme|bool) else False }}'
                                                                    # ]]]
                                                                    # ]]]
+# Certbot configuration [[[
+# -------------------------
+
+# The lists below define the contents of the :file:`/etc/letsencrypt/cli.ini`
+# configuration file. See :ref:`pki_ref_certbot_configuration` for more
+# details.
+
+# .. envvar:: pki_certbot_default_configuration [[[
+#
+# The default contents of the Certbot configuration file defined by the role.
+pki_certbot_default_configuration:
+
+  - name: 'max-log-backups'
+    comment: |
+      Because we are using logrotate for greater flexibility, disable the
+      internal certbot logrotation.
+    value: 0
+
+                                                                   # ]]]
+# .. envvar:: pki_certbot_configuration [[[
+#
+# The contents of the Certbot configuration file defined by the user.
+pki_certbot_configuration: []
+
+                                                                   # ]]]
+# .. envvar:: pki_certbot_combined_configuration [[[
+#
+# The variable which combines the Certbot configuration variables and is used
+# in role tasks and templates.
+pki_certbot_combined_configuration: '{{ pki_certbot_default_configuration
+                                        + pki_certbot_configuration }}'
+                                                                   # ]]]
+                                                                   # ]]]
 # Required software packages [[[
 # ------------------------------
 

--- a/ansible/roles/pki/files/etc/letsencrypt/renewal-hooks/post/000-fix-permissions
+++ b/ansible/roles/pki/files/etc/letsencrypt/renewal-hooks/post/000-fix-permissions
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2021 Maciej Delmanowski <drybjed@gmail.com>
+# Copyright (C) 2021 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+# Post-hook script for certbot(1) to fix permission issues in the
+# '/etc/letsencrypt/' directory.
+# Based on: https://sigmaris.info/blog/2019/01/make-certbot-lets-encrypt-certificates-readable-by-debian-ssl-cert-group/
+
+set -o nounset -o pipefail -o errexit
+
+if [ -d "/etc/letsencrypt/live" ] ; then
+    # Secure the private keys and make them readable by the 'ssl-cert' UNIX group
+    chmod 0640          /etc/letsencrypt/archive/*/privkey*.pem
+    chown root:ssl-cert /etc/letsencrypt/archive/*/privkey*.pem
+
+    # Allow read-only access to the certificates by anybody (they're public)
+    find /etc/letsencrypt/live    -type d -print0 | xargs -0 chmod 0755
+    find /etc/letsencrypt/archive -type d -print0 | xargs -0 chmod 0755
+fi

--- a/ansible/roles/pki/tasks/certbot.yml
+++ b/ansible/roles/pki/tasks/certbot.yml
@@ -1,0 +1,29 @@
+---
+# Copyright (C) 2021 Maciej Delmanowski <drybjed@gmail.com>
+# Copyright (C) 2021 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+# The 'certbot' package and its dependencies should be installed at this point.
+
+- name: Make sure that the post-hook directory exists
+  file:
+    path: '/etc/letsencrypt/renewal-hooks/post'
+    state: 'directory'
+    mode: '0755'
+
+- name: Install post-hook scripts
+  copy:
+    src: 'etc/letsencrypt/renewal-hooks/post/'
+    dest: '/etc/letsencrypt/renewal-hooks/post/'
+    mode: '0755'
+
+- name: Divert the original certbot configuration file
+  dpkg_divert:
+    path: '/etc/letsencrypt/cli.ini'
+    state: 'present'
+
+- name: Generate certbot configuration file
+  template:
+    src: 'etc/letsencrypt/cli.ini.j2'
+    dest: '/etc/letsencrypt/cli.ini'
+    mode: '0644'

--- a/ansible/roles/pki/tasks/main.yml
+++ b/ansible/roles/pki/tasks/main.yml
@@ -132,6 +132,12 @@
   when: (pki_enabled|bool and
          (pki_acme|bool or pki_acme_install|bool))
 
+- name: Configure certbot support
+  include: certbot.yml
+  when: (pki_enabled|bool and
+         (pki_acme|bool or pki_acme_install|bool) and
+          pki_acme_type != 'acme-tiny')
+
 # Initialize PKI realms [[[
 
 - name: Ensure that /etc/pki directory exists

--- a/ansible/roles/pki/templates/etc/letsencrypt/cli.ini.j2
+++ b/ansible/roles/pki/templates/etc/letsencrypt/cli.ini.j2
@@ -1,0 +1,19 @@
+{# Copyright (C) 2021 Maciej Delmanowski <drybjed@gmail.com>
+ # Copyright (C) 2021 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-only
+ #}
+# {{ ansible_managed }}
+
+{% for element in pki_certbot_combined_configuration | parse_kv_config %}
+{%   if element.state|d('present') not in [ 'absent', 'ignore' ] %}
+{%     if element.comment|d() %}
+{%       if not loop.first %}
+{{         '' }}
+{%       endif %}
+{{       element.comment | regex_replace('\n$','') | comment(prefix='', postfix='') -}}
+{%     endif %}
+{%     set element_comment = ('#' if element.state|d('present') == 'comment' else '') %}
+{%     set element_name = (element.option | d(element.name)) %}
+{{     '{}{} = {}'.format(element_comment, element_name, element.value) }}
+{%   endif %}
+{% endfor %}

--- a/docs/ansible/roles/pki/defaults-detailed.rst
+++ b/docs/ansible/roles/pki/defaults-detailed.rst
@@ -406,3 +406,121 @@ List of supported parameters:
                                + "permitted;DNS:.example.net,"
                                + "permitted;DNS:example.com,"
                                + "permitted;DNS:.example.com" }}'
+
+.. _pki_ref_certbot_configuration:
+
+pki_certbot_configuration
+-------------------------
+
+The ``pki_certbot_*_configuration`` variables can be used to define the
+contents of the :file:`/etc/letsencrypt/cli.ini` configuration file, which
+contains `global certbot configuration`__.
+
+.. __: https://certbot.eff.org/docs/using.html#configuration-file
+
+Examples
+~~~~~~~~
+
+Recreate the official example configuration file using DebOps:
+
+.. code-block:: yaml
+
+   pki_certbot_configuration:
+
+     - name: 'key-type'
+       comment: 'Use ECC for the private key'
+       value: 'ecdsa'
+
+     - 'elliptic-curve': 'secp384r1'
+
+     - name: 'rsa-key-size'
+       comment: 'Use a 4096 bit RSA key instead of 2048'
+       value: 4096
+
+     - name: 'email'
+       comment: 'Uncomment and update to register with the specified e-mail address'
+       value: 'foo@example.com'
+       state: 'comment'
+
+     - name: 'authenticator-standalone'
+       option: 'authenticator'
+       comment: 'Uncomment to use the standalone authenticator on port 443'
+       value: 'standalone'
+       state: 'comment'
+
+     - name: 'authenticator-webroot'
+       option: 'authenticator'
+       comment: |
+         Uncomment to use the webroot authenticator. Replace webroot-path with the
+         path to the public_html / webroot folder being served by your web server.
+       value: 'webroot'
+       state: 'comment'
+
+     - name: 'webroot-path'
+       value: '/usr/share/nginx/html'
+       state: 'comment'
+
+     - name: 'agree-tos'
+       comment: 'Uncomment to automatically agree to the terms of service of the ACME server'
+       value: True
+       state: 'comment'
+
+     - name: 'server'
+       comment: 'An example of using an alternate ACME server that uses EAB credentials'
+       value: 'https://acme.sectigo.com/v2/InCommonRSAOV'
+       state: 'comment'
+
+     - name: 'eab-kid'
+       value: 'somestringofstuffwithoutquotes'
+       state: 'comment'
+
+     - name: 'eab-hmac-key'
+       value: 'yaddayaddahexhexnotquoted'
+       state: 'comment'
+
+Define manual hook scripts used for certificate renewal and cleanup:
+
+.. code-block:: yaml
+
+   pki_certbot_configuration:
+
+     - 'authenticator': 'manual'
+     - 'manual-auth-hook': '/etc/letsencrypt/scripts/authenticator.php'
+     - 'manual-cleanup-hook': '/etc/letsencrypt/scripts/cleanup.php'
+     - 'manual-public-ip-logging-ok': True
+
+Syntax
+~~~~~~
+
+The contents of the configuration file are defined using the
+:ref:`universal_configuration` system. The variables are list of YAML
+dictionaries. You can use a dictionary key to define a parameter name, and
+a dictionary value as the value.
+
+If you use ``name`` as the key, the configuration options can be defined in
+a more extended format using specific parameters:
+
+``name``
+  Required. Name of the configuration option. Entries with the same ``name``
+  are merged together and can affect each other; this can be used to activate
+  configuration options conditionally.
+
+``option``
+  Optional. If you need to specify the same configuration option multiple
+  times, you need to use unique ``name`` parameters. In that case you can add
+  the ``option`` parameter to define the actual option name which will be used
+  in the configuration file.
+
+``value``
+  The value of a configuration option, added in the configuration file as-is.
+
+``state``
+  Optional. If not specified or ``present``, a given configuration option will
+  be included in the generated configuration file. If ``absent``, a given
+  option will not be included in the configuration file. If ``comment``, the
+  option will be included but commented out. if ``ignore``, a given entry will
+  not be processed by the role during execution.
+
+``comment``
+  Optional. String or YAML text block with a comment about a given
+  configuration option added in the generated file.


### PR DESCRIPTION
By default certbot uses very restrictive file and directory permissions
in its configuration directory. We can fix them using a post-hook
script.