### PR TITLE
[users]: Fix always creating a home directory

### DIFF
--- a/ansible/roles/users/tasks/main.yml
+++ b/ansible/roles/users/tasks/main.yml
@@ -96,20 +96,21 @@
   # Ref: https://github.com/ansible/ansible/issues/48722
 - name: Manage additional UNIX groups for UNIX accounts
   user:
-    name:   '{{ item.name }}'
-    groups: '{{ (( (([ item.groups ]
-                     if (item.groups is string)
-                     else item.groups)
-                    if (item.groups is defined)
-                    else [])
-                    + (users__chroot_groups
-                       if ((item.chroot|d())|bool)
-                       else []) )
-                   | intersect(getent_group.keys()) )
-                if (item.groups is defined or (item.chroot|d())|bool)
-                else omit }}'
-    append: '{{ item.append | d(True) }}'
-    state:  '{{ item.state  | d("present") }}'
+    name:         '{{ item.name }}'
+    groups:       '{{ (( (([ item.groups ]
+                          if (item.groups is string)
+                          else item.groups)
+                          if (item.groups is defined)
+                          else [])
+                          + (users__chroot_groups
+                            if ((item.chroot|d())|bool)
+                            else []) )
+                        | intersect(getent_group.keys()) )
+                      if (item.groups is defined or (item.chroot|d())|bool)
+                      else omit }}'
+    append:       '{{ item.append       | d(True) }}'
+    state:        '{{ item.state        | d("present") }}'
+    create_home:  '{{ item.create_home  | d(omit) }}'
   loop: '{{ users__combined_accounts | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"name": item.name,


### PR DESCRIPTION
When "managing additional UNIX groups for UNIX accounts", the `ansible.builtin.users` module is being used. In this usage, the `create_home` argument is not specified, and so it defaults to `True` according to [the documentation](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/user_module.html#parameter-create_home). This will always create a home directory, even if the corresponding `users__*_account` element in the `users__combined_accounts` list specified `create_home: False`.

This PR fixes this bug by adding the `create_home` argument as specified by the corresponding `users__*_account` element in the `users__combined_accounts` list, omitting it if it doesn't exist. (Some "tabbing" is also added to make the spacing consistent after the addition of this new argument)