### PR TITLE
Add note on ansible-console to delete realm files

### DIFF
--- a/docs/ansible/roles/pki/getting-started.rst
+++ b/docs/ansible/roles/pki/getting-started.rst
@@ -125,10 +125,14 @@ Renewing Certificates
 
 For renewing certificates, just
 
-1. remove file:`/etc/pki/realms/<realm>/` from the remote host and
+1. remove :file:`/etc/pki/realms/<realm>/` from the remote host and
 2. re-run debops.pki against it, e.g. this::
 
      debops service/pki  --limit=$REMOTE_HOST
 
 This will create a new key for the remote host.
 If you use external keys, they will be preserved
+
+.. note::
+   You can use ``ansible-console`` to delete the file on multiple
+   hosts at once.


### PR DESCRIPTION
- Add missing ':' for ":file:"
- Add a note on ansible-console (for those with big inventories).