### PR TITLE
[opensearch] Add new role debops.opensearch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1761,6 +1761,19 @@ stages:
     JANE_DIFF_PATTERN: '.*/roles/opendkim/.*'
     JANE_LOG_PATTERN: '\[opendkim\]'
 
+'opensearch role':
+  <<: *test_role_1st_deps
+  needs:
+    - 'keyring role'
+    - 'sysctl role'
+    - 'etc_services role'
+  variables:
+    JANE_TEST_FACT: 'opensearch.fact'
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/opensearch.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_opensearch'
+    JANE_DIFF_PATTERN: '.*/roles/opensearch/.*'
+    JANE_LOG_PATTERN: '\[opensearch\]'
+
 'owncloud/apache role':
   <<: *test_role_3rd_deps
   needs:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,12 @@ New DebOps roles
 
   .. __: https://www.elastic.co/beats/metricbeat
 
+- The :ref:`debops.opensearch` role can be used to set up an unsecured,
+  local-only installation of `OpenSearch`__. OpenSearch is a fork of
+  Elasticsearch that continues to be released under a free software license.
+
+  .. __: https://opensearch.org/
+
 - The :ref:`debops.reboot` role can be used to reboot, forcefully or only if
   required, any DebOps host.
 

--- a/ansible/playbooks/service/opensearch.yml
+++ b/ansible/playbooks/service/opensearch.yml
@@ -1,0 +1,34 @@
+---
+# Copyright (C) 2022 CipherMail B.V. <https://www.ciphermail.com/>
+# Copyright (C) 2022 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Install and manage OpenSearch
+  collections: [ 'debops.debops', 'debops.roles01',
+                 'debops.roles02', 'debops.roles03' ]
+  hosts: [ 'debops_service_opensearch' ]
+  become: True
+
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
+
+  roles:
+
+    - role: keyring
+      tags: [ 'role::keyring', 'skip::keyring' ]
+      keyring__dependent_gpg_keys:
+        - '{{ opensearch__keyring__dependent_gpg_keys }}'
+
+    - role: sysctl
+      tags: [ 'role::sysctl', 'skip::sysctl' ]
+      sysctl__dependent_parameters:
+        - '{{ opensearch__sysctl__dependent_parameters }}'
+
+    - role: etc_services
+      tags: [ 'role::etc_services', 'skip::etc_services' ]
+      etc_services__dependent_list:
+        - '{{ opensearch__etc_services__dependent_list }}'
+
+    - role: opensearch
+      tags: [ 'role::opensearch', 'skip::opensearch' ]

--- a/ansible/playbooks/srv/all.yml
+++ b/ansible/playbooks/srv/all.yml
@@ -110,3 +110,5 @@
 - import_playbook: pdns.yml
 
 - import_playbook: rspamd.yml
+
+- import_playbook: opensearch.yml

--- a/ansible/playbooks/srv/opensearch.yml
+++ b/ansible/playbooks/srv/opensearch.yml
@@ -1,0 +1,1 @@
+../service/opensearch.yml

--- a/ansible/roles/global_handlers/handlers/main.yml
+++ b/ansible/roles/global_handlers/handlers/main.yml
@@ -79,6 +79,8 @@
 
 - import_tasks: 'opendkim.yml'
 
+- import_tasks: 'opensearch.yml'
+
 - import_tasks: 'pdns.yml'
 
 - import_tasks: 'pki.yml'

--- a/ansible/roles/global_handlers/handlers/opensearch.yml
+++ b/ansible/roles/global_handlers/handlers/opensearch.yml
@@ -1,0 +1,9 @@
+---
+# Copyright (C) 2022 CipherMail B.V. <https://www.ciphermail.com/>
+# Copyright (C) 2022 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Restart opensearch
+  ansible.builtin.service:
+    name: 'opensearch'
+    state: 'restarted'

