### PR TITLE
[pdns] Add new role debops.pdns

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1781,6 +1781,15 @@ stages:
     JANE_DIFF_PATTERN: '.*/roles/pam_access/.*'
     JANE_LOG_PATTERN: '\[pam_access\]'
 
+'pdns role':
+  <<: *test_role_2nd_deps
+  variables:
+    JANE_TEST_FACT: 'pdns.fact'
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/pdns.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_pdns'
+    JANE_DIFF_PATTERN: '.*/roles/pdns/.*'
+    JANE_LOG_PATTERN: '\[pdns\]'
+
 'persistent_paths role':
   <<: *test_role_no_deps
   variables:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,14 @@ New DebOps roles
   used to provide media (video, music, images) to other devices on the local
   network that support the DLNA protocol.
 
+- The :ref:`debops.pdns` role manages the `PowerDNS Authoritative Server`__,
+  which is an authoritative DNS server with support for DNSSEC, DNS UPDATE,
+  geographical load balancing, and storing zone data and metadata in one or
+  more backends like relational databases, LDAP databases, and plain text
+  files.
+
+  .. __: https://www.powerdns.com/auth.html
+
 - The :ref:`debops.telegraf` role can be used to install and manage the
   `Telegraf`__ metrics server, which can send data to various other services.
 

--- a/ansible/playbooks/service/pdns-nginx.yml
+++ b/ansible/playbooks/service/pdns-nginx.yml
@@ -1,0 +1,55 @@
+---
+# Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+# Copyright (C) 2020 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Manage PowerDNS authoritative server with Nginx
+  hosts: [ 'debops_service_pdns_nginx' ]
+  become: True
+
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
+
+  roles:
+
+    - role: keyring
+      tags: [ 'role::keyring', 'skip::keyring' ]
+      keyring__dependent_apt_keys:
+        - '{{ nginx__keyring__dependent_apt_keys }}'
+
+    - role: apt_preferences
+      tags: [ 'role::apt_preferences', 'skip::apt_preferences' ]
+      apt_preferences__dependent_list:
+        - '{{ nginx__apt_preferences__dependent_list }}'
+
+    - role: etc_services
+      tags: [ 'role::etc_services', 'skip::etc_services' ]
+      etc_services__dependent_list:
+        - '{{ pdns__etc_services__dependent_list }}'
+
+    - role: ferm
+      tags: [ 'role::ferm', 'skip::ferm' ]
+      ferm__dependent_rules:
+        - '{{ nginx__ferm__dependent_rules }}'
+        - '{{ pdns__ferm__dependent_rules }}'
+
+    - role: postgresql
+      tags: [ 'role::postgresql', 'skip::postgresql' ]
+      postgresql__dependent_roles:
+        - '{{ pdns__postgresql__dependent_roles }}'
+
+    - role: python
+      tags: [ 'role::python', 'skip::python' ]
+      python__dependent_packages3:
+        - '{{ nginx__python__dependent_packages3 }}'
+      python__dependent_packages2:
+        - '{{ nginx__python__dependent_packages2 }}'
+
+    - role: nginx
+      tags: [ 'role::nginx', 'skip::nginx' ]
+      nginx__dependent_servers:
+        - '{{ pdns__nginx__dependent_servers }}'
+
+    - role: pdns
+      tags: [ 'role::pdns', 'skip::pdns' ]

--- a/ansible/playbooks/service/pdns-plain.yml
+++ b/ansible/playbooks/service/pdns-plain.yml
@@ -1,0 +1,32 @@
+---
+# Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+# Copyright (C) 2020 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Manage PowerDNS authoritative server
+  hosts: [ 'debops_service_pdns' ]
+  become: True
+
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
+
+  roles:
+
+    - role: etc_services
+      tags: [ 'role::etc_services', 'skip::etc_services' ]
+      etc_services__dependent_list:
+        - '{{ pdns__etc_services__dependent_list }}'
+
+    - role: ferm
+      tags: [ 'role::ferm', 'skip::ferm' ]
+      ferm__dependent_rules:
+        - '{{ pdns__ferm__dependent_rules }}'
+
+    - role: postgresql
+      tags: [ 'role::postgresql', 'skip::postgresql' ]
+      postgresql__dependent_roles:
+        - '{{ pdns__postgresql__dependent_roles }}'
+
+    - role: pdns
+      tags: [ 'role::pdns', 'skip::pdns' ]

--- a/ansible/playbooks/service/pdns.yml
+++ b/ansible/playbooks/service/pdns.yml
@@ -1,40 +1,8 @@
 ---
-# Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
-# Copyright (C) 2020 DebOps <https://debops.org/>
+# Copyright (C) 2022 CipherMail B.V. <https://www.ciphermail.com/>
+# Copyright (C) 2022 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: Manage PowerDNS authoritative server
-  hosts: [ 'debops_service_pdns' ]
-  become: True
+- import_playbook: pdns-plain.yml
 
-  environment: '{{ inventory__environment | d({})
-                   | combine(inventory__group_environment | d({}))
-                   | combine(inventory__host_environment  | d({})) }}'
-
-  roles:
-
-    - role: etc_services
-      tags: [ 'role::etc_services', 'skip::etc_services' ]
-      etc_services__dependent_list:
-        - '{{ pdns__etc_services__dependent_list }}'
-      when: pdns__api or pdns__metrics
-
-    - role: ferm
-      tags: [ 'role::ferm', 'skip::ferm' ]
-      ferm__dependent_rules:
-        - '{{ pdns__ferm__dependent_rules }}'
-
-    - role: postgresql
-      tags: [ 'role::postgresql', 'skip::postgresql' ]
-      postgresql__dependent_roles:
-        - '{{ pdns__postgresql__dependent_roles }}'
-      when: ('gpgsql' in pdns__backends)
-
-    - role: nginx
-      tags: [ 'role::nginx', 'skip::nginx' ]
-      nginx__dependent_servers:
-        - '{{ pdns__nginx__dependent_servers }}'
-      when: pdns__nginx_allow and (pdns__api or pdns__metrics)
-
-    - role: pdns
-      tags: [ 'role::pdns', 'skip::pdns' ]
+- import_playbook: pdns-nginx.yml

