### PR TITLE
[mariadb] add login_unix_socket parameter for ansible mysql connector

### DIFF
--- a/ansible/roles/icinga_web/tasks/main.yml
+++ b/ansible/roles/icinga_web/tasks/main.yml
@@ -166,6 +166,7 @@
     name: '{{ icinga_web__database_name }}'
     state: 'import'
     target: '{{ item }}'
+    login_unix_socket: '/run/mysqld/mysqld.sock'
   with_items:
     - '{{ icinga_web__database_schema }}'
     - '/tmp/icingaweb-initial-data.sql'
@@ -183,6 +184,7 @@
     login_port: '{{ icinga_web__x509_database_port }}'
     login_user: '{{ icinga_web__x509_database_user }}'
     login_password: '{{ icinga_web__x509_database_password }}'
+    login_unix_socket: '/run/mysqld/mysqld.sock'
   when: icinga_web__x509_enabled|bool and
         icinga_web__x509_database_init|bool
   no_log: '{{ debops__no_log | d(True) }}'

--- a/ansible/roles/librenms/tasks/main.yml
+++ b/ansible/roles/librenms/tasks/main.yml
@@ -111,6 +111,7 @@
   mysql_db:
     name: '{{ librenms__database_name }}'
     state: 'present'
+    login_unix_socket: '/run/mysqld/mysqld.sock'
   delegate_to: '{{ ansible_local.mariadb.delegate_to }}'
   register: librenms__register_database_status
   tags: [ 'role::librenms:database' ]

--- a/ansible/roles/mariadb/tasks/manage_contents.yml
+++ b/ansible/roles/mariadb/tasks/manage_contents.yml
@@ -7,6 +7,7 @@
   community.mysql.mysql_db:
     name: '{{ item.database | d(item.name) }}'
     state: 'absent'
+    login_unix_socket: '/run/mysqld/mysqld.sock'
   with_flattened: '{{ mariadb__databases + mariadb__dependent_databases + mariadb_databases|d([]) }}'
   delegate_to: '{{ mariadb__delegate_to }}'
   when: ((item.database|d(False) or item.name|d(False)) and
@@ -18,6 +19,7 @@
     state: 'present'
     encoding: '{{ item.encoding | d(omit) }}'
     collation: '{{ item.collation | d(omit) }}'
+    login_unix_socket: '/run/mysqld/mysqld.sock'
   with_flattened: '{{ mariadb__databases + mariadb__dependent_databases + mariadb_databases|d([]) }}'
   delegate_to: '{{ mariadb__delegate_to }}'
   when: ((item.database|d(False) or item.name|d(False)) and
@@ -47,6 +49,7 @@
     name: '{{ item.0.database | d(item.0.name) }}'
     target: '{{ item.0.target }}'
     state: 'import'
+    login_unix_socket: '/run/mysqld/mysqld.sock'
   with_together:
     - '{{ mariadb__databases
           + lookup("flattened", mariadb__dependent_databases, wantlist=True)
@@ -73,6 +76,7 @@
     name: '{{ item.user | d(item.name) }}'
     host: '{{ item.host | default(mariadb__client) }}'
     state: 'absent'
+    login_unix_socket: '/run/mysqld/mysqld.sock'
   with_flattened: '{{ mariadb__users + mariadb__dependent_users + mariadb_users|d([]) }}'
   delegate_to: '{{ mariadb__delegate_to }}'
   when: ((item.user|d(False) or item.name|d(False)) and
@@ -88,6 +92,7 @@
                   secret + "/mariadb/" + mariadb__delegate_to +
                   "/credentials/" + item.user | d(item.name) + "/password " +
                   "length=" + mariadb__password_length)) }}'
+    login_unix_socket: '/run/mysqld/mysqld.sock'
   with_flattened: '{{ mariadb__users + mariadb__dependent_users + mariadb_users|d([]) }}'
   delegate_to: '{{ mariadb__delegate_to }}'
   register: mariadb__register_create_users
