### PR TITLE
[imapproxy] Add new role

### DIFF
--- a/ansible/playbooks/app/all.yml
+++ b/ansible/playbooks/app/all.yml
@@ -42,3 +42,5 @@
 - import_playbook: debops_api.yml
 
 - import_playbook: roundcube.yml
+
+- import_playbook: imapproxy.yml

--- a/ansible/playbooks/app/imapproxy.yml
+++ b/ansible/playbooks/app/imapproxy.yml
@@ -1,0 +1,1 @@
+../service/imapproxy.yml

--- a/ansible/playbooks/service/imapproxy.yml
+++ b/ansible/playbooks/service/imapproxy.yml
@@ -1,0 +1,29 @@
+---
+# Copyright (C) 2021 David Härdeman <david@hardeman.nu>
+# Copyright (C) 2021 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+- name: Install and manage imapproxy
+  collections: [ 'debops.debops', 'debops.roles01',
+                 'debops.roles02', 'debops.roles03' ]
+  hosts: [ 'debops_service_imapproxy' ]
+  become: True
+
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
+
+  roles:
+
+    - role: etc_services
+      tags: [ 'role::etc_services', 'skip::etc_services' ]
+      etc_services__dependent_list:
+        - '{{ imapproxy__etc_services__dependent_list }}'
+
+    - role: ferm
+      tags: [ 'role::ferm', 'skip::ferm' ]
+      ferm__dependent_rules:
+        - '{{ imapproxy__ferm__dependent_rules }}'
+
+    - role: imapproxy
+      tags: [ 'role::imapproxy', 'skip::imapproxy' ]

--- a/ansible/roles/global_handlers/handlers/imapproxy.yml
+++ b/ansible/roles/global_handlers/handlers/imapproxy.yml
@@ -1,0 +1,9 @@
+---
+# Copyright (C) 2021 David Härdeman <david@hardeman.nu>
+# Copyright (C) 2021 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+- name: Restart imapproxy
+  service:
+    name: 'imapproxy'
+    state: 'restarted'

--- a/ansible/roles/global_handlers/handlers/main.yml
+++ b/ansible/roles/global_handlers/handlers/main.yml
@@ -47,6 +47,8 @@
 
 - import_tasks: 'icinga.yml'
 
+- import_tasks: 'imapproxy.yml'
+
 - import_tasks: 'influxdb_server.yml'
 
 - import_tasks: 'iscsi.yml'

--- a/ansible/roles/imapproxy/COPYRIGHT
+++ b/ansible/roles/imapproxy/COPYRIGHT
@@ -1,0 +1,19 @@
+debops.imapproxy - Manage imapproxy with Ansible
+
+Copyright (C) 2021 David Härdeman <david@hardeman.nu>
+Copyright (C) 2021 DebOps <https://debops.org/>
+Based on the roundcube role which is:
+Copyright (C) 2016-2018 Reto Gantenbein <reto.gantenbein@linuxmonk.ch>
+SPDX-License-Identifier: GPL-3.0-only
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 3, as
+published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see https://www.gnu.org/licenses/

