### PR TITLE
[dig_srv] Convert users of "dig" -> "dig_srv"

### DIFF
--- a/ansible/roles/gitlab_runner/defaults/main.yml
+++ b/ansible/roles/gitlab_runner/defaults/main.yml
@@ -139,11 +139,17 @@ gitlab_runner__fqdn: '{{ ansible_fqdn }}'
                                                                    # ]]]
 # .. envvar:: gitlab_runner__gitlab_srv_rr [[[
 #
-# List which contains the result of the :command:`dig` query for Gitlab server
-# ``SRV`` resource records in the host's domain. See :rfc:`6186` for details.
-gitlab_runner__gitlab_srv_rr: '{{ q("dig", "_gitlab._tcp."
-                                    + gitlab_runner__domain
-                                    + "./SRV", "flat=0") }}'
+# List which contains the result of the DNS query for Gitlab server ``SRV``
+# resource records in the host's domain. See :rfc:`6186` for details.
+#
+# If there are no resource records, the role checks if a local Gitlab
+# installation is present and uses the host FQDN as the Gitlab API server
+# address. Finally, ``code.<domain>`` is used as a fallback.
+gitlab_runner__gitlab_srv_rr: '{{ q("dig_srv", "_gitlab._tcp." + gitlab_runner__domain,
+                                    ansible_fqdn
+                                    if (ansible_local|d() and ansible_local.gitlab|d() and
+                                       (ansible_local.gitlab.installed|d())|bool)
+                                    else ("code." + gitlab_runner__domain), 443) }}'
 
                                                                    # ]]]
 # .. envvar:: gitlab_runner__api_fqdn [[[
@@ -151,22 +157,9 @@ gitlab_runner__gitlab_srv_rr: '{{ q("dig", "_gitlab._tcp."
 # The Fully Qualified Domain Name (FQDN) of the GitLab CI host which will control the
 # runner operation.
 #
-# By default the host is located using DNS SRV resource records; if there are none,
-# role checks if a local Gitlab installation is present and uses the host FQDN as
-# the Gitlab API server address. Finally, the static ``code.<domain>`` is used.
-#
-# Use of FQDN instead of ``localhost`` is required for X.509 certificate
-# verification and for correct information in system logs.
-gitlab_runner__api_fqdn: '{{ (gitlab_runner__gitlab_srv_rr | selectattr("target", "defined")
-                              | map(attribute="target")
-                              | map("regex_replace", "\.$","")
-                              | list | first)
-                              if ("NXDOMAIN" not in gitlab_runner__gitlab_srv_rr and
-                                  gitlab_runner__gitlab_srv_rr[0])
-                              else (ansible_fqdn
-                                    if (ansible_local|d() and ansible_local.gitlab|d() and
-                                       (ansible_local.gitlab.installed|d())|bool)
-                                    else ("code." + gitlab_runner__domain)) }}'
+# The use of the FQDN instead of ``localhost`` is required for X.509
+# certificate verification and for correct information in system logs.
+gitlab_runner__api_fqdn: '{{ gitlab_runner__gitlab_srv_rr[0]["target"] }}'
 
                                                                    # ]]]
 # .. envvar:: gitlab_runner__api_url [[[

--- a/ansible/roles/gitlab_runner/defaults/main.yml
+++ b/ansible/roles/gitlab_runner/defaults/main.yml
@@ -140,7 +140,7 @@ gitlab_runner__fqdn: '{{ ansible_fqdn }}'
 # .. envvar:: gitlab_runner__gitlab_srv_rr [[[
 #
 # List which contains the result of the DNS query for Gitlab server ``SRV``
-# resource records in the host's domain. See :rfc:`6186` for details.
+# resource records in the host's domain. See :rfc:`2782` for details.
 #
 # If there are no resource records, the role checks if a local Gitlab
 # installation is present and uses the host FQDN as the Gitlab API server

--- a/ansible/roles/icinga/defaults/main.yml
+++ b/ansible/roles/icinga/defaults/main.yml
@@ -123,33 +123,36 @@ icinga__domain: '{{ ansible_domain }}'
                                                                    # ]]]
 # .. envvar:: icinga__master_nodes [[[
 #