@@ -101,6 +106,7 @@
     host: '{{ item.0.host | default(mariadb__client) }}'
     priv: '{{ (item.0.database | d(item.0.name)) + ".*:" + mariadb__default_privileges_grant }}'
     append_privs: True
+    login_unix_socket: '/run/mysqld/mysqld.sock'
   with_together:
     - '{{ mariadb__users + lookup("flattened", mariadb__dependent_users, wantlist=True) + mariadb_users|d([]) }}'
     - '{{ mariadb__register_create_users.results }}'
@@ -117,6 +123,7 @@
     host: '{{ item.0.host | default(mariadb__client) }}'
     priv: '{{ (item.0.database | d(item.0.name)) + "\_%.*:" + mariadb__default_privileges_grant }}'
     append_privs: True
+    login_unix_socket: '/run/mysqld/mysqld.sock'
   with_together:
     - '{{ mariadb__users + lookup("flattened", mariadb__dependent_users, wantlist=True) + mariadb_users|d([]) }}'
     - '{{ mariadb__register_create_users.results }}'
@@ -133,6 +140,7 @@
     host: '{{ item.0.host | default(mariadb__client) }}'
     priv: '{{ item.0.priv if (item.0.priv is string) else (item.0.priv | join("/")) }}'
     append_privs: '{{ item.0.append_privs | default(True) }}'
+    login_unix_socket: '/run/mysqld/mysqld.sock'
   with_together:
     - '{{ mariadb__users + lookup("flattened", mariadb__dependent_users, wantlist=True) + mariadb_users|d([]) }}'
     - '{{ mariadb__register_create_users.results }}'

--- a/ansible/roles/mariadb_server/tasks/secure_installation.yml
+++ b/ansible/roles/mariadb_server/tasks/secure_installation.yml
@@ -8,11 +8,13 @@
     user: ""
     host: '{{ item }}'
     state: 'absent'
+    login_unix_socket: '/run/mysqld/mysqld.sock'
   with_items: [ '{{ ansible_hostname }}', 'localhost' ]
 
 - name: Remove test database on first install
   mysql_db:  # noqa no-handler
     db: 'test'
     state: 'absent'
+    login_unix_socket: '/run/mysqld/mysqld.sock'
   when: ((mariadb_server__register_version|d() and not mariadb_server__register_version.stdout) and
          (mariadb_server__register_install_status|d() and mariadb_server__register_install_status is changed))

--- a/ansible/roles/phpipam/tasks/phpipam.yml
+++ b/ansible/roles/phpipam/tasks/phpipam.yml
@@ -107,6 +107,7 @@
   mysql_db:
     name: '{{ phpipam__database_name }}'
     state: 'present'
+    login_unix_socket: '/run/mysqld/mysqld.sock'
   when: phpipam__database_host == 'localhost' and phpipam__register_mysql.stat.exists
   register: phpipam__register_database_status
 
@@ -115,6 +116,7 @@
     name: '{{ phpipam__database_name }}'
     state: 'import'
     target: '{{ phpipam__database_schema }}'
+    login_unix_socket: '/run/mysqld/mysqld.sock'
   when: (phpipam__database_host == 'localhost' and
          (phpipam__register_database_status is defined and phpipam__register_database_status is changed) and
          (phpipam__register_configuration is defined and not phpipam__register_configuration.stat.exists))

--- a/ansible/roles/phpmyadmin/tasks/main.yml
+++ b/ansible/roles/phpmyadmin/tasks/main.yml
@@ -31,10 +31,14 @@
     name: '{{ phpmyadmin_control_database | default("phpmyadmin") }}'
     state: 'import'
     target: '/usr/share/dbconfig-common/data/phpmyadmin/install/mysql'
+    login_unix_socket: '/run/mysqld/mysqld.sock'
   when: phpmyadmin_database is defined and phpmyadmin_database is changed
 
 - name: Create PHPMyAdmin control user
