### PR TITLE
rollback changes for docker unit file

### DIFF
--- a/ansible/roles/docker_server/templates/etc/systemd/system/docker.service.d/execstart-override.conf.j2
+++ b/ansible/roles/docker_server/templates/etc/systemd/system/docker.service.d/execstart-override.conf.j2
@@ -9,5 +9,7 @@
 # systemd unit. The socket configuration is specified in the 'daemon.json'
 # configuration file.
 [Service]
-ExecStart=
-ExecStart={{ ansible_local.docker_server.dockerd_binary|d("/usr/sbin/dockerd") }}
+ExecStart={{ ansible_local.docker_server.dockerd_binary
+             if (ansible_local|d() and ansible_local.docker_server|d() and
+                 ansible_local.docker_server.dockerd_binary|d())
+             else "/usr/sbin/dockerd" }}

--- a/ansible/roles/docker_server/templates/etc/systemd/system/docker.service.d/execstart-override.conf.j2
+++ b/ansible/roles/docker_server/templates/etc/systemd/system/docker.service.d/execstart-override.conf.j2
@@ -9,6 +9,7 @@
 # systemd unit. The socket configuration is specified in the 'daemon.json'
 # configuration file.
 [Service]
+ExecStart=
 ExecStart={{ ansible_local.docker_server.dockerd_binary
              if (ansible_local|d() and ansible_local.docker_server|d() and
                  ansible_local.docker_server.dockerd_binary|d())


### PR DESCRIPTION
 to 674412fad89a44145d66e394ad70ae4baa7944d9 since this had fixed an empty unit file, remove duplcate line