### PR TITLE
[icinga_web] Update modules and watch files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -174,6 +174,11 @@ Updates of upstream application versions
   the local facts or to set the ``elastic_co__version`` variable to '7.x' before
   running the playbook.
 
+- The Icinga Web 2 modules installed by :ref:`debops.icinga_web` have been
+  updated to their latest versions. A quick database migration is needed after
+  updating to get Director to work again. Just click the database migration
+  button on the 'Icinga Director' -> 'Activities log' page.
+
 General
 '''''''
 

--- a/ansible/roles/icinga_web/defaults/main.yml
+++ b/ansible/roles/icinga_web/defaults/main.yml
@@ -95,7 +95,7 @@ icinga_web__default_modules:
 
   - name: 'toplevelview'
     git_repo: 'https://github.com/Icinga/icingaweb2-module-toplevelview'
-    git_version: 'v0.3.1'
+    git_version: 'v0.3.3'
     state: 'present'
 
   - name: 'monitoring'
@@ -114,7 +114,7 @@ icinga_web__default_modules:
 
   - name: 'director'
     git_repo: 'https://github.com/Icinga/icingaweb2-module-director'
-    git_version: 'v1.7.2'
+    git_version: 'v1.8.1'
     state: '{{ "present" if icinga_web__director_enabled|bool else "ignore" }}'
 
   - name: 'generictts'
@@ -124,7 +124,7 @@ icinga_web__default_modules:
 
   - name: 'grafana'
     git_repo: 'https://github.com/Mikesch-mp/icingaweb2-module-grafana'
-    git_version: 'v1.3.6'
+    git_version: 'v1.4.2'
     state: 'present'
 
   - name: 'map'
@@ -145,7 +145,7 @@ icinga_web__default_modules:
 
   - name: 'cube'
     git_repo: 'https://github.com/Icinga/icingaweb2-module-cube'
-    git_version: 'v1.1.0'
+    git_version: 'v1.1.1'
     state: 'present'
 
   - name: 'netboximport'
@@ -158,17 +158,17 @@ icinga_web__default_modules:
 
   - name: 'ipl'
     git_repo: 'https://github.com/Icinga/icingaweb2-module-ipl'
-    git_version: 'v0.4.0'
+    git_version: 'v0.5.0'
     state: 'present'
 
   - name: 'reactbundle'
     git_repo: 'https://github.com/Icinga/icingaweb2-module-reactbundle'
-    git_version: 'v0.7.0'
+    git_version: 'v0.9.0'
     state: 'present'
 
   - name: 'incubator'
     git_repo: 'https://github.com/Icinga/icingaweb2-module-incubator'
-    git_version: 'v0.5.0'
+    git_version: 'v0.6.0'
     state: 'present'
 
   - name: 'x509'

--- a/ansible/roles/icinga_web/meta/watch-cube
+++ b/ansible/roles/icinga_web/meta/watch-cube
@@ -4,7 +4,7 @@
 
 # Role: icinga_web
 # Package: cube
-# Version: 1.1.0
+# Version: 1.1.1
 
 version=4
 https://github.com/Icinga/icingaweb2-module-cube/tags .*\/v?(\d\S+)\.tar\.gz

--- a/ansible/roles/icinga_web/meta/watch-director
+++ b/ansible/roles/icinga_web/meta/watch-director
@@ -4,7 +4,7 @@
 
 # Role: icinga_web
 # Package: director
-# Version: 1.7.2
+# Version: 1.8.1
 
 version=4
 https://github.com/Icinga/icingaweb2-module-director/tags .*\/v?(\d\S+)\.tar\.gz

--- a/ansible/roles/icinga_web/meta/watch-grafana
+++ b/ansible/roles/icinga_web/meta/watch-grafana
@@ -4,7 +4,7 @@
 
 # Role: icinga_web
 # Package: grafana
-# Version: 1.3.6
+# Version: 1.4.2
 
 version=4
 https://github.com/Mikesch-mp/icingaweb2-module-grafana/tags .*\/v?(\d\S+)\.tar\.gz

--- a/ansible/roles/icinga_web/meta/watch-incubator
+++ b/ansible/roles/icinga_web/meta/watch-incubator
@@ -4,7 +4,7 @@
 
 # Role: icinga_web
 # Package: incubator
-# Version: 0.7.0
+# Version: 0.6.0
 
 version=4
-https://github.com/Icinga/icingaweb2-module-incubator/tags .*\/v?(\d\S+)\.tar\.gz
+https://github.com/Icinga/icingaweb2-module-incubator/tags .*\/v?(\d[0-9.]+)\.tar\.gz

--- a/ansible/roles/icinga_web/meta/watch-reactbundle
+++ b/ansible/roles/icinga_web/meta/watch-reactbundle
@@ -4,7 +4,7 @@
 
 # Role: icinga_web
 # Package: reactbundle
-# Version: 0.7.0
+# Version: 0.9.0
 
 version=4
 https://github.com/Icinga/icingaweb2-module-reactbundle/tags .*\/v?(\d\S+)\.tar\.gz

--- a/ansible/roles/icinga_web/meta/watch-toplevelview
+++ b/ansible/roles/icinga_web/meta/watch-toplevelview
@@ -4,7 +4,7 @@
 
 # Role: icinga_web
 # Package: toplevelview
-# Version: 0.3.1
+# Version: 0.3.3
 
 version=4
 https://github.com/Icinga/icingaweb2-module-toplevelview/tags .*\/v?(\d\S+)\.tar\.gz

--- a/ansible/roles/icinga_web/meta/watch-x509
+++ b/ansible/roles/icinga_web/meta/watch-x509
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 # Role: icinga_web
-# Package: ipl
-# Version: 0.5.0
+# Package: x509
+# Version: 1.0.0
 
 version=4
-https://github.com/Icinga/icingaweb2-module-ipl/tags .*\/v?(\d\S+)\.tar\.gz
+https://github.com/Icinga/icingaweb2-module-x509/tags .*\/v?(\d\S+)\.tar\.gz

--- a/docs/news/upgrades.rst
+++ b/docs/news/upgrades.rst
@@ -80,6 +80,15 @@ Changes in inventory variables
   +-----------------------+-----------------------------+---------------+
 
 
+Icinga Director database migrations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- After :ref:`debops.icinga_web` updates the Icinga Director module, you will
+  have to perform a quick database migration to get Director to work again. Just
+  click the database migration button on the 'Icinga Director' -> 'Activities
+  log' page.
+
+
 v2.3.0 (2021-06-04)
 -------------------
 


### PR DESCRIPTION
- Update all modules to the latest versions that are supported with
  Icinga Web 2.8 (the version in Debian 11).

- Fix the version number (and regex) specified in the watch-incubator
  file; the version number was incorrectly set to 0.7.0, a version that
  currently does not exist.

- Create a watch file for the x509 module.