--- a/ansible/playbooks/service/pdns.yml
+++ b/ansible/playbooks/service/pdns.yml
@@ -1,0 +1,40 @@
+---
+# Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+# Copyright (C) 2020 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Manage PowerDNS authoritative server
+  hosts: [ 'debops_service_pdns' ]
+  become: True
+
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
+
+  roles:
+
+    - role: etc_services
+      tags: [ 'role::etc_services', 'skip::etc_services' ]
+      etc_services__dependent_list:
+        - '{{ pdns__etc_services__dependent_list }}'
+      when: pdns__api or pdns__metrics
+
+    - role: ferm
+      tags: [ 'role::ferm', 'skip::ferm' ]
+      ferm__dependent_rules:
+        - '{{ pdns__ferm__dependent_rules }}'
+
+    - role: postgresql
+      tags: [ 'role::postgresql', 'skip::postgresql' ]
+      postgresql__dependent_roles:
+        - '{{ pdns__postgresql__dependent_roles }}'
+      when: ('gpgsql' in pdns__backends)
+
+    - role: nginx
+      tags: [ 'role::nginx', 'skip::nginx' ]
+      nginx__dependent_servers:
+        - '{{ pdns__nginx__dependent_servers }}'
+      when: pdns__nginx_allow and (pdns__api or pdns__metrics)
+
+    - role: pdns
+      tags: [ 'role::pdns', 'skip::pdns' ]

--- a/ansible/playbooks/srv/all.yml
+++ b/ansible/playbooks/srv/all.yml
@@ -106,3 +106,5 @@
 - import_playbook: libuser.yml
 
 - import_playbook: minidlna.yml
+
+- import_playbook: pdns.yml

--- a/ansible/playbooks/srv/pdns-nginx.yml
+++ b/ansible/playbooks/srv/pdns-nginx.yml
@@ -1,0 +1,1 @@
+../service/pdns-nginx.yml

--- a/ansible/playbooks/srv/pdns-plain.yml
+++ b/ansible/playbooks/srv/pdns-plain.yml
@@ -1,0 +1,1 @@
+../service/pdns-plain.yml

--- a/ansible/playbooks/srv/pdns.yml
+++ b/ansible/playbooks/srv/pdns.yml
@@ -1,0 +1,1 @@
+../service/pdns.yml

--- a/ansible/roles/global_handlers/handlers/main.yml
+++ b/ansible/roles/global_handlers/handlers/main.yml
@@ -73,6 +73,8 @@
 
 - import_tasks: 'opendkim.yml'
 
+- import_tasks: 'pdns.yml'
+
 - import_tasks: 'pki.yml'
 
 - import_tasks: 'postfix.yml'

--- a/ansible/roles/global_handlers/handlers/pdns.yml
+++ b/ansible/roles/global_handlers/handlers/pdns.yml
@@ -1,0 +1,9 @@
+---
+# Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+# Copyright (C) 2020 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Restart pdns
+  service:
+    name: 'pdns'
+    state: 'restarted'

--- a/ansible/roles/pdns/COPYRIGHT
+++ b/ansible/roles/pdns/COPYRIGHT
@@ -1,0 +1,19 @@
+debops.pdns - Manage PowerDNS authoritative server
+
+Copyright (C) 2020 CipherMail B.V. https://www.ciphermail.com/
+Copyright (C) 2021 Imre Jonk <imre@imrejonk.nl>
+Copyright (C) 2020-2021 DebOps https://debops.org/
+SPDX-License-Identifier: GPL-3.0-or-later
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see https://www.gnu.org/licenses/.

--- a/ansible/roles/pdns/defaults/main.yml
+++ b/ansible/roles/pdns/defaults/main.yml
@@ -306,7 +306,8 @@ pdns__default_configuration:
     comment: |-
       Turn on primary operation. Note: the name of this setting was changed
       with the release of pdns 4.5.0.
-    value: '{{ pdns__primary }}'
+    value: True
+    state: '{{ "present" if pdns__primary else "absent" }}'
 
   - name: '{{ "secondary"
               if ansible_local.pdns.version is version("4.5.0", ">=")
@@ -314,19 +315,25 @@ pdns__default_configuration:
     comment: |-
       Turn on secondary operation. Note: the name of this setting was changed
       with the release of pdns 4.5.0.
-    value: '{{ pdns__secondary }}'
+    value: True
+    state: '{{ "present" if pdns__secondary else "absent" }}'
 
   - name: '{{ "autosecondary"
               if ansible_local.pdns.version is version("4.5.0", ">=")
-              else "superslave" }}'
+              else "superslave"
+                   if ansible_local.pdns.version is version("4.2.0", ">=")
+                   else "supermaster" }}'
     comment: |-
       Turn on autosecondary operation. Note: the name of this setting was
-      changed with the release of pdns 4.5.0.
-    value: '{{ pdns__autosecondary }}'
+      changed with the release of pdns 4.2.0, and once more with the release of
+      pdns 4.5.0.
+    value: True
+    state: '{{ "present" if pdns__autosecondary else "absent" }}'
 
   - name: 'api'
     comment: 'Enable/Disable the built-in webserver and HTTP API.'
-    value: '{{ pdns__api }}'
+    value: True
+    state: '{{ "present" if pdns__api else "absent" }}'
 
   - name: 'api-key'
     comment: 'Static pre-shared authentication key for access to the REST API.'
@@ -335,7 +342,8 @@ pdns__default_configuration:
 
   - name: 'dnsupdate'
     comment: 'Enable/Disable DNS update (RFC2136) support.'
-    value: '{{ pdns__dnsupdate }}'
+    value: True
+    state: '{{ "present" if pdns__dnsupdate else "absent" }}'
 
   - name: 'allow-dnsupdate-from'
     comment: 'Allow DNS updates from these IP ranges.'
@@ -378,7 +386,8 @@ pdns__default_configuration:
 
   - name: 'webserver'
     comment: 'Enable/Disable the built-in webserver and metrics endpoint.'
-    value: '{{ pdns__metrics }}'
+    value: True
+    state: '{{ "present" if pdns__metrics else "absent" }}'
 
   - name: 'webserver-port'
     comment: 'The TCP port the built-in webserver will listen on.'

