### PR TITLE
[sysctl] Enable forwarding on Docker Server hosts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -428,6 +428,16 @@ debops.reprepro role
   picked up as the version number when :command:`sudo` was configured to use
   LDAP, but the LDAP service was not available.
 
+:ref:`debops.sysctl` role
+'''''''''''''''''''''''''
+
+- The role's default of explicitly disabling packet forwarding conflicted with
+  the sysctl configuration done by Docker Server. The role would disable
+  essential (for Docker) packet forwarding, which would only be enabled again
+  when the Docker daemon was manually restarted or the sysctl parameter was
+  manually corrected. This has been fixed by letting the role default to
+  enabling packet forwarding on Docker Server hosts.
+
 :ref:`debops.system_users` role
 '''''''''''''''''''''''''''''''
 

--- a/ansible/roles/sysctl/defaults/main.yml
+++ b/ansible/roles/sysctl/defaults/main.yml
@@ -90,7 +90,9 @@ sysctl__hardening_enabled: True
 #
 # Should the system forward IP traffic for all interfaces?
 # Refer to ``debops.ifupdown`` which can selectively enable traffic forwarding.
-sysctl__system_ip_forwarding_enabled: False
+sysctl__system_ip_forwarding_enabled: '{{ True
+                                          if ansible_local.docker_server.installed|d(False)
+                                          else False }}'
 
                                                                    # ]]]
 # .. envvar:: sysctl__hardening_ipv6_disabled [[[


### PR DESCRIPTION
Docker Server needs packet forwarding for container networking to work. If this
role runs after the Docker daemon has started, it will reset the packet
forwarding parameters, breaking container networking.

This commit fixes that by enabling packet forwarding on Docker Server hosts.