--- a/ansible/roles/opensearch/COPYRIGHT
+++ b/ansible/roles/opensearch/COPYRIGHT
@@ -1,0 +1,18 @@
+debops.opensearch - Install and manage OpenSearch
+
+Copyright (C) 2022 CipherMail B.V. <https://www.ciphermail.com/>
+Copyright (C) 2022 DebOps <https://debops.org/>
+SPDX-License-Identifier: GPL-3.0-or-later
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/ansible/roles/opensearch/defaults/main.yml
+++ b/ansible/roles/opensearch/defaults/main.yml
@@ -1,0 +1,209 @@
+---
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+
+# .. Copyright (C) 2022 CipherMail B.V. <https://www.ciphermail.com/>
+# .. Copyright (C) 2022 DebOps <https://debops.org/>
+# .. SPDX-License-Identifier: GPL-3.0-or-later
+
+# .. _opensearch__ref_defaults:
+
+# debops.opensearch default variables [[[
+# ==========================================
+
+# .. contents:: Sections
+#    :local:
+#
+# .. include:: ../../../../includes/global.rst
+
+
+# General [[[
+# -----------
+
+# .. envvar:: opensearch__version [[[
+#
+# The OpenSearch version to install.
+opensearch__version: '2.0.1'
+
+                                                                   # ]]]
+# .. envvar:: opensearch__tarball [[[
+#
+# The name of the OpenSearch release tarball.
+opensearch__tarball: 'opensearch-{{ opensearch__version }}-linux-x64.tar.gz'
+
+                                                                   # ]]]
+# .. envvar:: opensearch__installation_directory [[[
+#
+# The directory where the OpenSearch release tarball should be extracted.
+opensearch__installation_directory: '/usr/local/share/opensearch'
+
+                                                                   # ]]]
+# .. envvar:: opensearch__user [[[
+#
+# Name of the UNIX user account used by OpenSearch.
+opensearch__user: 'opensearch'
+
+                                                                   # ]]]
+# .. envvar:: opensearch__group [[[
+#
+# Name of the UNIX primary group used by OpenSearch.
+opensearch__group: 'opensearch'
+                                                                   # ]]]
+                                                                   # ]]]
+# Memory options [[[
+# ------------------
+
+# The variables below configure JVM memory allocation options. See
+# https://opensearch.org/docs/latest/opensearch/install/important-settings/
+# for more details.
+
+# .. envvar:: opensearch__memory_lock [[[
+#
+# Enable or disable memory lock depending on availability of required POSIX
+# capabilities. If this variable is enabled, :command:`systemd` memlock limit
+# is configured.
+opensearch__memory_lock: '{{ True
+                                if (not (ansible_system_capabilities_enforced|d())|bool or
+                                    ((ansible_system_capabilities_enforced|d())|bool and
+                                     "cap_ipc_lock" in (ansible_system_capabilities|d([]))))
+                                else False }}'
+
+                                                                   # ]]]
+# .. envvar:: opensearch__jvm_memory_heap_size_multiplier [[[
+#
+# This variable defines a float value which will be used to select the JVM heap
+# size depending on the size of the available system RAM.
+opensearch__jvm_memory_heap_size_multiplier: '{{ "0.2"
+                                                    if (ansible_memtotal_mb|int / 2 <= 2048)
+                                                    else "0.45" }}'
+
+                                                                   # ]]]
+# .. envvar:: opensearch__jvm_memory_min_heap_size [[[
+#
+# Specify the minimum JVM heap size, depending on the available system RAM.
+opensearch__jvm_memory_min_heap_size: '{{ (((ansible_memtotal_mb|int
+                                               * opensearch__jvm_memory_heap_size_multiplier|float)
+                                               | round | int) | string + "m")
+                                             if (ansible_memtotal_mb|int / 2 <= 32768)
+                                             else "32600m" }}'
+
+                                                                   # ]]]
+# .. envvar:: opensearch__jvm_memory_max_heap_size [[[
+#
+# Specify the maximum JVM heap size, depending on the available system RAM.
+# This usually should be the same as the minimum heap size, for performance
+# reasons.
+opensearch__jvm_memory_max_heap_size: '{{ opensearch__jvm_memory_min_heap_size }}'
+                                                                   # ]]]
+                                                                   # ]]]
+# OpenSearch configuration [[[
+# ----------------------------
+
+# .. envvar:: opensearch__default_configuration [[[
+#
+# Default configuration provided by this role.
+opensearch__default_configuration:
+
+  - name: 'cluster.name'
+    comment: 'Use a descriptive name for your cluster'
+    value: '{{ ansible_domain | replace(".","-") }}'
+
+  - name: 'node.name'
+    comment: 'Use a descriptive name for the node'
+    value: '{{ ansible_hostname }}'
+
+  - name: 'path.data'
+    comment: |
+      Path to directory where to store the data (separate multiple locations by
+      comma)
+    value: '/var/local/opensearch'
+
+  - name: 'path.logs'
+    comment: 'Path to log files'
+    value: '/var/log/opensearch'
+
+  - name: 'plugins.security.disabled'
+    comment: 'Disable TLS support'
+    value: True
+
+  - name: 'bootstrap.memory_lock'
+    comment: '# Lock the memory on startup'
+    value: '{{ True if opensearch__memory_lock|bool else False }}'
+
+  - name: 'cluster.initial_master_nodes'
+    comment: |
+      Bootstrap the cluster using an initial set of master-eligible nodes
+    value: [ '{{ ansible_hostname }}' ]
+
+                                                                   # ]]]
+# .. envvar:: opensearch__configuration [[[
+#
+# Configuration to apply to all OpenSearch hosts.
+opensearch__configuration: []
+
+                                                                   # ]]]
+# .. envvar:: opensearch__group_configuration [[[
+#
+# Configuration to apply to all OpenSearch hosts in the inventory group.
+opensearch__group_configuration: []
+
+                                                                   # ]]]
+# .. envvar:: opensearch__host_configuration [[[
+#
+# Configuration to apply to individual OpenSearch hosts.
+opensearch__host_configuration: []
+
+                                                                   # ]]]
+# .. envvar:: opensearch__combined_configuration [[[
+#
+# Combined OpenSearch configuration.
+opensearch__combined_configuration: '{{ opensearch__default_configuration
+                                        + opensearch__configuration
+                                        + opensearch__group_configuration
+                                        + opensearch__host_configuration }}'
+                                                                   # ]]]
+                                                                   # ]]]
+# Configuration for other Ansible roles [[[
+# -----------------------------------------
+
+# .. envvar:: opensearch__etc_services__dependent_list [[[
+#
+# Configuration for the :ref:`debops.etc_services` Ansible role.
+opensearch__etc_services__dependent_list:
+
+  - name: 'opensearch-http'
+    port: 9200
+
+  - name: 'opensearch-tcp'
+    port: 9300
+
+                                                                   # ]]]
+# .. envvar:: opensearch__keyring__dependent_gpg_keys [[[
+#
+# Configuration for the :ref:`debops.keyring` Ansible role.
+opensearch__keyring__dependent_gpg_keys:
+
+  - id: 'C5B7 4989 65EF D1C2 924B  A9D5 39D3 1987 9310 D3FC'
+    url: 'https://artifacts.opensearch.org/publickeys/opensearch.pgp'
+    user: '{{ opensearch__user }}'
+    group: '{{ opensearch__group }}'
+    home: '/var/local/opensearch'
+
+                                                                   # ]]]
+# .. envvar:: opensearch__sysctl__dependent_parameters [[[
+#
+# Configuration for the :ref:`debops.sysctl` Ansible role.
+opensearch__sysctl__dependent_parameters:
+
+  - name: 'opensearch'
+    weight: 80
+    options:
+
+      - name: 'vm.max_map_count'
+        comment: |
+          The OpenSearch documentation recommends setting this as the minimum
+          for production workloads, see
+          https://opensearch.org/docs/latest/opensearch/install/important-settings/
+        value: 262144
+                                                                   # ]]]
+                                                                   # ]]]
+                                                                   # ]]]

