### PR TITLE
[sudo] Make use of sudo__ldap_enabled

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -481,6 +481,9 @@ debops.reprepro role
   picked up as the version number when :command:`sudo` was configured to use
   LDAP, but the LDAP service was not available.
 
+- The role will now skip installing the ``sudo-ldap`` package and creating the
+  LDAP account object if :envvar:`sudo__ldap_enabled` is ``False``.
+
 :ref:`debops.system_users` role
 '''''''''''''''''''''''''''''''
 

--- a/ansible/roles/sudo/defaults/main.yml
+++ b/ansible/roles/sudo/defaults/main.yml
@@ -29,9 +29,7 @@ sudo__enabled: True
 #
 # List of base APT packages to install for :command:`sudo` support.
 sudo__base_packages: '{{ [ "sudo-ldap" ]
-                         if (ansible_local|d() and ansible_local.ldap|d() and
-                             (ansible_local.ldap.posix_enabled|d())|bool and not
-                             (ansible_local.sssd|d() and ansible_local.sssd.installed|d())|bool)
+                         if sudo__ldap_enabled|bool
                          else [ "sudo" ] }}'
 
                                                                    # ]]]
@@ -255,8 +253,7 @@ sudo__ldap__dependent_tasks:
     attributes: '{{ sudo__ldap_self_attributes }}'
     no_log: True
     state: '{{ "present"
-               if ((ansible_local.ldap.posix_enabled|d())|bool and
-                   sudo__ldap_device_dn|d())
+               if sudo__ldap_enabled|bool
                else "ignore" }}'
                                                                    # ]]]
                                                                    # ]]]


### PR DESCRIPTION
- Let sudo__ldap_enabled decide if package `sudo` or `sudo-ldap` gets installed.
- Let sudo__ldap_enabled decide if the LDAP account object gets created.