### PR TITLE
[apt] Do not disable old backports repositories

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -278,6 +278,12 @@ General
 Fixed
 ~~~~~
 
+:ref:`debops.apt` role
+''''''''''''''''''''''
+
+- The role no longer disables the backports repository of a Debian LTS or
+  archive release.
+
 :ref:`debops.apt_cacher_ng` role
 ''''''''''''''''''''''''''''''''
 

--- a/ansible/roles/apt/defaults/main.yml
+++ b/ansible/roles/apt/defaults/main.yml
@@ -334,8 +334,8 @@ apt__distribution_suite: '{{ apt__distribution_suite_map[apt__distribution + "_"
 # If the combination of OS distribution and release is not found, the default
 # list of suffixes will be used automatically.
 apt__distribution_suffix_map:
-  'Debian_archive':  [ '' ]
-  'Debian_lts':      [ '' ]
+  'Debian_archive':  [ '', '-backports' ]
+  'Debian_lts':      [ '', '-backports' ]
   'Debian_stable':   [ '', '-updates', '-backports' ]
   'Debian_testing':  [ '', '-updates' ]
   'Debian_unstable': [ '' ]


### PR DESCRIPTION
Debian LTS and older releases indeed don't need the -updates
repositories anymore, but the -backports repositories can still be
useful. The golang role for example installs Go from backports on
Stretch.