--- a/ansible/roles/opensearch/meta/main.yml
+++ b/ansible/roles/opensearch/meta/main.yml
@@ -1,0 +1,26 @@
+---
+# Copyright (C) 2022 CipherMail B.V. <https://www.ciphermail.com/>
+# Copyright (C) 2022 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Ensure that custom Ansible plugins and modules included in the main DebOps
+# collection are available to roles in other collections.
+collections: [ 'debops.debops' ]
+
+dependencies: []
+
+galaxy_info:
+
+  company: 'DebOps'
+  author: 'Imre Jonk, CipherMail B.V.'
+  description: 'Install and manage OpenSearch'
+  license: 'GPL-3.0-or-later'
+  min_ansible_version: '2.10.0'
+  platforms:
+    - name: 'Debian'
+      versions:
+        - 'bullseye'
+  galaxy_tags:
+    - 'database'
+    - 'nosql'
+    - 'opensearch'

--- a/ansible/roles/opensearch/meta/watch-opensearch
+++ b/ansible/roles/opensearch/meta/watch-opensearch
@@ -1,0 +1,10 @@
+# Copyright (C) 2022 CipherMail B.V. <https://www.ciphermail.com/>
+# Copyright (C) 2022 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Role: opensearch
+# Package: opensearch
+# Version: 2.0.1
+
+version=4
+https://github.com/opensearch-project/OpenSearch/tags \/opensearch-project\/OpenSearch\/releases\/tag\/(\d+\.\d+\.\d+)