--- a/ansible/roles/imapproxy/defaults/main.yml
+++ b/ansible/roles/imapproxy/defaults/main.yml
@@ -1,0 +1,547 @@
+---
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+
+# .. Copyright (C) 2021 David Härdeman <david@hardeman.nu>
+# .. Copyright (C) 2021 DebOps <https://debops.org/>
+# .. SPDX-License-Identifier: GPL-3.0-only
+
+# .. _imapproxy__ref_defaults:
+
+# debops.imapproxy default variables [[[
+# ======================================
+
+# .. contents:: Sections
+#    :local:
+#
+# .. include:: ../../../../includes/global.rst
+
+
+# Packages and installation [[[
+# -----------------------------
+
+# .. envvar:: imapproxy__packages [[[
+#
+# List of additional APT packages that should be installed with imapproxy.
+imapproxy__packages: []
+
+                                                                   # ]]]
+# .. envvar:: imapproxy__base_packages__base_packages [[[
+#
+# APT packages required for the imapproxy installation.
+imapproxy__base_packages: [ 'imapproxy' ]
+                                                                   # ]]]
+                                                                   # ]]]
+# Network configuration [[[
+# -------------------------
+
+# .. envvar:: imapproxy__domain [[[
+#
+# The DNS domain of the imapproxy installation. Only used for DNS lookups
+# to set default values for connection variables.
+imapproxy__domain: '{{ ansible_domain }}'
+
+                                                                   # ]]]
+# .. envvar:: imapproxy__imap_srv_rr [[[
+#
+# List which contains the result of the DNS query for IMAP server ``SRV``
+# resource records in the host's domain. See :rfc:`6186` for details.
+imapproxy__imap_srv_rr: '{{ q("dig_srv", "_imap._tcp." + imapproxy__domain,
+                              "imap." + imapproxy__domain, 143) }}'
+
+                                                                   # ]]]
+# .. envvar:: imapproxy__imaps_srv_rr [[[
+#
+# List which contains the result of the DNS query for IMAPS server ``SRV``
+# resource records in the host's domain. See :rfc:`6186` for details.
+imapproxy__imaps_srv_rr: '{{ q("dig_srv", "_imaps._tcp." + imapproxy__domain,
+                               "imap." + imapproxy__domain, 993) }}'
+
+                                                                   # ]]]
+# .. envvar:: imapproxy__imap_fqdn [[[
+#
+# The FQDN address of the IMAP server which stores user mailboxes. The role
+# first checks if a local Dovecot installation is present and, if so, uses the
+# host FQDN. Next, the role uses DNS SRV resource records to try to find an
+# IMAP server. Finally, ``imap.<domain>`` is used as a fallback.
+#
+# The use of the FQDN instead of ``localhost`` is required for X.509
+# certificate verification.
+imapproxy__imap_fqdn: '{{ ansible_fqdn
+                          if (ansible_local|d() and ansible_local.dovecot|d() and
+                             (ansible_local.dovecot.installed|d())|bool)
+                          else imapproxy__imap_srv_rr[0]["target"]
+                              if imapproxy__imap_srv_rr[0]["dig_srv_src"]|d("") != "fallback"
+                              else imapproxy__imaps_srv_rr[0]["target"] }}'
+
+                                                                   # ]]]
+# .. envvar:: imapproxy__imap_port [[[
+#
+# TCP port used for connecting to the IMAP server.
+imapproxy__imap_port: '{{ "143"
+                          if (imapproxy__imap_fqdn == ansible_fqdn)
+                          else imapproxy__imap_srv_rr[0]["port"]
+                              if imapproxy__imap_srv_rr[0]["dig_srv_src"]|d("") != "fallback"
+                              else imapproxy__imaps_srv_rr[0]["port"] }}'
+
+                                                                   # ]]]
+# .. envvar:: imapproxy__listen_address [[[
+#
+# The address on which imapproxy should listen for incoming connections,
+# defaults to ``localhost`` for use with local webmail installations.
+# If this is changed, please review the firewall variables to avoid
+# security issues.
+imapproxy__listen_address: '127.0.0.1'
+
+                                                                   # ]]]
+# .. envvar:: imapproxy__listen_port [[[
+#
+# The port on which imapproxy should listen for incoming connections,
+# defaults to ``1143`` for use with local webmail installations.
+imapproxy__listen_port: '1143'
+
+                                                                   # ]]]
+# .. envvar:: imapproxy__allow [[[
+#
+# List of IP addresses or CIDR subnets which are allowed to connect to
+# imapproxy over the network, on all hosts in the Ansible
+# inventory. This variable configures the firewall for all instances at the
+# same time, for individual instance configuration you should modify the
+# :envvar:`imapproxy__ferm__dependent_rules` variable directly.
+imapproxy__allow: []
+
+                                                                   # ]]]
+# .. envvar:: imapproxy__group_allow [[[
+#
+# List of IP addresses or CIDR subnets which are allowed to connect to
+# imapproxy over the network, on hosts in the specific Ansible
+# inventory group. This variable configures the firewall for all instances at
+# the same time, for individual instance configuration you should modify the
+# :envvar:`imapproxy__ferm__dependent_rules` variable directly.
+imapproxy__group_allow: []
+
+                                                                   # ]]]
+# .. envvar:: imapproxy__host_allow [[[
+#
+# List of IP addresses or CIDR subnets which are allowed to connect to
+# imapproxy over the network, on specific hosts in the Ansible
+# inventory. This variable configures the firewall for all instances at the
+# same time, for individual instance configuration you should modify the
+# :envvar:`imapproxy__ferm__dependent_rules` variable directly.
+imapproxy__host_allow: []
+                                                                   # ]]]
+                                                                   # ]]]
+# PKI / TLS configuration [[[
+# ---------------------------
+
+# These variables configure the ``TLS`` support in :command:`imapproxy`.
+# Note that this should only be necessary if :command:`imapproxy` is not
+# installed on the same host as the ``IMAP`` server (e.g. the one managed
+# by the :ref:`debops.dovecot` role). Also not that ``SSL`` is **NOT**
+# supported out of the box by :command:`imapproxy`, see
+# :file:`/usr/share/doc/imapproxy/README.ssl` for more details.
+
+# .. envvar:: imapproxy__pki [[[
+#
+# Enable or disable support for TLS in imapproxy, managed by the
+# :ref:`debops.pki` Ansible role.
+imapproxy__pki: '{{ ansible_local.pki.enabled|d() | bool }}'
+
+                                                                   # ]]]
+# .. envvar:: imapproxy__pki_path [[[
+#
+# Absolute path to the directory where PKI realms are located.
+imapproxy__pki_path: '{{ ansible_local.pki.path|d("/etc/pki/realms") }}'
+
+                                                                   # ]]]
+# .. envvar:: imapproxy__pki_realm [[[
+#
+# Name of the default PKI realm used by imapproxy.
+imapproxy__pki_realm: '{{ ansible_local.pki.realm|d("domain") }}'
+
+                                                                   # ]]]
+# .. envvar:: imapproxy__pki_ca [[[
+#
+# Name of the Root Certificate Authority certificate file used by imapproxy,
+# relative to the PKI realm directory.
+imapproxy__pki_ca: '{{ ansible_local.pki.ca|d("CA.crt") }}'
+
+                                                                   # ]]]
+# .. envvar:: imapproxy__pki_crt [[[
+#
+# Name of the certificate file used by imapproxy, relative to the PKI realm
+# directory.
+imapproxy__pki_crt: '{{ ansible_local.pki.crt|d("default.crt") }}'
+
+                                                                   # ]]]
+# .. envvar:: imapproxy__pki_key [[[
+#
+# Name of the private key file used by imapproxy, relative to the PKI realm
+# directory.
+imapproxy__pki_key: '{{ ansible_local.pki.key|d("default.key") }}'
+
+                                                                   # ]]]
+# .. envvar:: imapproxy__tls_ca_path [[[
+#
+# Absolute path of the directory holding the Root Certificate Authority
+# certificate file used in the imapproxy configuration.
+imapproxy__tls_ca_path: '/etc/ssl/certs'
+
+                                                                   # ]]]
+# .. envvar:: imapproxy__tls_ca_file [[[
+#
+# Absolute path of the Root Certificate Authority certificate file used in the
+# imapproxy configuration.
+imapproxy__tls_ca_file: '{{ imapproxy__tls_ca_path + "/ca-certificates.crt" }}'
+
+                                                                   # ]]]
+# .. envvar:: imapproxy__tls_cert_file [[[
+#
+# Absolute path of the certificate file used in the imapproxy configuration.
+imapproxy__tls_cert_file: '{{ (imapproxy__pki_path + "/" + imapproxy__pki_realm + "/" + imapproxy__pki_crt)
+                            if imapproxy__pki|bool else "/etc/ssl/certs/ssl-cert-snakeoil.pem" }}'
+
+                                                                   # ]]]
+# .. envvar:: imapproxy__tls_key_file [[[
+#
+# Absolute path of the private key file used in the imapproxy configuration.
+imapproxy__tls_key_file: '{{ (imapproxy__pki_path + "/" + imapproxy__pki_realm + "/" + imapproxy__pki_key)
+                           if imapproxy__pki|bool else "/etc/ssl/private/ssl-cert-snakeoil.key" }}'
+                                                                   # ]]]
+# .. envvar:: imapproxy__tls_force [[[
+#
+# Imapproxy can autodetect whether to use ``STARTTLS`` by checking if the
+# remote server advertises the ``LOGIN`` capability. A correctly configured
+# IMAP server should not advertise this capability over remote connections.
+imapproxy__tls_force: '{{ "no" if (imapproxy__imap_fqdn == ansible_fqdn or
+                                   not imapproxy_pki|d(True))
+                          else "yes" }}'
+
+                                                                   # ]]]
+# .. envvar:: imapproxy__pki_hook_name [[[
+#
+# Name of the hook script which will be stored in hook directory.
+imapproxy__pki_hook_name: 'imapproxy'
+
+                                                                   # ]]]
+# .. envvar:: imapproxy__pki_hook_path [[[
+#
+# Directory with PKI hooks.
+imapproxy__pki_hook_path: '{{ ansible_local.pki.hooks|d("/etc/pki/hooks") }}'
+
+                                                                   # ]]]
+# .. envvar:: imapproxy__pki_hook_action [[[
+#
+# Specify how changes in PKI should affect imapproxy, only 'restart' is
+# supported.
+imapproxy__pki_hook_action: 'restart'
+                                                                   # ]]]
+                                                                   # ]]]
+# Imapproxy custom configuration [[[
+# ----------------------------------
+
+# These variables define the contents of the :file:`/etc/imapproxy.conf`
+# configuration file.
+
+# .. envvar:: imapproxy__default_configuration [[[
+#
+# The default :command:`imapproxy` configuration options defined by the role.
+imapproxy__default_configuration:
+
+  - name: 'server_hostname'
+    comment: |
+      This setting controls which IMAP server we proxy our connections to.
+    value: '{{ imapproxy__imap_fqdn }}'
+
+  - name: 'server_port'
+    comment: |
+      This setting specifies the port that server_hostname is listening on.
+      This is the TCP port that we proxy inbound connections to.
+
+      The original config file contains this note:
+      If you are using SSL with IMAP Proxy, note that unless the server is
+      highly non-standard, this should still be set to the server's normal,
+      unencrypted IMAP port and should NOT be set to port 993, since IMAP
+      Proxy uses STARTTLS to encrypt a "normal" IMAP connection.
+
+      But note that there is nothing "non-standard" about only supporting
+      IMAPS over 993 (see RFC8314).
+
+      If the server is only available via (encrypted) port 993, please
+      consult the README.ssl file for help.
+    value: '{{ imapproxy__imap_port }}'
+
+  - name: 'listen_address'
+    comment: |
+      This setting specifies which address the proxy server will bind to and
+      accept incoming connections to.  If undefined, bind to all.
+      Must be a dotted decimal IP address.
+    value: '{{ imapproxy__listen_address }}'
+
+  - name: 'listen_port'
+    comment: |
+      This setting specifies which port the proxy server will bind to and
+      accept incoming connections from.
+    value: '{{ imapproxy__listen_port }}'
+
+  - name: 'connect_retries'
+    comment: |
+      This setting controls how many times we retry connecting to our server.
+    value: '10'
+
+  - name: 'connect_delay'
+    comment: |
+      This setting controls the delay between retries in seconds.
+    value: '5'
+
+  - name: 'cache_size'
+    comment: |
+      This setting determines how many in-core IMAP connection structures
+      will be allocated.  As such, it determines not only how many cached
+      connections will be allowed, but really the total number of simultaneous
+      connections, cached and active.
+    value: '3072'
+
+  - name: 'cache_expiration_time'
+    comment: |
+      This setting controls how many seconds an inactive connection will be
+      cached.
+    value: '300'
+
+  - name: 'proc_username'
+    comment: |
+      This setting controls which username the IMAP proxy process will run as.
+      It is not allowed to run as "root".
+    value: 'nobody'
+
+  - name: 'proc_groupname'
+    comment: |
+      This setting controls which groupname the IMAP proxy process will run as.
+    value: 'nogroup'
+
+  - name: 'stat_filename'
+    comment: |
+      This is the path to the filename that the proxy server mmap()s to
+      write statistical data to.  This is the file that pimpstat needs to
+      look at to be able to provide its useful stats.
+    value: '/var/run/pimpstats'
+
+  - name: 'protocol_log_filename'
+    comment: |
+      protocol logging may only be turned on for one user at a time.  All
+      protocol logging data is written to the file specified by this path.
+    value: '/dev/null'
+
+  - name: 'syslog_facility'
+    comment: |
+      The logging facility to be used for all syslog calls.  If nothing is
+      specified here, it will default to LOG_MAIL.  Any of the possible
+      facilities listed in the syslog(3) manpage may be used here except
+      LOG_KERN.
+    value: 'LOG_MAIL'
+
+  - name: 'syslog_prioritymask'
+    comment: |
+      This configuration option is provided as a way to limit the verbosity
+      of imapproxy.  If no value is specified, it will default to no priority
+      mask and you'll see all possible log messages.  Any of the possible
+      priority values listed in the syslog(3) manpage may be used here.  By
+      default, you will see all possible log messages.
+    value: 'LOG_WARNING'
+
+  - name: 'send_tcp_keepalives'
+    comment: |
+      This determines whether the SO_KEEPALIVE option will be set on all
+      sockets.
+    value: 'no'
+
+  - name: 'enable_select_cache'
+    comment: |
+      This configuration option allows you to turn select caching on or off.
+      When select caching is enabled, imapproxy will cache SELECT responses
+      from an IMAP server.
+    value: 'no'
+
+  - name: 'foreground_mode'
+    comment: |
+      This will prevent imapproxy from detaching from its parent process and
+      controlling terminal on startup.
+    value: 'no'
+
+  - name: 'force_tls'
+    comment: |
+      Force imapproxy to use STARTTLS even if LOGIN is not disabled (unsecured
+      connections will not be used).
+    value: '{{ imapproxy__tls_force }}'
+
+  - name: 'chroot_directory'
+    comment: |
+      This allows imapproxy to run in a chroot jail if desired.
+      If commented out, imapproxy will not run chroot()ed.  If a directory is
+      specified here, imapproxy will chroot() to that directory.
+    value: '/var/lib/imapproxy/chroot'
+
+  - name: 'preauth_command'
+    comment: |
+      Arbitrary command that can be sent to the server before
+      authenticating users.  This can be useful to access non-
+      standard IMAP servers such as Yahoo!, which requires
+      (required?) the following command to be sent before
+      authentication is allowed:
+         ID ("GUID" "1")
+      (See: http://en.wikipedia.org/wiki/Yahoo!_Mail&oldid=447046431#Free_IMAP_and_SMTPs_access )
+      To use such a command, this setting should look like this:
+         preauth_command ID ("GUID" "1")
+      No matter what this command is, it is expected to return an
+      OK response
+    value: ''
+    state: 'comment'
+
+  - name: 'enable_admin_commands'
+    comment: |
+      Used to enable or disable the internal imapproxy administrative commands.
+    value: 'no'
+
+  - name: 'tls_ca_path'
+    comment: |
+      TLS configuration options
+    value: '{{ imapproxy__tls_ca_path }}'
+    state: '{{ "present" if imapproxy__pki|d(True) else "comment" }}'
+
+  - name: 'tls_ca_file'
+    value: '{{ imapproxy__tls_ca_file }}'
+    state: '{{ "present" if imapproxy__pki|d(True) else "comment" }}'
+
+  - name: 'tls_cert_file'
+    value: '{{ imapproxy__tls_cert_file }}'
+    state: '{{ "present" if imapproxy__pki|d(True) else "comment" }}'
+
+  - name: 'tls_key_file'
+    value: '{{ imapproxy__tls_key_file }}'
+    state: '{{ "present" if imapproxy__pki|d(True) else "comment" }}'
+
+  - name: 'tls_verify_server'
+    value: 'yes'
+    state: '{{ "present" if imapproxy__pki|d(True) else "comment" }}'
+
+  - name: 'tls_ciphers'
+    value: 'ALL:!aNULL:!eNULL'
+    state: '{{ "present" if imapproxy__pki|d(True) else "comment" }}'
+
+  - name: 'tls_no_tlsv1'
+    comment: |
+      Set any of these to "yes" if the corresponding TLS version is not
+      sufficiently secure for your needs.
+    value: 'yes'
+    state: '{{ "present" if imapproxy__pki|d(True) else "comment" }}'
+
+  - name: 'tls_no_tlsv1.1'
+    value: 'yes'
+    state: '{{ "present" if imapproxy__pki|d(True) else "comment" }}'
+
+  - name: 'tls_no_tlsv1.2'
+    value: 'no'
+    state: '{{ "present" if imapproxy__pki|d(True) else "comment" }}'
+
+  - name: 'auth_sasl_plain_username'
+    comment: |
+      Authenticate using SASL AUTHENTICATE PLAIN
+
+      The following authentication username and password are used
+      along with the username from the client as the authorization
+      identity.  In order to avoid having the service wide open (no
+      password needed from the client), the client is required to
+      send the auth_shared_secret in leiu of a user password.
+
+      NOTE: This functionality *assumes* that the server supports
+            AUTHENTICATE PLAIN, and it does *not* verify this by
+            looking at the server's capabilities list.
+    value: ''
+    state: 'comment'
+
+  - name: 'auth_sasl_plain_password'
+    value: ''
+    state: 'comment'
+
+  - name: 'auth_shared_secret'
+    value: ''
+    state: 'comment'
+
+  - name: 'dns_rr'
+    comment: |
+      Use DNS round robin to cycle through all returned RRs we
+      got when looking up the IMAP server with getaddrinfo().
+      Default is no.
+    value: 'yes'
+    state: 'comment'
+
+  - name: 'ipversion_only'
+    comment: |
+      Limit DNS requests to AF_INET or AF_INET6
+
+      Set ipversion_only to 4 or 6 accordingly.
+      Default if unset is AF_UNSPEC for both A and AAAA.
+    value: '6'
+    state: 'comment'
+
+                                                                   # ]]]
+# .. envvar:: imapproxy__configuration [[[
+#
+# The :command:`imapproxy` configuration options defined for all hosts in the
+# Ansible inventory.
+imapproxy__configuration: []
+
+                                                                   # ]]]
+# .. envvar:: imapproxy__group_configuration [[[
+#
+# The :command:`imapproxy` configuration options defined for hosts in a
+# specific Ansible inventory group.
+imapproxy__group_configuration: []
+
+                                                                   # ]]]
+# .. envvar:: imapproxy__host_configuration [[[
+#
+# The :command:`imapproxy` configuration options defined for a specific host
+# in the Ansible inventory.
+imapproxy__host_configuration: []
+
+                                                                   # ]]]
+# .. envvar:: imapproxy__combined_configuration [[[
+#
+# The variable that combines other :command:`imapproxy` configuration options
+# and is used in the dovecot.conf template.
+imapproxy__combined_configuration: '{{ imapproxy__default_configuration
+                                        + imapproxy__configuration
+                                        + imapproxy__group_configuration
+                                        + imapproxy__host_configuration }}'
+
+                                                                   # ]]]
+                                                                   # ]]]
+# Configuration for other Ansible roles [[[
+# -----------------------------------------
+
+# .. envvar:: imapproxy__etc_services__dependent_list [[[
+#
+# Configuration for the :ref:`debops.etc_services` Ansible role.
+imapproxy__etc_services__dependent_list:
+
+  - name: 'imapproxy'
+    port: '{{ imapproxy__listen_port }}'
+    comment: 'IMAP Proxy Server'
+    protocol: [ 'tcp' ]
+
+                                                                   # ]]]
+# .. envvar:: imapproxy__ferm__dependent_rules [[[
+#
+# Configuration for the :ref:`debops.ferm` Ansible role.
+imapproxy__ferm__dependent_rules:
+
+  - name: 'imapproxy'
+    type: 'accept'
+    dport: [ 'imapproxy' ]
+    saddr: '{{ imapproxy__allow + imapproxy__group_allow + imapproxy__host_allow }}'
+    weight: '40'
+    accept_any: False
+    by_role: 'debops.imapproxy'
+                                                                   # ]]]
+                                                                   # ]]]
+                                                                   # ]]]

