### PR TITLE
[grub] Fix password generation

### DIFF
--- a/ansible/roles/grub/tasks/main.yml
+++ b/ansible/roles/grub/tasks/main.yml
@@ -67,7 +67,7 @@
 ## This is not too bad because depending on the iteration count chosen this operation could take a while ;)
 - name: Generate salted hash from user password
   shell: set -o nounset -o pipefail -o errexit &&
-         echo '{{ item.0.password }}\n{{ item.0.password }}' | LANG=C LC_ALL=C grub-mkpasswd-pbkdf2
+         echo -en '{{ item.0.password }}\n{{ item.0.password }}\n' | LANG=C LC_ALL=C grub-mkpasswd-pbkdf2
          {{ "" if grub__iter_time|d()   == "default" else ("--iteration-count=" + grub__iter_time) }}
          {{ "" if grub__salt_length|d() == "default" else ("--salt=" + grub__salt_length) }}
          {{ "" if grub__hash_length|d() == "default" else ("--buflen=" + grub__hash_length) }}


### PR DESCRIPTION
Not sure how this could have worked before, without the "-e" option,
echo won't parse the newlines. With this patch applied I can create
grub users with passwords.

Note that the whole shell thing is still unsafe since it'll leak
the grub password to the process list, a more thorough fix would
be to template the password to a tmp file and then cat that to
grub-mkpasswd-pbkdf2 (I've tested it manually and it works).

That'll have to wait for another PR though.