--- a/ansible/roles/opensearch/tasks/main.yml
+++ b/ansible/roles/opensearch/tasks/main.yml
@@ -1,0 +1,142 @@
+---
+# Copyright (C) 2022 CipherMail B.V. <https://www.ciphermail.com/>
+# Copyright (C) 2022 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Import DebOps global handlers
+  ansible.builtin.import_role:
+    name: 'global_handlers'
+
+- name: Create directories
+  ansible.builtin.file:
+    path: '{{ item }}'
+    state: 'directory'
+    owner: '{{ opensearch__user }}'
+    group: '{{ opensearch__group }}'
+    mode: '0750'
+  loop:
+    - '/etc/opensearch'
+    - '/var/local/opensearch'
+    - '/var/log/opensearch'
+
+- when: ansible_local.opensearch.version|d("0.0.0") != opensearch__version
+  block:
+
+    - name: Download release files
+      ansible.builtin.get_url:
+        url: 'https://artifacts.opensearch.org/releases/bundle/opensearch/{{ opensearch__version + "/" + item }}'
+        dest: '/var/tmp/{{ item }}'
+      loop:
+        - '{{ opensearch__tarball }}'
+        - '{{ opensearch__tarball }}.sig'
+
+    - name: Verify release tarball
+      ansible.builtin.command: >-
+        gpg --verify /var/tmp/{{ opensearch__tarball }}.sig
+      become_user: '{{ opensearch__user }}'
+      changed_when: False
+
+    - name: Stop service
+      ansible.builtin.service:
+        name: 'opensearch'
+        state: 'stopped'
+
+    - name: Remove old installation directory
+      ansible.builtin.file:
+        path: '{{ opensearch__installation_directory }}'
+        state: 'absent'
+
+    - name: Create new installation directory
+      ansible.builtin.file:
+        path: '{{ opensearch__installation_directory }}'
+        state: 'directory'
+        mode: '0755'
+
+    - name: Extract release tarball
+      ansible.builtin.unarchive:
+        src: '/var/tmp/{{ opensearch__tarball }}'
+        dest: '{{ opensearch__installation_directory }}'
+        remote_src: True
+        owner: 'root'
+        group: 'root'
+        mode: 'u=rwX,g=rX,o=rX'
+        extra_opts:
+          - '--strip-components=1'
+      notify: [ 'Refresh host facts', 'Restart opensearch' ]
+
+    - name: Install new configuration files
+      ansible.builtin.copy:
+        src: '{{ opensearch__installation_directory }}/config/'
+        dest: '/etc/opensearch'
+        remote_src: True
+        owner: 'root'
+        group: '{{ opensearch__group }}'
+        mode: '0640'
+
+- name: Configure OpenSearch and the JVM
+  ansible.builtin.template:
+    src: 'etc/opensearch/{{ item }}.j2'
+    dest: '/etc/opensearch/{{ item }}'
+    owner: 'root'
+    group: '{{ opensearch__group }}'
+    mode: '0640'
+  loop:
+    - 'jvm.options'
+    - 'opensearch.yml'
+  notify: [ 'Restart opensearch' ]
+
+- name: Remove redundant configuration directory
+  ansible.builtin.file:
+    path: '{{ opensearch__installation_directory }}/config'
+    state: 'absent'
+
+- name: Symlink log directory
+  ansible.builtin.file:
+    path: '{{ opensearch__installation_directory }}/logs'
+    src: '/var/log/opensearch'
+    state: 'link'
+    force: True
+
+- name: Generate systemd configuration
+  ansible.builtin.template:
+    src: 'etc/systemd/system/opensearch.service.j2'
+    dest: '/etc/systemd/system/opensearch.service'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  notify: [ 'Reload service manager' ]
+
+- name: Make sure that Ansible local facts directory exists
+  ansible.builtin.file:
+    path: '/etc/ansible/facts.d'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+
+- name: Save local facts
+  ansible.builtin.template:
+    src: 'etc/ansible/facts.d/opensearch.fact.j2'
+    dest: '/etc/ansible/facts.d/opensearch.fact'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+  notify: [ 'Refresh host facts' ]
+  tags: [ 'meta::facts' ]
+
+- name: Flush handlers
+  ansible.builtin.meta: 'flush_handlers'
+
+- name: Start service
+  ansible.builtin.service:
+    name: 'opensearch'
+    state: 'started'
+    enabled: True
+
+- name: Clean up release files
+  ansible.builtin.file:
+    path: '/var/tmp/{{ item }}'
+    state: 'absent'
+  loop:
+    - '{{ opensearch__tarball }}'
+    - '{{ opensearch__tarball }}.sig'

