### PR TITLE
Switch 'from/to_json' to 'from/to_yaml' filters

### DIFF
--- a/ansible/playbooks/templates/debops__tpl_macros.j2
+++ b/ansible/playbooks/templates/debops__tpl_macros.j2
@@ -159,7 +159,7 @@
 {%       endfor %}
 {%     endif %}
 {%   endif %}
-{{ merged_dict | to_json }}
+{{ merged_dict | to_yaml }}
 {% endmacro %}{# ]]] #}
 
 {% macro flattened() %}{# [[[ #}
@@ -171,7 +171,7 @@
 ## Additional key-value arguments can be used to influence the behavoir of the macro.
 ## The macro uses recursion to flatten nested lists.
 ## Ref: https://stackoverflow.com/questions/13944751/args-kwargs-in-jinja2-macros
-## Retruns flattened object as JSON which you will need to deserialize using `from_json`.
+## Retruns flattened object as JSON which you will need to deserialize using `from_yaml`.
 ## Usage:
 ##
 ## {{ debops__tpl_macros.flattened(['list1', 55, ["deeplist1", "deeplist elem", True, False, undefined], {'mapping': True}], 'raw1', 22, True, False) }}
@@ -205,10 +205,10 @@
 {#     Filter out. #}
 {%   elif append_mapping_keys and (arg is mapping) %}
 {#     Does not work as of Jinja 2.8? #}
-{%     set _ = elem_flattened.extend(flattened(arg.keys(), filter_undef=filter_undef, filter_mapping=filter_mapping) | from_json) %}
+{%     set _ = elem_flattened.extend(flattened(arg.keys(), filter_undef=filter_undef, filter_mapping=filter_mapping) | from_yaml) %}
 {%   elif append_mapping_values and (arg is mapping) %}
 {#     Does not work as of Jinja 2.8? #}
-{%     set _ = elem_flattened.extend(flattened(arg.values(), filter_undef=filter_undef, filter_mapping=filter_mapping) | from_json) %}
+{%     set _ = elem_flattened.extend(flattened(arg.values(), filter_undef=filter_undef, filter_mapping=filter_mapping) | from_yaml) %}
 {%   elif filter_mapping and (arg is mapping) %}
 {#     Filter out. #}
 {%   elif (arg is undefined) %}
@@ -217,9 +217,9 @@
 {%     set _ = elem_flattened.append(arg) %}
 {%   elif (arg is iterable) %}
 {%     for element in arg %}
-{%       set _ = elem_flattened.extend(flattened(element, filter_undef=filter_undef, filter_mapping=filter_mapping) | from_json) %}
+{%       set _ = elem_flattened.extend(flattened(element, filter_undef=filter_undef, filter_mapping=filter_mapping) | from_yaml) %}
 {%     endfor %}
 {%   endif %}
 {% endfor %}
-{{ elem_flattened | to_json }}
+{{ elem_flattened | to_yaml }}
 {% endmacro %}{# ]]] #}

--- a/ansible/roles/apt/templates/etc/ansible/facts.d/apt.fact.j2
+++ b/ansible/roles/apt/templates/etc/ansible/facts.d/apt.fact.j2
@@ -27,11 +27,11 @@ import os
                  apt__security_sources ) %}
 {%   set _ = apt__tpl_security_sources.extend(
                  debops__tpl_macros.flattened(
-                     repo.uri, repo.uris) | from_json) %}
+                     repo.uri, repo.uris) | from_yaml) %}
 {% endfor %}
 {% for repo in apt__default_sources %}
 {%   set repo_uris = (debops__tpl_macros.flattened(
-                      repo.uri, repo.uris) | from_json) %}
+                      repo.uri, repo.uris) | from_yaml) %}
 {%   if repo.distribution | d() == apt__distribution %}
 {%     set _ = apt__tpl_default_sources.extend(repo_uris) %}
 {%   endif %}

--- a/ansible/roles/apt/templates/etc/apt/sources.list.j2
+++ b/ansible/roles/apt/templates/etc/apt/sources.list.j2
@@ -11,7 +11,7 @@
 {%     if key in [ 'state' ] %}
 {%       set _ = entry.update({ key: value | unique }) %}
 {%     else %}
