### PR TITLE
Fix Prosody PKI variable name typo

### DIFF
--- a/ansible/roles/prosody/defaults/main.yml
+++ b/ansible/roles/prosody/defaults/main.yml
@@ -49,7 +49,7 @@ prosody__pki: '{{ ansible_local.pki.enabled|d() | bool }}'
 # .. envvar:: prosody__pki_realm_path [[[
 #
 # Directory path where PKI realm live.
-prosdoy__pki_realm_path: '{{ ansible_local.pki.path|d("/etc/pki/realms") }}'
+prosody__pki_realm_path: '{{ ansible_local.pki.path|d("/etc/pki/realms") }}'
 
                                                                    # ]]]
 # .. envvar:: prosody__pki_realm [[[
@@ -227,8 +227,8 @@ prosody__config_http_server:
   https_interface:
     - '*'
   https_ssl:
-    certificate: '{{ prosdoy__pki_realm_path + "/" + prosody__pki_realm + "/" + prosody__pki_crt_filename }}'
-    key: '{{ prosdoy__pki_realm_path + "/" + prosody__pki_realm + "/" + prosody__pki_key_filename }}'
+    certificate: '{{ prosody__pki_realm_path + "/" + prosody__pki_realm + "/" + prosody__pki_crt_filename }}'
+    key: '{{ prosody__pki_realm_path + "/" + prosody__pki_realm + "/" + prosody__pki_key_filename }}'
 
                                                                    # ]]]
 # .. envvar:: prosody__config_gloabl [[[

--- a/ansible/roles/prosody/templates/etc/prosody/prosody.cfg.lua.j2
+++ b/ansible/roles/prosody/templates/etc/prosody/prosody.cfg.lua.j2
@@ -37,7 +37,7 @@ error unknown type
 
 {%   for item in prosody__config_virtual_hosts %}
 {% set prosody__tpl_pki_realm = item.pki_realm %}{#| d((debops__tpl_macros.get_realm_yaml_list(item.name, prosody__pki_realm) | from_yaml)[0]) %#}
-{% set prosody__tpl_pki_realm_path = prosdoy__pki_realm_path + "/" + prosody__tpl_pki_realm %}
+{% set prosody__tpl_pki_realm_path = prosody__pki_realm_path + "/" + prosody__tpl_pki_realm %}
 VirtualHost "{{ item.name }}"
   enabled = {{ item.enabled }}
 


### PR DESCRIPTION
As also happened in debops#2072, typo in variable name which is fixed.
There is no usage of the variable name that is changed in DebOps.