### PR TITLE
[misc] Finish the debops__no_log conversion

### DIFF
--- a/ansible/roles/freeradius/tasks/main.yml
+++ b/ansible/roles/freeradius/tasks/main.yml
@@ -79,7 +79,7 @@
   notify: [ 'Check freeradius configuration and restart' ]
   when: (item.name|d() and item.divert|d(False)|bool and
          item.state|d('present') in [ 'present', 'absent' ])
-  no_log: '{{ item.no_log | d(False) | bool }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(False) }}'
 
 - name: Create missing configuration directories
   file:
@@ -93,7 +93,7 @@
     label: '{{ {"path": ((freeradius__conf_base_path + "/" + (item.filename | d(item.name))) | dirname)} }}'
   when: (item.name|d() and item.state|d('present') not in [ 'absent', 'ignore', 'init' ] and
          (item.link_src|d() or item.options|d() or item.raw|d()))
-  no_log: '{{ (item.no_log | d(False)) | bool }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(False) }}'
 
 - name: Generate FreeRADIUS configuration files
   template:
@@ -106,7 +106,7 @@
   notify: [ 'Check freeradius configuration and restart' ]
   when: (item.name|d() and item.state|d('present') not in [ 'absent', 'ignore', 'init' ] and
          not item.link_src|d() and (item.options|d() or item.raw|d()))
-  no_log: '{{ (item.no_log | d(False)) | bool }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(False) }}'
 
 - name: Create configuration file symlinks
   file:
@@ -120,7 +120,7 @@
   notify: [ 'Check freeradius configuration and restart' ]
   when: (item.name|d() and item.state|d('present') not in [ 'absent', 'ignore', 'init' ] and
          item.link_src|d())
-  no_log: '{{ (item.no_log | d(False)) | bool }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(False) }}'
 
 - name: Remove FreeRADIUS configuration files
   file:
@@ -130,4 +130,4 @@
   notify: [ 'Check freeradius configuration and restart' ]
   when: (item.name|d() and not item.divert|d(False)|bool and
          item.state|d('present') == 'absent')
-  no_log: '{{ item.no_log | d(False) | bool }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(False) }}'

--- a/ansible/roles/icinga/tasks/main.yml
+++ b/ansible/roles/icinga/tasks/main.yml
@@ -103,7 +103,7 @@
   with_items: '{{ icinga__combined_configuration | debops.debops.parse_kv_items }}'
   notify: [ 'Check icinga2 configuration and restart' ]
   when: (item.name|d() and item.state|d('present') not in [ 'absent', 'ignore', 'init', 'divert', 'feature' ])
-  no_log: '{{ item.no_log | d(omit) }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(False) }}'
 
 - name: Ensure that configuration directories exist on the master node
   file:
@@ -138,7 +138,7 @@
   delegate_to: '{{ icinga__master_delegate_to }}'
   notify: [ 'Check icinga2 configuration and restart it on the master node' ]
   when: (item.name|d() and item.state|d('present') not in [ 'absent', 'ignore', 'init', 'divert', 'feature' ])
-  no_log: '{{ item.no_log | d(omit) }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(False) }}'
 
 - name: Configure state of Icinga features
   file:

--- a/ansible/roles/icinga_web/tasks/main.yml
+++ b/ansible/roles/icinga_web/tasks/main.yml
@@ -88,7 +88,7 @@
     owner: '{{ icinga_web__user }}'
     group: '{{ icinga_web__group }}'
     mode: '0660'
-  no_log: '{{ item.no_log | d(omit) }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(False) }}'
   with_items:
 
     - filename: 'authentication.ini'

--- a/ansible/roles/monit/tasks/main.yml
+++ b/ansible/roles/monit/tasks/main.yml
@@ -31,7 +31,7 @@
   with_items: '{{ monit__combined_config | debops.debops.parse_kv_items }}'
   when: item.name|d() and item.state|d('present') == 'absent'
   notify: [ 'Test monit and reload' ]
