### PR TITLE
Improve handling of openssl backup keys in autopostgresql backup

### DIFF
--- a/ansible/roles/postgresql_server/defaults/main.yml
+++ b/ansible/roles/postgresql_server/defaults/main.yml
@@ -549,7 +549,13 @@ postgresql_server__auto_backup_encryption: False
                                                                    # ]]]
 # .. envvar:: postgresql_server__auto_backup_encryption_key [[[
 #
-# Specify :command:`openssl` encryption key to use.
+# Specify :command:`openssl` encryption key to use, this should be
+# the contents of the key.
+# Encryption uses private/public keys. You can generate the key pairs like the following:
+# ``openssl req -x509 -nodes -days 100000 -newkey rsa:2048 -keyout backup.key -out backup.crt -subj '/'``
+#
+# Decryption of backups is possible with:
+# ``openssl smime -decrypt -in backup.sql.gz.enc -binary -inform DEM -inkey backup.key -out backup.sql.gz``
 postgresql_server__auto_backup_encryption_key: ''
 
                                                                    # ]]]

--- a/ansible/roles/postgresql_server/templates/usr/sbin/autopostgresqlbackup.j2
+++ b/ansible/roles/postgresql_server/templates/usr/sbin/autopostgresqlbackup.j2
@@ -291,11 +291,11 @@ encryption() {
     echo "      to $ENCRYPTED_FILE"
     echo "      using cypher $ENCRYPTION_CIPHER and public key $ENCRYPTION_PUBLIC_KEY"
 
-    $tempcrt=/tmp/autopostgresql.crt
-    echo "$ENCRYPTION_PUBLIC_KEY" > $tmpcrt
+    tempcrt=/tmp/autopostgresql.crt
+    echo "$ENCRYPTION_PUBLIC_KEY" > "$tempcrt"
     openssl smime -encrypt -"$ENCRYPTION_CIPHER" -binary -outform DEM \
-      -out "$ENCRYPTED_FILE" -in "$1" "$tmpcrt"
-    rm $tmpcrt
+      -out "$ENCRYPTED_FILE" -in "$1" "$tempcrt"
+    rm "$tempcrt"
 
     status=$?
     if [[ $status -eq 0 && -f "$ENCRYPTED_FILE" ]] ; then

--- a/ansible/roles/postgresql_server/templates/usr/sbin/autopostgresqlbackup.j2
+++ b/ansible/roles/postgresql_server/templates/usr/sbin/autopostgresqlbackup.j2
@@ -290,11 +290,19 @@ encryption() {
     echo "Encrypting $1"
     echo "      to $ENCRYPTED_FILE"
     echo "      using cypher $ENCRYPTION_CIPHER and public key $ENCRYPTION_PUBLIC_KEY"
-    if openssl smime -encrypt -"$ENCRYPTION_CIPHER" -binary -outform DEM \
-      -out "$ENCRYPTED_FILE" \
-      -in "$1" "$ENCRYPTION_PUBLIC_KEY" ; then
+
+    $tempcrt=/tmp/autopostgresql.crt
+    echo "$ENCRYPTION_PUBLIC_KEY" > $tmpcrt
+    openssl smime -encrypt -"$ENCRYPTION_CIPHER" -binary -outform DEM \
+      -out "$ENCRYPTED_FILE" -in "$1" "$tmpcrt"
+    rm $tmpcrt
+
+    status=$?
+    if [[ $status -eq 0 && -f "$ENCRYPTED_FILE" ]] ; then
       echo "    and remove $1"
       rm -f "$1"
+    else
+      echo "openssl exited with $status"
     fi
   fi
   return 0

--- a/ansible/roles/postgresql_server/templates/usr/sbin/autopostgresqlbackup.j2
+++ b/ansible/roles/postgresql_server/templates/usr/sbin/autopostgresqlbackup.j2
@@ -291,13 +291,13 @@ encryption() {
     echo "      to $ENCRYPTED_FILE"
     echo "      using cypher $ENCRYPTION_CIPHER and public key $ENCRYPTION_PUBLIC_KEY"
 
-    tempcrt=/tmp/autopostgresql.crt
+    tempcrt=$(mktemp)
     echo "$ENCRYPTION_PUBLIC_KEY" > "$tempcrt"
     openssl smime -encrypt -"$ENCRYPTION_CIPHER" -binary -outform DEM \
       -out "$ENCRYPTED_FILE" -in "$1" "$tempcrt"
+    status=$?
     rm "$tempcrt"
 
-    status=$?
     if [[ $status -eq 0 && -f "$ENCRYPTED_FILE" ]] ; then
       echo "    and remove $1"
       rm -f "$1"


### PR DESCRIPTION
I am trying to use the encryption support in autopostgreql backup, but I couldn't figure out how I was supposed to pass they key around, or why it wasn't working. I feel like I am maybe missing a trick here, was the intent that I copy the cert over to the host explicitly? At least like this debops does it all for you.

This also tweaks the backup script so that it only removes the unencrypted file if the encrypted file is present in the expected location rather than just relying on the exit status of openssl.