### PR TITLE
[icinga_web] upgrade businessprocess module

### DIFF
--- a/ansible/roles/icinga_web/defaults/main.yml
+++ b/ansible/roles/icinga_web/defaults/main.yml
@@ -103,7 +103,7 @@ icinga_web__default_modules:
 
   - name: 'businessprocess'
     git_repo: 'https://github.com/Icinga/icingaweb2-module-businessprocess'
-    git_version: 'v2.2.0'
+    git_version: 'v2.3.1'
     state: 'present'
 
   - name: 'graphite'


### PR DESCRIPTION
Business process module has buggy CSS in its 2.2.0 version (see https://github.com/Icinga/icingaweb2-module-businessprocess/blob/73ad4a25ddfb6e0e0914d65109f3a83a6f876d34/public/css/module.less#L386)

It makes the whole UI crash.

The typo was fixed in version 2.3.1.