### PR TITLE
[slapd] Add DB index for "dc"

### DIFF
--- a/ansible/roles/slapd/defaults/main.yml
+++ b/ansible/roles/slapd/defaults/main.yml
@@ -754,6 +754,7 @@ slapd__default_tasks:
     dn: [ 'olcDatabase={1}mdb', 'cn=config' ]
     attributes:
       olcDbIndex:
+        - 'dc eq'
         - 'cn,uid eq'
         - 'member,memberUid eq'
         - 'roleOccupant eq'


### PR DESCRIPTION
I'm seeing a lot of log spam like this:

	slapd[24293]: <= mdb_equality_candidates: (dc) not indexed

The reason is that postfix (see `/etc/postfix/ldap_virtual_mailbox_domains.cf`)
does a LDAP query with a "dc" comparison for each incoming email
(``(& (objectClass=dNSDomain) (dc=%s) )``).

Adding an index on dc makes the log spam go away (i.e. this is mostly cosmetic).