### PR TITLE
[dovecot] LDAP fixes

### DIFF
--- a/ansible/roles/dovecot/defaults/main.yml
+++ b/ansible/roles/dovecot/defaults/main.yml
@@ -1194,12 +1194,6 @@ dovecot__ldap_people_dn: '{{ [ dovecot__ldap_people_rdn ]
 dovecot__ldap_uri: '{{ ansible_local.ldap.uri|d([""]) }}'
 
                                                                    # ]]]
-# .. envvar:: dovecot__ldap_server_port [[[
-#
-# The TCP port which should be used for connections to the LDAP server.
-dovecot__ldap_server_port: '{{ ansible_local.ldap.port|d(("389" if dovecot__ldap_start_tls|bool else "636")) }}'
-
-                                                                   # ]]]
 # .. envvar:: dovecot__ldap_start_tls [[[
 #
 # If ``True``, STARTTLS will be used to connect to the LDAP server.

--- a/ansible/roles/dovecot/defaults/main.yml
+++ b/ansible/roles/dovecot/defaults/main.yml
@@ -1197,10 +1197,8 @@ dovecot__ldap_uri: '{{ ansible_local.ldap.uri|d([""]) }}'
 # .. envvar:: dovecot__ldap_start_tls [[[
 #
 # If ``True``, STARTTLS will be used to connect to the LDAP server.
-dovecot__ldap_start_tls: '{{ ansible_local.ldap.start_tls
-                             if (ansible_local|d() and ansible_local.ldap|d() and
-                                (ansible_local.ldap.start_tls|d())|bool)
-                             else True }}'
+dovecot__ldap_start_tls: '{{ ansible_local.ldap.start_tls|d(True)|bool }}'
+
                                                                    # ]]]
 # .. envvar:: dovecot__ldap_user_filter [[[
 #


### PR DESCRIPTION
Again, two small LDAP-related fixes to the ``dovecot`` role (fix the no-STARTTLS default and remove an unused variable)