### PR TITLE
[ferm] disable iptables backend symlink on Ubuntu Bionic 18.04

### DIFF
--- a/ansible/roles/ferm/defaults/main.yml
+++ b/ansible/roles/ferm/defaults/main.yml
@@ -46,7 +46,7 @@ ferm__flush: '{{ ferm__enabled | bool }}'
 # Enable or disable configuration of the :command:`iptables` backend symlink
 # using the "alternatives" system, supported on Debian 10 and later.
 ferm__iptables_backend_enabled: '{{ False
-                                    if ansible_distribution_release in [ "wheezy", "jessie", "stretch", "trusty", "xenial" ]
+                                    if ansible_distribution_release in [ "wheezy", "jessie", "stretch", "trusty", "xenial", "bionic" ]
                                     else True }}'
 
                                                                    # ]]]


### PR DESCRIPTION
Ubuntu Bionic 18.04 is compatible with nftables but **iptables** package does not include `/usr/sbin/iptables-nft` nor `/usr/sbin/iptables-legacy` so it makes sense to just disable it.