### PR TITLE
Fix lookup plugins to support 'standalone' mode again

### DIFF
--- a/ansible/plugins/lookup/file_src.py
+++ b/ansible/plugins/lookup/file_src.py
@@ -36,6 +36,8 @@ except AttributeError:
     except ImportError:
         pass
 except ModuleNotFoundError:
+    conf_section = ''
+    conf_key = ''
     pass
 
 try:

--- a/ansible/plugins/lookup/task_src.py
+++ b/ansible/plugins/lookup/task_src.py
@@ -36,6 +36,8 @@ except AttributeError:
     except ImportError:
         pass
 except ModuleNotFoundError:
+    conf_section = ''
+    conf_key = ''
     pass
 
 try:

--- a/ansible/plugins/lookup/template_src.py
+++ b/ansible/plugins/lookup/template_src.py
@@ -36,6 +36,8 @@ except AttributeError:
     except ImportError:
         pass
 except ModuleNotFoundError:
+    conf_section = ''
+    conf_key = ''
     pass
 
 try:

--- a/ansible/roles/ansible_plugins/lookup_plugins/file_src.py
+++ b/ansible/roles/ansible_plugins/lookup_plugins/file_src.py
@@ -36,6 +36,8 @@ except AttributeError:
     except ImportError:
         pass
 except ModuleNotFoundError:
+    conf_section = ''
+    conf_key = ''
     pass
 
 try:

--- a/ansible/roles/ansible_plugins/lookup_plugins/task_src.py
+++ b/ansible/roles/ansible_plugins/lookup_plugins/task_src.py
@@ -36,6 +36,8 @@ except AttributeError:
     except ImportError:
         pass
 except ModuleNotFoundError:
+    conf_section = ''
+    conf_key = ''
     pass
 
 try:

--- a/ansible/roles/ansible_plugins/lookup_plugins/template_src.py
+++ b/ansible/roles/ansible_plugins/lookup_plugins/template_src.py
@@ -36,6 +36,8 @@ except AttributeError:
     except ImportError:
         pass
 except ModuleNotFoundError:
+    conf_section = ''
+    conf_key = ''
     pass
 
 try:


### PR DESCRIPTION
I am using the debops collection in so called standalone mode.
After upgrading to v3.0.1 I get errors executing role `debops.debops.sshd`.

The bug was introduced with a26174380e64074ba14df52b7e612129bd5c1bd1

I fixed the files relevant for my use case. My implementation might be naive as I am not familiar with the codebase.

I took a look at the history to find and patch other relevant files (76877807043d209deb395889c1cad391e35e6bb9 and 3e1d6b593bfd38afec93572a2491dcda43d0de53).

