### PR TITLE
Fix name of the scrape_yahoo script when called from cron

### DIFF
--- a/ansible/roles/postwhite/tasks/main.yml
+++ b/ansible/roles/postwhite/tasks/main.yml
@@ -103,7 +103,7 @@
 
 - name: Update Yahoo IP address list weekly
   cron:
-    job: 'bash {{ postwhite__git_dest + "/scrap_yahoo" }} > /dev/null'
+    job: 'bash {{ postwhite__git_dest + "/scrape_yahoo" }} > /dev/null'
     cron_file: 'postwhite'
     name: 'Update Yahoo IP address list'
     special_time: '{{ postwhite__cron_yahoo_update_frequency }}'


### PR DESCRIPTION
See https://github.com/stevejenkins/postwhite -- this logs an error every week on my system