### PR TITLE
fix #2067 by dropping the superfluous ipaddr call

### DIFF
--- a/ansible/roles/ldap/templates/lookup/ldap__device_ip_addresses.j2
+++ b/ansible/roles/ldap/templates/lookup/ldap__device_ip_addresses.j2
@@ -16,7 +16,7 @@
 {% for iface in ldap__tpl_device_interfaces %}
 {%   if hostvars[inventory_hostname][iface].ipv6|d() %}
 {%     for element in hostvars[inventory_hostname][iface].ipv6 %}
-{%       set address = ((element.address + '/' + element.prefix) | ipaddr('host/prefix')) %}
+{%       set address = element.address + '/' + element.prefix %}
 {%       if not address | ipv6('link-local') %}
 {%         set _ = ldap__tpl_device_ip_addresses.append(element.address) %}
 {%       endif %}
@@ -38,7 +38,7 @@
 {%     if hostvars[inventory_hostname][iface].interfaces | intersect(ldap__tpl_device_interfaces) %}
 {%       if hostvars[inventory_hostname][iface].ipv6|d() %}
 {%         for element in hostvars[inventory_hostname][iface].ipv6 %}
-{%           set address = ((element.address + '/' + element.prefix) | ipaddr('host/prefix')) %}
+{%           set address = element.address + '/' + element.prefix %}
 {%           if not address | ipv6('link-local') %}
 {%             set _ = ldap__tpl_device_ip_addresses.append(element.address) %}
 {%           endif %}


### PR DESCRIPTION
A thorough description of the problem can be found in #2067.
The text below reflects the commit message.

---

This allows usage of the first IPv6 address in a network (e.g. 2001:db8::/64).
Upstream seems to have issues with that usage pattern:

```bash
ansible -m debug -a 'msg={{ "2001:db8::1/64" | ansible.utils.ipaddr("address/prefix") }}' localhost
```

```text
localhost | SUCCESS => {
    "msg": "2001:db8::1/64"
}
```

```bash
ansible -m debug -a 'msg={{ "2001:db8::/64" | ansible.utils.ipaddr("address/prefix") }}' localhost
```

```text
localhost | SUCCESS => {
    "msg": false
}
```