--- a/ansible/roles/imapproxy/meta/main.yml
+++ b/ansible/roles/imapproxy/meta/main.yml
@@ -1,0 +1,40 @@
+---
+# Copyright (C) 2021 David Härdeman <david@hardeman.nu>
+# Copyright (C) 2021 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+# Ensure that custom Ansible plugins and modules included in the main DebOps
+# collection are available to roles in other collections.
+collections: [ 'debops.debops' ]
+
+dependencies: []
+
+galaxy_info:
+
+  company: 'DebOps'
+  author: 'David Härdeman'
+  description: 'Manage imapproxy, used to speed up e.g. webmail clients'
+  license: 'GPL-3.0-only'
+  min_ansible_version: '2.9.0'
+
+  platforms:
+
+    - name: Ubuntu
+      versions:
+        - trusty
+        - xenial
+        - zesty
+
+    - name: Debian
+      versions:
+        - jessie
+        - stretch
+        - buster
+        - bullseye
+
+  galaxy_tags:
+    - debops
+    - email
+    - mail
+    - imap
+    - web

--- a/ansible/roles/imapproxy/tasks/main.yml
+++ b/ansible/roles/imapproxy/tasks/main.yml
@@ -1,0 +1,80 @@
+---
+# Copyright (C) 2021 David Härdeman <david@hardeman.nu>
+# Copyright (C) 2021 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+- name: Import custom Ansible plugins
+  import_role:
+    name: 'ansible_plugins'
+
+- name: Import DebOps global handlers
+  import_role:
+    name: 'global_handlers'
+
+- name: Install imapproxy packages
+  package:
+    name: '{{ q("flattened", (imapproxy__base_packages
+                              + imapproxy__packages)) }}'
+    state: 'present'
+  register: imapproxy__register_packages
+  until: imapproxy__register_packages is succeeded
+  tags: [ 'role::imapproxy:pkg' ]
+
+- name: Make sure that Ansible local facts directory exists
+  file:
+    path: '/etc/ansible/facts.d'
+    state: 'directory'
+    mode: '0755'
+
+- name: Save imapproxy local facts
+  template:
+    src: 'etc/ansible/facts.d/imapproxy.fact.j2'
+    dest: '/etc/ansible/facts.d/imapproxy.fact'
+    mode: '0755'
+  notify: [ 'Refresh host facts' ]
+
+- name: Update Ansible facts if they were modified
+  meta: 'flush_handlers'
+
+- name: Divert original imapproxy configuration file
+  command: dpkg-divert --quiet --local
+           --divert /etc/imapproxy.conf.dpkg-divert
+           --rename /etc/imapproxy.conf
+  args:
+    creates: /etc/imapproxy.conf.dpkg-divert
+  notify: [ 'Restart imapproxy' ]
+  tags: [ 'role::imapproxy:config' ]
+
+- name: Generate imapproxy configuration
+  template:
+    src: 'etc/imapproxy.conf.j2'
+    dest: '/etc/imapproxy.conf'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  notify: [ 'Restart imapproxy' ]
+  tags: [ 'role::imapproxy:config' ]
+
+- name: Make sure that PKI hook directory exists
+  file:
+    path: '{{ imapproxy__pki_hook_path }}'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+  when: imapproxy__pki|bool
+
+- name: Manage PKI imapproxy hook
+  template:
+    src: 'etc/pki/hooks/imapproxy.j2'
+    dest: '{{ imapproxy__pki_hook_path + "/" + imapproxy__pki_hook_name }}'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+  when: imapproxy__pki|bool
+
+- name: Ensure the PKI imapproxy hook is absent
+  file:
+    path: '{{ imapproxy__pki_hook_path + "/" imapproxy__pki_hook_name }}'
+    state: 'absent'
+  when: not (imapproxy__pki|bool)

