### PR TITLE
[postfix] Put all milter_* parameters in the right section

### DIFF
--- a/ansible/roles/postfix/templates/lookup/postfix__init_maincf.j2
+++ b/ansible/roles/postfix/templates/lookup/postfix__init_maincf.j2
@@ -26,7 +26,9 @@
 {%       set _ = postfix__tpl_init_maincf.append({'name': entry_name, 'state': 'init', 'section': 'route'}) %}
 {%     elif entry_name in [ 'canonical_maps', 'relay_domains', 'local_recipient_maps', 'relay_recipient_maps', 'transport_maps' ] %}
 {%       set _ = postfix__tpl_init_maincf.append({'name': entry_name, 'state': 'init', 'section': 'route'}) %}
-{%     elif entry_name in [ 'smtpd_milters', 'non_smtpd_milters', 'milter_mail_macros', 'header_checks', 'body_checks', 'content_filter' ] %}
+{%     elif entry_name in [ 'smtpd_milters', 'non_smtpd_milters', 'header_checks', 'body_checks', 'content_filter' ] %}
+{%       set _ = postfix__tpl_init_maincf.append({'name': entry_name, 'state': 'init', 'section': 'filter'}) %}
+{%     elif entry_name.startswith('milter_') %}
 {%       set _ = postfix__tpl_init_maincf.append({'name': entry_name, 'state': 'init', 'section': 'filter'}) %}
 {%     elif entry_name in [ 'smtpd_client_event_limit_exceptions', 'smtpd_error_sleep_time' ] %}
 {%       set _ = postfix__tpl_init_maincf.append({'name': entry_name, 'state': 'init', 'section': 'limit'}) %}


### PR DESCRIPTION
Postfix supports a large number of milter_* parameters, this makes
sure that they all end up in the "filter" section.