--- a/ansible/roles/pdns/defaults/main.yml
+++ b/ansible/roles/pdns/defaults/main.yml
@@ -1,0 +1,470 @@
+---
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+
+# .. Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+# .. Copyright (C) 2021 Imre Jonk <imre@imrejonk.nl>
+# .. Copyright (C) 2020-2021 DebOps <https://debops.org/>
+# .. SPDX-License-Identifier: GPL-3.0-or-later
+
+# .. _pdns__ref_defaults:
+
+# debops.pdns default variables
+# =============================
+
+# .. contents:: Sections
+#    :local:
+#
+# .. include:: ../../../../includes/global.rst
+
+# APT packages [[[
+# ----------------
+
+# .. envvar:: pdns__base_packages [[[
+#
+# List of default packages to install for PowerDNS Authoritative Server
+# support.
+pdns__base_packages: '{{ [ "pdns-server" ]
+                         + ([ "pdns-backend-pgsql" ]
+                            if "gpgsql" in pdns__backends
+                            else []) }}'
+
+                                                                   # ]]]
+# .. envvar:: pdns__packages [[[
+#
+# List of additional packages to install with PowerDNS Authoritative Server.
+pdns__packages: []
+                                                                   # ]]]
+                                                                   # ]]]
+# Basic settings [[[
+# ------------------
+
+# .. envvar:: pdns__allow [[[
+#
+# List of addresses/subnets that can access the pdns service.
+pdns__allow: [ '0.0.0.0/0', '::/0' ]
+
+                                                                   # ]]]
+# .. envvar:: pdns__local_address [[[
+#
+# Local IPv4 and IPv6 addresses to bind to.
+pdns__local_address: [ '0.0.0.0', '::' ]
+
+                                                                   # ]]]
+# .. envvar:: pdns__local_port [[[
+#
+# Local port (TCP and UDP) to bind to.
+pdns__local_port: '53'
+
+                                                                   # ]]]
+# .. envvar:: pdns__primary [[[
+#
+# Whether to enable primary operation. Enabling this will instruct pdns to send
+# (optionally TSIG-signed) notifications of changes to secondaries, which can
+# then initiate zone transfers. Notifications are only sent for domains with
+# type MASTER in your backend.
+# See also https://doc.powerdns.com/authoritative/modes-of-operation.html#primary-operation
+pdns__primary: False
+
+                                                                   # ]]]
+# .. envvar:: pdns__secondary [[[
+#
+# Whether to enable secondary operation. Enabling this will instruct pdns to
+# periodically check for zone changes at the primary nameservers, and update
+# the local zones accordingly. These checks happen every 'refresh' seconds (as
+# specified by the SOA record) and are only performed for domains with type
+# SLAVE in your backend.
+# See also https://doc.powerdns.com/authoritative/modes-of-operation.html#secondary-operation
+pdns__secondary: False
+
+                                                                   # ]]]
+# .. envvar:: pdns__autosecondary [[[
+#
+# Whether to enable autosecondary support. Enabling this will instruct pdns to
+# automatically provision domains that it receives notifications for, if the
+# notifications come from an IP address listed in the 'supermasters' table in
+# your backend database. pdns will then act as a secondary for those domains.
+# See also https://doc.powerdns.com/authoritative/modes-of-operation.html#autoprimary-operation
+pdns__autosecondary: False
+
+                                                                   # ]]]
+# .. envvar:: pdns__resolver [[[
+#
+# Recursive DNS server to use for ALIAS lookups and the internal stub resolver.
+# Only one address can be given. A port may be specified after a colon; with
+# IPv6, the address must in that case be enclosed in square brackets.
+pdns__resolver: '{{ ansible_local.resolvconf.nameservers[0]
+                    |d(ansible_dns.nameservers[0]) }}'
+
+                                                                   # ]]]
+# .. envvar:: pdns__backends [[[
+#
+# The backends to enable. These can be used for storing DNS records and
+# metadata and will be added to the 'launch' setting. Each backend can be
+# configured separately.
+# See https://doc.powerdns.com/authoritative/backends/index.html
+pdns__backends: [ 'gpgsql' ]
+                                                                   # ]]]
+                                                                   # ]]]
+# Built-in webserver and HTTP API [[[
+# -----------------------------------
+
+# .. envvar:: pdns__api [[[
+#
+# Enable/Disable the built-in webserver and HTTP API. For details, see:
+# https://doc.powerdns.com/authoritative/http-api/index.html#enabling-the-api
+pdns__api: False
+
+                                                                   # ]]]
+# .. envvar:: pdns__api_key [[[
+#
+# Static pre-shared authentication key for access to the HTTP API.
+pdns__api_key: '{{ lookup("password", secret + "/pdns/" + ansible_fqdn
+                          + "/api_key chars=ascii_letters,digits length=22")
+                   if pdns__api
+                   else "" }}'
+
+                                                                   # ]]]
+# .. envvar:: pdns__metrics [[[
+#
+# Enable/Disable the built-in webserver and metrics endpoint. For details, see:
+# https://doc.powerdns.com/authoritative/http-api/index.html#metrics-endpoint
+pdns__metrics: False
+
+                                                                   # ]]]
+# .. envvar:: pdns__http_port [[[
+#
+# TCP port which the built-in webserver will bind to. This is different from
+# the default port 8081 because that port is already assigned in the Debian
+# /etc/services file for the tproxy "Transparent Proxy" service.
+pdns__http_port: '16836'
+
+                                                                   # ]]]
+# .. envvar:: pdns__nginx_fqdn [[[
+#
+# The fully qualified domain name used to set up the NGINX webserver for
+# proxying requests to the pdns built-in webserver and HTTP API.
+pdns__nginx_fqdn: 'powerdns.{{ ansible_domain }}'
+
+                                                                   # ]]]
+# .. envvar:: pdns__nginx_allow [[[
+#
+# List of IP addresses and/or subnets that NGINX allows access to the pdns
+# webserver and HTTP API. An empty list denies all. Note: this does not
+# influence the pdns built-in webserver ACL. For that, see the
+# '`webserver-allow-from`__' setting.
+#
+# .. __: https://doc.powerdns.com/authoritative/settings.html#webserver-allow-from
+pdns__nginx_allow: []
+                                                                   # ]]]
+                                                                   # ]]]
+# Dynamic DNS Update (RFC 2136) [[[
+# ---------------------------------
+
+# pdns has support for updating zone contents using the DNS UPDATE mechanism
+# specified in :rfc:`2136`.
+
+# .. envvar:: pdns__dnsupdate [[[
+#
+# Whether to enable DNS UPDATE processing. Not all backends support this.
+# See https://doc.powerdns.com/authoritative/dnsupdate.html
+pdns__dnsupdate: True
+
+                                                                   # ]]]
+# .. envvar:: pdns__allow_dnsupdate_from [[[
+#
+# List of IP ranges that are allowed to perform DNS updates on all domains
+# **without any authentication**. An empty list denies all. Note that this
+# setting can be applied on a per-domain basis using the ALLOW-DNSUPDATE-FROM
+# domain metadata. You are encouraged to specify fine-grained DNS UPDATE access
+# controls using the ALLOW-DNSUPDATE-FROM and optionally TSIG-ALLOW-DNSUPDATE
+# domain metadata.
+# See https://doc.powerdns.com/authoritative/dnsupdate.html#per-zone-settings
+pdns__allow_dnsupdate_from: []
+                                                                   # ]]]
+                                                                   # ]]]
+# PostgreSQL database configuration [[[
+# -------------------------------------
+
+# The PostgreSQL database will only be configured if :envvar:`pdns__backends`
+# contains 'gpgsql'. Upstream documentation on this backend is available here:
+# https://doc.powerdns.com/authoritative/backends/generic-postgresql.html
+
+# .. envvar:: pdns__postgresql_delegate_to [[[
+#
+# The host that Ansible should configure the PostgreSQL database on.
+pdns__postgresql_delegate_to: '{{ ansible_local.postgresql.delegate_to
+                                  |d(ansible_fqdn) }}'
+
+                                                                   # ]]]
+# .. envvar:: pdns__postgresql_server [[[
+#
+# The host that should be configured in pdns as the PostgreSQL server.
+pdns__postgresql_server: '{{ ansible_local.postgresql.server|d("localhost") }}'
+
+                                                                   # ]]]
+# .. envvar:: pdns__postgresql_port [[[
+#
+# The TCP port of the PostgreSQL server.
+pdns__postgresql_port: '{{ ansible_local.postgresql.port|d("5432") }}'
+
+                                                                   # ]]]
+# .. envvar:: pdns__postgresql_database [[[
+#
+# The PostgreSQL database name.
+pdns__postgresql_database: 'pdns'
+
+                                                                   # ]]]
+# .. envvar:: pdns__postgresql_role [[[
+#
+# The role used to authenticate to the PostgreSQL database.
+pdns__postgresql_role: 'pdns'
+
+                                                                   # ]]]
+# .. envvar:: pdns__postgresql_password [[[
+#
+# The password used to authenticate to the PostgreSQL database.
+pdns__postgresql_password: '{{ lookup("password", secret + "/postgresql/"
+                                      + pdns__postgresql_delegate_to + "/"
+                                      + pdns__postgresql_port + "/credentials/"
+                                      + pdns__postgresql_role
+                                      + "/password chars=ascii_letters,digits "
+                                      + "length=22")
+                               if "gpgsql" in pdns__backends
+                               else "" }}'
+
+                                                                   # ]]]
+# .. envvar:: pdns__postgresql_schema [[[
+#
+# Filesystem path to the initial PostgreSQL database schema.
+pdns__postgresql_schema: '/usr/share/pdns-backend-pgsql/schema/schema.pgsql.sql'
+
+                                                                   # ]]]
+# .. envvar:: pdns__postgresql_dnssec [[[
+#
+# Whether to enable DNSSEC processing for the PostgreSQL backend.
+# Note that you still need to enable DNSSEC on a per-domain basis.
+# See https://doc.powerdns.com/authoritative/dnssec/index.html
+pdns__postgresql_dnssec: True
+                                                                   # ]]]
+                                                                   # ]]]
+# pdns.conf templating [[[
+# ------------------------
+
+# .. envvar:: pdns__original_configuration [[[
+#
+# The original ``/etc/powerdns/pdns.conf`` configuration as supplied by the
+# 'pdns-server' Debian package.
+pdns__original_configuration:
+
+  - name: 'include-dir'
+    comment: 'Directory to scan for additional config files.'
+    value: '/etc/powerdns/pdns.d'
+
+  - name: 'launch'
+    comment: 'Which backends to launch and order to query them in.'
+    value: ''
+
+  - name: 'security-poll-suffix'
+    comment: 'Zone name from which to query security update notifications.'
+    value: ''
+
+                                                                   # ]]]
+# .. envvar:: pdns__default_configuration [[[
+#
+# The default ``/etc/powerdns/pdns.conf`` configuration provided by this role.
+pdns__default_configuration:
+
+  - name: 'local-address'
+    comment: |-
+      Local IP addresses to which we bind. Accepts IPv6 addresses since pdns
+      4.3.0.
+    value: '{{ (pdns__local_address
+                if ansible_local.pdns.version is version("4.5.0", ">=")
+                else (pdns__local_address | ipv4)) | join ("") }}'
+
+  - name: 'local-ipv6'
+    comment: |-
+      Local IPv6 addresses to which we bind. Will be deprecated in pdns 4.3.0.
+    value: '{{ pdns__local_address | ipv6 | join(",") }}'
+    state: '{{ "present"
+               if ansible_local.pdns.version is version("4.5.0", "<")
+               else "absent" }}'
+
+  - name: 'local-port'
+    comment: 'Local TCP and UDP port to bind to.'
+    value: '{{ pdns__local_port }}'
+
+  - name: 'resolver'
+    comment: |-
+      Recursive DNS server to use for ALIAS lookups and the internal stub
+      resolver. Only one address can be given.
+    value: '{{ pdns__resolver }}'
+
+  - name: '{{ "primary"
+              if ansible_local.pdns.version is version("4.5.0", ">=")
+              else "master" }}'
+    comment: |-
+      Turn on primary operation. Note: the name of this setting was changed
+      with the release of pdns 4.5.0.
+    value: '{{ pdns__primary }}'
+
+  - name: '{{ "secondary"
+              if ansible_local.pdns.version is version("4.5.0", ">=")
+              else "slave" }}'
+    comment: |-
+      Turn on secondary operation. Note: the name of this setting was changed
+      with the release of pdns 4.5.0.
+    value: '{{ pdns__secondary }}'
+
+  - name: '{{ "autosecondary"
+              if ansible_local.pdns.version is version("4.5.0", ">=")
+              else "superslave" }}'
+    comment: |-
+      Turn on autosecondary operation. Note: the name of this setting was
+      changed with the release of pdns 4.5.0.
+    value: '{{ pdns__autosecondary }}'
+
+  - name: 'api'
+    comment: 'Enable/Disable the built-in webserver and HTTP API.'
+    value: '{{ pdns__api }}'
+
+  - name: 'api-key'
+    comment: 'Static pre-shared authentication key for access to the REST API.'
+    value: '{{ pdns__api_key }}'
+    state: '{{ "present" if pdns__api else "absent" }}'
+
+  - name: 'dnsupdate'
+    comment: 'Enable/Disable DNS update (RFC2136) support.'
+    value: '{{ pdns__dnsupdate }}'
+
+  - name: 'allow-dnsupdate-from'
+    comment: 'Allow DNS updates from these IP ranges.'
+    value: '{{ pdns__allow_dnsupdate_from | join(",") }}'
+    state: '{{ "present" if pdns__dnsupdate else "absent" }}'
+
+  - name: 'launch'
+    comment: 'Which backends to launch and order to query them in.'
+    value: '{{ pdns__backends | join(",") }}'
+
+  - name: 'gpgsql-host'
+    comment: 'The PostgreSQL backend host.'
+    value: '{{ pdns__postgresql_server }}'
+    state: '{{ "present" if "gpgsql" in pdns__backends else "absent" }}'
+
+  - name: 'gpgsql-port'
+    comment: 'The PostgreSQL backend port.'
+    value: '{{ pdns__postgresql_port }}'
+    state: '{{ "present" if "gpgsql" in pdns__backends else "absent" }}'
+
+  - name: 'gpgsql-dbname'
+    comment: 'The PostgreSQL backend database name.'
+    value: '{{ pdns__postgresql_database }}'
+    state: '{{ "present" if "gpgsql" in pdns__backends else "absent" }}'
+
+  - name: 'gpgsql-user'
+    comment: 'The username to authenticate to the PostgreSQL backend with.'
+    value: '{{ pdns__postgresql_role }}'
+    state: '{{ "present" if "gpgsql" in pdns__backends else "absent" }}'
+
+  - name: 'gpgsql-password'
+    comment: 'The password to authenticate to the PostgreSQL backend with.'
+    value: '{{ pdns__postgresql_password }}'
+    state: '{{ "present" if "gpgsql" in pdns__backends else "absent" }}'
+
+  - name: 'gpgsql-dnssec'
+    comment: 'Whether to enable DNSSEC processing for the PostgreSQL backend.'
+    value: '{{ pdns__postgresql_dnssec }}'
+    state: '{{ "present" if "gpgsql" in pdns__backends else "absent" }}'
+
+  - name: 'webserver'
+    comment: 'Enable/Disable the built-in webserver and metrics endpoint.'
+    value: '{{ pdns__metrics }}'
+
+  - name: 'webserver-port'
+    comment: 'The TCP port the built-in webserver will listen on.'
+    value: '{{ pdns__http_port }}'
+    state: '{{ "present" if pdns__api or pdns__metrics else "absent" }}'
+
+                                                                   # ]]]
+# .. envvar:: pdns__configuration [[[
+#
+# Additional ``/etc/powerdns/pdns.conf`` configuration that should be present
+# on all hosts in the Ansible inventory.
+pdns__configuration: []
+
+                                                                   # ]]]
+# .. envvar:: pdns__group_configuration [[[
+#
+# Additional ``/etc/powerdns/pdns.conf`` configuration that should be present
+# on all hosts in the Ansible inventory group.
+pdns__group_configuration: []
+
+                                                                   # ]]]
+# .. envvar:: pdns__host_configuration [[[
+#
+# Additional ``/etc/powerdns/pdns.conf`` configuration that should be present
+# on specific hosts in the Ansible inventory.
+pdns__host_configuration: []
+
+                                                                   # ]]]
+# .. envvar:: pdns__combined_configuration [[[
+#
+# The combined pdns configuration variables that will be used to template the
+# ``/etc/powerdns/pdns.conf`` file.
+pdns__combined_configuration: '{{ pdns__original_configuration
+                                  + pdns__default_configuration
+                                  + pdns__configuration
+                                  + pdns__group_configuration
+                                  + pdns__host_configuration }}'
+                                                                   # ]]]
+                                                                   # ]]]
+# Configuration for other Ansible roles [[[
+# -----------------------------------------
+
+# .. envvar:: pdns__etc_services__dependent_list [[[
+#
+# Configuration for the :ref:`debops.etc_services` role.
+pdns__etc_services__dependent_list:
+
+  - name: 'powerdns-http'
+    port: '{{ pdns__http_port }}'
+    protocols: [ 'tcp' ]
+    comment: 'Added by debops.pdns Ansible role.'
+
+                                                                   # ]]]
+# .. envvar:: pdns__ferm__dependent_rules [[[
+#
+# Configuration for the :ref:`debops.ferm` role.
+pdns__ferm__dependent_rules:
+
+  - name: 'pdns'
+    by_role: 'debops.pdns'
+    type: 'accept'
+    protocol: [ 'tcp', 'udp' ]
+    dport: [ '{{ pdns__local_port }}' ]
+    saddr: '{{ pdns__allow }}'
+
+                                                                   # ]]]
+# .. envvar:: pdns__nginx__dependent_servers [[[
+#
+# Configuration for the :ref:`debops.nginx` role.
+pdns__nginx__dependent_servers:
+
+  - name: '{{ pdns__nginx_fqdn }}'
+    filename: 'debops.pdns'
+    allow: '{{ pdns__nginx_allow }}'
+    type: 'proxy'
+    proxy_pass: 'http://127.0.0.1:{{ pdns__http_port }}'
+    webroot_create: False
+
+                                                                   # ]]]
+# .. envvar:: pdns__postgresql__dependent_roles [[[
+#
+# Configuration for the :ref:`debops.postgresql` role.
+pdns__postgresql__dependent_roles:
+
+  - role: '{{ pdns__postgresql_role }}'
+    port: '{{ pdns__postgresql_port }}'
+    password: '{{ pdns__postgresql_password }}'
+                                                                   # ]]]
+                                                                   # ]]]

