### PR TITLE
[core] Allow to remove/reset fact `ansible_controllers`

### DIFF
--- a/ansible/roles/core/templates/etc/ansible/facts.d/core.fact.j2
+++ b/ansible/roles/core/templates/etc/ansible/facts.d/core.fact.j2
@@ -56,8 +56,8 @@ else:
 {%   endfor %}
 {% endif %}
 {% set core__tpl_ansible_controllers = [] %}
-{% if ansible_local.core.ansible_controllers|d() %}
-{%   for element in ansible_local.core.ansible_controllers %}
+{% if core__tpl_facts.ansible_controllers|d() %}
+{%   for element in core__tpl_facts.ansible_controllers %}
 {%     set _ = core__tpl_ansible_controllers.append(element) %}
 {%   endfor %}
 {% endif %}


### PR DESCRIPTION
Hello,

The template for the `core.fact` script in the DebOps `core` role never clears the contents of the `ansible_controllers` fact, even when it is listed in the `core__remove_facts` variable or when `core__reset_facts` is set to `True`.

To reproduce:
1. Run the `/etc/ansible/facts.d/core.fact` on a DebOps-managed host, and look at the `ansible_controllers` fact. E.g.,
   ```json
       "ansible_controllers": [
           "192.168.13.1"
       ],
   ```
2. Run the DebOps `core` role from the controller, with the following variables set for the target host:
   ```yaml
   core__remove_facts: [ ansible_controllers ]
   core__active_controller: 192.168.13.12   # ... or change the IP address the
                                            # controller uses to connect to the host
   ```
3. Run once again the `/etc/ansible/facts.d/core.fact` on the host.

The expected result is that the previous content of the `ansible_controllers` fact was removed and replaced with the new IP address of the controller:
```json
    "ansible_controllers": [
        "192.168.13.12"
    ],
```

However,  the obtained result is:
```json
    "ansible_controllers": [
        "192.168.13.1",
        "192.168.13.12"
    ],
```

This is due to the fact that, when building the `core__tpl_ansible_controllers` list in the `core.fact` script template, the value of `core__remove_facts` and `core__reset_facts` is ignored: the `core__tpl_ansible_controllers` is always initialized using the contents of `ansible_local.core.ansible_controllers`: https://github.com/debops/debops/blob/a1a88ab9732fd13d1bed5ce09f10c5e0b2e6f531/ansible/roles/core/templates/etc/ansible/facts.d/core.fact.j2#L58-L63

This can be problematic, as it means that there is no DebOps-idiomatic way to clear the list of known Ansible controllers on the host (apart from directly modifying or removing the `core.fact` script): this list can only grow.

However, the list of available local facts after taking the `core__remove_facts` and `core__reset_facts` variables into account is computed just before as `core__tpl_facts`. Therefore, one can just use the contents of this mapping instead, and read the initial list of Ansible controllers from `core__tpl_facts.ansible_controllers`.

This is the idea behind this simple PR, and, from what I could test, it fixes the reported issue.

Thank you!

snipfoo