### PR TITLE
Loop log spam fixes

### DIFF
--- a/ansible/roles/ferm/tasks/main.yml
+++ b/ansible/roles/ferm/tasks/main.yml
@@ -44,7 +44,7 @@
     owner: 'root'
     group: 'adm'
     mode: '02750'
-  with_items:
+  loop:
     - '/etc/ferm/rules.d'
     - '/etc/ferm/filter-input.d'
     - '/etc/ferm/hooks/pre.d'
@@ -62,10 +62,10 @@
     directory_mode: '{{ item.directory_mode | d(omit) }}'
     follow: '{{ item.follow | d(omit) }}'
     force:  '{{ item.force  | d(omit) }}'
-  with_flattened:
-    - '{{ ferm__custom_files }}'
-    - '{{ ferm__group_custom_files }}'
-    - '{{ ferm__host_custom_files }}'
+  loop: '{{ (ferm__custom_files + ferm__group_custom_files
+             + ferm__host_custom_files) | flatten }}'
+  loop_control:
+    label: '{{ item.dest }}'
   when: ((item.src is defined or item.content is defined) and
          item.dest is defined)
   register: ferm__register_files
@@ -109,7 +109,9 @@
                                                  | d(item.value.type | d("default"))] | d("80"))|int
                                 + (item.value.weight | d("0"))|int) }}_rule_{{ item.value.name | d(item.key) }}.conf'
     state: 'absent'
-  with_dict: '{{ ferm__parsed_rules }}'
+  loop: '{{ ferm__parsed_rules | dict2items }}'
+  loop_control:
+    label: '{{ item.key }}'
   register: ferm__register_rules_removed
   when: (item.value.rule_state|d(item.value.state|d('present')) == 'absent')
   tags: [ 'role::ferm:rules' ]
@@ -123,7 +125,9 @@
     owner: 'root'
     group: 'adm'
     mode: '0644'
-  with_dict: '{{ ferm__parsed_rules }}'
+  loop: '{{ ferm__parsed_rules | dict2items }}'
+  loop_control:
+    label: '{{ item.key }}'
   register: ferm__register_rules_created
   when: (item.value.rule_state|d(item.value.state|d('present')) not in [ 'absent', 'ignore' ])
   tags: [ 'role::ferm:rules' ]
@@ -136,9 +140,10 @@
                      + (item.item.value.weight | d("0"))|int) }}_rule_{{ item.item.value.name
                                                                          | d(item.item.key) }}.conf'
          -exec rm -vf {} +
-  with_items:  # noqa no-handler
-    - '{{ ferm__register_rules_removed.results }}'
-    - '{{ ferm__register_rules_created.results }}'
+  loop: '{{ ferm__register_rules_removed.results
+            + ferm__register_rules_created.results }}'
+  loop_control:
+    label: '{{ item.item.key }}'
   when: (item.item.key|d() and item is changed)
   tags: [ 'role::ferm:rules' ]
 

--- a/ansible/roles/machine/tasks/main.yml
+++ b/ansible/roles/machine/tasks/main.yml
@@ -121,7 +121,9 @@
     creates: '{{ "/etc/update-motd.d/" + (item.filename
                                           | d(("%02d" | format(item.weight|int))|string + "-" + item.name))
                                        + ".disabled" }}'
-  with_flattened: '{{ machine__motd_combined_scripts | debops.debops.parse_kv_items }}'
+  loop: '{{ machine__motd_combined_scripts | debops.debops.parse_kv_items }}'
+  loop_control:
+    label: '{{ item.filename|d() or item.name }}'
   when: (machine__enabled|bool and
          (item.filename is defined or item.name is defined) and
          (item.state|d('present') not in [ 'init', 'absent', 'ignore', 'revert' ]) and
@@ -150,7 +152,9 @@
     owner: 'root'
     group: 'root'
     mode: '0755'
-  with_flattened: '{{ machine__motd_combined_scripts | debops.debops.parse_kv_items }}'
+  loop: '{{ machine__motd_combined_scripts | debops.debops.parse_kv_items }}'
+  loop_control:
+    label: '{{ item.filename|d() or item.name }}'
   register: machine__register_motd_scripts_created
   when: (machine__enabled|bool and
          (item.filename is defined or item.name is defined) and
@@ -162,9 +166,10 @@
          -name '*-{{ item.item.name }}'
          ! -name '{{ ("%02d" | format((item.item.weight | d("0"))|int))|string + "-" + item.item.name }}'
          -exec rm -vf {} +
-  with_items:  # noqa no-handler
-    - '{{ machine__register_motd_scripts_removed.results }}'
-    - '{{ machine__register_motd_scripts_created.results }}'
+  loop: '{{ machine__register_motd_scripts_removed.results
+            + machine__register_motd_scripts_created.results }}'
+  loop_control:
+    label: '{{ item.item.name }}'
   when: (item.item.name|d() and not (item.item.divert|d())|bool and
          item.item.filename is undefined and item is changed)
 
@@ -180,7 +185,9 @@
     removes: '{{ "/etc/update-motd.d/" + (item.filename
                                           | d(("%02d" | format(item.weight|int))|string + "-" + item.name))
                                        + ".disabled" }}'
-  with_flattened: '{{ machine__motd_combined_scripts | debops.debops.parse_kv_items }}'
+  loop: '{{ machine__motd_combined_scripts | debops.debops.parse_kv_items }}'
+  loop_control:
+    label: '{{ item.filename|d() or item.name }}'
   when: ((not machine__enabled|bool and (item.divert|d())|bool) or
           ((item.filename is defined or item.name is defined) and
            item.state|d('present') in [ 'absent', 'revert' ] and

--- a/ansible/roles/sysctl/tasks/main.yml
+++ b/ansible/roles/sysctl/tasks/main.yml
@@ -80,7 +80,9 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  with_items: '{{ sysctl__combined_parameters | debops.debops.parse_kv_items }}'
+  loop: '{{ sysctl__combined_parameters | debops.debops.parse_kv_items }}'
+  loop_control:
+    label: '{{ item.name }}'
   register: sysctl__register_config_created
   when: sysctl__enabled|bool and item.name|d() and item.options|d() and item.state|d('present') not in [ 'absent', 'ignore', 'init' ]
 
@@ -89,7 +91,9 @@
          ; dpkg-divert --quiet --local --rename --remove /etc/sysctl.d/{{ item.filename | d(item.weight|string + "-" + item.name + ".conf") }}
   args:
     warn: False
-  with_items: '{{ sysctl__combined_parameters | debops.debops.parse_kv_items }}'
+  loop: '{{ sysctl__combined_parameters | debops.debops.parse_kv_items }}'
+  loop_control:
+    label: '{{ item.name }}'
   when: (sysctl__enabled|bool and item.name|d() and item.state|d('present') == 'absent' and (item.divert|d())|bool and
           ('/etc/sysctl.d/' + item.filename | d(item.weight|string + "-" + item.name + ".conf")
            + '.dpkg-divert') in sysctl__register_diversions.stdout_lines)


### PR DESCRIPTION
These patches removes the wall of text that some roles like to generate by changing them over to use ``loop`` instead of ``with_*`` 