-# List of ``dig`` Ansible module results that define which Icinga 2 nodes are
-# "master" nodes that manage the monitoring.
+# List which contains the result of the DNS query for Icinga 2 master node
+# ``SRV`` resource records in the host's domain. This is a DebOps-specific
+# feature, which does not have a corresponding RFC.
 #
 # See :ref:`icinga__ref_dns_config` for details if you want to specify this
 # list manually.
-icinga__master_nodes: '{{ lookup("dig", "_icinga-master._tcp." + icinga__domain + "./SRV",
-                                 "flat=0", wantlist=True) }}'
+icinga__master_nodes: '{{ q("dig_srv", "_icinga-master._tcp." + icinga__domain,
+                            "icinga-master." + icinga__domain, icinga__api_port) }}'
 
                                                                    # ]]]
 # .. envvar:: icinga__master_delegate_to [[[
 #
-# The host where tasks that must execute on the master node will be delegated.
+# The host to which tasks that must execute on the master node will be delegated.
 # It's used when ``icinga__master_*_configuration`` is set and configuration
 # files are written on the master node.
-icinga__master_delegate_to: '{{ icinga__master_nodes.0.target }}'
+icinga__master_delegate_to: '{{ icinga__master_nodes[0]["target"] }}'
 
                                                                    # ]]]
 # .. envvar:: icinga__director_nodes [[[
 #
-# List of ``dig`` Ansible module results that define which Icinga 2 nodes are
-# "director" nodes, used for registering the Icinga 2 client nodes. Only the
-# first list entry will be used to register a node.
+# List which contains the result of the DNS query for Icinga 2 director node
+# ``SRV`` resource records in the host's domain. This is a DebOps-specific
+# feature, which does not have a corresponding RFC.
+#
+# Only the first entry in the list will be used to register a node.
 #
 # See :ref:`icinga__ref_dns_config` for details if you want to specify this
 # list manually.
-icinga__director_nodes: '{{ lookup("dig", "_icinga-director._tcp." + icinga__domain + "./SRV",
-                                   "flat=0", wantlist=True) }}'
+icinga__director_nodes: '{{ q("dig_srv", "_icinga-director._tcp." + icinga__domain,
+                              "icinga-director." + icinga__domain, 443) }}'
 
                                                                    # ]]]
 # .. envvar:: icinga__node_type [[[
@@ -161,10 +164,8 @@ icinga__director_nodes: '{{ lookup("dig", "_icinga-director._tcp." + icinga__dom
 #
 # Client nodes are registered in the Icinga 2 Director if one is available.
 icinga__node_type: '{{ "master"
-                       if (icinga__fqdn in (icinga__master_nodes
-                           | selectattr("target", "defined")
-                           | map(attribute="target")
-                           | map("regex_replace", "\.$","")) or
+                       if (icinga__fqdn in
+                           (icinga__master_nodes | map(attribute="target")) or
                            not icinga__director_enabled|bool)
                        else "client" }}'
 
@@ -244,19 +245,20 @@ icinga__api_permissions: [ '*' ]
 # .. envvar:: icinga__director_enabled [[[
 #
 # Enable or disable support for the Icinga 2 Director configuration. Support
-# will be automatically enabled of Icinga 2 master and director nodes are
-# configured as the DNS SRV records. See :ref:`icinga__ref_dns_config` for more
-# details.
+# will be automatically enabled if DNS ``SRV`` records exist for the Icinga 2
+# master and director nodes.
+#
+# See :ref:`icinga__ref_dns_config` for more details.
 icinga__director_enabled: '{{ True
-                              if ((icinga__master_nodes   | selectattr("target", "defined") | list | count > 0) and
-                                  (icinga__director_nodes | selectattr("target", "defined") | list | count > 0))
+                              if (icinga__master_nodes[0]["dig_srv_src"]|d("") != "fallback" and
+                                  icinga__director_nodes[0]["dig_srv_src"]|d("") != "fallback")
                               else False }}'
 
                                                                    # ]]]
 # .. envvar:: icinga__director_register [[[
 #
-# Enable or disable automatic registering of configured hosts in Icinga
-# 2 Director.
+# Enable or disable automatic registration of configured hosts in Icinga 2
+# Director.
 icinga__director_register: '{{ True
                                if (icinga__director_enabled|bool)
                                else False }}'