--- a/ansible/roles/pdns/defaults/main.yml
+++ b/ansible/roles/pdns/defaults/main.yml
@@ -268,6 +268,14 @@ pdns__original_configuration:
     comment: 'Zone name from which to query security update notifications.'
     value: ''
 
+  - name: 'setgid'
+    comment: 'Run as an unprivileged group instead of root.'
+    value: 'pdns'
+
+  - name: 'setuid'
+    comment: 'Run as an unprivileged user instead of root.'
+    value: 'pdns'
+
                                                                    # ]]]
 # .. envvar:: pdns__default_configuration [[[
 #

--- a/ansible/roles/pdns/defaults/main.yml
+++ b/ansible/roles/pdns/defaults/main.yml
@@ -112,7 +112,9 @@ pdns__backends: [ 'gpgsql' ]
 #
 # Enable/Disable the built-in webserver and HTTP API. For details, see:
 # https://doc.powerdns.com/authoritative/http-api/index.html#enabling-the-api
-pdns__api: False
+pdns__api: '{{ True
+               if "debops_service_pdns_nginx" in group_names
+               else False }}'
 
                                                                    # ]]]
 # .. envvar:: pdns__api_key [[[
@@ -128,7 +130,7 @@ pdns__api_key: '{{ lookup("password", secret + "/pdns/" + ansible_fqdn
 #
 # Enable/Disable the built-in webserver and metrics endpoint. For details, see:
 # https://doc.powerdns.com/authoritative/http-api/index.html#metrics-endpoint