--- a/ansible/roles/opensearch/templates/etc/ansible/facts.d/opensearch.fact.j2
+++ b/ansible/roles/opensearch/templates/etc/ansible/facts.d/opensearch.fact.j2
@@ -1,0 +1,26 @@
+#!{{ ansible_python['executable'] }}
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2022 CipherMail B.V. <https://www.ciphermail.com/>
+# Copyright (C) 2022 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# {{ ansible_managed }}
+
+from json import dumps
+import re
+
+output = {}
+
+try:
+    # Search the manifest file for the version number. Return on first match.
+    for line in open('{{ opensearch__installation_directory }}/manifest.yml'):
+        match = re.search(r"^\s*version: (\d+\.\d+\.\d+)$", line)
+        if match:
+            output['version'] = match.group(1)
+            break
+
+except Exception:
+    pass
+
+print(dumps(output, sort_keys=True, indent=4))

--- a/ansible/roles/opensearch/templates/etc/opensearch/jvm.options.j2
+++ b/ansible/roles/opensearch/templates/etc/opensearch/jvm.options.j2
@@ -1,0 +1,85 @@
+{# Copyright (C) 2022 CipherMail B.V. <https://www.ciphermail.com/>
+ # Copyright (C) 2022 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-or-later
+ #}
+
+## JVM configuration
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://opensearch.org/docs/opensearch/install/important-settings/
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+-Xms{{ opensearch__jvm_memory_min_heap_size }}
+-Xmx{{ opensearch__jvm_memory_max_heap_size }}
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+8-10:-XX:+UseConcMarkSweepGC
+8-10:-XX:CMSInitiatingOccupancyFraction=75
+8-10:-XX:+UseCMSInitiatingOccupancyOnly
+
+## G1GC Configuration
+# NOTE: G1 GC is only supported on JDK version 10 or later
+# to use G1GC, uncomment the next two lines and update the version on the
+# following three lines to your version of the JDK
+# 10:-XX:-UseConcMarkSweepGC
+# 10:-XX:-UseCMSInitiatingOccupancyOnly
+11-:-XX:+UseG1GC
+11-:-XX:G1ReservePercent=25
+11-:-XX:InitiatingHeapOccupancyPercent=30
+
+## JVM temporary directory
+-Djava.io.tmpdir=${OPENSEARCH_TMPDIR}
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps; ensure the directory exists and
+# has sufficient space
+-XX:HeapDumpPath=data
+
+# specify an alternative path for JVM fatal error logs
+-XX:ErrorFile=logs/hs_err_pid%p.log
+
+## JDK 8 GC logging
+8:-XX:+PrintGCDetails
+8:-XX:+PrintGCDateStamps
+8:-XX:+PrintTenuringDistribution
+8:-XX:+PrintGCApplicationStoppedTime
+8:-Xloggc:logs/gc.log
+8:-XX:+UseGCLogFileRotation
+8:-XX:NumberOfGCLogFiles=32
+8:-XX:GCLogFileSize=64m
+
+# JDK 9+ GC logging
+9-:-Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+
+# Explicitly allow security manager (https://bugs.openjdk.java.net/browse/JDK-8270380)
+18-:-Djava.security.manager=allow

--- a/ansible/roles/opensearch/templates/etc/opensearch/opensearch.yml.j2
+++ b/ansible/roles/opensearch/templates/etc/opensearch/opensearch.yml.j2
@@ -1,0 +1,21 @@
+{# Copyright (C) 2022 CipherMail B.V. <https://www.ciphermail.com/>
+ # Copyright (C) 2022 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-or-later
+ #}
+# {{ ansible_managed }}
+
+{%  for element in opensearch__combined_configuration | debops.debops.parse_kv_items %}
+{%      if element.state == "present" %}
+{%          if element.comment|d() %}
+{{ element.comment | regex_replace('$\n', '') | comment(prefix='', postfix='') -}}
+{%          endif %}
+{%          if element.value is boolean or element.value is integer %}
+{{ element.name }}: {{ element.value }}
+{%          elif element.value is string %}
+{{ element.name }}: "{{ element.value }}"
+{%          elif element.value is iterable %}
+{{ element.name }}: [ "{{ element.value | join('", "') }}" ]
+{%          endif %}
+
+{%      endif %}
+{%  endfor %}

--- a/ansible/roles/opensearch/templates/etc/systemd/system/opensearch.service.j2
+++ b/ansible/roles/opensearch/templates/etc/systemd/system/opensearch.service.j2
@@ -1,0 +1,63 @@
+{# Copyright (C) 2022 CipherMail B.V. <https://www.ciphermail.com/>
+ # Copyright (C) 2022 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-or-later
+ #}
+# {{ ansible_managed }}
+
+[Unit]
+Description=OpenSearch
+Documentation=https://opensearch.org/docs/latest
+Requires=network.target remote-fs.target
+After=network.target remote-fs.target
+ConditionPathExists={{ opensearch__installation_directory }}
+ConditionPathExists=/var/local/opensearch
+
+[Service]
+Environment=OPENSEARCH_HOME={{ opensearch__installation_directory }}
+Environment=OPENSEARCH_PATH_CONF=/etc/opensearch
+ReadWritePaths=/var/log/opensearch
+
+WorkingDirectory={{ opensearch__installation_directory }}
+
+User={{ opensearch__user }}
+Group={{ opensearch__group }}
+
+ExecStart=/usr/local/share/opensearch/bin/opensearch
+
+# Specifies the maximum file descriptor number that can be opened by this
+# process
+LimitNOFILE=65535
+
+# Specifies the maximum number of processes
+LimitNPROC=4096
+
+# Specifies the maximum size of virtual memory
+LimitAS=infinity
+
+# Specifies the maximum file size
+LimitFSIZE=infinity
+
+# Specifies the maximum size that may be locked into memory
+LimitMEMLOCK=infinity
+
+# Disable timeout logic and wait until process is stopped
+TimeoutStopSec=0
+
+# SIGTERM signal is used to stop the Java process
+KillSignal=SIGTERM
+
+# Send the signal only to the JVM rather than its control group
+KillMode=process
+
+# Java process is never killed
+SendSIGKILL=no
+
+# When a JVM receives a SIGTERM signal it exits with code 143
+SuccessExitStatus=143
+
+# Allow a slow startup before the systemd notifier module kicks in to extend
+# the timeout
+TimeoutStartSec=180
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/ansible/role-index.rst
+++ b/docs/ansible/role-index.rst
@@ -221,6 +221,7 @@ Logging
 - :ref:`debops.journald`
 - :ref:`debops.kibana`
 - :ref:`debops.logrotate`
+- :ref:`debops.opensearch`
 - :ref:`debops.rsyslog`
 
 

--- a/docs/ansible/roles/opensearch/defaults-detailed.rst
+++ b/docs/ansible/roles/opensearch/defaults-detailed.rst
@@ -1,0 +1,49 @@
+.. Copyright (C) 2022 CipherMail B.V. <https://www.ciphermail.com/>
+.. Copyright (C) 2022 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-or-later
+
+Default variable details
+========================
+
+Some of the ``debops.opensearch`` default variables have more extensive
+configuration than simple strings or lists. Here you can find documentation and
+examples for them.
+
+
+.. _opensearch__configuration:
+
+opensearch__configuration
+-------------------------
+
+The ``opensearch__*_configuration`` variables define the OpenSearch
+configuration options that are set in the
+:file:`/etc/opensearch/opensearch.yml` configuration file. For example:
+
+.. code-block:: yaml
+
+   opensearch__configuration:
+
+     - name: 'cluster.name'
+       value: 'example-cluster'
+
+     - name: 'node.name'
+       comment: 'My first node'
+       value: 'node-1'
+
+Each configuration entry is a list item containing a YAML dictionary. These
+parameters are supported:
+
+``name``
+  String, mandatory. The name of the OpenSearch configuration entry.
+
+``value``
+  String, mandatory. The value of the OpenSearch configuration entry. Can be a
+  string, an integer, a boolean or a list.
+
+``comment``
+  String or YAML text block, optional. A comment added to the configuration
+  entry.
+
+``state``
+  String, optional. If not specified or ``present``, the entry will be included
+  in the configuration file. If ``absent``, the entry will not be included.

--- a/docs/ansible/roles/opensearch/getting-started.rst
+++ b/docs/ansible/roles/opensearch/getting-started.rst
@@ -1,0 +1,55 @@
+.. Copyright (C) 2022 CipherMail B.V. <https://www.ciphermail.com/>
+.. Copyright (C) 2022 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-or-later
+
+Getting started
+===============
+
+.. only:: html
+
+   .. contents::
+      :local:
+
+
+When to use this role
+---------------------
+
+WARNING: this role can only manage local, unsecured OpenSearch installations.
+This is useful when running it alongside dependent software like Graylog, which
+switched from Elasticsearch to OpenSearch due to
+`issues with the new Elasticsearch license <https://www.graylog.org/post/graylog-to-add-support-for-opensearch>`_.
+
+If you are not encumbered by Elasticsearch's new license, then please consider
+using the :ref:`debops.elasticsearch` role instead.
+
+Installation
+------------
+
+This role installs OpenSearch from the release tarball. The PGP signature is
+used to verify the tarball. Directories for configuration and logging are
+created according to the
+`Filesystem Hierarchy Standard <https://refspecs.linuxfoundation.org/fhs.shtml>`_.
+The role is able to upgrade your installation automatically, and can configure
+OpenSearch, the included JVM, and the systemd service.
+
+Example inventory
+-----------------
+
+To deploy OpenSearch, you can add the host to the
+``[debops_service_opensearch]`` Ansible inventory group:
+
+.. code-block:: none
+
+   [debops_service_opensearch]
+   hostname
+
+
+Example playbook
+----------------
+
+If you are using this role without DebOps, here's an example Ansible playbook
+that uses the ``debops.opensearch`` role:
+
+.. literalinclude:: ../../../../ansible/playbooks/service/opensearch.yml
+   :language: yaml
+   :lines: 1,5-

--- a/docs/ansible/roles/opensearch/index.rst
+++ b/docs/ansible/roles/opensearch/index.rst
@@ -1,0 +1,29 @@
+.. Copyright (C) 2022 CipherMail B.V. <https://www.ciphermail.com/>
+.. Copyright (C) 2022 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-or-later
+
+.. _debops.opensearch:
+
+debops.opensearch
+====================
+
+.. include:: man_description.rst
+   :start-line: 7
+
+.. toctree::
+   :maxdepth: 2
+
+   getting-started
+   defaults/main
+   defaults-detailed
+
+Copyright
+---------
+
+.. literalinclude:: ../../../../ansible/roles/opensearch/COPYRIGHT
+
+..
+ Local Variables:
+ mode: rst
+ ispell-local-dictionary: "american"
+ End:

--- a/docs/ansible/roles/opensearch/man_description.rst
+++ b/docs/ansible/roles/opensearch/man_description.rst
@@ -1,0 +1,16 @@
+.. Copyright (C) 2022 CipherMail B.V. <https://www.ciphermail.com/>
+.. Copyright (C) 2022 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-or-later
+
+Description
+===========
+
+`OpenSearch <https://www.opensearch.org/>`_ is a fork of the popular
+distributed search engine and storage system Elasticsearch (see
+:ref:`debops.elasticsearch`). Some software vendors, for example Graylog, have
+switched to OpenSearch because of legal concerns regarding the Server Side
+Public License under which Elasticsearch is nowadays released.
+
+The ``debops.opensearch`` role only implements a subsection of the features
+supported by :ref:`debops.elasticsearch`. The role is currently only suitable
+for setting up a local OpenSearch instance without TLS support.

--- a/docs/ansible/roles/opensearch/man_index.rst
+++ b/docs/ansible/roles/opensearch/man_index.rst
@@ -1,0 +1,22 @@
+:orphan:
+
+.. Copyright (C) 2022 CipherMail B.V. <https://www.ciphermail.com/>
+.. Copyright (C) 2022 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-or-later
+
+debops.opensearch
+=================
+
+.. toctree::
+   :maxdepth: 2
+
+   man_synopsis
+   man_description
+   getting-started
+   defaults-detailed
+
+..
+ Local Variables:
+ mode: rst
+ ispell-local-dictionary: "american"
+ End:

--- a/docs/ansible/roles/opensearch/man_synopsis.rst
+++ b/docs/ansible/roles/opensearch/man_synopsis.rst
@@ -1,0 +1,8 @@
+.. Copyright (C) 2022 CipherMail B.V. <https://www.ciphermail.com/>
+.. Copyright (C) 2022 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-or-later
+
+Synopsis
+========
+
+``debops run [<``debops run`` options>] [--] service/opensearch`` [**--limit** `group,host,`...] [**--diff**] [**--check**] [**--tags** `tag1,tag2,`...] [**--skip-tags** `tag1,tag2,`...] [<``ansible-playbook`` options>] ...


### PR DESCRIPTION
The new role can only manage local, unsecured installations, which is what my employer needed for our Graylog installation. I decided not to copy the existing `debops.elasticsearch` role with all its features, because OpenSearch has some subtle differences and I have yet to set up a full Elasticsearch/OpenSearch cluster before I can properly implements such things in a role like this. This is a completely separate role with just the things necessary to do what it promises.

Tested with OpenSearch 1.3.3 and 2.0.1.