### PR TITLE
[ci] DebOps is now an Ansible Collection

### DIFF
--- a/lib/tests/ansible.cfg
+++ b/lib/tests/ansible.cfg
@@ -5,7 +5,7 @@
 [defaults]
 force_color = 1
 retry_files_enabled = false
-roles_path = /vagrant/ansible/roles
+collections_paths = /vagrant/ansible/collections
 control_path = /tmp/ansible-ssh-%%p-%%r
 allow_world_readable_tmpfiles = true
 pipelining = False


### PR DESCRIPTION
The 'ansible.cfg' configuration file needs to point to the DebOps
Collection in order to test it properly in the CI pipeline.