### PR TITLE
[postconf] Disable EHLO IP address check

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -176,6 +176,15 @@ debops.boxbackup role
   service without it actually being present on the host. This should now be
   avoided by carefully checking the service status.
 
+:ref:`debops.postconf` role
+'''''''''''''''''''''''''''
+
+- The EHLO IP address check was removed. This check would reject a message if
+  the EHLO hostname of the connecting mailserver resolved to a non-publicly
+  routable IP address. However, rejecting messages for this reason is
+  prohibited by :rfc:`5321` section 4.1.4, and sometimes caused deliverability
+  issues for Office 365 users.
+
 Removed
 ~~~~~~~
 

--- a/ansible/roles/postconf/defaults/main.yml
+++ b/ansible/roles/postconf/defaults/main.yml
@@ -147,9 +147,9 @@ postconf__default_lookup_tables:
   - name: 'mx_access.cidr'
     by_role: 'debops.postconf'
     comment: |
-      Check if HELO or sender MX server is in subnets not accessible from the
-      public Internet. If so, reject mail delivery from these servers, because
-      any replies will be non-deliverable.
+      Check if sender MX server is in subnets not accessible from the public
+      Internet. If so, reject mail delivery from these servers, because any
+      replies will be non-deliverable.
     options:
       - '0.0.0.0/8':       'REJECT Domain MX in broadcast network'
       - '10.0.0.0/8':      'REJECT Domain MX in RFC 1918 private network'
@@ -312,13 +312,6 @@ postconf__postfix__dependent_maincf:
                else "private/auth" }}'
     state: '{{ "present"
                if ("auth" in postconf__combined_capabilities)
-               else "ignore" }}'
-
-  - name: 'smtpd_helo_restrictions'
-    value:
-      - name: 'check_helo_mx_access cidr:${config_directory}/mx_access.cidr'
-    state: '{{ "present"
-               if ("public-mx-required" in postconf__combined_capabilities)
                else "ignore" }}'
 
   - name: 'smtpd_sender_restrictions'

--- a/docs/ansible/roles/postconf/getting-started.rst
+++ b/docs/ansible/roles/postconf/getting-started.rst
@@ -65,10 +65,10 @@ Supported Postfix capabilities and their effects:
   assumption that the host will receive mail messages from public Internet
   servers.
 
-  This capability will enable HELO and sender checks which will verify that
-  a given HELO domain or sender domain MX host has a public IP address.
-  Otherwise, mail messages directed to this MX won't be deliverable, therefore
-  it's better to reject the messages early.
+  This capability will enable sender checks which will verify that a given
+  sender domain MX host has a public IP address. Otherwise, mail messages
+  directed to this MX won't be deliverable, therefore it's better to reject the
+  messages early.
 
 
 ``unauth-sender``


### PR DESCRIPTION
Rejecting messages based on the resolved EHLO hostname is prohibited by
https://datatracker.ietf.org/doc/html/rfc5321#section-4.1.4:

An SMTP server MAY verify that the domain name argument in the EHLO
command actually corresponds to the IP address of the client. However,
if the verification fails, the server MUST NOT refuse to accept a
message on that basis.

Some Office 365 (outlook.com) servers have EHLO hostnames that resolve
to 127.0.0.1, which caused our mail servers to reject a few (legitimate)
messages.

This change disables the EHLO IP address check on the next playbook run.