### PR TITLE
[librenms] fix config defaults 'snmp.version' type

### DIFF
--- a/ansible/roles/librenms/defaults/main.yml
+++ b/ansible/roles/librenms/defaults/main.yml
@@ -467,7 +467,7 @@ librenms__config_autodiscovery:
 librenms__config_snmp:
   comment: 'SNMP configuration'
   snmp:
-    version: '{{ librenms__snmp_version }}'
+    version: { array: [ '{{ librenms__snmp_version }}' ] }
     community: { array: '{{ librenms__snmp_communities }}' }
     v3: '{{ librenms__snmp_credentials }}'
 


### PR DESCRIPTION
LibreNMS expects an array of SNMP versions in its config, rather than just a single string.  Specifying a single string leads to unexpected silent failures due to type errors (and lax handling of them as 'warnings' by PHP), such as a failure to add auto-discovered hosts, which is how I uncovered this bug.

For example, this is correct:
```php
$config['snmp']['version'] = array("v2c", "v3");
```

But this (which the role is currently generating) is not, even though LibreNMS doesn't complain loudly about it:
```php
$config['snmp']['version'] = "v2c";
```

This PR is a minimal fix: for compatibility with existing projects, it does not add the ability to specify multiple SNMP versions through `librenms__snmp_version`, but just fixes the bug.  Advanced role users who want multiple SNMP versions can override `librenms__config_snmp` carefully :)