### PR TITLE
Add replace capabilities to debops.resources

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,9 @@ New DebOps roles
 - The :ref:`debops.reboot` role can be used to reboot, forcefully or only if
   required, any DebOps host.
 
+- The :ref:`debops.resources` role can now be used to repace a line via the
+  ``ansible.builtin.replace`` module.
+
 General
 '''''''
 

--- a/ansible/roles/resources/defaults/main.yml
+++ b/ansible/roles/resources/defaults/main.yml
@@ -379,4 +379,38 @@ resources__combined_commands: '{{ resources__commands
                                   + resources__group_commands
                                   + resources__host_commands }}'
                                                                    # ]]]
+# String replacement management [[[
+# ---------------------------------
+
+# The variables below let you define string replacement in files.
+
+# .. envvar:: resources__replacements [[[
+#
+# List of replacements which should be executed on all hosts in the
+# Ansible inventory.
+resources__replacements: []
+
+                                                                   # ]]]
+# .. envvar:: resources__group_replacements [[[
+#
+# List of replacements which should be executed on hosts in a
+# specific Ansible inventory group.
+resources__group_replacements: []
+
+                                                                   # ]]]
+# .. envvar:: resources__host_replacements [[[
+#
+# List of replacements which should be executed on specific hosts
+# in the Ansible inventory.
+resources__host_replacements: []
+
+                                                                   # ]]]
+# .. envvar:: resources__combined_replacements[[[
+#
+# Variable which combines all other line replacements variables and
+# is used in the role tasks.
+resources__combined_replacements: '{{ resources__replacements
+                                      + resources__group_replacements
+                                      + resources__host_replacements }}'
+                                                                   # ]]]
                                                                    # ]]]

--- a/ansible/roles/resources/tasks/main.yml
+++ b/ansible/roles/resources/tasks/main.yml
@@ -227,6 +227,33 @@
          (item.state | d('present') != 'absent'))
   tags: [ 'role::resources:files' ]
 
+- name: Manage replacements files
+  ansible.builtin.replace:
+    dest:          '{{ item.dest          | d(item.name | d(item.path)) }}'
+    after:         '{{ item.after         | d(omit) }}'
+    attributes:    '{{ item.attributes    | d(item.attr | d(omit)) }}'
+    backup:        '{{ item.backup        | d(omit) }}'
+    before:        '{{ item.before        | d(omit) }}'
+    encoding:      '{{ item.encoding      | d(omit) }}'
+    group:         '{{ item.group         | d(omit) }}'
+    mode:          '{{ item.mode          | d(omit) }}'
+    others:        '{{ item.others        | d(omit) }}'
+    owner:         '{{ item.owner         | d(omit) }}'
+    regexp:        '{{ item.regexp        | d(omit) }}'
+    replace:       '{{ item.replace       | d(omit) }}'
+    selevel:       '{{ item.selevel       | d(omit) }}'
+    serole:        '{{ item.serole        | d(omit) }}'
+    setype:        '{{ item.setype        | d(omit) }}'
+    seuser:        '{{ item.seuser        | d(omit) }}'
+    unsafe_writes: '{{ item.unsafe_writes | d(omit) }}'
+    validate:      '{{ item.validate      | d(omit) }}'
+  loop: '{{ q("flattened", resources__replacements
+                           + resources__group_replacements
+                           + resources__host_replacements) }}'
+  when: (resources__enabled | bool and item.regexp | d() and
+         (item.dest | d() or item.path | d() or item.name | d()))
+  tags: [ 'role::resources:lineinfile' ]
+
 # Manage ACLs [[[1
 - name: Set ACLs on remote hosts
   ansible.posix.acl:


### PR DESCRIPTION
Context: After installing and running the playbook against my Debian 11 hosts, I always end up with `use_authtok` in one of the lines of `/etc/pam.d/common-password`.

The presence `use_authtok` in said file prevents people, including root, from changing their password. The error message always being `passwd: Authentication token manipulation error`.

By adding `ansible.builtin.replace` capacities to service/resources, this enables the end user to remove erroneous `use_authtok` without having to either create a specific task, or a any other role.

Of course, this is just one use case, many more are possible since this solution is generic.