-  no_log: '{{ True if (item.mode|d("0644") == "0600") else False }}'
+  no_log: '{{ debops__no_log | d(True if (item.mode|d("0644") == "0600") else False) }}'
 
 - name: Generate Monit configuration
   template:
@@ -43,7 +43,7 @@
   with_items: '{{ monit__combined_config | debops.debops.parse_kv_items }}'
   when: item.name|d() and item.state|d('present') not in [ 'init', 'absent' ]
   notify: [ 'Test monit and reload' ]
-  no_log: '{{ True if (item.mode|d("0644") == "0600") else False }}'
+  no_log: '{{ debops__no_log | d(True if (item.mode|d("0644") == "0600") else False) }}'
 
 - name: Make sure Ansible local facts directory exists
   file:

--- a/ansible/roles/postfix/tasks/main.yml
+++ b/ansible/roles/postfix/tasks/main.yml
@@ -108,7 +108,8 @@
     - '{{ postfix__combined_lookup_tables | debops.debops.parse_kv_items }}'
   when: item.name|d() and item.state|d('present') == 'absent'
   notify: [ 'Process Postfix Makefile', 'Check postfix and reload' ]
-  no_log: '{{ item.no_log | d(True if (item.mode|d("0644") == "0600") else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log)
+              | d(True if (item.mode|d("0644") == "0600") else False) }}'
 
 - name: Generate Postfix lookup tables
   template:
@@ -121,9 +122,9 @@
     - '{{ postfix__combined_lookup_tables | debops.debops.parse_kv_items }}'
   notify: [ 'Process Postfix Makefile', 'Check postfix and reload' ]
   when: item.name|d() and item.state|d('present') != 'absent'
-  no_log: '{{ item.no_log | d(True
-                              if (item.mode|d("0640") in ["0640","0600"])
-                              else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log)
+              | d(True if (item.mode|d("0640") in ["0640","0600"])
+                  else False) }}'
 
 - name: Save dependent configuration on Ansible Controller
   template:

--- a/ansible/roles/resources/tasks/main.yml
+++ b/ansible/roles/resources/tasks/main.yml
@@ -319,7 +319,7 @@
     label: '{{ {"name": item.name} }}'
   when: resources__enabled|bool and
         item.name|d() and item.state|d('present') not in [ 'absent', 'ignore' ]
-  no_log: '{{ item.no_log | d(False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(False) }}'
   tags: [ 'role::resources:commands' ]
 
 # DebOps post-hook [[[1

--- a/ansible/roles/resources/tasks/shell_commands.yml
+++ b/ansible/roles/resources/tasks/shell_commands.yml
@@ -11,5 +11,5 @@
     removes:    '{{ item.removes    | d(omit) }}'
     executable: '{{ item.executable | d("bash") }}'
   when: item.name|d() and item.state not in [ 'absent', 'ignore' ]
-  no_log: '{{ item.no_log | d(False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(False) }}'
   tags: [ 'role::resources:commands' ]

--- a/ansible/roles/secret/defaults/main.yml
+++ b/ansible/roles/secret/defaults/main.yml
@@ -54,14 +54,6 @@ secret__levels: '..'
 secret__directories: []
 
                                                                    # ]]]
-# .. envvar:: secret__no_log [[[
-#
-# This variable can be used in the Ansible tasks to set the ``no_log``
-# parameter. Changing it to ``False`` can help with debugging issues with the
-# roles, but otherwise it should be set to ``True`` to ensure that Ansible
-# doesn't leak sensitive data in its logs.
-secret__no_log: '{{ debops__no_log | d(True) }}'
-                                                                   # ]]]
                                                                    # ]]]
 # LDAP server admin access [[[
 # ----------------------------

--- a/ansible/roles/slapd/tasks/main.yml
+++ b/ansible/roles/slapd/tasks/main.yml
@@ -152,10 +152,11 @@
   when: item.name|d() and item.dn|d() and
         item.state|d('present') not in [ 'init', 'ignore' ]
   tags: [ 'role::slapd:tasks' ]
