### PR TITLE
[libvirt] No longer install virtual qemu-kvm pkg

### DIFF
--- a/ansible/roles/libvirtd/defaults/main.yml
+++ b/ansible/roles/libvirtd/defaults/main.yml
@@ -55,10 +55,11 @@ libvirtd__base_packages_map:
 #
 # List of QEMU KVM packages to install. They will be installed on all hosts
 # apart from KVM guests, to not create redundant support.
-libvirtd__kvm_packages:
-  - 'qemu-system-x86'
-  - 'qemu-kvm'
-  - 'qemu-utils'
+libvirtd__kvm_packages: '{{ [ "qemu-system-x86", "qemu-utils" ]
+                            + [ "qemu-kvm" ]
+                              if ansible_distribution_release in [ "stretch",
+                                   "buster", "bionic", "focal" ]
+                              else [] }}'
 
                                                                    # ]]]
 # .. envvar:: libvirtd__network_packages [[[

--- a/ansible/roles/libvirtd_qemu/defaults/main.yml
+++ b/ansible/roles/libvirtd_qemu/defaults/main.yml
@@ -52,10 +52,12 @@ libvirtd_qemu__base_packages_map:
 #
 # List of QEMU KVM packages to install. They will be installed on all hosts
 # apart from KVM guests, to not create redundant support.
-libvirtd_qemu__kvm_packages:
-  - 'qemu-system-x86'
-  - 'qemu-kvm'
-  - 'qemu-utils'
+libvirtd_qemu__kvm_packages: '{{ [ "qemu-system-x86", "qemu-utils" ]
+                                 + [ "qemu-kvm" ]
+                                   if ansible_distribution_release in [
+                                        "stretch", "buster", "bionic", "focal"
+                                      ]
+                                   else [] }}'
 
                                                                    # ]]]
 # .. envvar:: libvirtd_qemu__packages [[[


### PR DESCRIPTION
The /usr/bin/kvm binary is now provided by the qemu-system-x86 package.