### PR TITLE
[resolvconf] Enable full static resolvconf without package

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -87,6 +87,9 @@ Updates of upstream application versions
 - In the :ref:`debops.netbox` role, the NetBox version has been updated to
   ``v3.2.4``.
 
+- In the :ref:`debops.resolvconf` role, you can now write a fully static 
+  :file:`/etc/resolv.conf` file without the ``resolvconf`` package.
+
 General
 ~~~~~~~
 

--- a/ansible/roles/resolvconf/defaults/main.yml
+++ b/ansible/roles/resolvconf/defaults/main.yml
@@ -77,6 +77,10 @@ resolvconf__static_filename: 'lo.static'
 # String or YAML text block with static :man:`resolv.conf(5)` configuration
 # which should be merged into the generated :file:`/etc/resolv.conf`
 # configuration file.
+#
+# If ``resolvconf__deploy_state`` is not ``present``, that is either
+# ``absent`` or ``ignore``, then contents will be copied as-is to
+# :file:`/etc/resolv.conf`.
 resolvconf__static_content: ''
                                                                    # ]]]
                                                                    # ]]]

--- a/ansible/roles/resolvconf/tasks/main.yml
+++ b/ansible/roles/resolvconf/tasks/main.yml
@@ -15,10 +15,11 @@
   ansible.builtin.package:
     name: '{{ q("flattened", (resolvconf__base_packages
                               + resolvconf__packages)) }}'
-    state: 'present'
+    state: '{{ resolvconf__deploy_state }}'
   register: resolvconf__register_packages
   until: resolvconf__register_packages is succeeded
-  when: resolvconf__enabled | bool
+  when: (resolvconf__enabled | bool and
+         resolvconf__deploy_state in [ 'present', 'absent' ])
 
 - name: Generate static configuration script
   ansible.builtin.template:
@@ -26,14 +27,16 @@
     dest: '/usr/local/lib/resolvconf-static'
     mode: '0755'
   notify: [ 'Apply static resolvconf configuration' ]
-  when: resolvconf__enabled | bool and resolvconf__static_enabled | bool
+  when: (resolvconf__enabled | bool and resolvconf__static_enabled | bool and
+         resolvconf__deploy_state in [ 'present' ])
 
 - name: Create systemd override directory
   ansible.builtin.file:
     path: '/etc/systemd/system/resolvconf.service.d'
     state: 'directory'
     mode: '0755'
-  when: resolvconf__enabled | bool and resolvconf__static_enabled | bool
+  when: (resolvconf__enabled | bool and resolvconf__static_enabled | bool and
+         resolvconf__deploy_state in [ 'present' ])
 
 - name: Generate systemd service override
   ansible.builtin.template:
@@ -41,16 +44,25 @@
     dest: '/etc/systemd/system/resolvconf.service.d/static.conf'
     mode: '0644'
   notify: [ 'Reload service manager' ]
-  when: resolvconf__enabled | bool and resolvconf__static_enabled | bool
+  when: (resolvconf__enabled | bool and resolvconf__static_enabled | bool and
+         resolvconf__deploy_state in [ 'present' ])
 
-- name: Add/remove diversion of /etc/resolvconf/interface-order
+- name: Add diversion of /etc/resolvconf/interface-order
   dpkg_divert:
     path: '/etc/resolvconf/interface-order'
     state: '{{ resolvconf__deploy_state }}'
     delete: True
   notify: [ 'Refresh /etc/resolv.conf' ]
   when: (resolvconf__enabled | bool and
-         resolvconf__deploy_state in [ 'present', 'absent' ])
+         resolvconf__deploy_state in [ 'present' ])
+
+- name: Remove diversion of /etc/resolvconf/interface-order
+  dpkg_divert:
+    path: '/etc/resolvconf/interface-order'
+    state: '{{ resolvconf__deploy_state }}'
+    delete: True
+  when: (resolvconf__enabled | bool and
+         resolvconf__deploy_state in [ 'absent' ])
 
 - name: Generate /etc/resolvconf/interface-order configuration
   ansible.builtin.template:
@@ -59,6 +71,25 @@
     mode: '0644'
   notify: [ 'Refresh /etc/resolv.conf' ]
   when: resolvconf__enabled | bool and resolvconf__deploy_state == 'present'
+
+- name: Remove configuration
+  ansible.builtin.file:
+    path: '{{ item }}'
+    state: 'absent'
+  when: (resolvconf__enabled | bool and
+         resolvconf__deploy_state in [ 'absent' ])
+  loop:
+    - '/usr/local/lib/resolvconf-static'
+    - '/etc/systemd/system/resolvconf.service.d/static.conf'
+    - '/etc/systemd/system/resolvconf.service.d'
+
+- name: Create static /etc/resolv.conf
+  ansible.builtin.copy:
+    mode: '0755'
+    dest: "/etc/resolv.conf"
+    content: '{{ resolvconf__static_content }}'
+  when: (resolvconf__enabled | bool and resolvconf__static_enabled | bool and
+         resolvconf__static_content != '' and resolvconf__deploy_state != 'present')
 
 - name: Make sure Ansible fact directory exists
   ansible.builtin.file:


### PR DESCRIPTION
If the idea is OK, then I'll write up documentation and changelog.

Works with the following example:

```
---
# debops/roles/resolvconf/defaults/main.yml
groups:
  debops_service_resolvconf:

vars:
  resolvconf__enabled: true

  resolvconf__deploy_state: 'absent'
  resolvconf__static_enabled: True

  resolvconf__static_content: |
    domain {{ netbase__domain }}
    search {{ netbase__domain }}.
    nameserver 1.1.1.1
```
