### PR TITLE
fix #1882, use nginx_flavor 'light' by default

### DIFF
--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -52,7 +52,7 @@ nginx_base_packages: []
 # .. envvar:: nginx_flavor [[[
 #
 # What type of nginx server to install (see :envvar:`nginx_flavor_package_map`)
-nginx_flavor: 'full'
+nginx_flavor: 'light'
 
                                                                    # ]]]
 # .. envvar:: nginx__flavor_distribution_release [[[


### PR DESCRIPTION
This changes the default nginx_flavor from 'full' to 'light'.

Signed-off-by: Sergio E. Nemirowski <sergio@outerface.net>