### PR TITLE
[libvirtd] Install UEFI firmware for amd64 VMs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -92,6 +92,12 @@ General
   communication with the Elasticsearch cluster, based on the PKI environment
   managed by the :ref:`debops.pki` Ansible role.
 
+:ref:`debops.libvirtd` role
+'''''''''''''''''''''''''''
+
+- The role will now install UEFI firmware for amd64 VMs, alongside traditional
+  BIOS.
+
 :ref:`debops.lvm` role
 ''''''''''''''''''''''
 

--- a/ansible/roles/libvirtd/defaults/main.yml
+++ b/ansible/roles/libvirtd/defaults/main.yml
@@ -35,8 +35,8 @@ libvirtd__kvm_support: '{{ True
 
 # .. envvar:: libvirtd__base_packages [[[
 #
-# List of :program:`libvirtd` packages which will be installed on all distribution
-# releases, unless overridden.
+# List of :program:`libvirtd` packages which will be installed on all
+# distribution releases, unless overridden.
 libvirtd__base_packages:
   - 'libvirt-daemon-system'
   - 'libvirt-clients'
@@ -80,6 +80,7 @@ libvirtd__network_packages:
 libvirtd__misc_packages:
   - 'gawk'
   - 'netcat-openbsd'
+  - 'ovmf'  # UEFI firmware for amd64 VMs
   - 'pm-utils'
   - 'sysfsutils'
   - '{{ [] if (ansible_distribution_release in [ "bullseye" ])


### PR DESCRIPTION
The OVMF build allows for things like Secure Boot:
https://wiki.debian.org/SecureBoot/VirtualMachine