### PR TITLE
Correct default adddress to current apt packages

### DIFF
--- a/ansible/roles/influxdata/defaults/main.yml
+++ b/ansible/roles/influxdata/defaults/main.yml
@@ -29,7 +29,7 @@ influxdata__key_id: '05CE 1508 5FC0 9D18 E99E FB22 684A 14CF 2582 E0C5'
 # .. envvar:: influxdata__repository [[[
 #
 # APT repository entry to configure for InfluxData repository.
-influxdata__repository: 'deb https://repos.influxdata.com/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} stable'
+influxdata__repository: 'deb https://repos.influxdata.com/debian stable main'
                                                                    # ]]]
                                                                    # ]]]
 # APT packages [[[

--- a/ansible/roles/influxdata/defaults/main.yml
+++ b/ansible/roles/influxdata/defaults/main.yml
@@ -29,7 +29,7 @@ influxdata__key_id: '05CE 1508 5FC0 9D18 E99E FB22 684A 14CF 2582 E0C5'
 # .. envvar:: influxdata__repository [[[
 #
 # APT repository entry to configure for InfluxData repository.
-influxdata__repository: 'deb https://repos.influxdata.com/debian stable main'
+influxdata__repository: 'deb https://repos.influxdata.com/{{ ansible_distribution|lower }} stable main'
                                                                    # ]]]
                                                                    # ]]]
 # APT packages [[[


### PR DESCRIPTION
Stable repo has changed according to discussions on https://community.influxdata.com/t/repo-for-ubuntu-jammy/24657

One address covers all distros.