### PR TITLE
[docker_server] Enable live restore by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -249,6 +249,13 @@ Continuous Integration
 
 - The role defaults have been updated, Bullseye is the new Stable.
 
+:ref:`debops.docker_server` role
+''''''''''''''''''''''''''''''''
+
+- The role now enables `live restore`__ by default.
+
+  .. __: https://docs.docker.com/config/containers/live-restore/
+
 :ref:`debops.elasticsearch` role
 ''''''''''''''''''''''''''''''''
 

--- a/ansible/roles/docker_server/defaults/main.yml
+++ b/ansible/roles/docker_server/defaults/main.yml
@@ -347,7 +347,7 @@ docker_server__debug: False
 #
 # Enables keeping containers alive during daemon downtime. Only supported from
 # Docker version 1.12 and above.
-docker_server__live_restore: False
+docker_server__live_restore: True
 
                                                                    # ]]]
 # .. envvar:: docker_server__data_root [[[


### PR DESCRIPTION
Live restore reduces downtime for containers during a Docker daemon restart.

https://docs.docker.com/config/containers/live-restore/