### PR TITLE
roundcube: Lock contextmenu-plugin version for roundcube 1.4.x

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -657,6 +657,12 @@ debops.reprepro role
 - Ensure that the fact script correctly includes information about upstream
   nameservers when :command:`systemd-resolved` service is used.
 
+:ref:`debops.roundcube` role
+''''''''''''''''''''''''''''
+
+- Locked johndoh/contextmenu plugin to version 3.2.1 for Roundcube < 1.5 due to
+  compatibility issues.
+
 :ref:`debops.rsyslog` role
 ''''''''''''''''''''''''''
 

--- a/ansible/roles/roundcube/defaults/main.yml
+++ b/ansible/roles/roundcube/defaults/main.yml
@@ -3307,7 +3307,8 @@ roundcube__default_plugins:
     # This plugin adds right-click context menus to various parts of the
     # Roundcube interface.
   - name: 'contextmenu'
-    package: 'johndoh/contextmenu'
+    package: 'johndoh/contextmenu{{ ":3.2.1"
+              if roundcube__git_version is version("1.5", "<") else "" }}'
     state: 'enabled'
 
     # This plugin provides a toolbar button annd folder menu option which


### PR DESCRIPTION
Since the release of Roundcube 1.5 a couple of days ago, the plugin [johndoh/contextmenu](https://github.com/johndoh/roundcube-contextmenu/releases) also released a new version that doesn't seem to be compatible with Roundcube 1.4.x.

This commit should lock the johndoh/contextmenu version to 3.2.1 when Roundcube 1.4.x is installed.
I have only tested this change with Roundcube 1.4.11.

Closes: #2000 