@@ -265,13 +267,9 @@ icinga__director_register: '{{ True
 # .. envvar:: icinga__director_register_api_fqdn [[[
 #
 # The Fully Qualified Domain Name of the Icinga 2 Director host where a given
-# host will be registered. The address will be found using DNS SRV records by
-# default. See :ref:`icinga__ref_dns_config` for more details.
-icinga__director_register_api_fqdn: '{{ icinga__director_nodes
-                                        | selectattr("target", "defined")
-                                        | map(attribute="target")
-                                        | map("regex_replace","\.$","")
-                                        | first }}'
+# host will be registered. The address will be found using DNS ``SRV`` records
+# by default. See :ref:`icinga__ref_dns_config` for more details.
+icinga__director_register_api_fqdn: '{{ icinga__director_nodes[0]["target"] }}'
 
                                                                    # ]]]
 # .. envvar:: icinga__director_register_api_url [[[
@@ -401,11 +399,7 @@ icinga__director_deploy: '{{ True
 # The Fully Qualified Domain Name of the Icinga 2 Director host where the
 # deployment will be performed. The address will be found using DNS SRV records
 # by default. See :ref:`icinga__ref_dns_config` for more details.
-icinga__director_deploy_api_fqdn: '{{ icinga__director_nodes
-                                      | selectattr("target", "defined")
-                                      | map(attribute="target")
-                                      | map("regex_replace","\.$","")
-                                      | first }}'
+icinga__director_deploy_api_fqdn: '{{ icinga__director_nodes[0]["target"] }}'
 
                                                                    # ]]]
 # .. envvar:: icinga__director_deploy_api_url [[[
@@ -623,11 +617,11 @@ icinga__default_configuration:
           {% endif %}
           {% endfor %}
           object Zone "master" {
-            endpoints = [ "{{ icinga__master_nodes | selectattr('target', 'defined') | map(attribute='target') | map('regex_replace', '\.$','') | join('", "') }}" ]
+            endpoints = [ "{{ icinga__master_nodes | map(attribute='target') | join('", "') }}" ]
           }
         state: '{{ "present"
                    if (icinga__node_type != "master" and
-                       icinga__master_nodes | selectattr("target", "defined") | list | count > 0)
+                       icinga__master_nodes[0]["dig_srv_src"]|d("") != "fallback")
                    else "absent" }}'
 
       - name: 'object_node'

--- a/ansible/roles/ldap/defaults/main.yml
+++ b/ansible/roles/ldap/defaults/main.yml
@@ -97,9 +97,10 @@ ldap__domain: '{{ ansible_domain }}'
                                                                    # ]]]
 # .. envvar:: ldap__servers_srv_rr [[[
 #
-# List which contains the result of the :command:`dig` query for LDAP server
-# ``SRV`` resource records in the host's domain.
-ldap__servers_srv_rr: '{{ q("dig", "_ldap._tcp." + ldap__domain + "./SRV", "flat=0") }}'
+# List which contains the result of the DNS query for LDAP server ``SRV``
+# resource records in the host's domain.
+ldap__servers_srv_rr: '{{ q("dig_srv", "_ldap._tcp." + ldap__domain,
+                            "ldap." + ldap__domain, 389) }}'
 
                                                                    # ]]]
 # .. envvar:: ldap__servers [[[
@@ -111,11 +112,7 @@ ldap__servers_srv_rr: '{{ q("dig", "_ldap._tcp." + ldap__domain + "./SRV", "flat
 # The role tries to detect LDAP servers to use via published ``_ldap._tcp`` SRV
 # resource records, and if there aren't any, will fallback to the ``ldap.*``
 # Fully Qualified Domain Name.
-ldap__servers: '{{ (ldap__servers_srv_rr | selectattr("target", "defined")
-                    | map(attribute="target") | map("regex_replace", "\.$","") | list)
-                   if ("NXDOMAIN" not in ldap__servers_srv_rr and
-                       ldap__servers_srv_rr[0])
-                   else [ "ldap." + ldap__domain ] }}'
+ldap__servers: '{{ ldap__servers_srv_rr | map(attribute="target") }}'
 
                                                                    # ]]]
 # .. envvar:: ldap__servers_protocol [[[