-pdns__metrics: False
+pdns__metrics: '{{ pdns__api }}'
 
                                                                    # ]]]
 # .. envvar:: pdns__http_port [[[

--- a/ansible/roles/pdns/meta/main.yml
+++ b/ansible/roles/pdns/meta/main.yml
@@ -13,7 +13,7 @@ galaxy_info:
   author: 'Imre Jonk, CipherMail B.V.'
   description: 'Manage PowerDNS Authoritative Server'
   license: 'GPL-3.0-or-later'
-  min_ansible_version: '0.0.0'
+  min_ansible_version: '2.10.0'
   platforms:
     - name: 'Debian'
       versions:

--- a/ansible/roles/pdns/meta/main.yml
+++ b/ansible/roles/pdns/meta/main.yml
@@ -1,0 +1,26 @@
+---
+# Copyright (C) 2021 CipherMail B.V. <https://www.ciphermail.com/>
+# Copyright (C) 2021 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+collections: [ 'debops.debops' ]
+
+dependencies: []
+
+galaxy_info:
+
+  company: 'DebOps'
+  author: 'Imre Jonk, CipherMail B.V.'
+  description: 'Manage PowerDNS Authoritative Server'
+  license: 'GPL-3.0-or-later'
+  min_ansible_version: '0.0.0'
+  platforms:
+    - name: 'Debian'
+      versions:
+        - 'buster'
+        - 'bullseye'
+  galaxy_tags:
+    - 'powerdns'
+    - 'pdns'
+    - 'authoritative'
+    - 'dns'

