### PR TITLE
Add a reboot role, and upgrade without reboot

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2113,6 +2113,16 @@ stages:
     JANE_LOG_PATTERN: '\[radvd\]'
   tags: [ 'shell', 'vagrant-vm' ]
 
+'reboot role':
+  <<: *test_role_3rd_deps
+  needs:
+    - 'sshd role'
+  variables:
+    JANE_TEST_FACT: 'reboot.fact'
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/reboot.yml'
+    JANE_DIFF_PATTERN: '.*/roles/reboot/.*'
+    JANE_LOG_PATTERN: '\[reboot\]'
+
 'redis_sentinel role':
   <<: *test_role_2nd_deps
   needs:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,9 @@ New DebOps roles
 
   .. __: https://www.elastic.co/beats/metricbeat
 
+- The :ref:`debops.reboot` role can be used to reboot, forcefully or only if
+  required, any DebOps host.
+
 General
 '''''''
 

--- a/ansible/playbooks/reboot.yml
+++ b/ansible/playbooks/reboot.yml
@@ -1,9 +1,11 @@
 ---
 # Copyright (C) 2020 Nicolas Quiniou-Briand <nqb@azyx.fr>
+# Copyright (C) 2022 Julien Lecomte <julien@lecomte.at>
+# Copyright (C) 2022 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # This playbook will reboot all DebOps hosts (use with caution)
-# after explicit confirmation on command-line.
+# if required, or if forced.
 
 - name: Reboot DebOps hosts
   hosts: [ 'debops_all_hosts' ]
@@ -15,20 +17,7 @@
                    | combine(inventory__group_environment | d({}))
                    | combine(inventory__host_environment  | d({})) }}'
 
-  vars_prompt:
+  roles:
 
-    - name: 'reboot_confirmation'
-      prompt: 'Are you sure you want to reboot all these nodes ?'
-      default: no
-      private: no
-
-  tasks:
-
-    - name: Reboot DebOps hosts
-      reboot:
-        search_paths:
-          - '/lib/molly-guard'
-          - '/sbin'
-          - '/usr/sbin'
-          - '/usr/local/sbin'
-      when: reboot_confirmation|bool
+    - role: reboot
+      tags: [ 'role::reboot', 'skip::reboot' ]

--- a/ansible/playbooks/tools/upgrade-reboot.yml
+++ b/ansible/playbooks/tools/upgrade-reboot.yml
@@ -1,10 +1,12 @@
 ---
 # Copyright (C) 2020 Ellen Papsch <ellenpapsch@gmail.com>
+# Copyright (C) 2022 Julien Lecomte <julien@lecomte.at>
+# Copyright (C) 2022 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # Upgrade packages which are safe to be updated. This means no
 # packages will be removed. The machine is rebooted if
-# necessary. Skip the reboot tag to avoid that.
+# necessary.
 
 - name: Upgrade a machine and reboot if necessary
   hosts: [ 'debops_all_hosts' ]
@@ -22,19 +24,7 @@
         update_cache: yes
         upgrade: 'safe'
 
-    - name: Check if reboot is required
-      stat:
-        path: '/var/run/reboot-required'
-        get_checksum: no
-      register: reboot_required
-
-    - name: Reboot a machine when required
-      reboot:
-        search_paths:
-          - '/lib/molly-guard'
-          - '/sbin'
-          - '/usr/sbin'
-          - '/usr/local/sbin'
-      when: reboot_required.stat.exists
-      tags:
-        - reboot
+    - name: Reboot DebOps host if necessary
+      include_role:
+        name: reboot
+      tags: [ 'role::reboot', 'skip::reboot' ]

--- a/ansible/playbooks/upgrade.yml
+++ b/ansible/playbooks/upgrade.yml
@@ -5,10 +5,9 @@
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # Upgrade packages which are safe to be updated. This means no
-# packages will be removed. The machine is rebooted if
-# necessary.
+# packages will be removed.
 