-  mysql_user: name={{ phpmyadmin_control_user | default('phpmyadmin') }} state=present
-              password={{ phpmyadmin_control_password }} priv='{{ phpmyadmin_control_database
-                                                                  | default('phpmyadmin') }}.*:ALL'
+  mysql_user:
+    name: "{{ phpmyadmin_control_user | default('phpmyadmin') }}"
+    state: 'present'
+    password: '{{ phpmyadmin_control_password }}'
+    priv: "{{ phpmyadmin_control_database | default('phpmyadmin') }}.*:ALL"
+    login_unix_socket: '/run/mysqld/mysqld.sock'
   no_log: '{{ debops__no_log | d(True) }}'

--- a/ansible/roles/rails_deploy/tasks/database.yml
+++ b/ansible/roles/rails_deploy/tasks/database.yml
@@ -49,6 +49,7 @@
     name: '{{ rails_deploy_service }}'
     password: '{{ rails_deploy_mysql_user_password }}'
     state: 'present'
+    login_unix_socket: '/run/mysqld/mysqld.sock'
   when: rails_deploy_database_adapter == 'mysql' and
         inventory_hostname == rails_deploy_hosts_master
   become: True
@@ -64,6 +65,7 @@
     name: '{{ rails_deploy_service }}_{{ rails_deploy_system_env }}'
     encoding: 'UTF-8'
     state: 'present'
+    login_unix_socket: '/run/mysqld/mysqld.sock'
   register: rails_deploy_register_database_created
   when: rails_deploy_database_adapter == 'mysql' and
         inventory_hostname == rails_deploy_hosts_master

--- a/ansible/roles/roundcube/tasks/configure_mysql.yml
+++ b/ansible/roles/roundcube/tasks/configure_mysql.yml
@@ -7,6 +7,7 @@
   mysql_db:
     name: '{{ roundcube__database_map[roundcube__database].dbname }}'
     state: 'present'
+    login_unix_socket: '/run/mysqld/mysqld.sock'
   delegate_to: '{{ ansible_local.mariadb.delegate_to }}'
   register: roundcube__register_database_status
 
@@ -18,5 +19,6 @@
     login_user: '{{ roundcube__database_map[roundcube__database].dbuser }}'
     login_password: '{{ roundcube__database_map[roundcube__database].dbpass }}'
     login_host: '{{ ansible_local.mariadb.server }}'
+    login_unix_socket: '/run/mysqld/mysqld.sock'
   when: (roundcube__register_database_status|d() is defined and roundcube__register_database_status is changed)
   no_log: '{{ debops__no_log | d(True) }}'

--- a/ansible/roles/volkszaehler/tasks/main.yml
+++ b/ansible/roles/volkszaehler/tasks/main.yml
@@ -99,6 +99,7 @@
     name: '{{ volkszaehler__database_name }}'
     target: '{{ (volkszaehler__home_path + "/create_db.sql")|quote }}'
     state: 'import'
+    login_unix_socket: '/run/mysqld/mysqld.sock'
   when: (volkszaehler__register_sql_init_dump is changed and volkszaehler__database in ['mariadb'])
 
 - name: Insert demo data into database


### PR DESCRIPTION
In mariadb >=10.4 default local connection for root is only available through file socket. Since Debian Bullseye come with mariadb 10.5 we should fix every local connection to pass through this socket.

Documentation of authentification mecanism for mariadb >= 10.4 can be found here:
https://mariadb.com/kb/en/authentication-from-mariadb-104/

I didn't fix every debops connection. For instance I didn't fix librenms connection:
https://github.com/debops/debops/blob/c1db9901ac2dd18cf24d2472fc2ff8c2ef7238ad/ansible/roles/librenms/tasks/main.yml#L110
I don't know if I should fix every connection in debops repository or should we do one PR by specific connection ?!

This PR has been tested on Debian Buster and Bullseye.

Related issue: https://github.com/debops/debops/issues/1525