### PR TITLE
[icinga] Improve initial host registration

### DIFF
--- a/ansible/roles/icinga/defaults/main.yml
+++ b/ansible/roles/icinga/defaults/main.yml
@@ -626,7 +626,7 @@ icinga__default_configuration:
         value: |
           include_recursive "repository.d"
         state: '{{ "absent"
-                   if (icinga__version is version("2.8.0", ">=")
+                   if (icinga__version is version("2.8.0", ">="))
                    else "present" }}'
 
       - name: 'conf.d'

--- a/ansible/roles/icinga/defaults/main.yml
+++ b/ansible/roles/icinga/defaults/main.yml
@@ -124,6 +124,26 @@ icinga__display_name: '{{ (inventory_hostname_short | d(inventory_hostname.split
                           else ansible_hostname }}'
 
                                                                    # ]]]
+# .. envvar:: icinga__ipv4_address [[[
+#
+# The IPv4 address (or FQDN used to lookup the IPv4 address) of this Icinga 2
+# node. This variable is used during the node registration in the Icinga 2
+# Director (and will be used to contact the node for monitoring purposes).
+icinga__ipv4_address: '{{ ansible_default_ipv4.address
+                          | d(ansible_all_ipv4_addresses | d([]) | first)
+                          | d(icinga_fqdn) }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga__ipv6_address [[[
+#
+# The IPv6 address (or FQDN used to lookup the IPv4 address) of this Icinga 2
+# node. This variable is used during the node registration in the Icinga 2
+# Director (and will be used to contact the node for monitoring purposes).
+icinga__ipv6_address: '{{ ansible_default_ipv6.address
+                          | d(ansible_all_ipv6_addresses | d([]) | first)
+                          | d(omit, true) }}'
+
+                                                                   # ]]]
 # .. envvar:: icinga__domain [[[
 #
 # The main DNS domain used by the role to configure Icinga 2.
@@ -403,8 +423,8 @@ icinga__director_register_host_object:
   object_type: 'object'
   object_name: '{{ icinga__fqdn }}'
   display_name: '{{ icinga__display_name }}'
-  address: '{{ ansible_default_ipv4.address | d(ansible_all_ipv4_addresses | d([]) | first) | d(icinga_fqdn) }}'
-  address6: '{{ ansible_default_ipv6.address | d(ansible_all_ipv6_addresses | d([]) | first) | d(omit, true) }}'
+  address: '{{ icinga__ipv4_address }}'
+  address6: '{{ icinga__ipv6_address }}'
   imports: '{{ q("flattened",
                  (icinga__director_register_default_templates
                   + icinga__director_register_templates

--- a/ansible/roles/icinga/defaults/main.yml
+++ b/ansible/roles/icinga/defaults/main.yml
@@ -110,8 +110,18 @@ icinga__additional_groups:
 # .. envvar:: icinga__fqdn [[[
 #
 # The Fully Qualified Domain Name of this Icinga 2 node. This variable is used
-# during node registration in Icinga 2 Director and in the zone configuration.
+# during the node registration in the Icinga 2 Director and in the zone
+# configuration.
 icinga__fqdn: '{{ ansible_fqdn }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga__display_name [[[
+#
+# The short display name of this Icinga 2 node. This variable is used during
+# the node registration in the Icinga 2 Director and in the zone configuration.
+icinga__display_name: '{{ (inventory_hostname_short | d(inventory_hostname.split(".")[0]))
+                          if (inventory_hostname_short | d(inventory_hostname.split(".")[0]) != "localhost")
+                          else ansible_hostname }}'
 
                                                                    # ]]]
 # .. envvar:: icinga__domain [[[
@@ -296,12 +306,34 @@ icinga__director_register_api_password: '{{ lookup("password", secret + "/icinga
                                             + icinga__director_register_api_user + "/password") }}'
 
                                                                    # ]]]
+# .. envvar:: icinga__director_default_host_templates [[[
+#
+# List of default host templates to create before attempting to register any
+# given host.
+icinga__director_default_host_templates:
+
+  - object_type: 'template'
+    object_name: 'generic-host'
+    check_command: 'hostalive'
+    check_interval: '5m'
+    retry_interval: '30s'
+    max_check_attempts: '5'
+
+  - object_type: 'template'
+    object_name: 'icinga-agent-host'
+    has_agent: true
+    master_should_connect: true
+    accept_config: true
+    imports:
+      - 'generic-host'
+
+                                                                   # ]]]
 # .. envvar:: icinga__director_register_default_templates [[[
 #
 # List of default host templates to use for a given host during registration.
 # The templates need to be prepared beforehand in the Icinga 2 Director.
 icinga__director_register_default_templates:
-  - 'generic-host'
+  - 'icinga-agent-host'
 
                                                                    # ]]]
 # .. envvar:: icinga__director_register_templates [[[
@@ -370,13 +402,14 @@ icinga__director_register_host_vars: {}
 icinga__director_register_host_object:
   object_type: 'object'
   object_name: '{{ icinga__fqdn }}'
