### PR TITLE
[icinga_web] Improve LDAP defaults

### DIFF
--- a/ansible/roles/icinga_web/defaults/main.yml
+++ b/ansible/roles/icinga_web/defaults/main.yml
@@ -749,17 +749,19 @@ icinga_web__ldap_hostname: '{{ ansible_local.ldap.hosts|d([""]) | first }}'
                                                                    # ]]]
 # .. envvar:: icinga_web__ldap_encryption [[[
 #
-# The LDAP encryption to use, either ``starttls`` (recommended), ``ldaps`` or
-# ``plain`` (discouraged).
-icinga_web__ldap_encryption: 'starttls'
+# The LDAP encryption to use, either ``starttls``, ``ldaps`` or ``plain``
+# (discouraged).
+icinga_web__ldap_encryption: '{{ "ldaps"
+                                 if ansible_local.ldap.protocol|d("") == "ldaps"
+                                 else ("starttls"
+                                       if ansible_local.ldap.start_tls|d(True)|bool
+                                       else "plain") }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__ldap_port [[[
 #
 # The TCP port to use for LDAP connections.
-icinga_web__ldap_port: '{{ 636
-                           if (icinga_web__ldap_encryption in ["ldaps"])
-                           else 389 }}'
+icinga_web__ldap_port: '{{ ansible_local.ldap.port|d(389) }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__ldap_user_filter [[[


### PR DESCRIPTION
The LDAP encryption and port parameters are normally already available
as local facts, so use that as the default.

I noted this issue when trying to setup Icinga in a test environment
where LDAP was only available over LDAPS. /etc/ldap/ldap.conf was
correctly setup, but the Icinga defaults did not adapt.

The problem with incorrect LDAP settings is that the resulting errors
are not very straightforward to diagnose. The "Register Icinga node
in Icinga Director" task from debops.icinga will fail. By increasing
the verbosity, one can see that the Icinga director returns a HTTP 200
response rather than 201 (the expected).

It's only after digging through the Icinga web log files that you
can see that the web app fails to initialise the LDAP connection.

Also, I took the liberty of removing the "recommended" for STARTTLS,
since the general trend is towards recommending implicit TLS (i.e.
ldaps) over explicit TLS, as STARTTLS is subject to downgrade attacks:
https://fy.blackhats.net.au/blog/html/2021/08/12/starttls_in_ldap.html