### PR TITLE
[libvirtd] No longer add root to 'libvirt' group

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -375,6 +375,8 @@ Fixed
 - The ``virt-top`` APT package is not part of the Debian Bullseye release,
   therefore the role will not try to install it by default.
 
+- The root account will no longer be added to the 'libvirt' group by default.
+
 :ref:`debops.lxc` role
 ''''''''''''''''''''''
 

--- a/ansible/roles/libvirtd/defaults/main.yml
+++ b/ansible/roles/libvirtd/defaults/main.yml
@@ -113,8 +113,11 @@ libvirtd__deployment_mode: '{{ "opennebula"
                                                                    # ]]]
 # .. envvar:: libvirtd__admins [[[
 #
-# List of administrator accounts which should have access to :program:`libvirtd`.
-libvirtd__admins: [ '{{ ansible_user | d(lookup("env", "USER")) }}' ]
+# List of administrator accounts which should have access to
+# :program:`libvirtd`.
+libvirtd__admins: '{{ [ ansible_user | d(lookup("env", "USER")) ]
+                      if ansible_user | d(lookup("env", "USER")) != "root"
+                      else [] }}'
 
                                                                    # ]]]
 # .. envvar:: libvirtd__unix_sock_group [[[


### PR DESCRIPTION
The role used to add the user executing the Ansible tasks to the
'libvirt' group, even if that user was root. The root account does not
need 'libvirt' membership in order to access libvirtd. Also, adding the
root account to any group causes an idempotency issue with
`debops.root_account`, which enforces the group membership of the root
account.