-- name: Upgrade a machine and reboot if necessary
+- name: Upgrade a machine
   hosts: [ 'debops_all_hosts' ]
   become: True
   gather_facts: False
@@ -20,11 +19,6 @@
   tasks:
 
     - name: Upgrade safe packages with refreshed cache
-      apt:
+      ansible.builtin.apt:
         update_cache: yes
         upgrade: 'safe'
-
-    - name: Reboot DebOps host if necessary
-      include_role:
-        name: reboot
-      tags: [ 'role::reboot', 'skip::reboot' ]

--- a/ansible/roles/reboot/COPYRIGHT
+++ b/ansible/roles/reboot/COPYRIGHT
@@ -1,0 +1,19 @@
+debops.reboot - Reboot DebOps hosts
+
+Copyright (C) 2022 Julien Lecomte <julien@lecomte.at>
+Copyright (C) 2022 DebOps <https://debops.org/>
+SPDX-License-Identifier: GPL-3.0-only
+
+This Ansible role is part of DebOps.
+
+DebOps is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 3, as
+published by the Free Software Foundation.
+
+DebOps is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with DebOps. If not, see https://www.gnu.org/licenses/.

--- a/ansible/roles/reboot/defaults/main.yml
+++ b/ansible/roles/reboot/defaults/main.yml
@@ -1,0 +1,40 @@
+---
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+
+# Copyright (C) 2022 Julien Lecomte <julien@lecomte.at>
+# Copyright (C) 2022 DebOps <https://debops.org/>
+# .. SPDX-License-Identifier: GPL-3.0-only
+
+# .. _reboot__ref_defaults:
+
+# .. contents:: Sections
+#    :local:
+#
+# .. include:: ../../../../includes/global.rst
+
+# Reboot configuration [[[
+# ------------------------
+#
+# Force reboot and ignore presence of /var/run/reboot-required.
+reboot__force: false
+
+# Paths to search on the remote machine for the shutdown command.
+# Only these paths will be searched for the shutdown command.
+# PATH is ignored in the remote node when searching for the shutdown command.
+reboot__search_paths:
+  - '/lib/molly-guard'
+  - '/sbin'
+  - '/usr/sbin'
+  - '/usr/local/sbin'
+
+# Paths to prefix on search path for the shutdown command.
+reboot__additional_search_paths: []
+
+# Maximum seconds to wait for machine to reboot and respond
+# to a test command.
+# This timeout is evaluated separately for both reboot verification
+# and test command success so the maximum execution time for the
+# module is twice this amount.
+reboot__timeout: 600
+
+                                                                   # ]]]

--- a/ansible/roles/reboot/meta/main.yml
+++ b/ansible/roles/reboot/meta/main.yml
@@ -1,0 +1,27 @@
+---
+# Copyright (C) 2022 Julien Lecomte <julien@lecomte.at>
+# Copyright (C) 2022 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+collections: [ 'debops.debops' ]
+
+dependencies: []
+
+galaxy_info:
+
+  author: 'Julien Lecomte'
+  description: 'Reboot DebOps hosts'
+  company: 'DebOps'
+  license: 'GPL-3.0-only'
+  min_ansible_version: '2.2.0'
+
+  platforms:
+
+    - name: 'Ubuntu'
+      versions: [ 'all' ]
+
+    - name: 'Debian'
+      versions: [ 'all' ]
+
+  galaxy_tags:
+    - system

--- a/ansible/roles/reboot/tasks/main.yml
+++ b/ansible/roles/reboot/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+
+# Copyright (C) 2022 Julien Lecomte <julien@lecomte.at>
+# Copyright (C) 2022 DebOps <https://debops.org/>
+# .. SPDX-License-Identifier: GPL-3.0-only
+
+- name: Check if reboot is required
+  ansible.builtin.stat:
+    path: '/var/run/reboot-required'
+    get_checksum: false
+  register: reboot__register_required
+
+- name: Reboot DebOps hosts
+  ansible.builtin.reboot:
+    search_paths: '{{ (reboot__search_paths + reboot__additional_search_paths) | flatten }}'
+    reboot_timeout: "{{ reboot__timeout | d(600) }}"
+  when: "reboot__register_required.stat.exists|bool or reboot__force | d(false)"

