### PR TITLE
[ntp] fix disable systemd-timesyncd for bullseye

### DIFF
--- a/ansible/roles/ntp/tasks/install.yml
+++ b/ansible/roles/ntp/tasks/install.yml
@@ -22,7 +22,8 @@
     enabled: '{{ True if (ntp__daemon in [ "systemd-timesyncd" ]) else False }}'
   when:
     - ansible_service_mgr == "systemd"
-    - ("systemd-timesyncd.service" in ansible_facts.services)
+    - ("systemd-timesyncd.service" in ansible_facts.services and
+       ansible_facts.services['systemd-timesyncd.service'].status != 'not-found')
 
 # NTPdate does not need to be configured separately as the script `/usr/sbin/ntpdate-debian`
 # will pick up the configuration from `/etc/ntp.conf` when it exists.


### PR DESCRIPTION
Since Bullseye, systemd-timesyncd is present in systemd services but
with not-found as status.