### PR TITLE
[nginx|apache] Remove FLoC (Federated Learning of Cohorts) support

### DIFF
--- a/ansible/roles/apache/templates/etc/apache2/sites-available/default.conf.j2
+++ b/ansible/roles/apache/templates/etc/apache2/sites-available/default.conf.j2
@@ -281,9 +281,6 @@ Header {{ apache__tpl_directive_options }} Content-Security-Policy "{{ item.csp|
 {% if item.csp_report_enabled|d(False) | bool %}
 Header {{ apache__tpl_directive_options }} Content-Security-Policy-Report-Only "{{ item.csp_report|d(item.csp|d("default-src https: ;")) + (" " + item.csp_append|d(apache__http_csp_append) if (item.csp_append|d(apache__http_csp_append)) else "") }}"
 {% endif %}
-{% if (item.floc_optout|d(True))|bool %}
-Header {{ apache__tpl_directive_options }} Permissions-Policy "interest-cohort=()"
-{% endif %}
 {% if item.http_frame_options|d(apache__http_frame_options) != omit %}
 Header {{ apache__tpl_directive_options }} X-Frame-Options "{{ item.http_frame_options|d(apache__http_frame_options) }}"
 {% endif %}

--- a/ansible/roles/nginx/templates/etc/nginx/sites-available/default.conf.j2
+++ b/ansible/roles/nginx/templates/etc/nginx/sites-available/default.conf.j2
@@ -725,9 +725,6 @@ server {
 {% if item.csp_report_enabled|d(False) | bool %}
         add_header                Content-Security-Policy-Report-Only "{{ item.csp_report|d(item.csp|d("default-src https: ;")) + (" " + item.csp_append|d(nginx__http_csp_append) if (item.csp_append|d(nginx__http_csp_append)) else "") }}";
 {% endif %}
-{% if (item.floc_optout|d(True))|bool %}
-        add_header                Permissions-Policy "interest-cohort=()";
-{% endif %}
 {%     if item.content_type_options|d(True) != omit             %}
         add_header                X-Content-Type-Options "{{ item.content_type_options | d('nosniff') }}"{% if nginx_version is version_compare('1.7.5','>=') %} always{% endif %};
 {%     endif                                                    %}

--- a/docs/ansible/roles/apache/defaults-detailed.rst
+++ b/docs/ansible/roles/apache/defaults-detailed.rst
@@ -498,14 +498,6 @@ HTTP security headers
   draft as of 2016-10-11 but it is already supported by the majority of web
   browsers.
 
-``floc_optout``
-  Optional, boolean. If not specified or ``True``, the server will send the
-  ``Permissions-Policy`` HTTP header which will tell the browser to opt-out
-  from the `Federated Learning of Cohorts`__ feature. If ``False``, the header
-  will not be configured for a given website.
-
-  .. __: https://github.com/WICG/floc
-
 
 .. _apache__ref_vhost_apache_status:
 

--- a/docs/ansible/roles/nginx/defaults-detailed.rst
+++ b/docs/ansible/roles/nginx/defaults-detailed.rst
@@ -589,14 +589,6 @@ HTTP security headers
   Optional, string. Value of the ``X-Frame-Options`` HTTP header field. Set to ``{{ omit }}``
   to not send the header field. Defaults to ``SAMEORIGIN``.
 
-``floc_optout``
-  Optional, boolean. If not specified or ``True``, the server will send the
-  ``Permissions-Policy`` HTTP header which will tell the browser to opt-out
-  from the `Federated Learning of Cohorts`__ feature. If ``False``, the header
-  will not be configured for a given website.
-
-  .. __: https://github.com/WICG/floc
-
 Search engine optimization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Google has killed off the FLoC initiative and even removed the experimental
support from Chrome.

This reverts commit 402b4b659d27e6f356c23a2ed8b8dc670649272a.