### PR TITLE
[apt_install] Autodetect presence of virtual RNG

### DIFF
--- a/ansible/roles/apt_install/defaults/main.yml
+++ b/ansible/roles/apt_install/defaults/main.yml
@@ -274,7 +274,9 @@ apt_install__conditional_packages:
     whitelist: '{{ apt_install__conditional_whitelist_packages }}'
     state: '{{ "present"
                if (ansible_virtualization_role|d("guest") in [ "guest" ] and
-                   ansible_virtualization_type|d("unknown") not in ["lxc", "openvz"]
+                   ansible_virtualization_type|d("unknown") not in ["lxc", "openvz"] and
+                   not (ansible_local|d() and ansible_local.apt_install|d() and
+                        ansible_local.apt_install.have_virtual_rng|d(False)|bool)
                )
                else "absent" }}'
 

--- a/ansible/roles/apt_install/tasks/main.yml
+++ b/ansible/roles/apt_install/tasks/main.yml
@@ -8,8 +8,35 @@
   import_role:
     name: 'ansible_plugins'
 
+- name: Import DebOps global handlers
+  import_role:
+    name: 'global_handlers'
+
 - name: Pre hooks
   include: '{{ lookup("debops.debops.task_src", "apt_install/pre_main.yml") }}'
+
+- name: Make sure that Ansible fact directory exists
+  file:
+    path: '/etc/ansible/facts.d'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+  when: apt_install__enabled|bool
+
+- name: Save local Ansible facts
+  template:
+    src: 'etc/ansible/facts.d/apt_install.fact.j2'
+    dest: '/etc/ansible/facts.d/apt_install.fact'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+  when: apt_install__enabled|bool
+  notify: [ 'Refresh host facts' ]
+  tags: [ 'meta::facts' ]
+
+- name: Update Ansible facts if they were modified
+  meta: 'flush_handlers'
 
 - name: Debconf module dependencies
   apt:
@@ -79,25 +106,6 @@
     dest: '/etc/needrestart/conf.d/no-kernel-hints.conf'
     mode: '0644'
   when: apt_install__enabled|bool and apt_install__no_kernel_hints|bool
-
-- name: Make sure that Ansible fact directory exists
-  file:
-    path: '/etc/ansible/facts.d'
-    state: 'directory'
-    owner: 'root'
-    group: 'root'
-    mode: '0755'
-  when: apt_install__enabled|bool
-
-- name: Save local Ansible facts
-  template:
-    src: 'etc/ansible/facts.d/apt_install.fact.j2'
-    dest: '/etc/ansible/facts.d/apt_install.fact'
-    owner: 'root'
-    group: 'root'
-    mode: '0644'
-  when: apt_install__enabled|bool
-  tags: [ 'meta::facts' ]
 
 - name: Post hooks
   include: '{{ lookup("debops.debops.task_src", "apt_install/post_main.yml") }}'

--- a/ansible/roles/apt_install/templates/etc/ansible/facts.d/apt_install.fact.j2
+++ b/ansible/roles/apt_install/templates/etc/ansible/facts.d/apt_install.fact.j2
@@ -1,8 +1,30 @@
-{# Copyright (C) 2016-2017 Maciej Delmanowski <drybjed@gmail.com>
- # Copyright (C) 2016-2017 Robin Schneider <ypid@riseup.net>
- # Copyright (C) 2016-2017 DebOps <https://debops.org/>
- # SPDX-License-Identifier: GPL-3.0-only
- #}
-{
-"configured": "true"
+#!{{ ansible_python['executable'] }}
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2016-2017 Maciej Delmanowski <drybjed@gmail.com>
+# Copyright (C) 2016-2017 Robin Schneider <ypid@riseup.net>
+# Copyright (C) 2022 David Härdeman <david@hardeman.nu>
+# Copyright (C) 2016-2022 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+# {{ ansible_managed }}
+
+from __future__ import print_function
+from json import dumps
+import os
+
+
+def dir_exists(path):
+    return os.path.isdir(path)
+
+
+def module_loaded(mod):
+    return dir_exists(os.path.join('/sys/module', mod))
+
+
+output = {
+    'configured': True,
+    'have_virtual_rng': module_loaded('virtio_rng')
 }
+
+print(dumps(output, sort_keys=True, indent=4))

--- a/docs/ansible/roles/apt_install/defaults-detailed.rst
+++ b/docs/ansible/roles/apt_install/defaults-detailed.rst
@@ -23,9 +23,10 @@ examples for them.
 apt_install__debconf
 -------------------------
 
-These YAML lists can be used to add some values to Debconf database. Each entry
-has the same keys as the ones used by `Ansible ansible.builtin.debconf module`_.
-See its documentation for parameter advanced usage and syntax.
+These lists of YAML dictionaries can be used to add some values to the Debconf
+database. Each entry has the same keys as the ones used by the
+`Ansible ansible.builtin.debconf module`_.  See its documentation for detailed
+parameter usage and syntax.
 
 ``name``
   Required. Name of the package to configure.


### PR DESCRIPTION
apt_install currently installs "haveged" unconditionally on e.g.
KVM guests. There is a comment in defaults.yml to the effect that
while the host can provide entropy to the guest, this cannot be
assumed.

This patch enables checking for if a virtual RNG is present in
the guest, and skips the installation of "haveged" in that case.