--- a/ansible/roles/imapproxy/templates/etc/ansible/facts.d/imapproxy.fact.j2
+++ b/ansible/roles/imapproxy/templates/etc/ansible/facts.d/imapproxy.fact.j2
@@ -1,0 +1,67 @@
+#!{{ ansible_python['executable'] }}
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2021 David Härdeman <david@hardeman.nu>
+# Copyright (C) 2021 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+# {{ ansible_managed }}
+
+from __future__ import print_function
+from json import loads, dumps
+from sys import exit
+import subprocess
+import signal
+import os
+
+
+def cmd_exists(cmd):
+    return any(
+        os.access(os.path.join(path, cmd), os.X_OK)
+        for path in os.environ["PATH"].split(os.pathsep)
+    )
+
+
+def get_value(input_line, key, output):
+    if input_line.startswith(key):
+        output[key] = input_line.split()[1].strip()
+
+
+output = {}
+
+output['installed'] = cmd_exists('imapproxyd')
+
+if output['installed']:
+    try:
+        imapproxy_version_stdout = subprocess.check_output(
+                ["dpkg-query", "-W", "-f=${Version}",
+                 "imapproxy"]).decode('utf-8').split('-')[0]
+        output['version'] = imapproxy_version_stdout
+
+    except Exception:
+        pass
+
+    try:
+        if os.path.isfile('/etc/imapproxy.conf'):
+            try:
+                with open('/etc/imapproxy.conf') as fh:
+                    for line in fh:
+                        get_value(line, 'server_hostname', output)
+                        get_value(line, 'server_port', output)
+                        get_value(line, 'listen_address', output)
+                        get_value(line, 'listen_port', output)
+                        get_value(line, 'force_tls', output)
+                        get_value(line, 'chroot_directory', output)
+                        get_value(line, 'enable_admin_commands', output)
+                        get_value(line, 'cache_expiration_time', output)
+                        get_value(line, 'cache_size', output)
+                        get_value(line, 'ipversion_only', output)
+
+            except Exception:
+                pass
+
+    except Exception:
+        pass
+
+
+print(dumps(output, sort_keys=True, indent=4))