--- a/ansible/roles/pdns/tasks/init_postgresql.yml
+++ b/ansible/roles/pdns/tasks/init_postgresql.yml
@@ -1,0 +1,21 @@
+---
+# Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+# Copyright (C) 2020 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Create PostgreSQL database
+  postgresql_db:
+    name: '{{ pdns__postgresql_database }}'
+    owner: '{{ pdns__postgresql_role }}'
+    state: 'present'
+  delegate_to: '{{ pdns__postgresql_delegate_to }}'
+  register: pdns__register_postgresql_status
+
+- name: Import initial database schema
+  postgresql_db:
+    login_user: '{{ pdns__postgresql_role }}'
+    login_password: '{{ pdns__postgresql_password }}'
+    name: '{{ pdns__postgresql_database }}'
+    target: '{{ pdns__postgresql_schema }}'
+    state: 'restore'
+  when: pdns__register_postgresql_status is changed  # noqa no-handler

--- a/ansible/roles/pdns/tasks/main.yml
+++ b/ansible/roles/pdns/tasks/main.yml
@@ -1,0 +1,56 @@
+---
+# Copyright (C) 2020 CipherMail B.V. <https://www.ciphermail.com/>
+# Copyright (C) 2021 Imre Jonk <imre@imrejonk.nl>
+# Copyright (C) 2020 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Import custom Ansible plugins
+  import_role:
+    name: 'ansible_plugins'
+
+- name: Import DebOps global handlers
+  import_role:
+    name: 'global_handlers'
+
+- name: Import DebOps secret role
+  import_role:
+    name: 'secret'
+
+- name: Ensure PowerDNS support is installed
+  package:
+    name: '{{ (pdns__base_packages + pdns__packages) | flatten }}'
+    state: 'present'
+  register: pdns__register_packages
+  until: pdns__register_packages is succeeded
+
+- include_tasks: init_postgresql.yml
+  when: ('gpgsql' in pdns__backends)
+
+- name: Divert original configuration
+  dpkg_divert:
+    path: '/etc/powerdns/pdns.conf'
+
+- name: Make sure that Ansible local facts directory exists
+  file:
+    path: '/etc/ansible/facts.d'
+    state: 'directory'
+    mode: '0755'
+
+- name: Save local facts
+  template:
+    src: 'etc/ansible/facts.d/pdns.fact.j2'
+    dest: '/etc/ansible/facts.d/pdns.fact'
+    mode: '0755'
+  notify: [ 'Refresh host facts' ]
+
+- name: Update Ansible facts if they were modified
+  meta: 'flush_handlers'
+
+- name: Configure local PowerDNS changes
+  template:
+    src: 'etc/powerdns/pdns.conf.j2'
+    dest: '/etc/powerdns/pdns.conf'
+    owner: 'root'
+    group: 'pdns'
+    mode: '0640'
+  notify: [ 'Restart pdns' ]

--- a/ansible/roles/pdns/templates/etc/ansible/facts.d/pdns.fact.j2
+++ b/ansible/roles/pdns/templates/etc/ansible/facts.d/pdns.fact.j2
@@ -1,0 +1,28 @@
+#!{{ ansible_python['executable'] }}
+
+# Copyright (C) 2021 Imre Jonk <imre@imrejonk.nl>
+# Copyright (C) 2020 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# {{ ansible_managed }}
+
+from json import dumps
+import os
+import subprocess
+
+
+def cmd_exists(cmd):
+    return any(
+        os.access(os.path.join(path, cmd), os.X_OK)
+        for path in os.environ['PATH'].split(os.pathsep)
+    )
+
+
+output = {'installed': cmd_exists('pdnsutil')}
+
+if output['installed']:
+    output['version'] = subprocess.check_output(
+        ['pdnsutil', '--version'], stderr=subprocess.STDOUT
+    ).decode('utf-8').split(' ')[1].replace('\n', '')
+
+print(dumps(output, sort_keys=True, indent=4))

--- a/ansible/roles/pdns/templates/etc/powerdns/pdns.conf.j2
+++ b/ansible/roles/pdns/templates/etc/powerdns/pdns.conf.j2
@@ -1,0 +1,15 @@
+{# Copyright (C) 2021 Imre Jonk <imre@imrejonk.nl>
+ # Copyright (C) 2021 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-or-later
+ #}
+# {{ ansible_managed }}
+
+{%  for element in pdns__combined_configuration | parse_kv_config %}
+{%      if element.state == "present" %}
+{%          if element.comment|d() %}
+# {{ element.comment | replace('\n', '\n# ') }}
+{%          endif %}
+{{ element.name }} = {{ element.value }}
+
+{%      endif%}
+{%  endfor %}

--- a/docs/ansible/role-index.rst
+++ b/docs/ansible/role-index.rst
@@ -156,6 +156,7 @@ It's always DNS.
 - :ref:`debops.avahi`
 - :ref:`debops.dnsmasq`
 - :ref:`debops.netbase`
+- :ref:`debops.pdns`
 - :ref:`debops.resolvconf`
 - :ref:`debops.unbound`
 

--- a/docs/ansible/roles/pdns/defaults-detailed.rst
+++ b/docs/ansible/roles/pdns/defaults-detailed.rst
@@ -1,0 +1,49 @@
+.. Copyright (C) 2021 <imre@imrejonk.nl>
+.. Copyright (C) 2021 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-or-later
+
+Default variables: configuration
+================================
+
+Some of the ``debops.pdns`` default variables have more extensive configuration
+than simple strings or lists, here you can find documentation and examples for
+them.
+
+.. _pdns__ref_configuration:
+
+pdns__*_configuration
+---------------------
+
+The ``pdns__configuration``, ``pdns__group_configuration`` and
+``pdns__host_configuration`` variables allow you to override
+``/etc/powerdns/pdns.conf`` settings on a global, group or host basis. The
+variables are lists of dicts that get merged using the principles of
+:ref:`Universal Configuration <universal_configuration>`.
+
+``name``
+  Required. Name of the setting you want to change.
+
+``comment``
+  Optional. Comment added in the configuration file.
+
+``value``
+  Required. The value to configure as a string or YAML text block.
+
+``state``
+  Optional. The state of the setting in ``/etc/powerdns/pdns.conf``, either
+  "present" or "absent". Defaults to "present".
+
+
+Example::
+
+  pdns__configuration:
+
+    - name: 'also-notify'
+      comment: |-
+        Our secondary DNS provider uses unicast hosts to collect zone transfer
+        data, and then distributes it internally to all their anycast servers.
+      value: '2001:db8:a::1, 2001:db8:b::1, 2001:db8:c::1'
+      state: '{{ "present"
+                 if ansible_local.machine.deployment
+                    |d("production") == "production"
+                 else "absent" }}'

