### PR TITLE
Execute Ansible commands in shell environment

### DIFF
--- a/src/debops/ansibleplaybookrunner.py
+++ b/src/debops/ansibleplaybookrunner.py
@@ -200,7 +200,7 @@ class AnsiblePlaybookRunner(object):
             print('Executing Ansible playbooks:')
             for playbook in self._found_playbooks:
                 print(unexpanduser(playbook))
-            return subprocess.call(self._ansible_command)
+            return subprocess.call(' '.join(self._ansible_command), shell=True)
         except KeyboardInterrupt:
             if unlocked:
                 self.inventory.lock()


### PR DESCRIPTION
This patch should fix an issue where certain 'ansible-playbook'
arguments, for example values of --extra-vars parameter, were
incorrectly passed via the 'subprocess.call' command.

Fixes #1996