### PR TITLE
Loop appends to a wrong variable

### DIFF
--- a/ansible/roles/radvd/templates/etc/radvd.conf.j2
+++ b/ansible/roles/radvd/templates/etc/radvd.conf.j2
@@ -67,7 +67,7 @@
 {%           set _ = radvd__tpl_dnssl.append(element) %}
 {%         elif element is mapping %}
 {%           if element.name|d() and element.state|d('present') != 'absent' %}
-{%             set _ = radvd__tpl_rdnss.append(element.name) %}
+{%             set _ = radvd__tpl_dnssl.append(element.name) %}
 {%           endif %}
 {%         endif %}
 {%       endfor %}


### PR DESCRIPTION
Apparently a copy-paste error, appends to `rdnss` where it should append to `dnssl`