-  no_log: '{{ item.no_log | d(True
-                              if ("userPassword" in (item.attributes|d({})).keys() or
-                                  "olcRootPW"    in (item.attributes|d({})).keys())
-                              else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log)
+              | d(True
+                  if ("userPassword" in (item.attributes|d({})).keys() or
+                      "olcRootPW"    in (item.attributes|d({})).keys())
+                  else False) }}'
 
 - name: Remove slapacl test suite if requested
   file:
@@ -175,10 +176,11 @@
         item.name|d() and item.dn|d() and
         item.state|d('present') not in [ 'init', 'ignore' ]
   tags: [ 'role::slapd:slapacl', 'role::slapd:tasks' ]
-  no_log: '{{ item.no_log | d(True
-                              if ("userPassword" in (item.attributes|d({})).keys() or
-                                  "olcRootPW"    in (item.attributes|d({})).keys())
-                              else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log)
+              | d(True
+                  if ("userPassword" in (item.attributes|d({})).keys() or
+                      "olcRootPW"    in (item.attributes|d({})).keys())
+                  else False) }}'
 
 - name: Generate slapacl test suite script
   template:

--- a/ansible/roles/slapd/tasks/slapd_tasks.yml
+++ b/ansible/roles/slapd/tasks/slapd_tasks.yml
@@ -12,10 +12,11 @@
   run_once:      '{{ item.run_once | d(False) }}'
   when: (item.objectClass|d() or item.entry_state|d()) and item.state not in [ 'init', 'ignore' ]
   tags: [ 'role::slapd:tasks', 'role::slapd:slapacl' ]
-  no_log: '{{ item.no_log | d(True
-                              if ("userPassword" in (item.attributes|d({})).keys() or
-                                  "olcRootPW"    in (item.attributes|d({})).keys())
-                              else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log)
+              | d(True
+                  if ("userPassword" in (item.attributes|d({})).keys() or
+                      "olcRootPW"    in (item.attributes|d({})).keys())
+                  else False) }}'
 
 - name: '{{ item.name }}'
   ldap_attrs:
@@ -26,7 +27,8 @@
   run_once:     '{{ item.run_once | d(False) }}'
   when: not item.objectClass|d() and not item.entry_state|d() and item.state not in [ 'init', 'ignore' ]
   tags: [ 'role::slapd:tasks', 'role::slapd:slapacl' ]
-  no_log: '{{ item.no_log | d(True
-                              if ("userPassword" in (item.attributes|d({})).keys() or
-                                  "olcRootPW"    in (item.attributes|d({})).keys())
-                              else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log)
+              | d(True
+                  if ("userPassword" in (item.attributes|d({})).keys() or
+                      "olcRootPW"    in (item.attributes|d({})).keys())
+                  else False) }}'

--- a/ansible/roles/system_users/tasks/main.yml
+++ b/ansible/roles/system_users/tasks/main.yml
@@ -55,7 +55,7 @@
   when: (system_users__enabled|bool and item.name|d() and item.name != 'root' and
          item.state|d('present') not in [ 'absent', 'ignore' ] and
          (item.private_group|d(True))|bool)
-  no_log: '{{ item.no_log | d((debops__no_log | d(True)) if item.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password|d() else False) }}'
 
 - name: Gather information about existing remote users
   getent:
@@ -100,7 +100,7 @@
                 "state": item.state|d("present"), "gecos": item.comment|d()} }}'
   when: (system_users__enabled|bool and item.name|d() and item.name != 'root' and
          item.state|d('present') not in [ 'ignore' ] and (item.user|d(True))|bool)
-  no_log: '{{ item.no_log | d((debops__no_log | d(True)) if item.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password|d() else False) }}'
 
 - name: Gather information about existing remote groups
   getent:
@@ -134,7 +134,7 @@
          item.state|d('present') not in [ 'ignore' ] and
          (item.groups|d() or (item.admin|d())|bool) and
          (item.user|d(True))|bool)
-  no_log: '{{ item.no_log | d((debops__no_log | d(True)) if item.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password|d() else False) }}'
 
 - name: Manage system users home directories
   file:
