### PR TITLE
[netbase] Use `==` for string comparisons in fact script

### DIFF
--- a/ansible/roles/netbase/templates/etc/ansible/facts.d/netbase.fact.j2
+++ b/ansible/roles/netbase/templates/etc/ansible/facts.d/netbase.fact.j2
@@ -79,7 +79,7 @@ with open('/etc/hosts', 'r') as hosts:
     for line in hosts:
         if not line.startswith('#'):
             if (output['self_fqdn'] in line.split()[1:]
-                    and output['self_address'] in line.split()[0]):
+                    and output['self_address'] == line.split()[0]):
                 output['self_local_hostname'] = True
                 output['self_domain_source'] = 'standalone'
                 aliases = ([e for e in line.split()
@@ -91,8 +91,8 @@ with open('/etc/hosts', 'r') as hosts:
 
             if (output['self_fqdn'] in line.split()
                     and '.' in output['self_fqdn']
-                    and output['self_address'] in line.split()[0]
-                    and (output['self_domain'] in
+                    and output['self_address'] == line.split()[0]
+                    and (output['self_domain'] ==
                          '.'.join(line.split()[1].split('.')[1:]))):
                 output['self_domain_source'] = 'localhost'
 


### PR DESCRIPTION
Hello,

Just a quick patch for the fact script in the `netbase` DebOps role. Comparing strings using the `in` operator will also match substrings, which I guess is not the desired behavior here.

See, e.g.,
https://github.com/debops/debops/blob/a1a88ab9732fd13d1bed5ce09f10c5e0b2e6f531/ansible/roles/netbase/templates/etc/ansible/facts.d/netbase.fact.j2#L81-L82
(Note that the first `in` above is correct, as `line.split()[1:]` is an array of strings. Only the second occurrence, on line 82, is used to compare two strings.)

On a host where `self_fqdn` is `foo.example.org` and `self_address` is `192.168.13.1`, the above condition would incorrectly match lines in `/etc/hosts` such as the following:
```hosts
192.168.13.12       foo.example.org foo
```

Thank you!

snipfoo