### PR TITLE
[bootstrap-*] Improve mitogen compatibility

### DIFF
--- a/ansible/playbooks/bootstrap-ldap.yml
+++ b/ansible/playbooks/bootstrap-ldap.yml
@@ -29,6 +29,7 @@
   collections: [ 'debops.debops', 'debops.roles01',
                  'debops.roles02', 'debops.roles03' ]
   hosts: [ 'debops_all_hosts', 'debops_service_bootstrap' ]
+  strategy: linear
   gather_facts: False
   become: True
 

--- a/ansible/playbooks/bootstrap-sss.yml
+++ b/ansible/playbooks/bootstrap-sss.yml
@@ -31,6 +31,7 @@
   collections: [ 'debops.debops', 'debops.roles01',
                  'debops.roles02', 'debops.roles03' ]
   hosts: [ 'debops_all_hosts', 'debops_service_bootstrap' ]
+  strategy: linear
   gather_facts: False
   become: True
 

--- a/ansible/playbooks/bootstrap.yml
+++ b/ansible/playbooks/bootstrap.yml
@@ -36,6 +36,7 @@
   collections: [ 'debops.debops', 'debops.roles01',
                  'debops.roles02', 'debops.roles03' ]
   hosts: [ 'debops_all_hosts', 'debops_service_bootstrap' ]
+  strategy: linear
   gather_facts: False
   become: True
 

--- a/ansible/playbooks/service/python_raw.yml
+++ b/ansible/playbooks/service/python_raw.yml
@@ -7,6 +7,7 @@
   collections: [ 'debops.debops', 'debops.roles01',
                  'debops.roles02', 'debops.roles03' ]
   hosts: [ 'debops_all_hosts', 'debops_service_python' ]
+  strategy: linear
   become: True
   gather_facts: False
 


### PR DESCRIPTION
Mitogen[1][2] is a great way to speed up Ansible runs, but it doesn't
support running raw tasks. This makes sure that the normal Ansible
strategy is used for raw tasks (in other words, it should have no
effect on non-Mitogen users).

[1] https://mitogen.networkgenomics.com/ansible_detailed.html
[2] https://github.com/mitogen-hq/mitogen