@@ -161,7 +161,7 @@
          item.state|d('present') not in [ 'absent', 'ignore' ] and (item.create_home|d(True))|bool and
          (item.home_owner|d() or item.home_group|d() or item.home_mode|d() or (item.local|d(True))|bool) and
          (item.user|d(True))|bool)
-  no_log: '{{ item.no_log | d((debops__no_log | d(True)) if item.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password|d() else False) }}'
 
 - name: Manage system users home directory ACLs
   acl:
@@ -189,7 +189,7 @@
          item.0.name|d() and item.0.name != 'root' and
          item.0.state|d('present') not in [ 'absent', 'ignore' ] and (item.0.create_home|d(True))|bool and
          item.0.home_acl|d() and (item.user|d(True))|bool)
-  no_log: '{{ item.0.no_log | d((debops__no_log | d(True)) if item.0.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.0.no_log) | d(True if item.0.password|d() else False) }}'
   tags: [ 'role::system_users:home_acl', 'skip::system_users:home_acl', 'skip::check' ]
 
 - name: Allow specified system UNIX accounts to linger when not logged in
@@ -204,7 +204,7 @@
          item.name|d() and item.name != 'root' and
          item.state|d('present') not in [ 'absent', 'ignore' ] and
          item.linger is defined and item.linger|bool and (item.user|d(True))|bool)
-  no_log: '{{ item.no_log | d((debops__no_log | d(True)) if item.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password|d() else False) }}'
 
 - name: Disallow specified UNIX accounts to linger when not logged in
   command: loginctl disable-linger {{ (item.prefix | d(system_users__prefix)) + item.name }}
@@ -218,7 +218,7 @@
          item.name|d() and item.name != 'root' and
          item.state|d('present') not in [ 'absent', 'ignore' ] and
          item.linger is defined and not item.linger|bool and (item.user|d(True))|bool)
-  no_log: '{{ item.no_log | d((debops__no_log | d(True)) if item.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password|d() else False) }}'
 
 - name: Configure SSH authorized keys for system users
   authorized_key:
@@ -234,7 +234,7 @@
          item.state|d('present') not in [ 'absent', 'ignore' ] and (item.create_home|d(True))|bool and
          item.sshkeys|d() and item.sshkeys_state|d('present') != 'absent' and (item.user|d(True))|bool and
          not ansible_check_mode)
-  no_log: '{{ item.no_log | d((debops__no_log | d(True)) if item.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password|d() else False) }}'
   tags: [ 'role::system_users:authorized_keys', 'skip::system_users:authorized_keys', 'skip::check' ]
 
 - name: Remove SSH authorized keys from system user accounts if requested
@@ -249,7 +249,7 @@
   when: (system_users__enabled|bool and item.name|d() and item.name != 'root' and
          item.state|d('present') not in [ 'absent', 'ignore' ] and (item.create_home|d(True))|bool and
          item.sshkeys|d() and item.sshkeys_state|d('present') == 'absent' and (item.user|d(True))|bool)
-  no_log: '{{ item.no_log | d((debops__no_log | d(True)) if item.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password|d() else False) }}'
 
 - name: Configure system user mail forwarding
   lineinfile:
@@ -269,7 +269,7 @@
   when: (system_users__enabled|bool and item.name|d() and item.name != 'root' and
          item.state|d('present') not in [ 'absent', 'ignore' ] and
          item.create_home|d(True) and item.forward|d() and (item.user|d(True))|bool)
-  no_log: '{{ item.no_log | d((debops__no_log | d(True)) if item.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password|d() else False) }}'
   tags: [ 'role::system_users:forward', 'skip::system_users:forward', 'skip::check' ]
 
 - name: Manage system users dotfiles
@@ -299,7 +299,7 @@
          (ansible_local|d() and ansible_local.yadm|d() and (ansible_local.yadm.installed|d())|bool) and
          (item.dotfiles | d(item.dotfiles_enabled | d(system_users__dotfiles_enabled))) | bool and
          (item.dotfiles_repo | d(system_users__dotfiles_repo)) and (item.user|d(True))|bool)