-  address: '{{ icinga__fqdn }}'
-  imports: '{{ lookup("flattened",
-               (icinga__director_register_default_templates
-                + icinga__director_register_templates
-                + icinga__director_register_group_templates
-                + icinga__director_register_host_templates),
-               wantlist=True) }}'
+  display_name: '{{ icinga__display_name }}'
+  address: '{{ ansible_default_ipv4.address | d(ansible_all_ipv4_addresses | d([]) | first) | d(icinga_fqdn) }}'
+  address6: '{{ ansible_default_ipv6.address | d(ansible_all_ipv6_addresses | d([]) | first) | d(omit, true) }}'
+  imports: '{{ q("flattened",
+                 (icinga__director_register_default_templates
+                  + icinga__director_register_templates
+                  + icinga__director_register_group_templates
+                  + icinga__director_register_host_templates)) }}'
   vars: '{{ icinga__director_register_default_vars
             | combine(icinga__director_register_vars,
                       icinga__director_register_group_vars,

--- a/ansible/roles/icinga/tasks/main.yml
+++ b/ansible/roles/icinga/tasks/main.yml
@@ -180,7 +180,7 @@
 # Note: can't use "run_once" here due to "when" conditional
 #       Ansible issue: #11496
 - name: Register Icinga host templates in Icinga Director
-  uri:
+  ansible.builtin.uri:
     body_format: 'json'
     headers:
       Accept: 'application/json'

--- a/ansible/roles/icinga/tasks/main.yml
+++ b/ansible/roles/icinga/tasks/main.yml
@@ -177,6 +177,31 @@
   become: False
   delegate_to: 'localhost'
 
+# Note: can't use "run_once" here due to "when" conditional
+#       Ansible issue: #11496
+- name: Register Icinga host templates in Icinga Director
+  uri:
+    body_format: 'json'
+    headers:
+      Accept: 'application/json'
+    method: 'POST'
+    body: '{{ item }}'
+    url: '{{ icinga__director_register_api_url }}'
+    user: '{{ icinga__director_register_api_user }}'
+    password: '{{ icinga__director_register_api_password }}'
+    status_code: [ 201, 422, 500 ]
+    force_basic_auth: True
+  loop: '{{ icinga__director_default_host_templates }}'
+  loop_control:
+    label: '{{ item.object_name }}'
+  register: icinga__register_director_host_templates
+  throttle: 1  # avoid race condition in director
+  notify: [ 'Trigger Icinga Director configuration deployment' ]
+  when: icinga__director_enabled|bool and icinga__director_register|bool and
+        icinga__node_type != 'master'
+  changed_when: icinga__register_director_host_templates.status == 201
+  tags: [ 'role::icinga:register' ]
+
 - name: Register Icinga node in Icinga Director
   ansible.builtin.uri:
     body_format: 'json'
@@ -187,7 +212,7 @@
     url: '{{ icinga__director_register_api_url }}'
     user: '{{ icinga__director_register_api_user }}'
     password: '{{ icinga__director_register_api_password }}'
-    status_code: '201,422,500'
+    status_code: [ 201, 422, 500 ]
     force_basic_auth: True
   register: icinga__register_director_host
   notify: [ 'Trigger Icinga Director configuration deployment' ]

--- a/docs/ansible/roles/icinga/deployment.rst
+++ b/docs/ansible/roles/icinga/deployment.rst
@@ -142,25 +142,21 @@ in the
 :file:`secret/icinga_web/auth/<inventory_hostname>/credentials/root/password`
 file (see :ref:`debops.secret` for more details).
 
-After logging in, you should create a new basic host template. By default, the
-role will try and register the nodes using the ``generic-host`` template. To
-create it, go to the "Icinga Director" -> "Hosts" -> "Host Templates" section
-and click on "Add". Enter "generic-host" as the "Hostname", set the "Check
-command" option as "hostalive". You should also set a reasonable "Check
-interval", "Retry interval' and "Max check attempts" fields, for example with
-5 minutes, 30 seconds and 5 tries.
+After logging in, and if you haven't already done so, try applying the
+:ref:`debops.icinga` role to some other host which is to be monitored. If
+everything is configured correctly, the role should automatically register the
+new host in Icinga via the Director REST API.  Subsequent execution of the role
+will not change the status of the host in Icinga, but if you remove the host
+from the web interface and re-run the :ref:`debops.icinga` role, the host will
+be registered again.
 
-It might be best to add a separate host template for hosts with Icinga 2 Agent
-installed, in case that you want to include other hosts as well. For this,
-create a new template with a chosen name, and in the "Icinga Agent and zone
-settings" section set the "Icinga 2 Agent", "Estabilish connection" and
-"Accepts config" options to "Yes". You can define the list of templates
-automatically applied during registration using the
-``icinga__director_register_*_templates`` default variables.
+By default, the role will automatically create two host templates,
+``generic-host`` and ``icinga-agent-host`` (the latter depending on the former)
+as part of the host registration process and will register new hosts using the
+``icinga-agent-host`` template.  See
+:envvar:`icinga__director_default_host_templates` for more details. Note that
+if you delete these templates they will, by default, be recreated every time a
+host is (re-)registered with the Director.
 
-After this you can apply the :ref:`debops.icinga` role to other hosts. If
-everything was configured correctly, the role should automatically register
-a new host in Icinga via the Director REST API. Subsequent execution of the
-role will not change the status of the host in Icinga, but if you remove the
-host from the web interface and re-run the :ref:`debops.icinga` role, the host
-will be registered again.
+You can define the list of templates automatically applied during registration
+using the ``icinga__director_register_*_templates`` default variables.


### PR DESCRIPTION
This patch is an attempt to improve the icinga initial setup by automatically creating the default groups which are explained in [the documentation](https://docs.debops.org/en/master/ansible/roles/icinga/deployment.html#initial-deployment). With this patch applied, it's possible to setup icinga and register all hosts without having to touch the web interface at all.

Also, some more information is created for the host objects when they are created (a short display_name, and IPv4/IPv6 addresses).

This is just a draft because:
a) I want to see if you agree with the change before spending the time to update the documentation
b) I'm not sure if ``icinga__director_combined_host_templates`` should be changed to use universal configuration style