### PR TITLE
[sshd] Improve LDAP bind password file generation

### DIFF
--- a/ansible/roles/sshd/COPYRIGHT
+++ b/ansible/roles/sshd/COPYRIGHT
@@ -2,7 +2,8 @@ debops.sshd - Manage OpenSSH server using Ansible
 
 Copyright (C) 2013-2016 Maciej Delmanowski <drybjed@gmail.com>
 Copyright (C) 2015-2017 Robin Schneider <ypid@riseup.net>
-Copyright (C) 2014-2017 DebOps <https://debops.org/>
+Copyright (C) 2022 David Härdeman <david@hardeman.nu>
+Copyright (C) 2014-2022 DebOps <https://debops.org/>
 SPDX-License-Identifier: GPL-3.0-only
 
 This Ansible role is part of DebOps.

--- a/ansible/roles/sshd/defaults/main.yml
+++ b/ansible/roles/sshd/defaults/main.yml
@@ -625,13 +625,6 @@ sshd__ldap_bindpw: '{{ lookup("password", secret + "/ldap/credentials/"
                               + sshd__ldap_binddn | to_uuid + ".password length=32") }}'
 
                                                                    # ]]]
-# .. envvar:: sshd__ldap_bind_pw_file [[[
-#
-# Absolute path to the file on the remote host that stores the password to the
-# ``sshd`` LDAP account object..
-sshd__ldap_bind_pw_file: '/etc/ssh/ldap_authorized_keys_bindpw'
-
-                                                                   # ]]]
 # .. envvar:: sshd__ldap_filter [[[
 #
 # Active ``ldapsearch`` filter used to select correct account while looking up

--- a/ansible/roles/sshd/tasks/authorized_keys_lookup.yml
+++ b/ansible/roles/sshd/tasks/authorized_keys_lookup.yml
@@ -1,20 +1,25 @@
 ---
 # Copyright (C) 2013-2016 Maciej Delmanowski <drybjed@gmail.com>
 # Copyright (C) 2015-2017 Robin Schneider <ypid@riseup.net>
-# Copyright (C) 2014-2017 DebOps <https://debops.org/>
+# Copyright (C) 2022 David Härdeman <david@hardeman.nu>
+# Copyright (C) 2014-2022 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-only
 
 - name: Create OpenSSH LDAP bind password file
-  environment:
-    ANSIBLE_SSHD_LDAP_BINDPW: '{{ sshd__ldap_bindpw }}'
-  shell: echo -n ${ANSIBLE_SSHD_LDAP_BINDPW} > {{ sshd__ldap_bind_pw_file }} ;
-         chmod 0600 {{ sshd__ldap_bind_pw_file }} ;
-         chown {{ sshd__authorized_keys_lookup_user }}:root {{ sshd__ldap_bind_pw_file }}
-  args:
-    creates: '{{ sshd__ldap_bind_pw_file }}'
-  when: sshd__authorized_keys_lookup_type|d() and
-        "ldap" in sshd__authorized_keys_lookup_type
+  template:
+    src: 'etc/ssh/ldap_authorized_keys_bindpw.j2'
+    dest: '/etc/ssh/ldap_authorized_keys_bindpw'
+    owner: '{{ sshd__authorized_keys_lookup_user }}'
+    group: 'root'
+    mode: '0600'
+  when: '"ldap" in sshd__authorized_keys_lookup_type|d([])'
   no_log: True
+
+- name: Remove OpenSSH LDAP bind password file
+  file:
+    path: '/etc/ssh/ldap_authorized_keys_bindpw'
+    state: 'absent'
+  when: '"ldap" not in sshd__authorized_keys_lookup_type|d([])'
 
 - name: Create /etc/ssh/authorized_keys_lookup.d directory
   file:

--- a/ansible/roles/sshd/templates/etc/ssh/authorized_keys_lookup.d/ldap.j2
+++ b/ansible/roles/sshd/templates/etc/ssh/authorized_keys_lookup.d/ldap.j2
@@ -25,11 +25,10 @@ domain="$(dnsdomainname)"
 fqdn="$(hostname --fqdn)"
 
 ldap_binddn="{{ sshd__ldap_binddn }}"
-ldap_bindpw="{{ sshd__ldap_bind_pw_file }}"
 
 ldap_filter="{{ sshd__ldap_filter }}"
 
-ATTRIBUTE=$(ldapsearch -Z -LLL -x -y "${ldap_bindpw}" -D "${ldap_binddn}" -o ldif-wrap=no -S sshPublicKey "${ldap_filter}" sshPublicKey | grep -v 'dn:')
+ATTRIBUTE=$(ldapsearch -Z -LLL -x -y /etc/ssh/ldap_authorized_keys_bindpw -D "${ldap_binddn}" -o ldif-wrap=no -S sshPublicKey "${ldap_filter}" sshPublicKey | grep -v 'dn:')
 
 if [[ $ATTRIBUTE == sshPublicKey::* ]];
 then

--- a/ansible/roles/sshd/templates/etc/ssh/ldap_authorized_keys_bindpw.j2
+++ b/ansible/roles/sshd/templates/etc/ssh/ldap_authorized_keys_bindpw.j2
@@ -1,0 +1,5 @@
+{# Copyright (C) 2022 David Härdeman <david@hardeman.nu>
+ # Copyright (C) 2022 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-only
+ #}
+{{- sshd__ldap_bindpw -}}


### PR DESCRIPTION
First, to echo a password means it'll show up temporarily in the process list.

Second, to first create the file and then set the right permissions is also not
a good idea.

This patch also removes a variable which seems kind of pointless. Roles usually
don't make file paths configurable, and I can't see why anyone would like to
change it. If it's better to keep the variable around, I can rework the patch.