-{%       set _ = entry.update({ key: debops__tpl_macros.flattened(value) | from_json | unique }) %}
+{%       set _ = entry.update({ key: debops__tpl_macros.flattened(value) | from_yaml | unique }) %}
 {%     endif %}
 {%   endfor %}
 {%   set entry_disabled = '# ' if (entry.state == 'disabled') else '' %}
@@ -49,7 +49,7 @@
 {% endmacro %}
 {% set apt__tpl_seen_sources = {} %}
 {% set apt__tpl_suites = [] %}
-{% for apt__tpl_suffix in debops__tpl_macros.flattened(apt__distribution_suffixes) | from_json %}
+{% for apt__tpl_suffix in debops__tpl_macros.flattened(apt__distribution_suffixes) | from_yaml %}
 {%   set _ = apt__tpl_suites.append(apt__distribution_release + apt__tpl_suffix) %}
 {% endfor %}
 {% set apt__tpl_sources = [] %}
@@ -70,12 +70,12 @@
 {%     set _ = apt__tpl_source.update({ "uris": [ element ]}) %}
 {%   elif element is mapping %}
 {%     set _ = apt__tpl_source.update({
-         "types": debops__tpl_macros.flattened(element.type, element.types) | from_json,
-         "options": debops__tpl_macros.flattened(element.option, element.options) | from_json,
-         "uris": debops__tpl_macros.flattened(element.uri, element.uris) | from_json,
-         "suites": debops__tpl_macros.flattened(element.suite, element.suites) | from_json,
-         "components": debops__tpl_macros.flattened(element.component, element.components) | from_json,
-         "comments": debops__tpl_macros.flattened(element.comment, element.comments) | from_json,
+         "types": debops__tpl_macros.flattened(element.type, element.types) | from_yaml,
+         "options": debops__tpl_macros.flattened(element.option, element.options) | from_yaml,
+         "uris": debops__tpl_macros.flattened(element.uri, element.uris) | from_yaml,
+         "suites": debops__tpl_macros.flattened(element.suite, element.suites) | from_yaml,
+         "components": debops__tpl_macros.flattened(element.component, element.components) | from_yaml,
+         "comments": debops__tpl_macros.flattened(element.comment, element.comments) | from_yaml,
          "state": element.state | d(apt__tpl_source.state),
          "architecture": element.architecture | d(apt__tpl_source.architecture),
          "distribution": element.distribution | d(apt__tpl_source.distribution),
@@ -88,12 +88,12 @@
 {%     set _ = apt__tpl_source.update({ "uris": element }) %}
 {%   endif %}
 {%   if not apt__tpl_source.types %}
-{%     set _ = apt__tpl_source.types.extend(debops__tpl_macros.flattened(apt__source_types) | from_json) %}
+{%     set _ = apt__tpl_source.types.extend(debops__tpl_macros.flattened(apt__source_types) | from_yaml) %}
 {%   endif %}
 {%   if not apt__tpl_source.uris %}
 {%     if element is mapping %}
 {%       if apt__distribution in element.keys() %}
-{%         set _ = apt__tpl_source.uris.extend(debops__tpl_macros.flattened(element[apt__distribution]) | from_json) %}
+{%         set _ = apt__tpl_source.uris.extend(debops__tpl_macros.flattened(element[apt__distribution]) | from_yaml) %}
 {%       endif %}
 {%     endif %}
 {%   endif %}
@@ -101,7 +101,7 @@
 {%     set _ = apt__tpl_source.suites.extend(apt__tpl_suites) %}
 {%   endif %}
 {%   if not apt__tpl_source.components %}
-{%     set _ = apt__tpl_source.components.extend(debops__tpl_macros.flattened(apt__distribution_components) | from_json) %}
+{%     set _ = apt__tpl_source.components.extend(debops__tpl_macros.flattened(apt__distribution_components) | from_yaml) %}
 {%   endif %}
 {%   set _ = apt__tpl_sources.append(apt__tpl_source) %}
 {% endfor %}

--- a/ansible/roles/apt/templates/import/debops__tpl_macros.j2
+++ b/ansible/roles/apt/templates/import/debops__tpl_macros.j2
@@ -116,7 +116,7 @@
 {%       endfor %}
 {%     endif %}
 {%   endif %}
-{{ merged_dict | to_json }}
+{{ merged_dict | to_yaml }}
 {% endmacro %}{# ]]] #}
 
 {% macro flattened() %}{# [[[ #}
@@ -161,10 +161,10 @@
 {#     Filter out. #}
 {%   elif append_mapping_keys and (arg is mapping) %}
 {#     Does not work as of Jinja 2.8? #}
-{%     set _ = elem_flattened.extend(flattened(arg.keys(), filter_undef=filter_undef, filter_mapping=filter_mapping) | from_json) %}
+{%     set _ = elem_flattened.extend(flattened(arg.keys(), filter_undef=filter_undef, filter_mapping=filter_mapping) | from_yaml) %}
 {%   elif append_mapping_values and (arg is mapping) %}
 {#     Does not work as of Jinja 2.8? #}
-{%     set _ = elem_flattened.extend(flattened(arg.values(), filter_undef=filter_undef, filter_mapping=filter_mapping) | from_json) %}
+{%     set _ = elem_flattened.extend(flattened(arg.values(), filter_undef=filter_undef, filter_mapping=filter_mapping) | from_yaml) %}
 {%   elif filter_mapping and (arg is mapping) %}
 {#     Filter out. #}
 {%   elif (arg is undefined) %}
@@ -173,9 +173,9 @@
 {%     set _ = elem_flattened.append(arg) %}
 {%   elif (arg is iterable) %}
 {%     for element in arg %}
-{%       set _ = elem_flattened.extend(flattened(element, filter_undef=filter_undef, filter_mapping=filter_mapping) | from_json) %}
+{%       set _ = elem_flattened.extend(flattened(element, filter_undef=filter_undef, filter_mapping=filter_mapping) | from_yaml) %}
 {%     endfor %}
 {%   endif %}
 {% endfor %}
-{{ elem_flattened | to_json }}
+{{ elem_flattened | to_yaml }}
 {% endmacro %}{# ]]] #}

--- a/ansible/roles/apt_install/tasks/main.yml
+++ b/ansible/roles/apt_install/tasks/main.yml
@@ -67,7 +67,7 @@
   ansible.builtin.apt:
     name: '{{ q("flattened", lookup("template",
                              "lookup/apt_install__all_packages.j2",
-                             convert_data=False) | from_json) }}'
+                             convert_data=False) | from_yaml) }}'
     state: '{{ apt_install__state }}'
     install_recommends: '{{ apt_install__recommends | bool }}'
     update_cache: '{{ apt_install__update_cache | bool }}'

--- a/ansible/roles/apt_install/templates/lookup/apt_install__all_packages.j2
+++ b/ansible/roles/apt_install/templates/lookup/apt_install__all_packages.j2
@@ -6,7 +6,7 @@
 {% macro get_yaml_list_from_string_or_list(package_map, item) %}{# ((( #}
 {{ ([ package_map[item] ]
    if (package_map[item] is string)
-   else (package_map[item] | list)) | to_json }}
+   else (package_map[item] | list)) | to_yaml }}
 {% endmacro %}{# ))) #}
 {% macro process_packages(packages, apt_install__tpl_package_list) %}{# ((( #}
 {%   for element in packages %}
@@ -18,8 +18,8 @@
 {%         set apt_install__tpl_met_condition_list = [] %}
 {%         for condition_name_to_meet in apt_install__tpl_to_meet_condition_list %}
 {%           if element[condition_name_to_meet] is defined %}
-{%             for condition_item_to_meet in get_yaml_list_from_string_or_list(element, condition_name_to_meet) | from_json | map('lower') %}
-{%               if condition_item_to_meet in (get_yaml_list_from_string_or_list(apt_install__condition_map, condition_name_to_meet) | from_json | map('lower')) %}
+{%             for condition_item_to_meet in get_yaml_list_from_string_or_list(element, condition_name_to_meet) | from_yaml | map('lower') %}
+{%               if condition_item_to_meet in (get_yaml_list_from_string_or_list(apt_install__condition_map, condition_name_to_meet) | from_yaml | map('lower')) %}
 {%                 set _ = apt_install__tpl_met_condition_list.append(condition_name_to_meet) %}
 {%               endif %}
 {%             endfor %}
@@ -28,8 +28,8 @@
 {%           endif %}
 {%         endfor %}
 {%         if (apt_install__tpl_met_condition_list | unique | length) == (apt_install__tpl_to_meet_condition_list | unique | length) %}
-{%           set _ = apt_install__tpl_package_list.append(get_yaml_list_from_string_or_list(element, 'name') | from_json
-                       | intersect(element.whitelist | d(get_yaml_list_from_string_or_list(element, 'name') | from_json)) | list) %}
+{%           set _ = apt_install__tpl_package_list.append(get_yaml_list_from_string_or_list(element, 'name') | from_yaml
+                       | intersect(element.whitelist | d(get_yaml_list_from_string_or_list(element, 'name') | from_yaml)) | list) %}
 {%         endif %}
 {%       endif %}
 {%     else %}
@@ -44,4 +44,4 @@
 {% for elements in apt_install__all_packages %}
 {%   set _ = process_packages(elements, apt_install__tpl_package_list) %}
 {% endfor %}
-{{ [ apt_install__tpl_package_list ] | to_nice_json }}
+{{ [ apt_install__tpl_package_list ] | to_nice_yaml }}

--- a/ansible/roles/cron/templates/lookup/cron__combined_jobs.j2
+++ b/ansible/roles/cron/templates/lookup/cron__combined_jobs.j2
@@ -22,13 +22,13 @@
 {%       endfor %}
 {%     endif %}
 {%   endif %}
-{{ merged_dict | to_json }}
+{{ merged_dict | to_yaml }}
 {% endmacro %}
-{% set cron__tpl_merge_default =   (merge_dict({},                        cron__default_jobs,   'file') | from_json) %}
-{% set cron__tpl_merge_dependent = (merge_dict(cron__tpl_merge_default,   cron__dependent_jobs, 'file') | from_json) %}
-{% set cron__tpl_merge_all =       (merge_dict(cron__tpl_merge_dependent, cron__jobs,           'file') | from_json) %}
-{% set cron__tpl_merge_group =     (merge_dict(cron__tpl_merge_all,       cron__group_jobs,     'file') | from_json) %}
-{% set cron__tpl_items =           (merge_dict(cron__tpl_merge_group,     cron__host_jobs,      'file') | from_json) %}
+{% set cron__tpl_merge_default =   (merge_dict({},                        cron__default_jobs,   'file') | from_yaml) %}
+{% set cron__tpl_merge_dependent = (merge_dict(cron__tpl_merge_default,   cron__dependent_jobs, 'file') | from_yaml) %}
+{% set cron__tpl_merge_all =       (merge_dict(cron__tpl_merge_dependent, cron__jobs,           'file') | from_yaml) %}
+{% set cron__tpl_merge_group =     (merge_dict(cron__tpl_merge_all,       cron__group_jobs,     'file') | from_yaml) %}
+{% set cron__tpl_items =           (merge_dict(cron__tpl_merge_group,     cron__host_jobs,      'file') | from_yaml) %}
 {% set cron__tpl_filtered_items = [] %}
 {% for item_name, params in cron__tpl_items.items() %}
 {%   set cron_file = (params["file"] | d(item_name)) %}

--- a/ansible/roles/ferm/defaults/main.yml
+++ b/ansible/roles/ferm/defaults/main.yml
@@ -301,7 +301,7 @@ ferm__dependent_rules: []
 # not rely on it.
 ferm__fix_dependent_rules: '{{ lookup("template",
                                "lookup/ferm__fix_dependent_rules.j2",
-                               convert_data=False) | from_json }}'
+                               convert_data=False) | from_yaml }}'
 
                                                                    # ]]]
 # .. envvar:: ferm__rules [[[

