### PR TITLE
[dhparam] Use `dhparam__openssl_options` in the host script as well

### DIFF
--- a/ansible/roles/dhparam/templates/usr/local/lib/dhparam-generate-params.j2
+++ b/ansible/roles/dhparam/templates/usr/local/lib/dhparam-generate-params.j2
@@ -71,6 +71,8 @@ fi
 dhparam_library="{{ dhparam__library }}"
 dhparam_path="{{ dhparam__path + '/params' }}"
 
+dhparam_openssl_options=( {{ dhparam__openssl_options }} )
+
 dhparam_prefix="{{ dhparam__prefix }}"
 read -r -a dhparam_bits <<< "{{ dhparam__bits | join(' ') }}"
 dhparam_suffix="{{ dhparam__suffix }}"
@@ -100,7 +102,7 @@ generate_params () {
       if [ "${dhparam_library}" == "gnutls" ] ; then
         certtool --generate-dh-params --outfile "${dhparam_file}.tmp" --bits "${length}" > /dev/null 2>&1 && mv "${dhparam_file}.tmp" "${dhparam_file}"
       elif [ "${dhparam_library}" == "openssl" ] ; then
-        openssl dhparam -out "${dhparam_file}.tmp" "${length}" > /dev/null 2>&1 && mv "${dhparam_file}.tmp" "${dhparam_file}"
+        openssl dhparam "${dhparam_openssl_options[@]}" -out "${dhparam_file}.tmp" "${length}" > /dev/null 2>&1 && mv "${dhparam_file}.tmp" "${dhparam_file}"
       fi
 
     done


### PR DESCRIPTION
Hello,

The `dhparam__openssl_options` variable introduced by #1006 is [documented](https://docs.debops.org/en/stable-3.0/ansible/roles/dhparam/defaults/main.html#envvar-dhparam__openssl_options) as providing *“additional options to the openssl dhparam generator (eg. -dsaparam).”*

However, this variable is only taken into account when generating DH parameters on the Ansible controller, but not by the `dhparam-generate-params` script running on the hosts:
https://github.com/debops/debops/blob/a1a88ab9732fd13d1bed5ce09f10c5e0b2e6f531/ansible/roles/dhparam/tasks/main.yml#L59
https://github.com/debops/debops/blob/a1a88ab9732fd13d1bed5ce09f10c5e0b2e6f531/ansible/roles/dhparam/templates/usr/local/lib/dhparam-generate-params.j2#L103

Maybe this discrepancy can be resolved by having `dhparam-generate-params` use these options as well? This is what this PR proposes to do.

Otherwise, I think the documentation should clarify that `dhparam__openssl_options` only applies to the generation of DH parameters on the Ansible controller and is ignored on the hosts. I can propose something along these lines, if this is the preferred solution.

Thank you!

snipfoo