### PR TITLE
[dovecot] Fix broken PKI hook script

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -167,6 +167,14 @@ debops.boxbackup role
   playbook. This fixes an issue with Ansible stopping the site playbook
   execution when it cannot find the ``boxbackup`` role in the Collection.
 
+:ref:`debops.dovecot` role
+''''''''''''''''''''''''''
+
+- The role's PKI hook script still referenced an old configuration file that
+  was no longer being managed by :ref:`debops.dovecot` since the role redesign,
+  resulting in the hook script failing to reload dovecot after a certificate or
+  DH param change.
+
 :ref:`debops.elasticsearch` role
 ''''''''''''''''''''''''''''''''
 

--- a/ansible/roles/dovecot/templates/etc/pki/hooks/dovecot.j2
+++ b/ansible/roles/dovecot/templates/etc/pki/hooks/dovecot.j2
@@ -11,7 +11,7 @@
 
 set -o nounset -o pipefail -o errexit
 
-dovecot_config="/etc/dovecot/conf.d/10-ssl.conf"
+dovecot_config="/etc/dovecot/dovecot.conf"
 dovecot_action="{{ dovecot__pki_hook_action }}"
 
 # Check if current PKI realm is used by the 'dovecot' webserver


### PR DESCRIPTION
Noticed this when Icinga alerted me of an expiring IMAP certificate yesterday: the Dovecot PKI hook script is broken since the role redesign. It's important that we fix this, as this will cause TLS certificates to become untrusted unless the administrator reloads/restarts the Dovecot service or reboots their server on a very regular basis.

I've tested this as follows:

1. Log in to a server that has the broken PKI hook script installed.
2. `# PKI_SCRIPT_DEFAULT_CRT="/etc/pki/realms/SOME_PKI_REALM/default.crt" PKI_SCRIPT_STATE="changed-certificate" /etc/pki/hooks/dovecot`
3. Notice that the Dovecot service did not reload.
4. Fix the PKI hook script.
5. Retry step 2
6. Notice that the Dovecot service did reload this time.