### PR TITLE
replace all -> debops_all_hosts in docs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -643,15 +643,15 @@ if ! [ -d src/controller ] ; then
     sed -i '/ansible_connection=local$/ s/^#//' src/controller/ansible/inventory/hosts
 
     vagrant_controller="$(printf "${SSH_CLIENT}\\n" | awk '{print $1}')"
-    mkdir -p "src/controller/ansible/inventory/group_vars/all"
+    mkdir -p "src/controller/ansible/inventory/group_vars/debops_all_hosts"
     mkdir -p "src/controller/ansible/inventory/host_vars/$(hostname)"
-    cat <<EOF >> "src/controller/ansible/inventory/group_vars/all/dhparam.yml"
+    cat <<EOF >> "src/controller/ansible/inventory/group_vars/debops_all_hosts/dhparam.yml"
 ---
 
 # Use smaller Diffie-Hellman parameters to speed up test runs
 dhparam__bits: [ '1024' ]
 EOF
-    cat <<EOF >> "src/controller/ansible/inventory/group_vars/all/core.yml"
+    cat <<EOF >> "src/controller/ansible/inventory/group_vars/debops_all_hosts/core.yml"
 ---
 
 # Vagrant client detected from \\$SSH_CLIENT variable

--- a/ansible/roles/apt_preferences/defaults/main.yml
+++ b/ansible/roles/apt_preferences/defaults/main.yml
@@ -24,7 +24,7 @@
 #
 # List of :manpage:`apt_preferences(5)` pins to configure in
 # :file:`/etc/apt/preferences.d/`.  These pins will be configured on all hosts
-# in the cluster, if set in :file:`inventory/group_vars/all/`. See
+# in the cluster, if set in :file:`inventory/group_vars/debops_all_hosts/`. See
 # :ref:`apt_preferences__list` for more details.
 apt_preferences__list: []
 

--- a/docs/ansible/roles/apt_install/getting-started.rst
+++ b/docs/ansible/roles/apt_install/getting-started.rst
@@ -52,7 +52,7 @@ installed on hosts, depending on the inventory level:
 
 :envvar:`apt_install__packages`
   This variable should be used in
-  :file:`ansible/inventory/group_vars/all/apt_install.yml` file and is meant to
+  :file:`ansible/inventory/group_vars/debops_all_hosts/apt_install.yml` file and is meant to
   specify packages present on all hosts in the inventory.
 
 :envvar:`apt_install__group_packages`

--- a/docs/ansible/roles/authorized_keys/defaults-detailed.rst
+++ b/docs/ansible/roles/authorized_keys/defaults-detailed.rst
@@ -68,7 +68,7 @@ different hosts:
 
 .. code-block:: yaml
 
-   # ansible/inventory/group_vars/all/authorized_keys.yml
+   # ansible/inventory/group_vars/debops_all_hosts/authorized_keys.yml
    authorized_keys__identities:
 
      - name: 'manager'

--- a/docs/ansible/roles/core/guides.rst
+++ b/docs/ansible/roles/core/guides.rst
@@ -63,7 +63,7 @@ configured in the Ansible local facts on a given host. Three levels of
 variables that can be used:
 
 :envvar:`core__facts`
-  Dictionary which should be defined in the :file:`inventory/group_vars/all/`
+  Dictionary which should be defined in the :file:`inventory/group_vars/debops_all_hosts/`
   group which applies to all hosts in the inventory.
 
 :envvar:`core__group_facts`
@@ -139,7 +139,7 @@ only a single list of items, merged from separate variables on all levels of
 the inventory. You can set host tags using the variables:
 
 :envvar:`core__tags`
-  Global list of tags, should be defined in :file:`inventory/group_vars/all/`
+  Global list of tags, should be defined in :file:`inventory/group_vars/debops_all_hosts/`
 
 :envvar:`core__group_tags`
   List of tags for a specific group, should be defined in

--- a/docs/ansible/roles/environment/getting-started.rst
+++ b/docs/ansible/roles/environment/getting-started.rst
@@ -41,7 +41,7 @@ The role uses multiple lists of variables which can be defined in Ansible
 inventory:
 
 ``environment__variables``
-  This list can be defined in ``inventory/group_vars/all/environment.yml`` file
+  This list can be defined in ``inventory/group_vars/debops_all_hosts/environment.yml`` file
   to define variables that should be set on all hosts in the inventory.
 
 ``environment__group_variables``

--- a/docs/ansible/roles/fail2ban/getting-started.rst
+++ b/docs/ansible/roles/fail2ban/getting-started.rst
@@ -44,7 +44,7 @@ group::
 To manage jails, you use ``fail2ban_*_jails`` list variables by adding them in
 ``group_vars/`` or ``host_vars/`` directories. For example, to disable the
 ``ssh`` jail by default on all hosts, create
-``inventory/group_vars/all/fail2ban.yml`` file and add inside::
+``inventory/group_vars/debops_all_hosts/fail2ban.yml`` file and add inside::
 
     ---
 

--- a/docs/ansible/roles/keyring/getting-started.rst
+++ b/docs/ansible/roles/keyring/getting-started.rst
@@ -38,7 +38,7 @@ The role supports usage of a local key store on the Ansible Controller, by
 setting the absolute path to a directory with the GPG key files in the
 :envvar:`keyring__local_path` variable. For example, to store the GPG keys
 inside of the DebOps project directory, :file:`ansible/keyring/` subdirectory,