--- a/ansible/roles/ferm/templates/etc/ferm/rules.d/rule.conf.j2
+++ b/ansible/roles/ferm/templates/etc/ferm/rules.d/rule.conf.j2
@@ -29,10 +29,10 @@
 {%   if config.type | d() %}
 {%     set _ = ferm__tpl_config.update({'type': config.type }) %}
 {%   endif %}
-{%   set _ = ferm__tpl_config.update({'domain': (debops__tpl_macros.flattened(config.domain | d(config.domains | d(ferm__domains))) | from_json) }) %}
+{%   set _ = ferm__tpl_config.update({'domain': (debops__tpl_macros.flattened(config.domain | d(config.domains | d(ferm__domains))) | from_yaml) }) %}
 {%   if ferm__tpl_config['type'] != 'dmz' %}
-{%     set _ = ferm__tpl_config.update({'table': (debops__tpl_macros.flattened(config.table | d(config.tables | d('filter'))) | from_json) }) %}
-{%     set _ = ferm__tpl_config.update({'chain': (debops__tpl_macros.flattened(config.chain | d(config.chains | d('INPUT'))) | from_json) }) %}
+{%     set _ = ferm__tpl_config.update({'table': (debops__tpl_macros.flattened(config.table | d(config.tables | d('filter'))) | from_yaml) }) %}
+{%     set _ = ferm__tpl_config.update({'chain': (debops__tpl_macros.flattened(config.chain | d(config.chains | d('INPUT'))) | from_yaml) }) %}
 {%   endif %}
 {%   if ferm__tpl_config['domain'] | d() %}
 {%     set _ = ferm__tpl_config['domain_args'].append(print_list(ferm__tpl_config['domain'], prefix='domain')) %}
