### PR TITLE
[sshd] Only create LDAP account when needed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -474,6 +474,11 @@ debops.reprepro role
 - The rsyslog role always configured the streamDriverPermittedPeers option,
   even when the ``anon`` network driver authentication mode was selected.
 
+:ref:`debops.sshd` role
+'''''''''''''''''''''''
+
+- The role will no longer create an LDAP account when it is not needed.
+
 :ref:`debops.sudo` role
 '''''''''''''''''''''''
 

--- a/ansible/roles/sshd/defaults/main.yml
+++ b/ansible/roles/sshd/defaults/main.yml
@@ -895,8 +895,8 @@ sshd__ldap__dependent_tasks:
     attributes: '{{ sshd__ldap_self_attributes }}'
     no_log: True
     state: '{{ "present"
-               if ((ansible_local.ldap.posix_enabled|d())|bool and
-                   sshd__ldap_device_dn|d())
+               if (sshd__authorized_keys_lookup|bool and
+                   ("ldap" in sshd__authorized_keys_lookup_type))
                else "ignore" }}'
 
                                                                    # ]]]


### PR DESCRIPTION
An LDAP account for sshd is only needed when authorized key lookups are
to be performed over LDAP.