-  no_log: '{{ item.no_log | d((debops__no_log | d(True)) if item.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password|d() else False) }}'
   tags: [ 'role::system_users:dotfiles', 'skip::system_users:dotfiles', 'skip::check' ]
 
 - name: Manage system user resource directories
@@ -324,7 +324,7 @@
          item.0.create_home|d(True) and item.0.resources|d() and (item.0.user|d(True))|bool and
          item.1.state|d('directory') in [ 'directory', 'link', 'touch' ] and
          item.1.content is undefined)
-  no_log: '{{ item.0.no_log | d((debops__no_log | d(True)) if item.0.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.0.no_log) | d(True if item.0.password|d() else False) }}'
 
 - name: Manage system user resource parent directories
   file:
@@ -346,7 +346,7 @@
          item.0.state|d('present') not in [ 'absent', 'ignore' ] and
          item.0.create_home|d(True) and item.0.resources|d() and (item.0.user|d(True))|bool and
          item.1.state|d('directory') in [ 'present', 'file' ])
-  no_log: '{{ item.0.no_log | d((debops__no_log | d(True)) if item.0.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.0.no_log) | d(True if item.0.password|d() else False) }}'
 
 - name: Manage system user resource files
   copy:
@@ -369,7 +369,7 @@
          item.0.create_home|d(True) and item.0.resources|d() and (item.0.user|d(True))|bool and
          item.1.state|d('directory') in [ 'present', 'file' ] and
          (item.1.dest|d() or item.1.path|d()) and (item.1.src|d() or item.1.content|d()))
-  no_log: '{{ item.0.no_log | d((debops__no_log | d(True)) if item.0.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.0.no_log) | d(True if item.0.password|d() else False) }}'
 
 - name: Remove system user resources if requested
   file:
@@ -386,7 +386,7 @@
          item.0.state|d('present') not in [ 'absent', 'ignore' ] and
          item.0.create_home|d(True) and item.0.resources|d() and (item.0.user|d(True))|bool and
          item.1.state|d('directory') == 'absent')
-  no_log: '{{ item.0.no_log | d((debops__no_log | d(True)) if item.0.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.0.no_log) | d(True if item.0.password|d() else False) }}'
 
 - name: Remove user groups if requested
   group:
@@ -400,7 +400,7 @@
   when: (system_users__enabled|bool and item.name|d() and item.name != 'root' and
          item.state|d('present') == 'absent' and
          (item.private_group|d(True))|bool)
-  no_log: '{{ item.no_log | d((debops__no_log | d(True)) if item.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password|d() else False) }}'
 
 - name: Make sure that Ansible local facts directory exists
   file:

--- a/ansible/roles/users/tasks/main.yml
+++ b/ansible/roles/users/tasks/main.yml
@@ -41,7 +41,7 @@
                 "state": item.state|d("present")} }}'
   when: (users__enabled|bool and item.name|d() and item.name != 'root' and
          item.state|d('present') != 'absent' and (item.private_group|d(True))|bool)
-  no_log: '{{ item.no_log | d((debops__no_log | d(True)) if item.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password|d() else False) }}'
 
 - name: Gather information about existing remote users
   getent:
@@ -86,7 +86,7 @@
                 "state": item.state|d("present"), "gecos": item.comment|d()} }}'
   when: (users__enabled|bool and item.name|d() and item.name != 'root' and
          item.state|d('present') not in [ 'ignore' ] and (item.user|d(True))|bool)
-  no_log: '{{ item.no_log | d((debops__no_log | d(True)) if item.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password|d() else False) }}'
 
 - name: Gather information about existing remote groups
   getent:
@@ -120,7 +120,7 @@
          item.state|d('present') not in [ 'ignore' ] and
          (item.groups|d() or (item.chroot|d())|bool) and
          (item.user|d(True))|bool)
-  no_log: '{{ item.no_log | d((debops__no_log | d(True)) if item.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password|d() else False) }}'
 
 - name: Manage user home directories
   file:
