### PR TITLE
[nginx] improve documentation nginx_ocsp_resolvers

### DIFF
--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -580,7 +580,8 @@ nginx_ocsp_verify: '{{ nginx_ocsp | bool }}'
                                                                    # ]]]
 # .. envvar:: nginx_ocsp_resolvers [[[
 #
-# List of DNS servers used to resolve OCSP stapling. If it's empty, nginx role
+# List of DNS servers used to resolve OCSP stapling and other
+# dns queries (e.g. for proxy_path). If it's empty, nginx role
 # will try to use the nameservers from /etc/resolv.conf
 # Currently only the first nameserver is used
 nginx_ocsp_resolvers: []

--- a/docs/ansible/roles/nginx/defaults-detailed.rst
+++ b/docs/ansible/roles/nginx/defaults-detailed.rst
@@ -349,6 +349,12 @@ HTTPS and TLS
   intermediate+root CA certificate is required for this.
   FIXME: Rename to ocsp_stapling_verify
 
+``nginx_ocsp_resolvers``
+  Optional, string.  List of DNS servers used to for resolving. Among other things
+  used to resolve OCSP stapling but in general all dns queries (e.g. for proxy_path).
+  If it's empty, nginx role will try to use the nameservers from /etc/resolv.conf.
+  Currently only the first nameserver is used
+
 ``hsts_enabled``
   Optional, boolean. Defaults to ``True``. If this is set to ``True`` and HTTPS
   is enabled for this item, the `HTTP Strict Transport Security`_ header is set


### PR DESCRIPTION
  clarify that it's not only for ocsp resolving but all
  dns resolving.