### PR TITLE
Allow 3 tier apt packages installation for postfix

### DIFF
--- a/ansible/roles/postfix/defaults/main.yml
+++ b/ansible/roles/postfix/defaults/main.yml
@@ -35,8 +35,22 @@ postfix__dependent_packages: []
                                                                    # ]]]
 # .. envvar:: postfix__packages [[[
 #
-# List of additional APT packages to install with Postfix.
+# List of custom APT packages to install with Postfix.
 postfix__packages: []
+
+                                                                   # ]]]
+# .. envvar:: postfix__group_packages [[[
+#
+# List of custom APT packages installed on hosts in a specific group
+# in Ansible inventory.
+postfix__group_packages: []
+
+                                                                   # ]]]
+# .. envvar:: postfix__host_packages [[[
+#
+# List of custom APT packages installed on specific hosts in Ansible
+# inventory.
+postfix__host_packages: []
 
                                                                    # ]]]
 # .. envvar:: postfix__purge_packages [[[

--- a/ansible/roles/postfix/tasks/main.yml
+++ b/ansible/roles/postfix/tasks/main.yml
@@ -19,6 +19,8 @@
   ansible.builtin.apt:
     name: '{{ (postfix__base_packages
              + postfix__dependent_packages
+             + postfix__host_packages
+             + postfix__group_packages
              + postfix__packages)
              | flatten }}'
     state: 'present'


### PR DESCRIPTION
Allow 3 tier installation packages for postfix (postfix__host_packages, postfix__group_packages, postfix__packages)