--- a/ansible/roles/nullmailer/defaults/main.yml
+++ b/ansible/roles/nullmailer/defaults/main.yml
@@ -232,34 +232,23 @@ nullmailer__starttls: True
                                                                    # ]]]
 # .. envvar:: nullmailer__smtp_srv_rr [[[
 #
-# List which contains the result of the :command:`dig` query for SMTP
-# server ``SRV`` resource records in the host's domain. See
-# :rfc:`6186` for details.
-nullmailer__smtp_srv_rr: '{{ q("dig", "_smtp._tcp." + nullmailer__domain + "./SRV", "flat=0")
-                             if nullmailer__domain|d() else [] }}'
+# List which contains the result of the DNS query for SMTP server ``SRV``
+# resource records in the host's domain. See :rfc:`6186` for details.
+nullmailer__smtp_srv_rr: '{{ q("dig_srv", "_smtp._tcp." + nullmailer__domain,
+                               "smtp." + nullmailer__domain, 25) }}'
 
                                                                    # ]]]
 # .. envvar:: nullmailer__smtp_port [[[
 #
 # SMTP port (default is 25; use 587 for STARTTLS or 465 for Implicit TLS.
-nullmailer__smtp_port: '{{ (nullmailer__smtp_srv_rr | selectattr("target", "defined")
-                            | map(attribute="port") | list | sort | first)
-                           if ("NXDOMAIN" not in nullmailer__smtp_srv_rr and
-                               nullmailer__smtp_srv_rr[0])
-                           else "25" }}'
+nullmailer__smtp_port: '{{ nullmailer__smtp_srv_rr[0]["port"] }}'
 
                                                                    # ]]]
 # .. envvar:: nullmailer__relayhost [[[
 #
-# The FQDN address of the mail server to which all mail messages will be forwarded
+# The FQDN address of the mail server which all mail messages will be forwarded
 # to by the ``nullmailer`` service.
-nullmailer__relayhost: '{{ (nullmailer__smtp_srv_rr | selectattr("target", "defined")
-                           | map(attribute="target")
-                           | map("regex_replace", "\.$","")
-                           | list | sort | first)
-                          if ("NXDOMAIN" not in nullmailer__smtp_srv_rr and
-                              nullmailer__smtp_srv_rr[0])
-                          else ("smtp." + nullmailer__domain) }}'
+nullmailer__relayhost: '{{ nullmailer__smtp_srv_rr[0]["target"] }}'
 
                                                                    # ]]]
 # .. envvar:: nullmailer__relayhost_options [[[

--- a/ansible/roles/roundcube/defaults/main.yml
+++ b/ansible/roles/roundcube/defaults/main.yml
@@ -577,40 +577,32 @@ roundcube__domain: '{{ ansible_domain }}'
                                                                    # ]]]
 # .. envvar:: roundcube__imap_srv_rr [[[
 #
-# List which contains the result of the :command:`dig` query for IMAP server
-# ``SRV`` resource records in the host's domain. See :rfc:`6186` for details.
-roundcube__imap_srv_rr: '{{ q("dig", "_imaps._tcp." + roundcube__domain + "./SRV", "flat=0") }}'
+# List which contains the result of the DNS query for IMAP server ``SRV``
+# resource records in the host's domain. See :rfc:`6186` for details.
+#
+# If there are no resource records, the role checks if a local Dovecot
+# installation is present and uses the host FQDN as the IMAP server address.
+# Finally, ``imap.<domain>`` is used as a fallback.
+roundcube__imap_srv_rr: '{{ q("dig_srv", "_imaps._tcp." + roundcube__domain,
+                              ansible_fqdn
+                              if (ansible_local|d() and ansible_local.dovecot|d() and
+                                  (ansible_local.dovecot.installed|d())|bool)
+                              else "imap." + roundcube__domain, 993) }}'
 
                                                                    # ]]]
 # .. envvar:: roundcube__imap_fqdn [[[
 #
-# The FQDN address of the IMAP server which stores user mailboxes. By default
-# the host is located using DNS SRV resource records; if there are none, role
-# checks if a local Dovecot installation is present and uses the host FQDN as
-# the IMAP server address. Finally, the static ``imap.<domain>`` is used.
+# The FQDN address of the IMAP server which stores user mailboxes.
 #
