### PR TITLE
[owncloud] - nextcloud 23 compatibility

### DIFF
--- a/ansible/roles/owncloud/tasks/setup_owncloud.yml
+++ b/ansible/roles/owncloud/tasks/setup_owncloud.yml
@@ -89,6 +89,7 @@
   ansible.builtin.set_fact:
     owncloud__do_autosetup: '{{ (owncloud__autosetup and
                                  owncloud__admin_username|d() and
+                                 (owncloud__register_occ_check is not skipped) and
                                  ("is not installed" in owncloud__register_occ_check.stdout) or
                                  ("is not installed" in owncloud__register_occ_check.stderr)) }}'
 

--- a/ansible/roles/owncloud/tasks/setup_owncloud.yml
+++ b/ansible/roles/owncloud/tasks/setup_owncloud.yml
@@ -90,7 +90,8 @@
     owncloud__do_autosetup: '{{ (owncloud__autosetup and
                                  owncloud__admin_username|d() and
                                  (owncloud__register_occ_check is not skipped) and
-                                 "is not installed" in owncloud__register_occ_check.stdout) }}'
+                                 ("is not installed" in owncloud__register_occ_check.stdout) or
+                                 ("is not installed" in owncloud__register_occ_check.stderr)) }}'
 
 - name: Automatically finish setup via the occ tool
   ansible.builtin.command: |

--- a/ansible/roles/owncloud/tasks/setup_owncloud.yml
+++ b/ansible/roles/owncloud/tasks/setup_owncloud.yml
@@ -89,8 +89,8 @@
   ansible.builtin.set_fact:
     owncloud__do_autosetup: '{{ (owncloud__autosetup and
                                  owncloud__admin_username|d() and
-                                 (owncloud__register_occ_check is not skipped) and
-                                 "is not installed" in owncloud__register_occ_check.stdout) }}'
+                                 ("is not installed" in owncloud__register_occ_check.stdout) or
+                                 ("is not installed" in owncloud__register_occ_check.stderr)) }}'
 
 - name: Automatically finish setup via the occ tool
   ansible.builtin.command: |


### PR DESCRIPTION
owncloud role doesn't work with nextcloud 23 (since newest minor release) anymore because

  `owncloud__do_autosetup`

will be false since 

  `"is not installed" in owncloud__register_occ_check.stdout`

will never be True. The `occ check` command recently writes to stderr instead of stdout.