### PR TITLE
[icinga] no longer generate icinga_web password

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -398,6 +398,16 @@ Fixed
   needed when the host-identifier contains periods (e.g. fully qualified
   domain names).
 
+:ref:`debops.icinga` role
+'''''''''''''''''''''''''
+
+- The role no longer generates the Icinga Director API password right before
+  trying to log in with it. That is now left to the :ref:`debops.icinga_web`
+  role, which is actually in charge of the API authentication setup. If the
+  password does not yet exist (presumably because the Icinga Director has not
+  been installed yet), the task will report a sensible error message and
+  playbook execution will continue.
+
 :ref:`debops.ipxe` role
 '''''''''''''''''''''''
 

--- a/ansible/roles/icinga/defaults/main.yml
+++ b/ansible/roles/icinga/defaults/main.yml
@@ -289,14 +289,22 @@ icinga__director_register_api_url: 'https://{{ icinga__director_register_api_fqd
 icinga__director_register_api_user: 'director-api'
 
                                                                    # ]]]
+# .. envvar:: icinga__director_register_api_password_file [[[
+#
+# Path to the file on the Ansible Controller that contains the Icinga Director
+# API password.
+icinga__director_register_api_password_file: '{{
+  secret + "/icinga_web/api/" + icinga__director_register_api_fqdn
+  + "/credentials/" + icinga__director_register_api_user + "/password" }}'
+
+                                                                   # ]]]
 # .. envvar:: icinga__director_register_api_password [[[
 #
 # The password of the Icinga 2 Director REST API user used to register the host
 # in Icinga. This variable corresponds to the
 # :envvar:`icinga_web__director_api_password` variable.
-icinga__director_register_api_password: '{{ lookup("password", secret + "/icinga_web/api/"
-                                            + icinga__director_register_api_fqdn + "/credentials/"
-                                            + icinga__director_register_api_user + "/password") }}'
+icinga__director_register_api_password: '{{
+  lookup("file", icinga__director_register_api_password_file) }}'
 
                                                                    # ]]]
 # .. envvar:: icinga__director_register_default_templates [[[

--- a/ansible/roles/icinga/tasks/main.yml
+++ b/ansible/roles/icinga/tasks/main.yml
@@ -197,6 +197,14 @@
   become: False
   delegate_to: 'localhost'
 
+- name: Check if Icinga Director API password file exists on Ansible Controller
+  stat:
+    path: '{{ icinga__director_register_api_password_file }}'
+  delegate_to: 'localhost'
+  become: False
+  register: icinga__register_director_password_file
+  tags: [ 'role::icinga:register' ]
+
 - name: Register Icinga node in Icinga Director
   uri:
     body_format: 'json'
@@ -216,3 +224,6 @@
   changed_when: icinga__register_director_host.status == 201
   tags: [ 'role::icinga:register' ]
   no_log: True
+  ignore_errors: '{{ True
+                     if not icinga__register_director_password_file.stat.exists
+                     else False }}'


### PR DESCRIPTION
The 'file' lookup won't generate a password, but simply fail when it
can't find the Director API password.

Closes #1909