-# Use of FQDN instead of ``localhost`` is required for X.509 certificate
-# verification and for correct information in system logs.
-roundcube__imap_fqdn: '{{ (roundcube__imap_srv_rr | selectattr("target", "defined")
-                           | map(attribute="target")
-                           | map("regex_replace", "\.$","")
-                           | list | first)
-                          if ("NXDOMAIN" not in roundcube__imap_srv_rr and
-                              roundcube__imap_srv_rr[0])
-                          else (ansible_fqdn
-                                if (ansible_local|d() and ansible_local.dovecot|d() and
-                                    (ansible_local.dovecot.installed|d())|bool)
-                                else ("imap." + roundcube__domain)) }}'
+# The use of the FQDN instead of ``localhost`` is required for X.509
+# certificate verification and for correct information in system logs.
+roundcube__imap_fqdn: '{{ roundcube__imap_srv_rr[0]["target"] }}'
 
                                                                    # ]]]
 # .. envvar:: roundcube__imap_port [[[
 #
-# TCP port used for IMAP connections
-roundcube__imap_port: '{{ (roundcube__imap_srv_rr | selectattr("target", "defined")
-                           | map(attribute="port") | list | sort | first)
-                          if ("NXDOMAIN" not in roundcube__imap_srv_rr and
-                              roundcube__imap_srv_rr[0])
-                          else "993" }}'
+# The TCP port to use for IMAP connections.
+roundcube__imap_port: '{{ roundcube__imap_srv_rr[0]["port"] }}'
 
                                                                    # ]]]
 # .. envvar:: roundcube__imap_server [[[
@@ -637,45 +629,37 @@ roundcube__imap_server: '{{ ("ssl://"
                                                                    # ]]]
 # .. envvar:: roundcube__smtp_srv_rr [[[
 #
-# List which contains the result of the :command:`dig` query for SMTP
+# List which contains the result of the DNS query for the SMTP
 # (submission) server ``SRV`` resource records in the host's domain. See
 # :rfc:`6186` for details.
-roundcube__smtp_srv_rr: '{{ q("dig", "_submissions._tcp." + roundcube__domain + "./SRV", "flat=0") }}'
+#
+# If there are no resource records, the role checks if a local Postfix
+# installation is present and uses the host FQDN as the SMTP server address.
+# Finally, ``smtp.<domain>`` is used as a fallback.
+roundcube__smtp_srv_rr: '{{ q("dig_srv", "_submissions._tcp." + roundcube__domain,
+                              ansible_fqdn
+                              if (ansible_local|d() and ansible_local.postfix|d() and
+                                  (ansible_local.postfix.installed|d())|bool)
+                              else ("smtp." + roundcube__domain), 465) }}'
 
                                                                    # ]]]
 # .. envvar:: roundcube__smtp_fqdn [[[
 #
 # The FQDN address of the SMTP (submission) server which will be used to send
-# e-mail messages. By default the host is located using DNS SRV resource
-# records; if there are none, role checks if a local Postfix installation is
-# present and uses the host FQDN as the SMTP (submission) server address.
-# Finally, the static ``smtp.<domain>`` is used.
+# e-mail messages.
 #
-# Use of FQDN instead of ``localhost`` is required for X.509 certificate
-# verification and for correct information in system logs.
-roundcube__smtp_fqdn: '{{ (roundcube__smtp_srv_rr | selectattr("target", "defined")
-                           | map(attribute="target")
-                           | map("regex_replace", "\.$","")
-                           | list | first)
-                          if ("NXDOMAIN" not in roundcube__smtp_srv_rr and
-                              roundcube__smtp_srv_rr[0])
-                          else (ansible_fqdn
-                                if (ansible_local|d() and ansible_local.postfix|d() and
-                                    (ansible_local.postfix.installed|d())|bool)
-                                else ("smtp." + roundcube__domain)) }}'
+# The use of the FQDN instead of ``localhost`` is required for X.509
+# certificate verification and for correct information in system logs.
+roundcube__smtp_fqdn: '{{ roundcube__smtp_srv_rr[0]["target"] }}'
 
                                                                    # ]]]
 # .. envvar:: roundcube__smtp_port [[[
 #
-# SMTP port.
+# The TCP port to use for SMTP connections.
 #