@@ -83,7 +83,7 @@
 {%   if config.subchain | d() %}
 {%     set _ = ferm__tpl_config.update({'subchain': (ferm__tpl_config['type'] + "-" + config.name | d((ferm__tpl_config['dport'][0] if ferm__tpl_config['dport'] | d() else "rules")))}) %}
 {%   endif %}
-{%   set _ = ferm__tpl_config.update({'interface': (debops__tpl_macros.flattened(config.interface | d(config.interfaces)) | from_json) }) %}
+{%   set _ = ferm__tpl_config.update({'interface': (debops__tpl_macros.flattened(config.interface | d(config.interfaces)) | from_yaml) }) %}
 {%   if ferm__tpl_config['type'] == 'connection_tracking' %}
 {%     set _ = ferm__tpl_config.update({'tracking_invalid_target': (config.tracking_invalid_target | d('DROP'))}) %}
 {%     set _ = ferm__tpl_config.update({'tracking_active_target':  (config.tracking_active_target  | d('ACCEPT'))}) %}
@@ -102,27 +102,27 @@
 {%       set _ = ferm__tpl_config.update({'private_ip': ([ config.private_ip ] if config.private_ip is string else config.private_ip) }) %}
 {%     endif %}
 {%     if config.port | d() or config.ports | d() %}
