### PR TITLE
[ipxe] Update release map for Bullseye 11.2

### DIFF
--- a/ansible/roles/ipxe/defaults/main.yml
+++ b/ansible/roles/ipxe/defaults/main.yml
@@ -179,19 +179,19 @@ ipxe__debian_netboot_default_release_map:
   - name: 'bullseye-amd64'
     release: 'bullseye'
     architecture: 'amd64'
-    netboot_version: '20210731+deb11u1'
-    netboot_checksum: 'sha256:dd7e30b1e90bb3347d3584e941aa86e180d5367fe0a3166d93603ef209db73db'  # netboot.tar.gz
-    firmware_version: '20211009'
-    firmware_checksum: 'sha256:17ad5dcda8889ddae116fc0669bf0b5897b448b17a002b728d1bd300328a1db6'  # firmware.cpio.gz
+    netboot_version: '20210731+deb11u2'
+    netboot_checksum: 'sha256:04efe11bb7fdd5d9fd850b19d03163bc9a8c6b6a7da875bb68b883697119caec'  # netboot.tar.gz
+    firmware_version: '20211218'
+    firmware_checksum: 'sha256:96b98f5bfdf13e0d4434fd12e42cd49b719221a313c8cf9caa4bc9d6e66b3822'  # firmware.cpio.gz
 
   - name: 'bullseye-amd64-gtk'
     release: 'bullseye'
     architecture: 'amd64'
     netboot_subdir: '/gtk'
-    netboot_version: '20210731+deb11u1'
-    netboot_checksum: 'sha256:9794bbbfba6b1968e8a99be2b36191b8aa7e03d67b662c99e8e1af162857c215'  # netboot.tar.gz
-    firmware_version: '20211009'
-    firmware_checksum: 'sha256:17ad5dcda8889ddae116fc0669bf0b5897b448b17a002b728d1bd300328a1db6'  # firmware.cpio.gz
+    netboot_version: '20210731+deb11u2'
+    netboot_checksum: 'sha256:35c775aa31e53ebba53375f42c021ce6baf5f360a2b956fae6fd5f2e5bf5cbe1'  # netboot.tar.gz
+    firmware_version: '20211218'
+    firmware_checksum: 'sha256:96b98f5bfdf13e0d4434fd12e42cd49b719221a313c8cf9caa4bc9d6e66b3822'  # firmware.cpio.gz
 
                                                                    # ]]]
 # .. envvar:: ipxe__debian_netboot_release_map [[[


### PR DESCRIPTION
The 11u1 installer media is already gone from the mirrors.