-users can define in the :file:`ansible/inventory/group_vars/all/keyring.yml`
+users can define in the :file:`ansible/inventory/group_vars/debops_all_hosts/keyring.yml`
 file:
 
 .. code-block:: yaml

--- a/docs/ansible/roles/ldap/getting-started.rst
+++ b/docs/ansible/roles/ldap/getting-started.rst
@@ -89,7 +89,7 @@ therefore you don't need to do anything special to enable it on a host. However
 it is deactivated by default.
 
 To enable the role, define in the Ansible inventory, for example in the
-:file:`ansible/inventory/group_vars/all/ldap.yml` file:
+:file:`ansible/inventory/group_vars/debops_all_hosts/ldap.yml` file:
 
 .. code-block:: yaml
 

--- a/docs/ansible/roles/minio/deployment-guide.rst
+++ b/docs/ansible/roles/minio/deployment-guide.rst
@@ -125,7 +125,7 @@ the inventory:
 
 .. code-block:: yaml
 
-   # ansible/inventory/group_vars/all/minio.yml
+   # ansible/inventory/group_vars/debops_all_hosts/minio.yml
 
    # Override configuration for 'main' instance
    minio__instances:

--- a/docs/ansible/roles/nullmailer/getting-started.rst
+++ b/docs/ansible/roles/nullmailer/getting-started.rst
@@ -98,7 +98,7 @@ inventory:
 
 .. code-block:: yaml
 
-   # ansible/inventory/group_vars/all/nullmailer.yml
+   # ansible/inventory/group_vars/debops_all_hosts/nullmailer.yml
 
    nullmailer__relayhost: '<FQDN address of mail server>'
 

--- a/docs/ansible/roles/pki/getting-started.rst
+++ b/docs/ansible/roles/pki/getting-started.rst
@@ -64,7 +64,7 @@ Ansible Controller and remote hosts. Due to how task delegation in Ansible is
 designed, some of the variables that are important for the operation of the
 Ansible Controller are "sourced" on remote hosts. Therefore it's a good
 practice to define them in the Ansible inventory ``all`` group (usually
-:file:`ansible/inventory/group_vars/all/pki.yml`) for consistency between different
+:file:`ansible/inventory/group_vars/debops_all_hosts/pki.yml`) for consistency between different
 remote hosts.
 
 Most of these variables are related to Certificate Authority operation, the

--- a/docs/ansible/roles/sshd/getting-started.rst
+++ b/docs/ansible/roles/sshd/getting-started.rst
@@ -40,7 +40,7 @@ different domain than the remote host.
 
 To disable the restricted access and allow connections to the ``root`` account
 from anywhere on the network, you can set in your Ansible inventory, for
-example in :file:`ansible/inventory/group_vars/all/pam_access.yml` file:
+example in :file:`ansible/inventory/group_vars/debops_all_hosts/pam_access.yml` file:
 
 .. code-block:: yaml
 

--- a/docs/ansible/roles/system_users/control-user.rst
+++ b/docs/ansible/roles/system_users/control-user.rst
@@ -81,7 +81,7 @@ define in the inventory variables:
 .. code-block:: yaml
 
    ---
-   # ansible/inventory/group_vars/all/system_users.yml
+   # ansible/inventory/group_vars/debops_all_hosts/system_users.yml
 
    system_users__accounts:
 
@@ -143,7 +143,7 @@ specify the ``_`` character manually in all locations, for example:
 .. code-block:: yaml
 
    ---
-   # ansible/inventory/group_vars/all/system_users.yml
+   # ansible/inventory/group_vars/debops_all_hosts/system_users.yml
 
    system_users__accounts:
 

--- a/docs/introduction/getting-started.rst
+++ b/docs/introduction/getting-started.rst
@@ -125,13 +125,13 @@ variables which, when set correctly in inventory, can save you a trip to the
 data center.
 
 To make sure that these variables apply to all hosts in your environment, you
-can include them in :file:`ansible/inventory/group_vars/all/` directory. A
+can include them in :file:`ansible/inventory/group_vars/debops_all_hosts/` directory. A
 common practice is to name the files inside inventory directories after
 variable prefixes, separately for each Ansible role. For example, variables
 related to :ref:`debops.sshd` role are stored in
-:file:`ansible/inventory/group_vars/all/sshd.yml`, variables used by the
+:file:`ansible/inventory/group_vars/debops_all_hosts/sshd.yml`, variables used by the
 :ref:`debops.postfix` role are written in
-:file:`ansible/inventory/group_vars/all/postfix.yml`, and so on. The same
+:file:`ansible/inventory/group_vars/debops_all_hosts/postfix.yml`, and so on. The same
 scheme can be used in other inventory groups or for separate hosts.
 
 ansible_user
@@ -204,7 +204,7 @@ expected, but if you still are getting blocked, or to be sure that remote
 access won't be interrupted, you can define a list of IP addresses or CIDR
 subnets that will be allowed to connect to SSH without restrictions.
 
-To do that, in :file:`ansible/inventory/group_vars/all/sshd.yml` add:
+To do that, in :file:`ansible/inventory/group_vars/debops_all_hosts/sshd.yml` add:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
'debops_all_hosts' folder should be used for all debops host yamls
instead of 'all'

Signed-off-by: Sergio E. Nemirowski <sergio@outerface.net>