### PR TITLE
Update Roundcube to 1.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,12 @@ You can read information about required changes between releases in the
 Changed
 ~~~~~~~
 
+Updates of upstream application versions
+''''''''''''''''''''''''''''''''''''''''
+
+- In the :ref:`debops.roundcube` role, the Roundcube version installed by
+  default has been updated to ``1.5.2``.
+
 General
 ~~~~~~~
 

--- a/ansible/roles/roundcube/defaults/main.yml
+++ b/ansible/roles/roundcube/defaults/main.yml
@@ -33,6 +33,7 @@ roundcube__required_php_packages:
   #- 'dom'
   - 'mbstring'
   - 'json'
+  - 'intl'
 
                                                                    # ]]]
 # .. envvar:: roundcube__optional_php_packages [[[
@@ -163,7 +164,7 @@ roundcube__git_dir: '{{ roundcube__src + "/"
 # .. envvar:: roundcube__git_version [[[
 #
 # Roundcube release tag to deploy.
-roundcube__git_version: '1.4.13'
+roundcube__git_version: '1.5.2'
 
                                                                    # ]]]
 # .. envvar:: roundcube__git_dest [[[

--- a/ansible/roles/roundcube/meta/watch-roundcubemail
+++ b/ansible/roles/roundcube/meta/watch-roundcubemail
@@ -4,7 +4,7 @@
 
 # Role: roundcube
 # Package: roundcubemail
-# Version: 1.4.13
+# Version: 1.5.2
 
 version=4
 https://github.com/roundcube/roundcubemail/tags .*/v?(.*\S+)\.tar\.gz


### PR DESCRIPTION
This updates the default Roundcube version to 1.5.2. Roundcube requires
PHP internationalisation support since 1.5-rc.