@@ -147,7 +147,7 @@
          item.state|d('present') not in [ 'absent', 'ignore' ] and item.create_home|d(True) and
          (item.home_owner|d() or item.home_group|d() or item.home_mode|d() or (item.local|d(True))|bool) and
          (item.user|d(True))|bool)
-  no_log: '{{ item.no_log | d((debops__no_log | d(True)) if item.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password|d() else False) }}'
 
 - name: Manage home directory ACLs
   acl:
@@ -175,7 +175,7 @@
          item.0.name|d() and item.0.name != 'root' and
          item.0.state|d('present') not in [ 'absent', 'ignore' ] and
          item.0.create_home|d(True) and item.0.home_acl|d() and (item.0.user|d(True))|bool)
-  no_log: '{{ item.no_log | d((debops__no_log | d(True)) if item.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password|d() else False) }}'
   tags: [ 'role::users:home_acl', 'skip::users:home_acl', 'skip::check' ]
 
 - name: Allow specified UNIX accounts to linger when not logged in
@@ -190,7 +190,7 @@
          item.name|d() and item.name != 'root' and
          item.state|d('present') not in [ 'absent', 'ignore' ] and
          item.linger is defined and item.linger|bool and (item.user|d(True))|bool)
-  no_log: '{{ item.no_log | d((debops__no_log | d(True)) if item.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password|d() else False) }}'
 
 - name: Disallow specified UNIX accounts to linger when not logged in
   command: loginctl disable-linger {{ item.name }}
@@ -204,7 +204,7 @@
          item.name|d() and item.name != 'root' and
          item.state|d('present') not in [ 'absent', 'ignore' ] and
          item.linger is defined and not item.linger|bool and (item.user|d(True))|bool)
-  no_log: '{{ item.no_log | d((debops__no_log | d(True)) if item.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password|d() else False) }}'
 
 - name: Configure ~/.ssh/authorized_keys for users
   authorized_key:
@@ -219,7 +219,7 @@
   when: (users__enabled|bool and item.name|d() and item.name != 'root' and
          item.state|d('present') not in [ 'absent', 'ignore' ] and item.create_home|d(True) and
          item.sshkeys|d() and item.sshkeys_state|d('present') != 'absent' and (item.user|d(True))|bool)
-  no_log: '{{ item.no_log | d((debops__no_log | d(True)) if item.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password|d() else False) }}'
   tags: [ 'role::users:authorized_keys', 'skip::users:authorized_keys', 'skip::check' ]
 
 - name: Remove ~/.ssh/authorized_keys from user account if disabled
@@ -234,7 +234,7 @@
   when: (users__enabled|bool and item.name|d() and item.name != 'root' and
          item.state|d('present') not in [ 'absent', 'ignore' ] and item.create_home|d(True) and
          item.sshkeys_state|d('present') == 'absent' and (item.user|d(True))|bool)
-  no_log: '{{ item.no_log | d((debops__no_log | d(True)) if item.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password|d() else False) }}'
 
 - name: Configure user mail forwarding
   lineinfile:
@@ -256,7 +256,7 @@
   when: (users__enabled|bool and item.name|d() and item.name != 'root' and
          item.state|d('present') not in [ 'absent', 'ignore' ] and
          item.create_home|d(True) and item.forward|d() and (item.user|d(True))|bool)
-  no_log: '{{ item.no_log | d((debops__no_log | d(True)) if item.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password|d() else False) }}'
   tags: [ 'role::users:forward', 'skip::users:forward', 'skip::check' ]
 
 - name: Manage users dotfiles
@@ -286,7 +286,7 @@
          (ansible_local|d() and ansible_local.yadm|d() and (ansible_local.yadm.installed|d())|bool) and
          (item.dotfiles | d(item.dotfiles_enabled | d(users__dotfiles_enabled))) | bool and
          (item.dotfiles_repo | d(users__dotfiles_repo)) and (item.user|d(True))|bool and not (item.chroot|d())|bool)
