### PR TITLE
[sshd] Increase LoginGraceTime to 60s

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -474,6 +474,13 @@ debops.reprepro role
 - The rsyslog role always configured the streamDriverPermittedPeers option,
   even when the ``anon`` network driver authentication mode was selected.
 
+:ref:`debops.sshd` role
+'''''''''''''''''''''''
+
+- The default :envvar:`sshd__login_grace_time` has been increased from 30 to 60
+  seconds. This mitigates a lock-out issue when :envvar:`sshd__use_dns` is
+  enabled (the default) and your DNS resolvers are unreachable.
+
 :ref:`debops.sudo` role
 '''''''''''''''''''''''
 

--- a/ansible/roles/sshd/defaults/main.yml
+++ b/ansible/roles/sshd/defaults/main.yml
@@ -296,8 +296,10 @@ sshd__max_startups: '3:80:7'
                                                                    # ]]]
 # .. envvar:: sshd__login_grace_time [[[
 #
-# Time after which unauthenticated sessions are disconnected.
-sshd__login_grace_time: '30s'
+# Time after which unauthenticated sessions are disconnected. Note: setting this
+# much lower is not recommended when ``sshd__use_dns`` is enabled.
+# Ref: https://github.com/debops/debops/issues/1904
+sshd__login_grace_time: '60s'
 
                                                                    # ]]]
 # .. envvar:: sshd__client_alive_count_max [[[


### PR DESCRIPTION
Mitigates a lock-out issue when DNS resolvers are unreachable.
Closes: #1904