### PR TITLE
[root_account] Remove fix for Debian bug #794727

### DIFF
--- a/ansible/roles/root_account/defaults/main.yml
+++ b/ansible/roles/root_account/defaults/main.yml
@@ -133,14 +133,6 @@ root_account__group: '{{ "wheel"
 root_account__shell: ''
 
                                                                    # ]]]
-# .. envvar:: root_account__fix_no_tty [[[
-#
-# When enabled, the role will ensure that the :command:`mesg n` command located
-# in the :file:`/root/.profile` file will be run only when TTY is present. This
-# fixes the "mesg: ttyname failed: Inappropriate ioctl for device" error message.
-# See also: https://bugs.debian.org/794727, https://superuser.com/a/1253889
-root_account__fix_no_tty: True
-                                                                   # ]]]
                                                                    # ]]]
 # The root dotfiles [[[
 # ---------------------

--- a/ansible/roles/root_account/tasks/main.yml
+++ b/ansible/roles/root_account/tasks/main.yml
@@ -107,15 +107,6 @@
   when: root_account__enabled|bool and root_account__subuid_enabled|bool and
         not root_account__register_subuid.stdout|d()
 
-- name: Fix shell usage without TTY present
-  ansible.builtin.lineinfile:
-    dest: '/root/.profile'
-    regexp: "^.*mesg n.*$"
-    line: 'tty -s && mesg n || true'
-    state: 'present'
-    mode: '0644'
-  when: root_account__enabled|bool and root_account__fix_no_tty|bool
-
 - name: Manage root dotfiles
   environment:
     LC_MESSAGES: 'C'


### PR DESCRIPTION
The bug was fixed in base-files 9.3 (Aug 2015). Which means it only
affects Jessie and earlier, see:
https://sources.debian.org/patches/base-files/

Jessie = oldoldoldstable at this point, and even the ELTS support
will expire soon, see:
https://wiki.debian.org/LTS/Extended

So this should be safe to remove...DebOps 3.1 will be released
about the time when there's no Jessie ELTS support anymore...