### PR TITLE
fix #1888, use iptables-legacy by default

### DIFF
--- a/ansible/roles/ferm/defaults/main.yml
+++ b/ansible/roles/ferm/defaults/main.yml
@@ -60,7 +60,11 @@ ferm__iptables_backend_enabled: '{{ False
 #
 # Newer OS releases might need to use the legacy variant to be compatible with
 # :command:`ferm` manager.
-ferm__iptables_backend_path: '/usr/sbin/iptables-nft'
+# :command:`ferm` doesn't work well with nft
+# and starting with bullseye, it uses legacy tools directly,
+# regardless of the alternatives setting:
+# https://github.com/MaxKellermann/ferm/issues/47
+ferm__iptables_backend_path: '/usr/sbin/iptables-legacy'
 
                                                                    # ]]]
 # .. envvar:: ferm__base_packages [[[


### PR DESCRIPTION
Ferm 2.5.1-1 (bullseye) uses legacy tools
regardless of the alternatives setting:
https://github.com/MaxKellermann/ferm/issues/47
Thus, if ferm is used, iptables should point to iptables-legacy
to avoid getting confused by displaying "empty" rules.

Closes: #1888

Signed-off-by: Sergio E. Nemirowski <sergio@outerface.net>