### PR TITLE
[fhs] Add support for the *all/group/host* pattern to `fhs__*_directories`

### DIFF
--- a/ansible/roles/fhs/defaults/main.yml
+++ b/ansible/roles/fhs/defaults/main.yml
@@ -131,8 +131,23 @@ fhs__default_directories:
                                                                    # ]]]
 # .. envvar:: fhs__directories [[[
 #
-# List of additional base directories defined by the user.
+# List of additional base directories defined by the user for all hosts in the
+# Ansible inventory.
 fhs__directories: []
+
+                                                                   # ]]]
+# .. envvar:: fhs__group_directories [[[
+#
+# List of additional base directories defined by the user for hosts in a
+# specific Ansible inventory group.
+fhs__group_directories: []
+
+                                                                   # ]]]
+# .. envvar:: fhs__host_directories [[[
+#
+# List of additional base directories defined by the user for specific hosts in
+# the Ansible inventory.
+fhs__host_directories: []
 
                                                                    # ]]]
 # .. envvar:: fhs__combined_directories [[[
@@ -140,6 +155,8 @@ fhs__directories: []
 # Variable which combines all of the base directory lists and is used in role
 # tasks and templates.
 fhs__combined_directories: '{{ fhs__default_directories
-                               + fhs__directories }}'
+                               + fhs__directories
+                               + fhs__group_directories
+                               + fhs__host_directories }}'
                                                                    # ]]]
                                                                    # ]]]


### PR DESCRIPTION
Hello,

This PR is a simple proposal to add support for the [*all/group/host* configuration pattern](https://docs.debops.org/en/stable-3.0/user-guide/universal-configuration.html#the-all-group-host-pattern) to the `fhs__*_directories` variables in the `fhs` DebOps role.

It just add the `fhs__group_directories` and `fhs__host_directories` variables (both empty by default) and combines them into `fhs__combined_directories`, which already combined `fhs__default_directories` and `fhs__directories`.

Thank you!

snipfoo