### PR TITLE
[slapd] Reduce log level

### DIFF
--- a/ansible/roles/slapd/defaults/main.yml
+++ b/ansible/roles/slapd/defaults/main.yml
@@ -659,7 +659,7 @@ slapd__default_tasks:
   - name: 'Configure the OpenLDAP server log level'
     dn: 'cn=config'
     attributes:
-      olcLogLevel: 'stats'
+      olcLogLevel: 'none'
     state: 'exact'
 
   - name: 'Define the default password hashing method'


### PR DESCRIPTION
The default slapd log level generates quite a lot of log spam (the description
for olcLogLevel says that it "...specifies the level at which debugging
statements and operation statistics should be syslogged" [1]).

As an example, setting up a mail host which uses LDAP and receiving a couple
of hundred emails leads to:

24250

Setting the log level to "none" means that high priority messages will still
be logged, despite the somewhat confusing name (again, see [1]).

This seems like a more reasonable default for a production system.

[1]
https://www.openldap.org/doc/admin24/slapdconf2.html#olcLogLevel:%20%3Clevel%3E