### PR TITLE
[ldap-init] Allow plaintext password storage

### DIFF
--- a/ansible/playbooks/ldap/init-directory.yml
+++ b/ansible/playbooks/ldap/init-directory.yml
@@ -15,9 +15,14 @@
 
   vars_prompt:
 
-    - name: 'admin_plaintext_password'
-      prompt: 'New password for your LDAP user account'
+    - name: 'admin_input_plaintext_password'
+      prompt: 'New password for your LDAP user account (enter=random)'
+      default: ''
       private: True
+
+    - name: 'admin_use_password_store'
+      default: True
+      prompt: 'Use Password Store? (default=yes)'
 
   vars:
 
@@ -31,10 +36,26 @@
     # SSH public keys in the 'ssh-agent'
     admin_sshkeys: '{{ lookup("pipe", "ssh-add -L | grep ^\\\(sk-\\\)\\\?ssh || cat ~/.ssh/*.pub || true").split("\n") }}'
 
-    # Password of the administrator account, stored in the Password Store on
-    # the Ansible Controller
-    admin_saved_password: '{{ lookup("passwordstore", ldap__admin_passwordstore_path
-                                     + "/" + (admin_dn | to_uuid)
+    # Plaintext administrator password. If no password has been provided,
+    # a random password will be generated and stored either in a file or
+    # in the Password Store on the Ansible Controller. If a password has
+    # been provided and the Password Store is not used, the password will
+    # not be stored.
+    admin_plaintext_password: '{{ admin_input_plaintext_password
+                                  if admin_input_plaintext_password|d()
+                                  else (lookup("password", "/dev/null length=32")
+                                        if admin_use_password_store|d(True)|bool
+                                        else
+                                        lookup("password",
+                                               secret + "/ldap/credentials/"
+                                               + admin_dn | to_uuid
+                                               + ".password length=32")) }}'
+
+    # This variable is used to store the administrator password in the Password
+    # Store on the Ansible Controller, if requested
+    admin_saved_password: '{{ lookup("passwordstore",
+                                     ldap__admin_passwordstore_path
+                                     + "/" + admin_dn | to_uuid
                                      + " create=true overwrite=true userpass="
                                      + admin_plaintext_password) }}'
 
@@ -122,6 +143,7 @@
     - name: Save admin credential in the password store
       set_fact:
         admin_stored_password: '{{ admin_saved_password }}'
+      when: admin_use_password_store|d(True)|bool
       no_log: '{{ debops__no_log | d(True) }}'
       delegate_to: 'localhost'
       become: False

--- a/ansible/roles/ldap/defaults/main.yml
+++ b/ansible/roles/ldap/defaults/main.yml
@@ -612,7 +612,7 @@ ldap__admin_enabled: '{{ True if ldap__fact_admin_bindpw|d() else False }}'
 # The relative path in the :command:`pass` password database, where personal
 # LDAP credentials can be found by the role. See :ref:`ldap__ref_admin_pass`
 # for more details. This variable can be used in Ansible playbooks that use the
-# :ref:`debops.ldap` to create and update admin credentials.
+# :ref:`debops.ldap` role to create and update admin credentials.
 ldap__admin_passwordstore_path: 'debops/ldap/credentials'
 
                                                                    # ]]]
@@ -639,8 +639,7 @@ ldap__admin_dn: '{{ [ ldap__admin_rdn, ldap__people_rdn ] + ldap__base_dn }}'
 # administrative tasks. It can be overridden on the Ansible Controller through
 # use of the environment variables.
 ldap__admin_binddn: '{{ lookup("env", "DEBOPS_LDAP_ADMIN_BINDDN")
-                        if lookup("env", "DEBOPS_LDAP_ADMIN_BINDDN")|d()
-                        else (ldap__admin_dn | join(",")) }}'
+                        | d(ldap__admin_dn | join(","), True) }}'
 
                                                                    # ]]]
 # .. envvar:: ldap__admin_bindpw [[[
@@ -648,14 +647,22 @@ ldap__admin_binddn: '{{ lookup("env", "DEBOPS_LDAP_ADMIN_BINDDN")
 # The LDAP BindPW value which will be used to bind to the LDAP directory for
 # administrative tasks. It can be overridden on the Ansible Controller through
 # use of the environment variables. See :ref:`ldap__ref_admin_pass` for more
-# details about :command:`pass` password database integration.
+# details.
 ldap__admin_bindpw: '{{ (lookup("env", "DEBOPS_LDAP_ADMIN_BINDPW")
                          if lookup("env", "DEBOPS_LDAP_ADMIN_BINDPW")|d()
-                         else (lookup("passwordstore", ldap__admin_passwordstore_path
-                                      + "/" + (ldap__admin_binddn | to_uuid)
-                                      + " create=false", errors="ignore")))
-                        if ldap__enabled|bool
-                        else "" }}'
+                         else (lookup("file", secret + "/ldap/credentials/"
+                                              + ldap__admin_binddn | to_uuid
+                                              + ".password")
+                               if lookup("first_found",
+                                         [ secret + "/ldap/credentials/"
+                                           + ldap__admin_binddn | to_uuid
+                                           + ".password" ],
+                                         skip=True, errors="ignore")
+                               else lookup("passwordstore",
+                                           ldap__admin_passwordstore_path + "/"
+                                           + ldap__admin_binddn | to_uuid
+                                           + " create=false", errors="ignore"))
+                        ) if ldap__enabled|bool else "" }}'
 
                                                                    # ]]]
 # .. envvar:: ldap__admin_server_uri [[[