-{%       set _ = ferm__tpl_config.update({'dmz_ports': (debops__tpl_macros.flattened(config.port | d(config.ports))) | from_json }) %}
+{%       set _ = ferm__tpl_config.update({'dmz_ports': (debops__tpl_macros.flattened(config.port | d(config.ports))) | from_yaml }) %}
 {%       if ferm__tpl_config['dport'] == [] %}
 {%          set _ = ferm__tpl_config['dport'].extend(ferm__tpl_config['dmz_ports']) %}
 {%       endif %}
 {%     endif %}
 {%   endif %}
-{%   for interface in (debops__tpl_macros.flattened(config.interface_present | d(config.interfaces_present)) | from_json) %}
+{%   for interface in (debops__tpl_macros.flattened(config.interface_present | d(config.interfaces_present)) | from_yaml) %}
 {%     if hostvars[inventory_hostname]["ansible_" + interface] | d() %}
 {%       set _ = ferm__tpl_config.update({'interface_present': [ interface ] }) %}
 {%     endif %}
 {%   endfor %}
 {%   if config.outerface | d() or config.outerfaces | d() %}
-{%     set _ = ferm__tpl_config.update({'outerface': (debops__tpl_macros.flattened(config.outerface | d(config.outerfaces)) | from_json) }) %}
+{%     set _ = ferm__tpl_config.update({'outerface': (debops__tpl_macros.flattened(config.outerface | d(config.outerfaces)) | from_yaml) }) %}
 {%   endif %}