-# SMTP port (default is 25; use 587 for STARTTLS or 465 for the
-# deprecated SSL over SMTP (aka SMTPS))
-roundcube__smtp_port: '{{ (roundcube__smtp_srv_rr | selectattr("target", "defined")
-                           | map(attribute="port") | list | sort | first)
-                          if ("NXDOMAIN" not in roundcube__smtp_srv_rr and
-                              roundcube__smtp_srv_rr[0])
-                          else "465" }}'
+# Common values include 25 for unencrypted communication, 587 for STARTTLS,
+# or 465 for SMTP over SSL (aka SMTPS).
+roundcube__smtp_port: '{{ roundcube__smtp_srv_rr[0]["port"] }}'
 
                                                                    # ]]]
 # .. envvar:: roundcube__smtp_server [[[
@@ -715,41 +699,33 @@ roundcube__smtp_pass: '%p'
                                                                    # ]]]
 # .. envvar:: roundcube__sieve_srv_rr [[[
 #
-# List which contains the result of the :command:`dig` query for Sieve server
+# List which contains the result of the DNS query for Sieve server
 # ``SRV`` resource records in the host's domain. See :rfc:`5804` for details.
-roundcube__sieve_srv_rr: '{{ q("dig", "_sieve._tcp." + roundcube__domain + "./SRV", "flat=0") }}'
+#
+# If there are no resource records, the role checks if a local Dovecot
+# installation is present and uses the host FQDN as the Sieve server address.
+# Finally, ``sieve.<domain>`` is used as a fallback.
+roundcube__sieve_srv_rr: '{{ q("dig_srv", "_sieve._tcp." + roundcube__domain,
+                               ansible_fqdn
+                               if (ansible_local|d() and ansible_local.dovecot|d() and
+                                   (ansible_local.dovecot.installed|d())|bool)
+                               else ("sieve." + roundcube__domain), 4190) }}'
 
                                                                    # ]]]
 # .. envvar:: roundcube__sieve_fqdn [[[
 #
-# The FQDN address of the Sieve server which allows manageement of the Sieve
-# filter scripts. By default the host is located using DNS SRV resource
-# records; if there are none, role checks if a local Dovecot installation is
-# present and uses the host FQDN as the Sieve server address. Finally, the
-# static ``sieve.<domain>`` is used.
+# The FQDN address of the Sieve server which allows management of the Sieve
+# filter scripts.
 #
-# Use of FQDN instead of ``localhost`` is required for X.509 certificate
-# verification and for correct information in system logs.
-roundcube__sieve_fqdn: '{{ (roundcube__sieve_srv_rr | selectattr("target", "defined")
-                            | map(attribute="target")
-                            | map("regex_replace", "\.$","")
-                            | list | first)
-                           if ("NXDOMAIN" not in roundcube__sieve_srv_rr and
-                               roundcube__sieve_srv_rr[0])
-                           else (ansible_fqdn
-                                 if (ansible_local|d() and ansible_local.dovecot|d() and
-                                     (ansible_local.dovecot.installed|d())|bool)
-                                 else ("sieve." + roundcube__domain)) }}'
+# The use of the FQDN instead of ``localhost`` is required for X.509
+# certificate verification and for correct information in system logs.
+roundcube__sieve_fqdn: '{{ roundcube__sieve_srv_rr[0]["target"] }}'
 
                                                                    # ]]]
 # .. envvar:: roundcube__sieve_port [[[
 #
-# TCP port used for Sieve connections
-roundcube__sieve_port: '{{ (roundcube__sieve_srv_rr | selectattr("target", "defined")
-                            | map(attribute="port") | list | sort | first)
-                           if ("NXDOMAIN" not in roundcube__sieve_srv_rr and
-                               roundcube__sieve_srv_rr[0])
-                           else "4190" }}'
+# The TCP port used for Sieve connections.
+roundcube__sieve_port: '{{ roundcube__sieve_srv_rr[0]["port"] }}'
 
                                                                    # ]]]
 # .. envvar:: roundcube__sieve_server [[[

--- a/ansible/roles/rsyslog/defaults/main.yml
+++ b/ansible/roles/rsyslog/defaults/main.yml
@@ -47,7 +47,7 @@ rsyslog__unprivileged: '{{ "True"
 # .. envvar:: rsyslog__remote_enabled [[[
 #
 # Enable or disable support for receiving logs from remote hosts. It will be
