### PR TITLE
[environment] Fix fact handling

### DIFF
--- a/ansible/roles/environment/defaults/main.yml
+++ b/ansible/roles/environment/defaults/main.yml
@@ -102,8 +102,6 @@ environment__host_variables: []
 #
 # List of environment variables which are defined by other Ansible roles as
 # a dependency.
-environment__dependent_variables: '{{ [ ansible_local.environment.variables ]
-                                      if (ansible_local.environment.variables|d())
-                                      else [] }}'
+environment__dependent_variables: []
                                                                    # ]]]
                                                                    # ]]]

--- a/ansible/roles/environment/tasks/main.yml
+++ b/ansible/roles/environment/tasks/main.yml
@@ -3,6 +3,10 @@
 # Copyright (C) 2016 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-only
 
+- name: Import DebOps global handlers
+  ansible.builtin.import_role:
+    name: 'global_handlers'
+
 - name: Configure /etc/environment
   ansible.builtin.blockinfile:
     dest: '{{ environment__file }}'
@@ -26,4 +30,8 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
+  notify: [ 'Refresh host facts' ]
   tags: [ 'meta::facts' ]
+
+- name: Reload facts if they were modified
+  ansible.builtin.meta: 'flush_handlers'

--- a/ansible/roles/environment/templates/etc/ansible/facts.d/environment.fact.j2
+++ b/ansible/roles/environment/templates/etc/ansible/facts.d/environment.fact.j2
@@ -41,7 +41,7 @@
 {%     endfor %}
 {%   endif %}
 {% endmacro %}
-{% set environment__tpl_fact_variables = (print_environment(ansible_local.environment.variables) | from_yaml) if (ansible_local.environment.variables|d()) else {} %}
+{% set environment__tpl_fact_variables = ansible_local.environment.variables|d({}) %}
 {% set environment__tpl_dependent_variables = print_environment(environment__dependent_variables) | from_yaml %}
 {% set environment__tpl_entries = {} %}
 {% if environment__tpl_fact_variables %}

--- a/ansible/roles/environment/templates/lookup/environment__variables.j2
+++ b/ansible/roles/environment/templates/lookup/environment__variables.j2
@@ -45,7 +45,7 @@
 {% set environment__tpl_variables = print_environment(environment__variables) | from_yaml %}
 {% set environment__tpl_group_variables = print_environment(environment__group_variables) | from_yaml %}
 {% set environment__tpl_host_variables = print_environment(environment__host_variables) | from_yaml %}
-{% set environment__tpl_fact_variables = (print_environment(ansible_local.environment.variables) | from_yaml) if (ansible_local.environment.variables|d()) else {} %}
+{% set environment__tpl_fact_variables = ansible_local.environment.variables|d({}) %}
 {% set environment__tpl_dependent_variables = print_environment(environment__dependent_variables) | from_yaml %}
 {% set environment__tpl_entries = {} %}
 {% if environment__tpl_default_variables %}


### PR DESCRIPTION
Hello,

I've stumbled upon a couple of minor issues with the way facts are handled by the DepOps `environment` role. This PR proposes simple fixes.

* Consecutive calls to the `environment` role with different dependent environment variables forget the variables set by the previous roles: dependent variables are stored by the role in the local fact file `/etc/ansible/facts.d/environment.fact`, but the facts are not automatically refreshed to take them into account before the next call to the role.
To reproduce, one can try running the following play:
  ```yaml
  ---
  - hosts: all
    become: True
    roles:
      - role: debops.debops.environment
        environment__dependent_variables: [ var1: 'foo' ]
      - role: debops.debops.environment
        environment__dependent_variables: [ var2: 'bar' ]
  ```
  The `var1` variable will be lost, and only the `var2` variable will remain in `/etc/environment` at the end of the play.
  Reloading the facts at the end of the `environment` role fixes the issue.

* On a related note, since the `environment__dependent_variables` will be set by caller roles, its default value should be empty. In any case, the contents of the `variables` local fact will be used by the corresponding templates to write existing variables `/etc/environment` and `/etc/ansible/facts.d/environment.fact`, even when `environment__dependent_variables` is empty.

* Finally, in the `environment__variables.j2` and `environment.fact.j2` templates, the contents of the `variables` fact is fed again to the `print_environment()` macro in order to compute `environment__tpl_fact_variables`:
  https://github.com/debops/debops/blob/a1a88ab9732fd13d1bed5ce09f10c5e0b2e6f531/ansible/roles/environment/templates/lookup/environment__variables.j2#L48
  https://github.com/debops/debops/blob/a1a88ab9732fd13d1bed5ce09f10c5e0b2e6f531/ansible/roles/environment/templates/etc/ansible/facts.d/environment.fact.j2#L44
  However, due to the [different formats](https://docs.debops.org/en/stable-3.0/ansible/roles/environment/defaults-detailed.html#environment-variables) supported for `environment__variables`, the `print_environment()` macro is not idempotent, and applying it once again to the `variables` fact may trigger unwanted behaviors.
  Such a bug can be triggered by running the following play twice:
  ```yaml
  ---
  - hosts: all
    become: True
    roles:
      - role: debops.debops.environment
        environment__dependent_variables:
          - name: 'foo'
          - value: 'bar'
  ```
  The first run will correctly add the variables `name=foo` and `value=bar` the environment. However, the second run will incorrectly detect the `variables` fact as a dictionary of conditional variables (since it contains both a `name` and a `value` key) and add the `foo=bar` variable assignment to the environment.
  Directly initializing `environment__tpl_fact_variables` as `ansible_local.environment.variables|d({})` (as per the third commit in this PR) should fix this issue.

Thank you!

snipfoo