--- a/docs/ansible/roles/ldap/getting-started.rst
+++ b/docs/ansible/roles/ldap/getting-started.rst
@@ -35,29 +35,47 @@ LDAP directory initialization
 
 The base directory structure used by DebOps roles is defined and managed by the
 :ref:`debops.slapd` Ansible role. The :envvar:`slapd__structure_tasks` variable
-contains a list of LDAP objects which will be created on server installation,
-which conform to the :ref:`slapd__ref_acl` configuration.
+contains a list of LDAP objects which will be created during the server
+installation, which conform to the :ref:`slapd__ref_acl` configuration.
 
-The :file:`ansible/playbooks/ldap/init-directory.yml` Ansible playbooks
-contains additional configuration which can be used to create an admin account
-inside of the LDAP directory and grant it "LDAP Administrator" and "UNIX
-Administrator" roles. To use it with the new OpenLDAP servers, run the command:
+The :file:`ansible/playbooks/ldap/init-directory.yml` Ansible playbook can be
+used to create an admin account in the LDAP directory and to assign it to the
+"LDAP Administrator" and "UNIX Administrator" roles. To use it with a newly
+configured OpenLDAP server, run the command:
 
 .. code-block:: console
 
-   debops ldap/init-directory -l <slapd-server>
+   debops run ldap/init-directory -l <slapd-server>
 
 The playbook will use the current UNIX account information on the Ansible
-Controller (``passwd`` database, SSH public keys from :command:`ssh-agent`) to
-create a new user account in the LDAP directory with administrator privileges.
+Controller (username, etc, from the ``passwd`` database and SSH public keys
+from :command:`ssh-agent`) to create a new user account with administrative
+privileges in the LDAP directory.
 
-The user will be asked for a new password used to bind to the directory; this
-password will be stored on the Ansible Controller using Password Store, and
-used for :ref:`ldap__ref_admin`.
+The user will first be asked for a new password for the admin account which
+will be used in the future to bind to the directory. If no password is provided
+or Ansible is run in non-interactive mode, a random password will be generated.
 
-The playbook will not make any changes to existing LDAP objects.
+Next, the user will be asked whether the password should be stored on the
+Ansible Controller using the Password Store utility. If not, and the password
+is randomly generated, it will be stored under the :file:`/secret` hierarchy.
+If the password was not randomly generated *and* the Password Store is not
+being used, the password will not be stored (under the assumption that it is
+memorized) and will have to be provided manually, e.g. using the
+``DEBOPS_LDAP_ADMIN_BINDPW`` environment variable, in future playbook runs. See
+:ref:`ldap__ref_admin` for further details.
 
-.. note:: For the LDAP access to work, Ansible Controller needs to trust the
+The various defaults used in the playbook can also be overridden on the command
+line using the ``--extra-vars`` argument:
+
+.. code-block:: console
+
+   debops run ldap/init-directory -l <slapd-server> --extra-vars="admin_user=ansible admin_use_password_store=False"
+
+The playbook will not make any changes to any existing LDAP entries other than
+the administrative user.
+
+.. note:: For the LDAP access to work, the Ansible Controller needs to trust the
    Certificate Authority which is used by the OpenLDAP service. If you rely on
    the :ref:`debops.pki` internal CA, you will have to add the Root CA
    certificate managed by the role to the operating system certificate store.
@@ -70,18 +88,19 @@ The :ref:`debops.ldap` role is included in the DebOps common playbook,
 therefore you don't need to do anything special to enable it on a host. However
 it is deactivated by default.
 
-To enable the role, define in the Ansible inventory, for example in
+To enable the role, define in the Ansible inventory, for example in the
 :file:`ansible/inventory/group_vars/all/ldap.yml` file:
 
 .. code-block:: yaml
 
    ldap__enabled: True
 
-The :ref:`debops.ldap` role is used by many other DebOps roles [#f1]_, and enabling it
+The :ref:`debops.ldap` role is used by many other DebOps roles, and enabling it
 will affect the environment and configuration of multiple services, including
 basic things like UNIX system groups used to manage the host. It's best to
 either not enable LDAP support in a given environment, or enable it at the
-beginning of a new deployment.
+beginning of a new deployment (but after administrative access has been
+configured, as described above).
 
 The POSIX integration with the LDAP directory can be controlled using the
 :envvar:`ldap__posix_enabled` variable. If it's set to ``False``, services that
@@ -144,8 +163,3 @@ List of other useful resources related to the ``debops.ldap`` Ansible role:
 - The role does not rely on the Ansible ``ldap_attr`` module, instead it uses
   the ``ldap_attrs`` module included in the ``debops.ansible_plugins`` role to
   manage LDAP attributes of an entry.
-
-.. rubric:: Footnotes
-
-.. [#f1] Well, not yet, but that's the planned direction that DebOps
-         maintainers are looking into right now.


### PR DESCRIPTION
This introduces two changes to how ldap/init-directory.yml works:

First, it now supports optionally generating a random password.

Second, optional support is added for storing the random password unencrypted
in the /secret directory.

This makes it easier to e.g. run the Ansible Controller in an automated
fashion.

See the docs updates for more details.