### PR TITLE
[grub] Enable serial console by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -257,6 +257,11 @@ Continuous Integration
   and the options changed by the role are set in the
   :envvar:`elasticsearch__default_configuration` variable.
 
+:ref:`debops.grub` role
+'''''''''''''''''''''''
+
+- The role now enables the serial console by default.
+
 :ref:`debops.ipxe` role
 '''''''''''''''''''''''
 

--- a/ansible/roles/grub/defaults/main.yml
+++ b/ansible/roles/grub/defaults/main.yml
@@ -229,7 +229,7 @@ grub__combined_configuration: '{{ grub__original_configuration
 # .. envvar:: grub__serial_console [[[
 #
 # Enable serial console (in both grub and kernel)
-grub__serial_console: False
+grub__serial_console: True
 
                                                                    # ]]]
 # .. envvar:: grub__serial_console_unit [[[


### PR DESCRIPTION
The serial console is incredibly useful when working in the data center: instead of fiddling with the monitor trolley and having to wire up power, display and keyboard, you can just take out your laptop and plug in a USB to serial adapter.

Virtualization tools like Ganeti also depend on the (virtual) serial console of the guest, and cloud platforms like Azure require it for console access and dmesg logging.

I don't see any downsides to enabling it by default.