### PR TITLE
[dnmasq] Remove dvcpv6 tcp protocol from ferm

### DIFF
--- a/ansible/roles/dnsmasq/defaults/main.yml
+++ b/ansible/roles/dnsmasq/defaults/main.yml
@@ -605,7 +605,7 @@ dnsmasq__ferm__dependent_rules:
     saddr: [ 'fe80::/10' ]
     daddr: [ 'ff02::1:2' ]
     # https://tools.ietf.org/html/rfc3315#section-13
-    protocol: [ 'udp', 'tcp' ]
+    protocol: [ 'udp' ]
     sport: [ 'dhcpv6-client' ]
     dport: [ 'dhcpv6-server' ]
     interface: '{{ dnsmasq__combined_interfaces | flatten | parse_kv_items


### PR DESCRIPTION
Will close #1760

- In `dhcpd` only udp post is set
- In `ferm` only udp post is set
- It was removed from /etc/services starting Debian 11 and Ubuntu 20
