### PR TITLE
[dist-upgrade] do not depend on SUDO_USER

### DIFF
--- a/ansible/playbooks/tools/dist-upgrade.yml
+++ b/ansible/playbooks/tools/dist-upgrade.yml
@@ -55,7 +55,7 @@
 
           {{ ansible_fqdn }}
 
-      Upgrade has been orchestrated by {{ ansible_env.SUDO_USER }}.
+      Upgrade has been orchestrated by {{ansible_env.SUDO_USER | d("root")}}.
       You should reboot {{ ansible_fqdn }} as soon
       as possible to complete the upgrade process and boot
       with new kernel.


### PR DESCRIPTION
dist-upgrade.yml assumes that the variable ansible_env.SUDO_USER is set
This is not the case when sudo is not used to become root (lxc-ssh in my case)


Signed-off-by: Jérémy Rosen <jeremy.rosen@smile.fr>