### PR TITLE
Remove unsafe compression Prosody module

### DIFF
--- a/ansible/roles/prosody/defaults/main.yml
+++ b/ansible/roles/prosody/defaults/main.yml
@@ -129,7 +129,6 @@ prosody__modules_default:
   - "private"
   - "vcard"
   - "privacy"  #@TODO check version < 0.10
-  - "compression"
   - "version"
   - "uptime"
   - "time"


### PR DESCRIPTION
This module got removed from Prosody in 0.10 because of questionably security properties and resource usage.

See https://prosody.im/doc/modules/mod_compression