### PR TITLE
[ferm] Expose all options from /etc/default/ferm

### DIFF
--- a/ansible/roles/ferm/defaults/main.yml
+++ b/ansible/roles/ferm/defaults/main.yml
@@ -122,6 +122,24 @@ ferm__ansible_controllers_ports: [ 'ssh' ]
 ferm__ansible_controllers_interfaces: []
 
                                                                    # ]]]
+# .. envvar:: ferm__fast_mode [[[
+#
+# Use iptables-restore for fast firewall initialization?
+ferm__fast_mode: False
+
+                                                                   # ]]]
+# .. envvar:: ferm__use_cache [[[
+#
+# Use iptables-restore for fast firewall initialization?
+ferm__use_cache: False
+
+                                                                   # ]]]
+# .. envvar:: ferm__extra_options [[[
+#
+# Additional parameters for ferm (like --def '=bar')
+ferm__extra_options: ""
+
+                                                                   # ]]]
 # .. envvar:: ferm__default_policy_input [[[
 #
 # Default :command:`iptables` policy for ``INPUT`` chain.

--- a/ansible/roles/ferm/templates/etc/default/ferm.j2
+++ b/ansible/roles/ferm/templates/etc/default/ferm.j2
@@ -9,13 +9,21 @@
 # configuration for /etc/init.d/ferm
 
 # use iptables-restore for fast firewall initialization?
+{% if ferm__fast_mode | bool %}
+FAST=yes
+{% else %}
 FAST=no
+{% endif %}
 
 # cache the output of ferm --lines in /var/cache/ferm?
+{% if ferm__use_cache | bool %}
+CACHE=yes
+{% else %}
 CACHE=no
+{% endif %}
 
 # additional parameters for ferm (like --def '=bar')
-OPTIONS=
+OPTIONS={{ ferm__extra_options }}
 
 # Enable the ferm init script? (i.e. run on bootup)
 {% if ferm__enabled | bool %}


### PR DESCRIPTION
Hi debops-Team,

I have an use case where I need to set the fast mode of ferm. At the moment this option is not exposed as ansible variables. This PR exposes all options from `/etc/default/ferm` as variables.