--- a/docs/ansible/role-index.rst
+++ b/docs/ansible/role-index.rst
@@ -345,6 +345,7 @@ System configuration
 - :ref:`debops.nsswitch`
 - :ref:`debops.ntp`
 - :ref:`debops.pam_access`
+- :ref:`debops.reboot`
 - :ref:`debops.resources`
 - :ref:`debops.root_account`
 - :ref:`debops.sssd`

--- a/docs/ansible/roles/reboot/getting-started.rst
+++ b/docs/ansible/roles/reboot/getting-started.rst
@@ -1,0 +1,28 @@
+.. Copyright (C) 2022 Julien Lecomte <julien@lecomte.at>
+.. Copyright (C) 2022 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+Getting started
+===============
+
+Default configuration
+---------------------
+
+The service will be configured to only reboot if necessary unless forced via
+a variable.
+
+Caveat
+------
+
+If *display_skipped_hosts* is set to *False* in your *ansible.cfg*, the playbook
+will print the task reboot information after the reboot.
+
+Example playbook
+----------------
+
+If you are using this role without DebOps, here's an example Ansible playbook
+that uses the ``debops.reboot`` role:
+
+.. literalinclude:: ../../../../ansible/playbooks/reboot.yml
+   :language: yaml
+   :lines: 1,5-

--- a/docs/ansible/roles/reboot/index.rst
+++ b/docs/ansible/roles/reboot/index.rst
@@ -1,0 +1,28 @@
+.. Copyright (C) 2022 Julien Lecomte <julien@lecomte.at>
+.. Copyright (C) 2022 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+.. _debops.reboot:
+
+debops.reboot
+=============
+
+.. include:: man_description.rst
+   :start-line: 7
+
+.. toctree::
+   :maxdepth: 2
+
+   getting-started
+   defaults/main
+
+Copyright
+---------
+
+.. literalinclude:: ../../../../ansible/roles/reboot/COPYRIGHT
+
+..
+ Local Variables:
+ mode: rst
+ ispell-local-dictionary: "american"
+ End:

--- a/docs/ansible/roles/reboot/man_description.rst
+++ b/docs/ansible/roles/reboot/man_description.rst
@@ -1,0 +1,9 @@
+.. Copyright (C) 2022 Julien Lecomte <julien@lecomte.at>
+.. Copyright (C) 2022 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+Description
+===========
+
+The ``debops.reboot`` Ansible role can be used to forcefully or conditionnally
+reboot a DebOps host.

--- a/docs/ansible/roles/reboot/man_index.rst
+++ b/docs/ansible/roles/reboot/man_index.rst
@@ -1,0 +1,21 @@
+:orphan:
+
+.. Copyright (C) 2022 Julien Lecomte <julien@lecomte.at>
+.. Copyright (C) 2022 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+debops.reboot
+=============
+
+.. toctree::
+   :maxdepth: 2
+
+   man_synopsis
+   man_description
+   getting-started
+
+..
+ Local Variables:
+ mode: rst
+ ispell-local-dictionary: "american"
+ End:

--- a/docs/ansible/roles/reboot/man_synopsis.rst
+++ b/docs/ansible/roles/reboot/man_synopsis.rst
@@ -1,0 +1,8 @@
+.. Copyright (C) 2022 Julien Lecomte <julien@lecomte.at>
+.. Copyright (C) 2022 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+Synopsis
+========
+
+``debops service/reboot`` [**--limit** `group,host,`...] [**--diff**] [**--check**] [**--tags** `tag1,tag2,`...] [**--skip-tags** `tag1,tag2,`...] [<``ansible-playbook`` options>] ...


### PR DESCRIPTION
Same as https://github.com/debops/debops/pull/2109, but with the reboot removed from upgrade.yml (renamed from upgrade-reboot.yml)