--- a/docs/ansible/roles/pdns/getting-started.rst
+++ b/docs/ansible/roles/pdns/getting-started.rst
@@ -117,12 +117,41 @@ really want to.
 Anyone using pdns to serve DNSSEC-signed zone data is encouraged to read the
 DNSSEC guide: https://doc.powerdns.com/authoritative/dnssec/index.html
 
+Example inventory
+-----------------
+
+To run the pdns playbook against a host, it needs to be added to the
+``[debops_service_pdns]`` inventory group:
+
+.. code-block:: none
+
+   [debops_service_pdns]
+   hostname
+
+If you want to use the :command:`nginx` reverse proxy, useful for remotely
+accessing the pdns API or metrics endpoint over TLS, you can add the host to
+the ``[debops_service_pdns_nginx]`` inventory group instead:
+
+.. code-block:: none
+
+   [debops_service_pdns_nginx]
+   hostname
+
+Doing so will install the :command:`nginx` webserver, configure it for use with
+pdns, and automatically enable the pdns API and metrics endpoint.
+
 Example playbook
 ----------------
 
 If you are using this role without DebOps, here's an example Ansible playbook
 that uses the ``debops.pdns`` role:
 
-.. literalinclude:: ../../../../ansible/playbooks/service/pdns.yml
+.. literalinclude:: ../../../../ansible/playbooks/service/pdns-plain.yml
+   :language: yaml
+   :lines: 1,5-
+
+There is a separate playbook for pdns with :command:`nginx` as a reverse proxy:
+
+.. literalinclude:: ../../../../ansible/playbooks/service/pdns-nginx.yml
    :language: yaml
    :lines: 1,5-

--- a/docs/ansible/roles/pdns/getting-started.rst
+++ b/docs/ansible/roles/pdns/getting-started.rst
@@ -46,9 +46,12 @@ Secondary operation
 ~~~~~~~~~~~~~~~~~~~
 
 Secondary operation can be enabled by setting :envvar:`pdns__secondary` to
-``True``. Doing so will instruct pdns to periodically check for zone changes at the primary nameservers, and update the local zones accordingly. These checks happen every 'refresh' seconds (as specified by the SOA record) and are only performed for domains with type SLAVE in your backend. Additionally, if the primary
-nameserver sends notifications for such domains, pdns will initiate a zone
-transfer immediately.
+``True``. Doing so will instruct pdns to periodically check for zone changes at
+the primary nameservers, and update the local zones accordingly. These checks
+happen every 'refresh' seconds (as specified by the SOA record) and are only
+performed for domains with type SLAVE in your backend. Additionally, if the
+primary nameserver sends notifications for such domains, pdns will initiate a
+zone transfer immediately.
 
 Autosecondary operation
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/ansible/roles/pdns/getting-started.rst
+++ b/docs/ansible/roles/pdns/getting-started.rst
@@ -1,0 +1,125 @@
+.. Copyright (C) 2021 Imre Jonk <imre@imrejonk.nl>
+.. Copyright (C) 2021 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-or-later
+
+Getting started
+===============
+
+The default configuration assumes that the target host has been configured with
+:ref:`debops.postgresql_server`.
+
+Without any additional configuration, the ``service/pdns`` playbook will
+configure a PostgreSQL role on the target host, create a database and
+initialize it with the pdns PostgreSQL schema, install PowerDNS Authoritative
+Server, and set it up using the ``gpgsql`` backend. The only mode of operation
+available will be native replication (i.e. pdns relies on the backend doing the
+replication of zone data to other pdns servers).
+
+Modes of operation
+------------------
+
+pdns has four modes of operation: native replication, primary operation,
+secondary operation, and autosecondary operation. A brief description of each
+mode follows. For full details, refer to the `DNS Modes of Operation
+documentation`__.
+
+.. __: https://doc.powerdns.com/authoritative/modes-of-operation.html
+
+Native replication
+~~~~~~~~~~~~~~~~~~
+
+Native replication does not need to be enabled. It is always available,
+provided that your backend supports it. With native replication, pdns just lets
+the backend figure out how to get the zone data to the backends of your other
+pdns servers.
+
+Primary operation
+~~~~~~~~~~~~~~~~~
+
+Primary operation can be enabled by setting :envvar:`pdns__primary` to
+``True``. Doing so will instruct pdns to send (optionally TSIG-signed)
+notifications of changes to secondaries, which can then initiate zone
+transfers. Notifications are only sent for domains with type MASTER in your
+backend.
+
+Secondary operation
+~~~~~~~~~~~~~~~~~~~
+
+Secondary operation can be enabled by setting :envvar:`pdns__secondary` to
+``True``. Doing so will instruct pdns to periodically check for zone changes at the primary nameservers, and update the local zones accordingly. These checks happen every 'refresh' seconds (as specified by the SOA record) and are only performed for domains with type SLAVE in your backend. Additionally, if the primary
+nameserver sends notifications for such domains, pdns will initiate a zone
+transfer immediately.
+
+Autosecondary operation
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Autosecondary operation can be enabled by setting :envvar:`pdns__autosecondary`
+to ``True``. Doing so will instruct pdns to automatically provision domains
+that it receives notifications for, if the notifications come from an IP
+address listed in the 'supermasters' table in your backend database. pdns will
+then act as a secondary for those domains.
+
+Dynamic DNS Update (RFC 2136)
+-----------------------------
+
+Dynamic DNS Update (:rfc:`2136`) allows for changing authoritative zone data in
+a standardized way. It works by having a client send a DNS UPDATE message to
+the primary nameserver, which, after optional IP allowlist and/or transaction
+signature (TSIG) checking, updates the zone in whatever way the DNS UPDATE
+message tells it to. One service that supports sending these messages is the
+ISC DHCP Server, represented in the :ref:`debops.dhcpd` role.
+
+The ``debops.pdns`` role enables support for the DNS UPDATE mechanism by
+default, but also denies all DNS updates unless an IP allowlist or TSIG key has
+been specified in the domain metadata. If you want to allow all DNS updates
+from a list of IP ranges, see :envvar:`pdns__allow_dnsupdate_from`. For
+per-domain metadata related to DNS updates, see
+https://doc.powerdns.com/authoritative/dnsupdate.html#per-zone-settings
+
+Note that not all pdns backends support DNS updates.
+
+DNSSEC
+------
+
+When operating in primary or native replication mode, pdns can perform online
+signing of zone data, i.e. signed responses are generated on-the-fly. These
+responses are cached internally. In much the same fashion, pdns can operate as
+a "bump-in-the-wire" front-signing server between a legacy (non-DNSSEC-capable)
+authoritative server and its clients.
+
+A secondary pdns server can perform a DNSSEC-capable zone transfer, i.e. it
+stores and serves pre-signed zone data which it received from the primary.
+
+There is also BIND-mode operation, which takes a traditional BIND-style zone
+file and signs it using DNSSEC keys stored in another backend.
+
+The default setup when signing a zone with ``# pdnsutil secure-zone`` is a
+single ECDSAP256SHA256 key that is used as a Combined-Signing Key (CSK), with
+NSEC as the negative answer strategy. NSEC3 is also supported. If you use pdns,
+a split-key setup most likely makes little sense, but you can do it if you
+really want to.
+
+**Important caveats** regarding DNSSEC support in pdns:
+
+- When operating in online signing mode, the default pdns configuration will
+  not increase the SOA serial when signatures are being rolled. This is not a
+  problem in the default native replication mode. For primary operation
+  however, you need to pick a SOA-EDIT value to ensure signature freshness on
+  secondaries. Please refer to the `SOA-EDIT documentation`__ for this.
+
+- In online-signing mode, the ALIAS record type is not supported.
+
+.. __: https://doc.powerdns.com/authoritative/dnssec/operational.html#soa-edit-ensure-signature-freshness-on-slaves
+
+Anyone using pdns to serve DNSSEC-signed zone data is encouraged to read the
+DNSSEC guide: https://doc.powerdns.com/authoritative/dnssec/index.html
+
+Example playbook
+----------------
+
+If you are using this role without DebOps, here's an example Ansible playbook
+that uses the ``debops.pdns`` role:
+
+.. literalinclude:: ../../../../ansible/playbooks/service/pdns.yml
+   :language: yaml
+   :lines: 1,5-

