### PR TITLE
[dokuwiki] User shell as a variable

### DIFF
--- a/ansible/roles/dokuwiki/defaults/main.yml
+++ b/ansible/roles/dokuwiki/defaults/main.yml
@@ -72,6 +72,12 @@ dokuwiki__group: 'dokuwiki'
 dokuwiki__home: '{{ ansible_local.nginx.www|d("/srv/www") + "/" + dokuwiki__user }}'
 
                                                                    # ]]]
+# .. envvar:: dokuwiki__shell [[[
+#
+# DokuWiki user shell.
+dokuwiki__shell: '/bin/false'
+
+                                                                   # ]]]
 # .. envvar:: dokuwiki__src [[[
 #
 # Base path for git bare repository with DokuWiki source.

--- a/ansible/roles/dokuwiki/tasks/main.yml
+++ b/ansible/roles/dokuwiki/tasks/main.yml
@@ -29,7 +29,7 @@
     name: '{{ dokuwiki__user }}'
     group: '{{ dokuwiki__group }}'
     home: '{{ dokuwiki__home }}'
-    shell: '/bin/false'
+    shell: '{{ dokuwiki__shell }}'
     comment: 'DokuWiki'
     createhome: False
     system: True


### PR DESCRIPTION
Sometimes we want a real shell for the dokuwiki user. This PR set the dokuwiki user shell as a variable. 