### PR TITLE
[dig_srv] Enforce trailing period in lookups

### DIFF
--- a/ansible/plugins/lookup/dig_srv.py
+++ b/ansible/plugins/lookup/dig_srv.py
@@ -63,6 +63,8 @@ class LookupModule(LookupBase):
         myres.use_edns(0, ednsflags=dns.flags.DO, payload=edns_size)
 
         domain = terms[0]
+        if not domain.endswith('.'):
+            domain += '.'
         default_domain = terms[1]
         default_port = terms[2]
         qtype = 'SRV'

--- a/ansible/roles/ansible_plugins/lookup_plugins/dig_srv.py
+++ b/ansible/roles/ansible_plugins/lookup_plugins/dig_srv.py
@@ -63,6 +63,8 @@ class LookupModule(LookupBase):
         myres.use_edns(0, ednsflags=dns.flags.DO, payload=edns_size)
 
         domain = terms[0]
+        if not domain.endswith('.'):
+            domain += '.'
         default_domain = terms[1]
         default_port = terms[2]
         qtype = 'SRV'


### PR DESCRIPTION
The patches which changed the various roles over to use `dig_srv` introduced a slight change in behaviour as they omitted the trailing period.

Rather than changing all the roles, we can enforce the trailing period in the `dig_srv` lookup plugin instead (since all queries are presumably for FQDNs).

Fixes: #2001