-{%   for outerface in (debops__tpl_macros.flattened(config.outerface_present | d(config.outerfaces_present)) | from_json) %}
+{%   for outerface in (debops__tpl_macros.flattened(config.outerface_present | d(config.outerfaces_present)) | from_yaml) %}
 {%     if hostvars[inventory_hostname]["ansible_" + outerface] | d() %}
 {%       set _ = ferm__tpl_config.update({'outerface_present': [ outerface ] }) %}
 {%     endif %}
 {%   endfor %}
 {%   if config.protocol | d() or config.protocols | d() %}
-{%     set _ = ferm__tpl_config.update({'protocol': (debops__tpl_macros.flattened(config.protocol | d(config.protocols)) | from_json) }) %}
+{%     set _ = ferm__tpl_config.update({'protocol': (debops__tpl_macros.flattened(config.protocol | d(config.protocols)) | from_yaml) }) %}
 {%   endif %}
 {%   if config.protocol_syn | d() %}
 {%     if config.protocol_syn | bool %}
@@ -600,6 +600,6 @@
 {% endif %}
 {% if rule.debug | d() | bool or (ansible_local | d() and ansible_local.tags | d() and 'debug' in ansible_local.tags) %}
 
-{{ ("rule_name: " + (rule_name | to_nice_json)) | replace('\n$','') | comment(prefix='',postfix='') -}}
-{{ ("rule: " + (rule | to_nice_json)) | replace('\n$','') | comment(prefix='',postfix='') -}}
+{{ ("rule_name: " + (rule_name | to_nice_yaml)) | replace('\n$','') | comment(prefix='',postfix='') -}}
+{{ ("rule: " + (rule | to_nice_yaml)) | replace('\n$','') | comment(prefix='',postfix='') -}}
 {% endif %}

--- a/ansible/roles/ferm/templates/import/debops__tpl_macros.j2
+++ b/ansible/roles/ferm/templates/import/debops__tpl_macros.j2
@@ -159,7 +159,7 @@
 {%       endfor %}
 {%     endif %}
 {%   endif %}
