### PR TITLE
Don't try to install firmware-linux-*free when on Proxmox

### DIFF
--- a/ansible/roles/apt_install/defaults/main.yml
+++ b/ansible/roles/apt_install/defaults/main.yml
@@ -325,14 +325,16 @@ apt_install__firmware_packages:
     state: '{{ "present" if (ansible_form_factor in [ "Rack Mount Chassis" ])
                          and (ansible_virtualization_role is undefined or
                               ansible_virtualization_role not in [ "guest" ])
+                         and (ansible_kernel.find("-pve") == -1)
                          else "absent" }}'
 
   - name: 'firmware-linux-nonfree'
     distribution: [ 'Debian' ]
     areas: [ 'non-free' ]
     state: '{{ "present" if (ansible_form_factor in [ "Rack Mount Chassis" ])
-                             and (ansible_virtualization_role is undefined or
+                         and (ansible_virtualization_role is undefined or
                               ansible_virtualization_role not in [ "guest" ])
+                         and (ansible_kernel.find("-pve") == -1)
                          else "absent" }}'
 
   - name: 'intel-microcode'


### PR DESCRIPTION
I didn't find a more elegant solution than this.

It avoids needing to add the following to the inventory (for proxmox hosts only)

      apt_install__firmware_packages:
        - name: 'firmware-linux-free'
          state: "absent"
        - name: 'firmware-linux-nonfree'
          state: "absent"