-  no_log: '{{ item.no_log | d((debops__no_log | d(True)) if item.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password|d() else False) }}'
   tags: [ 'role::users:dotfiles', 'skip::users:dotfiles', 'skip::check' ]
 
 - name: Manage user resource directories
@@ -311,7 +311,7 @@
          item.0.create_home|d(True) and item.0.resources|d() and (item.0.user|d(True))|bool and
          item.1.state|d('directory') in [ 'directory', 'link', 'touch' ] and
          item.1.content is undefined)
-  no_log: '{{ item.0.no_log | d((debops__no_log | d(True)) if item.0.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.0.no_log) | d(True if item.0.password|d() else False) }}'
 
 - name: Manage user resource parent directories
   file:
@@ -333,7 +333,7 @@
          item.0.state|d('present') not in [ 'absent', 'ignore' ] and
          item.0.create_home|d(True) and item.0.resources|d() and (item.0.user|d(True))|bool and
          item.1.state|d('directory') in [ 'present', 'file' ])
-  no_log: '{{ item.0.no_log | d((debops__no_log | d(True)) if item.0.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.0.no_log) | d(True if item.0.password|d() else False) }}'
 
 - name: Manage user resource files
   copy:
@@ -356,7 +356,7 @@
          item.0.create_home|d(True) and item.0.resources|d() and (item.0.user|d(True))|bool and
          item.1.state|d('directory') in [ 'present', 'file' ] and
          (item.1.dest|d() or item.1.path|d()) and (item.1.src|d() or item.1.content|d()))
-  no_log: '{{ item.0.no_log | d((debops__no_log | d(True)) if item.0.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.0.no_log) | d(True if item.0.password|d() else False) }}'
 
 - name: Remove user resources if requested
   file:
@@ -373,7 +373,7 @@
          item.0.state|d('present') not in [ 'absent', 'ignore' ] and
          item.0.create_home|d(True) and item.0.resources|d() and (item.0.user|d(True))|bool and
          item.1.state|d('directory') == 'absent')
-  no_log: '{{ item.0.no_log | d((debops__no_log | d(True)) if item.0.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.0.no_log) | d(True if item.0.password|d() else False) }}'
 
 - name: Remove user groups if requested
   group:
@@ -387,7 +387,7 @@
   when: (users__enabled|bool and item.name|d() and item.name != 'root' and
          item.state|d('present') == 'absent' and
          (item.private_group|d(True))|bool)
-  no_log: '{{ item.no_log | d((debops__no_log | d(True)) if item.password|d() else False) }}'
+  no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password|d() else False) }}'
 
 - name: Make sure that Ansible local facts directory exists
   file:

--- a/docs/ansible/roles/secret/guides.rst
+++ b/docs/ansible/roles/secret/guides.rst
@@ -86,7 +86,7 @@ Example usage of LDAP secret variables:
        bind_pw:     '{{ secret__ldap_bind_pw }}'
      become:        '{{ secret__ldap_become }}'
      delegate_to:   '{{ secret__ldap_delegate_to }}'
-     no_log: '{{ secret__no_log | bool }}'
+     no_log: '{{ debops__no_log | d(True) }}'
 
    - name: Add attribute to an LDAP entry
      ldap_attr:
@@ -103,7 +103,7 @@ Example usage of LDAP secret variables:
      with_dict:
        uid:          '{{ user_username }}'
        userPassword: '{{ user_password }}'
-     no_log: '{{ secret__no_log | bool }}'
+     no_log: '{{ debops__no_log | d(True) }}'
 
 Of course for this to work, ``debops.secret`` needs to be included in the
 playbook, either as a role, or a role dependency. You can change the values of


### PR DESCRIPTION
This PR finishes up the `debops__no_log` conversion that @drybjed started by:
- fixing a few leftover non-uses of `debops__no_log`
- removing the superfluous (and unused) `secret__no_log`
- making sure that `debops__no_log` always takes precedence

Note that this PR will probably have merge conflicts with PR #2016, so when/if one of them is accepted I'll rebase the other one to sort out the conflict. 