### PR TITLE
[gitlab_runner] Fix vagrant-libvirt patching

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,6 +49,12 @@ General
 - Provide a help message in case the :file:`ansible.cfg` configuration file in
   the DebOps project directory does not include the ``inventory`` option.
 
+:ref:`debops.gitlab_runner` role
+''''''''''''''''''''''''''''''''
+
+- Fixed an error that could occur in the "Patch 'vagrant-libvirt' source code"
+  task on systems other than Debian 9 or 10.
+
 :ref:`debops.logrotate` role
 ''''''''''''''''''''''''''''
 

--- a/ansible/roles/gitlab_runner/defaults/main.yml
+++ b/ansible/roles/gitlab_runner/defaults/main.yml
@@ -145,7 +145,7 @@ gitlab_runner__fqdn: '{{ ansible_fqdn }}'
 # If there are no resource records, the role checks if a local Gitlab
 # installation is present and uses the host FQDN as the Gitlab API server
 # address. Finally, ``code.<domain>`` is used as a fallback.
-gitlab_runner__gitlab_srv_rr: '{{ q("debops.debops.dig_srv", "_gitlab._tcp." + gitlab_runner__domain,
+gitlab_runner__gitlab_srv_rr: '{{ q("dig_srv", "_gitlab._tcp." + gitlab_runner__domain,
                                     ansible_fqdn
                                     if (ansible_local|d() and ansible_local.gitlab|d() and
                                        (ansible_local.gitlab.installed|d())|bool)
@@ -369,7 +369,9 @@ gitlab_runner__vagrant_libvirt: '{{ True
 # keys that prevent interaction with Vagrant VMs.
 # See the patch file in :file:`files/patches/` directory for more details.
 gitlab_runner__vagrant_libvirt_patch: '{{ True
-                                          if (gitlab_runner__vagrant_libvirt|bool)
+                                          if (gitlab_runner__vagrant_libvirt|bool and
+                                              ansible_distribution_release in
+                                              [ "stretch", "buster" ])
                                           else False }}'
 
                                                                    # ]]]


### PR DESCRIPTION
This task only worked on Debian 9 and 10. On Debian 11, it would result
in this error:
`Could not find or access 'patches/package_domain-keep-ssh-host-keys-0.3.0.patch'`

vagrant-libvirt supports the `VAGRANT_LIBVIRT_VIRT_SYSPREP_OPERATIONS`
variable for setting the operations since version 0.1.0, removing the
need for these patches.