-# enabled automatically if list of hosts or subnets allowed to connect to
+# enabled automatically if a list of hosts or subnets allowed to connect to the
 # :command:`rsyslog` service is defined in the Ansible inventory.
 rsyslog__remote_enabled: '{{ True
                              if (rsyslog__allow
@@ -298,23 +298,20 @@ rsyslog__host_allow: []
 
 # .. envvar:: rsyslog__syslog_srv_rr [[[
 #
-# List which contains the result of the :command:`dig` query for syslog
-# server ``SRV`` resource records in the host's domain.
+# List which contains the result of the DNS query for syslog server ``SRV``
+# resource records in the host's domain.
 # See https://tools.ietf.org/html/draft-schoenw-opsawg-nm-srv-03 for details.
-rsyslog__syslog_srv_rr: '{{ q("dig", "_syslog._tcp." + rsyslog__domain + "./SRV", "flat=0")
-                            if rsyslog__domain|d() else [] }}'
+rsyslog__syslog_srv_rr: '{{ q("dig_srv", "_syslog._tcp." + rsyslog__domain,
+                              "syslog." + rsyslog__domain, 6514) }}'
 
                                                                    # ]]]
 # .. envvar:: rsyslog__default_forward [[[
 #
-# List of the hosts detected via the DNS SRV resource records to which log
+# List of the hosts detected via the DNS ``SRV`` resource records to which log
 # messages will be forwarded. If multiple servers are configured in the SRV
-# record, logs will be snet to all of them at the same time.
-rsyslog__default_forward: '{{ (rsyslog__syslog_srv_rr | selectattr("target", "defined")
-                               | list | sort)
-                              if (rsyslog__syslog_srv_rr and
-                                  "NXDOMAIN" not in rsyslog__syslog_srv_rr and
-                                  rsyslog__syslog_srv_rr[0] and
+# record, logs will be sent to all of them.
+rsyslog__default_forward: '{{ rsyslog__syslog_srv_rr
+                              if (rsyslog__syslog_srv_rr[0]["dig_srv_src"]|d("") != "fallback" and
                                   not rsyslog__remote_enabled|bool and
                                   rsyslog__pki|bool)
                               else [] }}'

--- a/docs/ansible/roles/icinga/deployment.rst
+++ b/docs/ansible/roles/icinga/deployment.rst
@@ -55,21 +55,21 @@ be implemented later if there's demand for it.
 DNS SRV records
 ---------------
 
-The ``debops.icinga`` role uses DNS SRV records to find the addresses of the
-master Icinga 2 nodes, as well as the Icinga 2 Director API. The nodes check
-the DNS records to determine if they should be configured as the "master"
+The ``debops.icinga`` role uses DNS ``SRV`` records to find the addresses of
+the master Icinga 2 nodes, as well as the Icinga 2 Director API. The nodes
+check the DNS records to determine if they should be configured as the "master"
 hosts, or client hosts that register themselves.
 
 The DNS SRV record service names are:
 
-- ``_icinga-master._tcp`` (the master node)
-- ``_icinga-director._tcp`` (the director node)
+- ``_icinga-master._tcp`` (for the master node(s))
+- ``_icinga-director._tcp`` (for the director node(s))
 
 There can be multiple master and director DNS SRV records. The role will
 configure multiple master nodes in the :file:`zones.conf` configuration file,
 however only one director node will be used.
 
-You should create the DNS SRV records for the master and Director hosts,
+You should create the DNS ``SRV`` records for the master and Director hosts,
 otherwise all of the Icinga 2 nodes will see themselves as "master" nodes and
 won't try to connect to each other. To do that in :command:`dnsmasq`, you can
 add the configuration options:


### PR DESCRIPTION
As noted in issue #1957, `q("dig"` has several issues. It ignores sorting order and also doesn't differentiate a DNS server timeout from a NXDOMAIN (and therefore isn't idempotent).

This patch series converts all users of the "dig" lookup to use the new "dig_srv" lookup.

I've tested the following roles:

- icinga
- roundcube
- rsyslog
- nullmailer
- ldap

I have not tested the `gitlab` role because it seems broken ATM (complains about version incompatibilities when installed in a clean Bullseye VM)

Closes: #1957 