### PR TITLE
[pdns] Fix syntax error on local-address option

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -193,6 +193,12 @@ debops.boxbackup role
   service without it actually being present on the host. This should now be
   avoided by carefully checking the service status.
 
+:ref:`debops.pdns` role
+'''''''''''''''''''''''
+
+- On pdns installations with version >= 4.5.0 (e.g. on Bookworm systems), the
+  role would cause a syntax error on the local-address configuration option.
+
 :ref:`debops.prosody` role
 ''''''''''''''''''''''''''
 

--- a/ansible/roles/pdns/defaults/main.yml
+++ b/ansible/roles/pdns/defaults/main.yml
@@ -289,15 +289,16 @@ pdns__default_configuration:
       Local IP addresses to which we bind. Accepts IPv6 addresses since pdns
       4.3.0.
     value: '{{ (pdns__local_address
-                if ansible_local.pdns.version is version("4.5.0", ">=")
-                else (pdns__local_address | ipv4)) | join ("") }}'
+                if ansible_local.pdns.version is version("4.3.0", ">=")
+                else (pdns__local_address | ipv4)) | join (",") }}'
 
   - name: 'local-ipv6'
     comment: |-
-      Local IPv6 addresses to which we bind. Will be deprecated in pdns 4.3.0.
+      Local IPv6 addresses to which we bind. Will be deprecated in pdns 4.3.0
+      and removed in pdns 4.5.0.
     value: '{{ pdns__local_address | ipv6 | join(",") }}'
     state: '{{ "present"
-               if ansible_local.pdns.version is version("4.5.0", "<")
+               if ansible_local.pdns.version is version("4.3.0", "<")
                else "absent" }}'
 
   - name: 'local-port'


### PR DESCRIPTION
This actually fixes two issues:

- Syntax error on the local-address option with pdns >= 4.5.0.
- The local-ipv6 option was actually deprecated in pdns 4.3.0 instead of in
  4.5.0. It was removed in 4.5.0.