### PR TITLE
fix #1888, Use legacy iptables and ip6tables by default as ferm backend

### DIFF
--- a/ansible/roles/ferm/defaults/main.yml
+++ b/ansible/roles/ferm/defaults/main.yml
@@ -60,7 +60,8 @@ ferm__iptables_backend_enabled: '{{ False
 #
 # Newer OS releases might need to use the legacy variant to be compatible with
 # :command:`ferm` manager.
-ferm__iptables_backend_path: '/usr/sbin/iptables-nft'
+ferm__iptables_backend_path: '/usr/sbin/iptables-legacy'
+ferm__ip6tables_backend_path: '/usr/sbin/ip6tables-legacy'
 
                                                                    # ]]]
 # .. envvar:: ferm__base_packages [[[

--- a/ansible/roles/ferm/tasks/main.yml
+++ b/ansible/roles/ferm/tasks/main.yml
@@ -32,6 +32,12 @@
     path: '{{ ferm__iptables_backend_path }}'
   when: ferm__enabled | bool and ferm__iptables_backend_enabled|bool
 
+- name: Manage ip6tables backend using alternatives
+  alternatives:
+    name: 'ip6tables'
+    path: '{{ ferm__ip6tables_backend_path }}'
+  when: ferm__enabled | bool and ferm__iptables_backend_enabled|bool
+
 - name: Make sure required directories exist
   file:
     path: '{{ item }}'


### PR DESCRIPTION
Closes: #1888

Overrides #1895 to also support alternatives for ip6tables