### PR TITLE
[roundcube] Update Roundcube to 1.5.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -92,7 +92,7 @@ Updates of upstream application versions
 ''''''''''''''''''''''''''''''''''''''''
 
 - In the :ref:`debops.roundcube` role, the Roundcube version installed by
-  default has been updated to ``1.5.2``.
+  default has been updated to ``1.5.3``.
 
 - In the :ref:`debops.ipxe` role, the Debian Buster netboot installer version
   has been updated to the next point release, 10.12. Debian Bullseye has been

--- a/ansible/roles/roundcube/defaults/main.yml
+++ b/ansible/roles/roundcube/defaults/main.yml
@@ -164,7 +164,7 @@ roundcube__git_dir: '{{ roundcube__src + "/"
 # .. envvar:: roundcube__git_version [[[
 #
 # Roundcube release tag to deploy.
-roundcube__git_version: '1.5.2'
+roundcube__git_version: '1.5.3'
 
                                                                    # ]]]
 # .. envvar:: roundcube__git_dest [[[

--- a/ansible/roles/roundcube/meta/watch-roundcubemail
+++ b/ansible/roles/roundcube/meta/watch-roundcubemail
@@ -4,7 +4,7 @@
 
 # Role: roundcube
 # Package: roundcubemail
-# Version: 1.5.2
+# Version: 1.5.3
 
 version=4
 https://github.com/roundcube/roundcubemail/tags .*/v?(.*\S+)\.tar\.gz


### PR DESCRIPTION
This version is a service release, providing "a bunch of small fixes and
improvements for the PHP8 compatibility"