-{{ merged_dict | to_json }}
+{{ merged_dict | to_yaml }}
 {% endmacro %}{# ]]] #}
 
 {% macro flattened() %}{# [[[ #}
@@ -171,7 +171,7 @@
 ## Additional key-value arguments can be used to influence the behavoir of the macro.
 ## The macro uses recursion to flatten nested lists.
 ## Ref: https://stackoverflow.com/questions/13944751/args-kwargs-in-jinja2-macros
-## Retruns flattened object as JSON which you will need to deserialize using `from_json`.
+## Retruns flattened object as JSON which you will need to deserialize using `from_yaml`.
 ## Usage:
 ##
 ## {{ debops__tpl_macros.flattened(['list1', 55, ["deeplist1", "deeplist elem", True, False, undefined], {'mapping': True}], 'raw1', 22, True, False) }}
@@ -205,10 +205,10 @@
 {#     Filter out. #}
 {%   elif append_mapping_keys and (arg is mapping) %}
 {#     Does not work as of Jinja 2.8? #}
-{%     set _ = elem_flattened.extend(flattened(arg.keys(), filter_undef=filter_undef, filter_mapping=filter_mapping) | from_json) %}
+{%     set _ = elem_flattened.extend(flattened(arg.keys(), filter_undef=filter_undef, filter_mapping=filter_mapping) | from_yaml) %}
 {%   elif append_mapping_values and (arg is mapping) %}
 {#     Does not work as of Jinja 2.8? #}
-{%     set _ = elem_flattened.extend(flattened(arg.values(), filter_undef=filter_undef, filter_mapping=filter_mapping) | from_json) %}
+{%     set _ = elem_flattened.extend(flattened(arg.values(), filter_undef=filter_undef, filter_mapping=filter_mapping) | from_yaml) %}
 {%   elif filter_mapping and (arg is mapping) %}
 {#     Filter out. #}
 {%   elif (arg is undefined) %}
@@ -217,9 +217,9 @@
 {%     set _ = elem_flattened.append(arg) %}
 {%   elif (arg is iterable) %}
 {%     for element in arg %}
-{%       set _ = elem_flattened.extend(flattened(element, filter_undef=filter_undef, filter_mapping=filter_mapping) | from_json) %}
+{%       set _ = elem_flattened.extend(flattened(element, filter_undef=filter_undef, filter_mapping=filter_mapping) | from_yaml) %}
 {%     endfor %}
 {%   endif %}
 {% endfor %}
-{{ elem_flattened | to_json }}
+{{ elem_flattened | to_yaml }}
 {% endmacro %}{# ]]] #}

--- a/ansible/roles/ferm/templates/lookup/ferm__fix_dependent_rules.j2
+++ b/ansible/roles/ferm/templates/lookup/ferm__fix_dependent_rules.j2
@@ -39,4 +39,4 @@
 {% for key, value in ferm__tpl_fixed_rules.items() %}
 {%   set _ = ferm__tpl_flattened_rules.append(value) %}
 {% endfor %}
-{{ ferm__tpl_flattened_rules | to_json }}
+{{ ferm__tpl_flattened_rules | to_yaml }}

--- a/ansible/roles/unattended_upgrades/templates/etc/ansible/facts.d/unattended_upgrades.fact.j2
+++ b/ansible/roles/unattended_upgrades/templates/etc/ansible/facts.d/unattended_upgrades.fact.j2
@@ -7,6 +7,6 @@
 {{ ({
       "enabled":   unattended_upgrades__enabled  | bool | lower,
       "periodic":  unattended_upgrades__periodic | bool | lower,
-      "blacklist": unattended_upgrades__tpl_macros.get_blacklist_as_json() | from_json,
-      "origins":   unattended_upgrades__tpl_macros.get_origins_as_json()   | from_json,
+      "blacklist": unattended_upgrades__tpl_macros.get_blacklist_as_json() | from_yaml,
+      "origins":   unattended_upgrades__tpl_macros.get_origins_as_json()   | from_yaml,
 }) | to_nice_json }}

--- a/ansible/roles/unattended_upgrades/templates/etc/apt/apt.conf.d/50unattended-upgrades.j2
+++ b/ansible/roles/unattended_upgrades/templates/etc/apt/apt.conf.d/50unattended-upgrades.j2
@@ -29,7 +29,7 @@ Unattended-Upgrade::Origins-Pattern {
 {%     endif %}
 {%   endfor %}
 {% endif %}
-{% set unattended_upgrades__tpl_origins = unattended_upgrades__tpl_macros.get_origins_as_json(unattended_upgrades__tpl_security_origins + unattended_upgrades__tpl_release_origins) | from_json %}
+{% set unattended_upgrades__tpl_origins = unattended_upgrades__tpl_macros.get_origins_as_json(unattended_upgrades__tpl_security_origins + unattended_upgrades__tpl_release_origins) | from_yaml %}
 {% for item in unattended_upgrades__tpl_origins %}
         "{{ item }}";
 {% endfor %}
@@ -40,7 +40,7 @@ Unattended-Upgrade::Package-Blacklist {
 {% set unattended_upgrades__tpl_blacklist = unattended_upgrades__tpl_macros.get_blacklist_as_json(
     unattended_upgrades__default_blacklist +
     unattended_upgrades__blacklist +
-    unattended_upgrades__group_blacklist) | from_json %}
+    unattended_upgrades__group_blacklist) | from_yaml %}
 {% for item in unattended_upgrades__tpl_blacklist %}
         "{{ item }}";
 {% endfor %}

--- a/ansible/roles/unattended_upgrades/templates/unattended_upgrades__tpl_macros.j2
+++ b/ansible/roles/unattended_upgrades/templates/unattended_upgrades__tpl_macros.j2
@@ -9,7 +9,7 @@
 {% macro get_string_or_list_as_json_list(item) %}{# [[[ #}
 {{ ([ item ]
    if (item is string)
-   else (item | list)) | to_nice_json }}
+   else (item | list)) | to_nice_yaml }}
 {% endmacro %}{# ]]] #}
 
 {% macro assemble_origins_list(origins, unattended_upgrades__tpl_origins, unattended_upgrades__tpl_origins_absent) %}{# [[[ #}
@@ -19,11 +19,11 @@
 {%   elif item is mapping %}
 {%     if item.origin | d(item.origins | d()) and "state" in item and item.state is string %}
 {%       if item.state == "present" %}
-{%         for origin in (get_string_or_list_as_json_list(item.origin | d(item.origins | d())) | from_json) %}
+{%         for origin in (get_string_or_list_as_json_list(item.origin | d(item.origins | d())) | from_yaml) %}
 {%           set _ = unattended_upgrades__tpl_origins.append(origin) %}
 {%         endfor %}
 {%       else %}
-{%         for origin in (get_string_or_list_as_json_list(item.origin | d(item.origins | d())) | from_json) %}
+{%         for origin in (get_string_or_list_as_json_list(item.origin | d(item.origins | d())) | from_yaml) %}
 {%           set _ = unattended_upgrades__tpl_origins_absent.append(origin) %}
 {%         endfor %}
 {%       endif %}
@@ -46,7 +46,7 @@
 {%     set _ = unattended_upgrades__tpl_origins.append(item) %}
 {%   endfor %}
 {% endif %}
-{{ unattended_upgrades__tpl_origins | difference(unattended_upgrades__tpl_origins_absent) | sort | unique | to_nice_json }}
+{{ unattended_upgrades__tpl_origins | difference(unattended_upgrades__tpl_origins_absent) | sort | unique | to_nice_yaml }}
 {% endmacro %}{# ]]] #}
 
 {% macro assemble_blacklist(blacklist, unattended_upgrades__tpl_blacklist, unattended_upgrades__tpl_blacklist_absent) %}{# [[[ #}
@@ -56,11 +56,11 @@
 {%   elif item is mapping %}
 {%     if "name" in item and "state" in item and item.state is string %}
 {%       if item.state == "present" %}
-{%         for name in (get_string_or_list_as_json_list(item.name) | from_json) %}
+{%         for name in (get_string_or_list_as_json_list(item.name) | from_yaml) %}
 {%           set _ = unattended_upgrades__tpl_blacklist.append(name) %}
 {%         endfor %}
 {%       else %}
-{%         for name in (get_string_or_list_as_json_list(item.name) | from_json) %}
+{%         for name in (get_string_or_list_as_json_list(item.name) | from_yaml) %}
 {%           set _ = unattended_upgrades__tpl_blacklist_absent.append(name) %}
 {%         endfor %}
 {%       endif %}
@@ -83,5 +83,5 @@
 {%     set _ = unattended_upgrades__tpl_blacklist.append(item) %}
 {%   endfor %}
 {% endif %}
-{{ unattended_upgrades__tpl_blacklist | difference(unattended_upgrades__tpl_blacklist_absent) | sort | unique | to_nice_json }}
+{{ unattended_upgrades__tpl_blacklist | difference(unattended_upgrades__tpl_blacklist_absent) | sort | unique | to_nice_yaml }}
 {% endmacro %}{# ]]] #}


### PR DESCRIPTION
The new Jinja2 3.x release changed the behaviour of 'to_json' filter
- it doesn't accept YAML lists as input anymore, only YAML dictionaries.
To fix this issue, we need to switch the filters to use YAML as
a transport between various places in the code, which permits lists to
be passed between variables.

There will be more places in the code that this might need to happen,
they will be dealt with on later commits.