### PR TITLE
[slapd] Make saslauthd role execution configurable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -71,6 +71,11 @@ General
   the :ref:`debops.ldap` role is detected on the host. Currently only user
   authentication and Django ACL system is supported via LDAP groups.
 
+:ref:`debops.slapd` role
+''''''''''''''''''''''''
+
+- The playbook can now be configured to skip the saslauthd role execution.
+
 Changed
 ~~~~~~~
 

--- a/ansible/playbooks/service/slapd.yml
+++ b/ansible/playbooks/service/slapd.yml
@@ -51,6 +51,7 @@
       tags: [ 'role::saslauthd', 'skip::saslauthd' ]
       saslauthd__dependent_instances:
         - '{{ slapd__saslauthd__dependent_instances }}'
+      when: slapd__saslauthd__enabled | bool
 
     - role: slapd
       tags: [ 'role::slapd', 'skip::slapd' ]

--- a/ansible/roles/slapd/defaults/main.yml
+++ b/ansible/roles/slapd/defaults/main.yml
@@ -1687,6 +1687,12 @@ slapd__tcpwrappers__dependent_allow:
     comment: 'Allow connections to OpenLDAP service'
 
                                                                    # ]]]
+# .. envvar:: slapd__saslauthd__enabled [[[
+#
+# Boolean, whether the saslauthd configuration should be managed.
+slapd__saslauthd__enabled: True
+
+                                                                   # ]]]
 # .. envvar:: slapd__saslauthd__dependent_instances [[[
 #
 # Configuration for the :ref:`debops.saslauthd` Ansible role.


### PR DESCRIPTION
This adds a new default variable `slapd__saslauthd__enabled` (which defaults to `True` for backwards compatibility) that allows users to skip the saslauthd service installation when running the slapd playbook.