### PR TITLE
[dnsmasq] Fix DNS A/AAAA record generation

### DIFF
--- a/ansible/roles/dnsmasq/templates/etc/dnsmasq.d/dhcp-dns-options.conf.j2
+++ b/ansible/roles/dnsmasq/templates/etc/dnsmasq.d/dhcp-dns-options.conf.j2
@@ -29,11 +29,11 @@
 {%     if entry.tag|d() %}
 {%       set _ = dhcp_host.append('set:' + entry.tag) %}
 {%     endif %}
-{%     if entry.ip|d() and entry.host is undefined %}
+{%     if entry.ip|d() and (entry.host is undefined and entry.a is undefined and entry.aaaa is undefined) %}
 {%       set _ = dhcp_host.extend( ([ entry.ip ] if (entry.ip is string) else entry.ip) | ipwrap ) %}
-{%     elif entry.ipaddr|d() and entry.host is undefined %}
+{%     elif entry.ipaddr|d() and (entry.host is undefined and entry.a is undefined and entry.aaaa is undefined) %}
 {%       set _ = dhcp_host.extend( ([ entry.ipaddr ] if (entry.ipaddr is string) else entry.ipaddr) | ipwrap ) %}
-{%     elif entry.address|d() and entry.host is undefined %}
+{%     elif entry.address|d() and (entry.host is undefined and entry.a is undefined and entry.aaaa is undefined) %}
 {%       set _ = dhcp_host.extend( ([ entry.address ] if (entry.address is string) else entry.address) | ipwrap ) %}
 {%     endif %}
 {%     if entry.name|d() %}

--- a/docs/ansible/roles/dnsmasq/defaults-detailed.rst
+++ b/docs/ansible/roles/dnsmasq/defaults-detailed.rst
@@ -364,9 +364,9 @@ Each entry in the list is a YAML dictionary with specific parameters:
   In DHCP host configuration this parameter specifies the IP addresses which
   will be reserved for a particular host.
 
-  In DNS record configuration this parameter along with the ``host`` parameter
-  defines a DNS A record; in case of multiple IP addresses, the first IP
-  address will be used to create the host's DNS PTR record.
+  In DNS record configuration this parameter along with the ``host`` / ``a`` /
+  ``aaaa`` parameter defines a DNS A record; in case of multiple IP addresses,
+  the first IP address will be used to create the host's DNS PTR record.
 
 ``cname``
   Optional. If defined in a DHCP client configuration, it's a list of DNS


### PR DESCRIPTION
The dnsmasq detailed documentation says that "host", "a" and "aaaa" are
synonyms which can be used interchangeably (further down, not in the
section touched by this patch).

However, a configuration like this:

```
dnsmasq__dns_records:

  - host: 'a.example.com'
    ip: '192.168.0.1'

  - a: 'b.example.com'
    ip: '192.168.0.2'
```

Currently results in this /etc/dnsmasq.d/host-resource-records.conf:

```
  host-record = a.example.com,192.168.0.1

  dhcp-host = 192.168.0.2
```

The reason is that the template only checks whether entry.host is
defined.