### PR TITLE
[misc] Update ssh key lookup

### DIFF
--- a/ansible/roles/preseed/defaults/main.yml
+++ b/ansible/roles/preseed/defaults/main.yml
@@ -62,7 +62,7 @@ preseed__www: '{{ (ansible_local.fhs.www|d("/srv/www"))
 #
 # List of SSH public keys installed on the ``root`` UNIX account of the
 # preseeded host.
-preseed__root_sshkeys: [ '{{ lookup("pipe", "ssh-add -L | grep ^\\\(sk-\\\)\\\?ssh || cat ~/.ssh/id_rsa.pub || true") }}' ]
+preseed__root_sshkeys: [ '{{ lookup("pipe", "ssh-add -L | grep ^\\\(sk-\\\)\\\?ssh || cat ~/.ssh/*.pub || cat ~/.ssh/authorized_keys || true") }}' ]
 
                                                                    # ]]]
 # .. envvar:: preseed__admin_name [[[
@@ -83,7 +83,7 @@ preseed__admin_fullname: 'Ansible Control User'
 #
 # List of SSH public keys installed on the administrative UNIX account of the
 # preseeded host.
-preseed__admin_sshkeys: [ '{{ lookup("pipe", "ssh-add -L | grep ^\\\(sk-\\\)\\\?ssh || cat ~/.ssh/id_rsa.pub || true") }}' ]
+preseed__admin_sshkeys: [ '{{ lookup("pipe", "ssh-add -L | grep ^\\\(sk-\\\)\\\?ssh || cat ~/.ssh/*.pub || cat ~/.ssh/authorized_keys || true") }}' ]
 
                                                                    # ]]]
 # .. envvar:: preseed__debian_postinst_commands [[[

--- a/ansible/roles/reprepro/defaults/main.yml
+++ b/ansible/roles/reprepro/defaults/main.yml
@@ -93,10 +93,10 @@ reprepro__spool_root: '{{ (ansible_local.fhs.spool | d("/var/spool"))
 # .. envvar:: reprepro__admin_sshkeys [[[
 #
 # List of public SSH keys which allow access to the :command:`reprepro` UNIX
-# account via SSH. By default Ansible will add the SSH keys of the person
+# account via SSH. By default this role will add the SSH keys of the person
 # currently executing the role to the account's SSH keyring.
 reprepro__admin_sshkeys:
-  - '{{ lookup("pipe", "ssh-add -L | grep ^\\\(sk-\\\)\\\?ssh || cat ~/.ssh/*.pub || true") }}'
+  - '{{ lookup("pipe", "ssh-add -L | grep ^\\\(sk-\\\)\\\?ssh || cat ~/.ssh/*.pub || cat ~/.ssh/authorized_keys || true") }}'
                                                                    # ]]]
                                                                    # ]]]
 # Global reprepro configuration [[[

--- a/ansible/roles/system_users/defaults/main.yml
+++ b/ansible/roles/system_users/defaults/main.yml
@@ -252,7 +252,7 @@ system_users__default_accounts:
                    in system_users__shell_package_map.keys())
                else omit }}'
     admin: True
-    sshkeys: '{{ lookup("pipe", "ssh-add -L | grep ^\\\(sk-\\\)\\\?ssh || cat ~/.ssh/*.pub || true") }}'
+    sshkeys: '{{ lookup("pipe", "ssh-add -L | grep ^\\\(sk-\\\)\\\?ssh || cat ~/.ssh/*.pub || cat ~/.ssh/authorized_keys || true") }}'
     state: '{{ "present"
                if system_users__self|bool
                else "ignore" }}'


### PR DESCRIPTION
This allows the preseed role to also consider non-RSA keys and
adds ~/.ssh/authorized_keys as a last fallback position in case
no other keys are found.