### PR TITLE
Only fill nullmailer__smtp_srv_rr when nullmailer__enabled

### DIFF
--- a/ansible/roles/nullmailer/defaults/main.yml
+++ b/ansible/roles/nullmailer/defaults/main.yml
@@ -237,7 +237,9 @@ nullmailer__starttls: True
 # List which contains the result of the DNS query for SMTP server ``SRV``
 # resource records in the host's domain. See :rfc:`6186` for details.
 nullmailer__smtp_srv_rr: '{{ q("debops.debops.dig_srv", "_smtp._tcp." + nullmailer__domain,
-                               "smtp." + nullmailer__domain, 25) }}'
+                               "smtp." + nullmailer__domain, 25)
+                             if nullmailer__enabled|bool
+                             else [] }}'
 
                                                                    # ]]]
 # .. envvar:: nullmailer__smtp_port [[[


### PR DESCRIPTION
Apart from a tiny performance boost, this solves an issue in our setup that leads to a failing debops run when we get a `SERVFAIL` response from the DNS server in `debops.debops.nullmailer: Generate configuration files` even though `nullmailer__enabled` has been set to `False` :

```
An unhandled exception occurred while templating ''{{ q("debops.debops.dig_srv", "_smtp._tcp." + nullmailer__domain, "smtp." + nullmailer__domain, 25) }}''.
Error was a <class ''ansible.errors.AnsibleError''>, original message:

An unhandled exception occurred while running the lookup plugin ''debops.debops.dig_srv''. Error was a <class ''ansible.errors.AnsibleError''>, original message:

dig_srv: unhandled exception All nameservers failed to answer the query _smtp._tcp.example.local. IN SRV: Server 127.0.0.53 UDP port 53 answered SERVFAIL.
```

This happens because the `with_flattened` key of the task gets evaluated even when nullmailer has been disabled and expands to this dig query.