--- a/ansible/roles/imapproxy/templates/etc/imapproxy.conf.j2
+++ b/ansible/roles/imapproxy/templates/etc/imapproxy.conf.j2
@@ -1,0 +1,36 @@
+{# Copyright (C) 2021 David Härdeman <david@hardeman.nu>
+ # Copyright (C) 2021 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-only
+ #}
+## imapproxy.conf
+##
+## {{ ansible_managed }}
+##
+## This is the global configuration file for imapproxy.
+## Lines beginning with a '#' sign are treated as comments and will be
+## ignored.  Each line to be processed must be a space delimited
+## keyword/value pair.  
+##
+{% for item in imapproxy__combined_configuration | debops.debops.parse_kv_items() %}
+{%   if item.state|d('present') not in [ 'absent', 'init', 'ignore' ] %}
+{%     if item.comment|d() %}
+
+#
+{{       item.comment | regex_replace('\n$', '') | comment(prefix='', decoration='## ', postfix='') -}}
+#
+{%     endif %}
+{%     if item.raw|d() %}
+{%       if item.state|d('present') == 'comment' %}
+{{         '{}'.format(item.raw | regex_replace('\n$', '')) | comment(prefix='', decoration='#', postfix='') -}}
+{%       else %}
+{{         '{}'.format(item.raw | regex_replace('\n$', '')) }}
+{%       endif %}
+{%     else %}
+{%       if item.state|d('present') == 'comment' %}
+{{         '{} {}'.format(item.option | d(item.name), item.value) | comment(prefix='', decoration='#', postfix='') -}}
+{%       else %}
+{{         '{} {}'.format(item.option | d(item.name), item.value) }}
+{%       endif %}
+{%     endif %}
+{%   endif %}
+{% endfor %}

--- a/ansible/roles/imapproxy/templates/etc/pki/hooks/imapproxy.j2
+++ b/ansible/roles/imapproxy/templates/etc/pki/hooks/imapproxy.j2
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Copyright (C)      2021 David Härdeman <david@hardeman.nu>
+# Copyright (C) 2018-2021 DebOps <https://debops.org/>
+# Based on the postfix hook which is:
+# Copyright (C)      2020 Rainer Schuth <devel@reixd.net>
+# Copyright (C)      2018 Norbert Summer <git@o-g.at>
+# SPDX-License-Identifier: GPL-3.0-only
+
+# {{ ansible_managed }}
+
+# Reload or restart imapproxy on a certificate state change
+
+set -o nounset -o pipefail -o errexit
+
+imapproxy_config="/etc/imapproxy.conf"
+imapproxy_action="{{ imapproxy__pki_hook_action }}"
+imapproxy_service="imapproxy.service"
+
+# Check if current PKI realm is used by the 'imapproxy' server
+certificate=$(grep -r "${PKI_SCRIPT_DEFAULT_CRT:-}" ${imapproxy_config} || true)
+
+# Get list of current realm states
+read -r -a states <<< "$(echo "${PKI_SCRIPT_STATE:-}" | tr "," " ")"
+
+if [ -n "${certificate}" ] && [[ ${states[*]} ]] ; then
+
+    for state in "${states[@]}" ; do
+
+        if [ "${state}" = "changed-certificate" ] || [ "${state}" = "changed-dhparam" ] ; then
+
+            # Check if current init is systemd
+            if pidof systemd > /dev/null 2>&1 ; then
+
+                imapproxy_state="$(systemctl is-active ${imapproxy_service})"
+                if [ "${imapproxy_state}" = "active" ] ; then
+		    systemctl "${imapproxy_action}" "${imapproxy_service}"
+                fi
+            fi
+
+            break
+        fi
+
+    done
+
+fi

--- a/docs/ansible/role-index.rst
+++ b/docs/ansible/role-index.rst
@@ -96,6 +96,7 @@ are not accessed directly by end users.
 - :ref:`debops.freeradius`
 - :ref:`debops.gunicorn`
 - :ref:`debops.keepalived`
+- :ref:`debops.imapproxy`
 - :ref:`debops.ldap`
 - :ref:`debops.mcli`
 - :ref:`debops.memcached`
@@ -228,6 +229,7 @@ Mail and SMS services
 
 - :ref:`debops.dovecot`
 - :ref:`debops.etc_aliases`
+- :ref:`debops.imapproxy`
 - :ref:`debops.mailman`
 - :ref:`debops.nullmailer`
 - :ref:`debops.opendkim`

--- a/docs/ansible/roles/imapproxy/defaults-detailed.rst
+++ b/docs/ansible/roles/imapproxy/defaults-detailed.rst
@@ -1,0 +1,128 @@
+.. Copyright (C) 2021 David Härdeman <david@hardeman.nu>
+.. Copyright (C) 2021 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+Default variable details
+========================
+
+Some of the ``debops.imapproxy`` default variables have more extensive
+configuration than simple strings or lists, here you can find documentation and
+examples for them.
+
+.. only:: html
+
+   .. contents::
+      :local:
+      :depth: 1
+
+.. _imapproxy__ref_configuration:
+
+imapproxy__configuration
+------------------------
+
+The ``imapproxy__*_configuration`` variables define the contents of the
+:file:`/etc/imapproxy.conf` configuration file. The contents are defined
+using YAML data structures and converted to a valid configuration file via
+the role template.
+
+The ``imapproxy__*_configuration`` variables are implemented using the
+:ref:`universal configuration <universal_configuration>` syntax.
+
+:file:`/etc/imapproxy.conf` is a simple configuration file which contains
+configuration parameters in a `key value` syntax (note: *not* `key = value`),
+meaning that the universal configuration variables are also a simple list of
+`name` and `value` parameters which end up as `key value` in
+:file:`/etc/imapproxy.conf`.
+
+:envvar:`imapproxy__default_configuration` already contains a list of all the
+configuration parameters which are supported by imapproxy and may appear in
+:file:`/etc/imapproxy.conf` together with comments documenting the parameters.
+
+If you need to override any parameter, you can do so by changing
+:envvar:`imapproxy__configuration`, :envvar:`imapproxy__group_configuration` or
+:envvar:`imapproxy__host_configuration` according to your needs.
+
+Examples
+~~~~~~~~
+
+Changing a couple of configuration options:
+
+.. code-block:: yaml
+
+   imapproxy__configuration:
+
+     - name: 'dns_rr'
+       value: 'yes'
+       state: 'present'
+
+     - name: 'chroot_directory'
+       state: 'comment'
+
+You can see more examples in the :envvar:`imapproxy__default_configuration`
+variable.
+
+Syntax
+~~~~~~
+
+The imapproxy configuration options can be configured using a number of
+configuration entries, each containing a ``name`` parameter and a number
+of additional parameters (see the example above).
+
+Supported parameters are:
+
+``name``
+  Required. imapproxy configuration option name. Configuration entries with the
+  same ``name`` parameter are merged in order of appearance; this can be used
+  to change configuration options conditionally.
+
+  If the ``option`` parameter is specified, it is used instead of the ``name``
+  parameter as the key value in the generated configuration file.
+
+``value``
+  Optional. The value of the imapproxy configuration option. It can be
+  specified as a string, a YAML list, ``True`` or ``False`` boolean, a ``null``
+  value, a positive or negative number. if the ``value`` parameter is not
+  specified, the result will be empty.
+
+  The ``value`` parameters from multiple configuration entries override each
+  other.
+
+``raw``
+  Optional. String or YAML text block with text which will be included in
+  the generated configuration file "as is". If the ``raw`` parameter is
+  defined, it takes precedence over ``value`` parameter.
+
+``state``
+  Optional. If not specified or ``present``, a given imapproxy option will be
+  present in the configuration file. If ``absent``, a given option will be
+  removed from the configuration file (or not included if not present).
+  If ``init``, the configuration option will be prepared, but will not be
+  active and won't show up on the generated configuration file - this can be
+  used to prepare configuration that will be activated conditionally in another
+  configuration entry. If ``ignore``, a given configuration entry will not be
+  evaluated during role execution. If ``comment``, a given imapproxy
+  configuration option will be present in the generated file, but commented
+  out.
+
+``comment``
+  Optional. String or YAML text block with comments about a given configuration
+  option.
+
+``copy_id_from``
+  Optional. Copy the internal "id" of a configuration option specified by the
+  ``name`` parameter to the current configuration option. This parameter can be
+  used to reorder configuration options relative to a specific option.
+
+``weight``
+  Optional. Positive or negative number which defines the additional "weight"
+  of an option. Smaller or negative weight will move the option higher in the
+  configuration file, Bigger weight will move the configuration option lower in
+  the configuration file.
+
+``value_cast``
+  Optional. Specify the type of a given value to use in the configuration file.
+  Supported types: ``int``/``integer``, ``str``/``string``, ``float``,
+  ``null``/``none``, ``bool``/``boolean``. This parameter is onlu useful when
+  the value is defined using another variable, in which case the type
+  information is not preserved by Jinja templating.
+

--- a/docs/ansible/roles/imapproxy/getting-started.rst
+++ b/docs/ansible/roles/imapproxy/getting-started.rst
@@ -1,0 +1,154 @@
+.. Copyright (C) 2021 David Härdeman <david@hardeman.nu>
+.. Copyright (C) 2021 DebOps <https://debops.org/>
+.. Based on the Roundcube docs which are:
+.. Copyright (C) 2016-2018 Reto Gantenbein <reto.gantenbein@linuxmonk.ch>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+.. _imapproxy__ref_getting_started:
+
+Getting started
+===============
+
+.. include:: ../../../includes/global.rst
+
+.. only:: html
+
+   .. contents::
+      :local:
+
+.. _imapproxy__ref_default_setup:
+
+Default setup
+-------------
+
+If you don't specify any configuration values, the role will attempt
+to automatically detect which IMAP server to connect to
+and listen for incoming connections on ``localhost``, port ``1143``.
+
+The defaults are based on the assumption that imapproxy will be installed
+on the same host as the service using imapproxy. If you want to proxy
+incoming connections from an external host, this can be controlled via the
+:envvar:`imapproxy__listen_address` and :envvar:`imapproxy__listen_port`
+variables. Note that external access also needs to be allowed using
+the firewall variables (:envvar:`imapproxy__allow`,
+:envvar:`imapproxy__host_allow` and :envvar:`imapproxy__group_allow`)
+if you are using the :ref:`Ferm <debops.ferm>` firewall.
+
+If you want to manually define the server to proxy connections to,
+use the :envvar:`imapproxy__imap_fqdn` and :envvar:`imapproxy__imap_port`
+variables.
+
+
+.. _imapproxy__ref_ssl_support:
+
+SSL support
+-----------
+
+While imapproxy supports TLS out of the box (using values from the
+:ref:`debops.pki` role, if enabled), it does **not** have native
+support for SSL.
+
+The recommended setup is either to run imapproxy on the same host
+as the IMAP server (meaning that TLS/SSL is not necessary as no
+proxy <-> IMAP traffic is sent over the network) or to setup the
+IMAP server to allow TLS traffic using explicit TLS.
+
+If you are trying to proxy to an IMAP server that is only available using
+IMAPS (usually port ``993``), manual configuration will be necessary.
+The authors of imapproxy suggest setting up a SSL tunnel (e.g. using
+:ref:`stunnel <debops.stunnel>`).
+
+See :file:`/usr/share/doc/imapproxy/README.ssl` in the imapproxy
+package for more details.
+
+
+.. _imapproxy__ref_srv_records:
+
+IMAP server detection
+---------------------
+
+The role first checks if :ref:`debops.dovecot` is installed on the same host.
+If so, the local IMAP server will be used.
+
+In the alternative, the role detects the preferred IMAP server by checking the
+DNS SRV resource records (defined by :rfc:`6186`), looking for the
+IMAP or IMAPS services. The example DNS resource records used by the role are:
+
+.. code-block:: none
+
+   _imap._tcp           SRV 0 1 143  imap.example.org.
+   _imaps._tcp          SRV 0 1 993  imap.example.org.
+
+At the moment only a single SRV resource record is supported by the role.
+
+If both SRV resource records and local Ansible facts are not available, the
+:ref:`debops.imapproxy` role will fall back to using static subdomains for the
+respective services, based on the host domain:
+
+.. code-block:: none
+
+   IMAP:  imap.example.org
+
+This allows for deployment of the proxy on a separate host or VM.
+
+
+.. _imapproxy__ref_example_inventory:
+
+Example inventory
+-----------------
+
+To install and configure imapproxy on a host, it needs to be present in the
+``[debops_service_imapproxy]`` Ansible inventory group. You may want to
+use the role on the same host that is also providing the
+:ref:`Dovecot <debops.dovecot>` and webmail (e.g.
+:ref:`Roundcube <debops.roundcube>`) services.
+
+.. code-block:: none
+
+   [debops_all_hosts]
+   webmail
+
+   [debops_service_dovecot]
+   webmail
+
+   [debops_service_imapproxy]
+   webmail
+
+
+.. _imapproxy__ref_example_playbook:
+
+Example playbook
+----------------
+
+The following playbook can be used with DebOps. If you are using these role
+without DebOps you might need to adapt them to make them work in your setup.
+
+.. literalinclude:: ../../../../ansible/playbooks/service/imapproxy.yml
+   :language: yaml
+   :lines: 1,5-
+
+This playbook is also shipped with DebOps at
+:file:`ansible/playbooks/service/imapproxy.yml`.
+
+
+.. _imapproxy__ref_ansible_tags:
+
+Ansible tags
+------------
+
+You can use Ansible ``--tags`` or ``--skip-tags`` parameters to limit what
+tasks are performed during Ansible run. This can be used after a host was first
+configured to speed up playbook execution, when you are sure that most of the
+configuration is already in the desired state.
+
+Available role tags:
+
+``role::imapproxy``
+  Main role tag, should be used in the playbook to execute all of the role
+  tasks as well as role dependencies.
+
+``role::imapproxy:pkg``
+  Run tasks related to system package installation.
+
+``role::imapproxy:config``
+  Run tasks related to the imapproxy configuration.

--- a/docs/ansible/roles/imapproxy/index.rst
+++ b/docs/ansible/roles/imapproxy/index.rst
@@ -1,0 +1,29 @@
+.. Copyright (C) 2021 David Härdeman <david@hardeman.nu>
+.. Copyright (C) 2021 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+.. _debops.imapproxy:
+
+debops.imapproxy
+================
+
+.. include:: man_description.rst
+   :start-line: 7
+
+.. toctree::
+   :maxdepth: 2
+
+   getting-started
+   defaults/main
+   defaults-detailed
+
+Copyright
+---------
+
+.. literalinclude:: ../../../../ansible/roles/imapproxy/COPYRIGHT
+
+..
+ Local Variables:
+ mode: rst
+ ispell-local-dictionary: "american"
+ End:

--- a/docs/ansible/roles/imapproxy/man_description.rst
+++ b/docs/ansible/roles/imapproxy/man_description.rst
@@ -1,0 +1,11 @@
+.. Copyright (C) 2021 David Härdeman <david@hardeman.nu>
+.. Copyright (C) 2021 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+Description
+===========
+
+The ``debops.imapproxy`` Ansible role manages `imapproxy`__, an IMAP proxy
+server which is used primarily to improve webmail performance.
+
+.. __: http://www.imapproxy.org/

--- a/docs/ansible/roles/imapproxy/man_index.rst
+++ b/docs/ansible/roles/imapproxy/man_index.rst
@@ -1,0 +1,22 @@
+:orphan:
+
+.. Copyright (C) 2021 David Härdeman <david@hardeman.nu>
+.. Copyright (C) 2021 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+debops.imapproxy
+================
+
+.. toctree::
+   :maxdepth: 2
+
+   man_synopsis
+   man_description
+   getting-started
+   defaults-detailed
+
+..
+ Local Variables:
+ mode: rst
+ ispell-local-dictionary: "american"
+ End:

--- a/docs/ansible/roles/imapproxy/man_synopsis.rst
+++ b/docs/ansible/roles/imapproxy/man_synopsis.rst
@@ -1,0 +1,8 @@
+.. Copyright (C) 2021 David Härdeman <david@hardeman.nu>
+.. Copyright (C) 2021 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+Synopsis
+========
+
+``debops service/imapproxy`` [**--limit** `group,host,`...] [**--diff**] [**--check**] [**--tags** `tag1,tag2,`...] [**--skip-tags** `tag1,tag2,`...] [<``ansible-playbook`` options>] ...


### PR DESCRIPTION
imapproxy is useful together with, in particular, webmail clients since
it caches open connections to the IMAP server which improves performance
and cuts down on log spam generated by repeated logins from the webmail
client.

Some stats (15 reloads using snappymail web mail on a local VM setup
using DebOps roles, time measured with Google Chrome developer tools
network finish time on reload):

```
        No proxy        Proxy
        ========        =====
Mean:   529 ms		211 ms
Min:    492 ms          194 ms
Max:    566 ms          261 ms
Stdev:	21 ms           17 ms
```

If this role is merged, I can prepare a separate PR to make the
roundcube role use imapproxy automatically when available.