### PR TITLE
[python] Decode subprocess output in fact script

### DIFF
--- a/ansible/roles/python/templates/etc/ansible/facts.d/python.fact.j2
+++ b/ansible/roles/python/templates/etc/ansible/facts.d/python.fact.j2
@@ -42,7 +42,7 @@ if output['installed2']:
         output['version2'] = subprocess.check_output(
             ['python2', '--version'],
             stderr=subprocess.STDOUT
-        ).strip().split(' ')[-1]
+        ).decode('utf-8').strip().split(' ')[-1]
     except Exception:
         pass
 
@@ -53,7 +53,7 @@ if output['installed3']:
         output['version3'] = subprocess.check_output(
             ['python3', '--version'],
             stderr=subprocess.STDOUT
-        ).strip().split(' ')[-1]
+        ).decode('utf-8').strip().split(' ')[-1]
     except Exception:
         pass
 


### PR DESCRIPTION
Hello,

When run with Python 3, the `/etc/ansible/facts.d/python.fact` script silently fails on the `.split(' ')` calls (lines 45 and 56) and therefore cannot properly set the `version2` and `version3` facts:
https://github.com/debops/debops/blob/a1a88ab9732fd13d1bed5ce09f10c5e0b2e6f531/ansible/roles/python/templates/etc/ansible/facts.d/python.fact.j2#L53-L56

This is because the subprocess output is a byte string, and it needs to be decoded into a regular string for further manipulation and JSON output.

The fix proposed in this PR simply adds a call to `.decode('utf-8')`, just as other DebOps fact scripts do. E.g., for the `apt` role:
https://github.com/debops/debops/blob/a1a88ab9732fd13d1bed5ce09f10c5e0b2e6f531/ansible/roles/apt/templates/etc/ansible/facts.d/apt.fact.j2#L135-L137

Thank you!

snipfoo