### PR TITLE
[apt] Fix collection of `original_mirrors_deb_src` fact

### DIFF
--- a/ansible/roles/apt/templates/etc/ansible/facts.d/apt.fact.j2
+++ b/ansible/roles/apt/templates/etc/ansible/facts.d/apt.fact.j2
@@ -75,16 +75,7 @@ try:
                        os.R_OK))))
 
     for line in fh:
-        if line.startswith('deb'):
-            source = line.split()
-            source_url = source[1].rstrip('/')
-            if (source_url not in source_deb
-                    and source_url not in security_sources):
-                for prefix in apt_uri_types:
-                    if source_url.startswith(prefix):
-                        source_deb.append(source_url)
-
-        elif line.startswith('deb-src'):
+        if line.startswith('deb-src'):
             source = line.split()
             source_url = source[1].rstrip('/')
             if (source_url not in source_deb_src
@@ -92,6 +83,15 @@ try:
                 for prefix in apt_uri_types:
                     if source_url.startswith(prefix):
                         source_deb_src.append(source_url)
+
+        elif line.startswith('deb'):
+            source = line.split()
+            source_url = source[1].rstrip('/')
+            if (source_url not in source_deb
+                    and source_url not in security_sources):
+                for prefix in apt_uri_types:
+                    if source_url.startswith(prefix):
+                        source_deb.append(source_url)
 
     fh.close()
 
@@ -105,17 +105,17 @@ try:
         fh = open(apt_sources_list[1])
 
         for line in fh:
-            if line.startswith('deb'):
+            if line.startswith('deb-src'):
+                source = line.split()
+                for component in source[3:]:
+                    if component in apt_nonfree_components:
+                        apt_nonfree = True
+
+            elif line.startswith('deb'):
                 source = line.split()
                 for component in source[3:]:
                     if component not in components:
                         components.append(component)
-                    if component in apt_nonfree_components:
-                        apt_nonfree = True
-
-            elif line.startswith('deb-src'):
-                source = line.split()
-                for component in source[3:]:
                     if component in apt_nonfree_components:
                         apt_nonfree = True
 


### PR DESCRIPTION
Hello,

When running the `/etc/ansible/facts.d/apt.fact` script generated by the DebOps `apt` role, the `original_mirrors_deb_src` list is always empty, and `deb-src` mirror URIs may incorrectly be added to the `original_mirrors_deb` list.

To reproduce:
1. On a DebOps-managed host, create a `/etc/apt/sources.list.dpkg-divert` file with the following content:
   ```
   deb http://mirror1.example.org bullseye main
   deb-src http://mirror2.example.org bullseye main
   ```
2. Run the `/etc/ansible/facts.d/apt.fact` script on the same host.

The expected result for the concerned facts should be:
```json
    "original_mirrors_deb": [
        "http://mirror1.example.org"
    ],
    "original_mirrors_deb_src": [
        "http://mirror2.example.org"
    ],
```

However, the obtained result is:
```json
    "original_mirrors_deb": [
        "http://mirror1.example.org",
        "http://mirror2.example.org"
    ],
    "original_mirrors_deb_src": [],
```

This is due to the fact that the `apt.fact` script will incorrectly identify each `deb-src` line in `sources.list` as a `deb` line: the script always tests first if a line begins with `deb` and, if not, tests if it begins with `deb-src`: https://github.com/debops/debops/blob/a1a88ab9732fd13d1bed5ce09f10c5e0b2e6f531/ansible/roles/apt/templates/etc/ansible/facts.d/apt.fact.j2#L78-L94

However, a line that begins with `deb-src` always begins with `deb` as well: consequently, the `if` branch is taken instead of the `elif` branch, and the `deb-src` lines are processed as if they were `deb` lines.

The same problem also occurs later in the same script, when parsing `sources.list` to build the `components` fact.

This PR proposes to swap the order of these tests so that `deb-src` lines can be matched and treated as such.

Thank you!

snipfoo