--- a/docs/ansible/roles/pdns/index.rst
+++ b/docs/ansible/roles/pdns/index.rst
@@ -1,0 +1,29 @@
+.. Copyright (C) 2021 Imre Jonk <imre@imrejonk.nl>
+.. Copyright (C) 2021 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-or-later
+
+.. _debops.pdns:
+
+debops.pdns
+===========
+
+.. include:: man_description.rst
+   :start-line: 7
+
+.. toctree::
+   :maxdepth: 3
+
+   getting-started
+   defaults/main
+   defaults-detailed
+
+Copyright
+---------
+
+.. literalinclude:: ../../../../ansible/roles/pdns/COPYRIGHT
+
+..
+ Local Variables:
+ mode: rst
+ ispell-local-dictionary: "american"
+ End:

--- a/docs/ansible/roles/pdns/man_description.rst
+++ b/docs/ansible/roles/pdns/man_description.rst
@@ -1,0 +1,17 @@
+.. Copyright (C) 2021 Imre Jonk <imre@imrejonk.nl>
+.. Copyright (C) 2021 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-or-later
+
+Description
+===========
+
+The ``debops.pdns`` role can be used to configure `PowerDNS Authoritative
+Server`_, whose service is called 'pdns' in Debian. pdns supports multiple
+backends like major relational databases, LDAP servers and plain text files.
+Backends that support native replication can be used in place of traditional
+zone transfers. Furthermore, pdns can be used for geographical load balancing
+and has excellent DNSSEC support, currently supporting the vast majority of
+DNSSEC-enabled domains in Europe. pdns is extensible using a wide variety
+of scripting languages.
+
+.. _PowerDNS Authoritative Server: https://www.powerdns.com/auth.html

--- a/docs/ansible/roles/pdns/man_index.rst
+++ b/docs/ansible/roles/pdns/man_index.rst
@@ -1,0 +1,22 @@
+:orphan:
+
+.. Copyright (C) 2021 Imre Jonk <imre@imrejonk.nl>
+.. Copyright (C) 2021 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-or-later
+
+debops.pdns
+===========
+
+.. toctree::
+   :maxdepth: 3
+
+   man_synopsis
+   man_description
+   getting-started
+   defaults-detailed
+
+..
+ Local Variables:
+ mode: rst
+ ispell-local-dictionary: "american"
+ End:

--- a/docs/ansible/roles/pdns/man_synopsis.rst
+++ b/docs/ansible/roles/pdns/man_synopsis.rst
@@ -1,0 +1,8 @@
+.. Copyright (C) 2021 Imre Jonk <imre@imrejonk.nl>
+.. Copyright (C) 2021 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-or-later
+
+Synopsis
+========
+
+``debops run [<args>] [--] service/pdns [ansible_args]``


### PR DESCRIPTION
This adds debops.pdns, a role for managing the PowerDNS Authoritative
Server. Configuration is based on the principles of Universal
Configuration and has been made explicitly forward-compatible up to
PowerDNS 4.5. Currently the role installs PowerDNS from the Debian
repositories, configures the gpgsql (PostgreSQL) backend by default and
performs a few overrides that make pdns more friendly to the DebOps
userbase:

- DNSSEC is automatically enabled for the gpgsql backend, but needs
  additional per-domain metadata to function. Hopefully this makes
  deploying DNSSEC a little more attractive.
- The IP address of the internal stub resolver is set automatically.
- The API key is created automatically when the API is enabled.
- The HTTP port is set to 16836 instead of 8081, which is reserved in
  Debian's /etc/services file.
- If the embedded webserver (for metrics and API usage) is enabled, a
  local NGINX server will be configured as a reverse proxy so that the
  webserver can be accessed securely over TLS.
- Dynamic DNS Update (RFC 2136) is automatically enabled, but needs
  additional per-domain configuration in the form of domain metadata to
  function. This makes pdns a little easier to use together with dhcpd.