### PR TITLE
feat(apt_install): Install `intel-microcode` from buster-backports

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -249,6 +249,11 @@ Continuous Integration
 
 - The role defaults have been updated, Bullseye is the new Stable.
 
+:ref:`debops.apt_install` role
+''''''''''''''''''''''''''''''
+
+- Install ``intel-microcode`` from buster-backports for improved security.
+
 :ref:`debops.elasticsearch` role
 ''''''''''''''''''''''''''''''''
 

--- a/ansible/roles/apt_install/defaults/main.yml
+++ b/ansible/roles/apt_install/defaults/main.yml
@@ -459,6 +459,12 @@ apt_install__apt_preferences__dependent_list:
     backports: [ 'wheezy', 'jessie', 'trusty' ]
     reason: 'Better support for container technologies'
     by_role: 'debops.apt_install'
+
+  - package: 'intel-microcode'
+    backports: [ 'buster' ]
+    reason: 'Get latest security updates. 1001 is required because of a bug: dpkg: warning: downgrading intel-microcode from 3.20210608.2~deb10u1 to 3.20201118.1~bpo10+1'
+    priority: 1001
+    by_role: 'debops.apt_install'
                                                                    # ]]]
                                                                    # ]]]
                                                                    # ]]]


### PR DESCRIPTION
I would be interested if you get the same "downgrading" warning or if that is something wrong with my machines. I did get it on multiple machines. Also of course if we should install `intel-microcode` from buster-backports by default.