### PR TITLE
[nginx] Remove SPDY option

### DIFF
--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -625,13 +625,6 @@ nginx_hsts_preload: False
 nginx_enable_http2: True
 
                                                                    # ]]]
-# .. envvar:: nginx_enable_spdy [[[
-#
-# Enables experimental support for .. _SPDY: https://www.chromium.org/spdy/spdy-protocol HTTP protocol.
-# Available with nginx version >= 1.4 && < 1.9.5
-nginx_enable_spdy: False
-
-                                                                   # ]]]
 # .. envvar:: nginx__http_csp_append [[[
 #
 # CSP directives to append to all policies. This can be used to set the

--- a/ansible/roles/nginx/templates/etc/nginx/sites-available/default.conf.j2
+++ b/ansible/roles/nginx/templates/etc/nginx/sites-available/default.conf.j2
@@ -665,10 +665,20 @@ server {
 
 server {
 
-{%     endif                                                %}
-{%     for port in nginx_tpl_listen_ssl                     %}
-        listen {{ port }} ssl{% if nginx_version is version_compare('1.9.5','>=') and nginx_enable_http2|bool %} http2{% elif nginx_version is version_compare('1.4','>=') and nginx_enable_spdy|bool %} spdy{% endif %}{% if nginx_tpl_default_server_ssl %} {{ nginx_tpl_default_server_ssl | join(" ") }}{% endif %}{% if (loop.first and nginx_tpl_ipv6only_ssl) %} {{ nginx_tpl_ipv6only_ssl | join(" ") }}{% endif %};
-{%     endfor                                               %}
+{%     endif %}
+{%     for port in nginx_tpl_listen_ssl %}
+{%      set opts = [ 'ssl' ] %}
+{%      if nginx_version is version_compare('1.9.5', '>=') %}
+{%        if nginx_enable_http2 | bool %}
+{%          set _ = opts.append('http2') %}
+{%        endif %}
+{%      endif %}
+{%      set _ = opts.extend(nginx_tpl_default_server_ssl) %}
+{%      if loop.first %}
+{%        set _ = opts.extend(nginx_tpl_ipv6only_ssl) %}
+{%      endif %}
+        listen {{ port }} {{ opts | join(" ") }};
+{%     endfor %}
 
         ssl_certificate           {{ nginx_tpl_ssl_certificate }};
         ssl_certificate_key       {{ nginx_tpl_ssl_certificate_key }};

--- a/docs/news/upgrades.rst
+++ b/docs/news/upgrades.rst
@@ -71,12 +71,12 @@ Redesign of the Debian Pressed support
 Changes in inventory variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- In the :ref:`debops.nginx` role some variables were renamed:
+- In the :ref:`debops.nginx` role one variable was removed:
 
   +-----------------------+-----------------------------+---------------+
   | Old variable name     | New variable name           | Changed value |
   +=======================+=============================+===============+
-  | ``nginx_enable_sdpy`` | :envvar:`nginx_enable_spdy` | No            |
+  | ``nginx_enable_sdpy`` | Removed                     | No            |
   +-----------------------+-----------------------------+---------------+
 
 


### PR DESCRIPTION
To quote Wikipedia: "Since 2021, no modern browser supports SPDY.".

So...remove this option, HTTP2 is already supported.

Also, since I had difficulties even parsing that 500 characters wide
line in the template, I took the liberty of rewriting it over a
couple of lines...