### PR TITLE
[mariadb_server] Fix bug introduced in f2ded8230

### DIFF
--- a/ansible/roles/mariadb_server/defaults/main.yml
+++ b/ansible/roles/mariadb_server/defaults/main.yml
@@ -40,7 +40,7 @@
 #   XtraDB and optionally TokuDB and MyRocks engines
 #
 # Percona needs to be selected explicitly.
-mariadb_server__flavor: '{{ ansible_local.mariadb.flavor | d("mariadb")) }}'
+mariadb_server__flavor: '{{ ansible_local.mariadb.flavor | d("mariadb") }}'
 
                                                                    # ]]]
 # .. envvar:: mariadb_server__apt_key [[[


### PR DESCRIPTION
A leftover closing paranthesis from f2ded8230 causes an jinja2 templating error. This pull request should fix that.