### PR TITLE
[nginx] Document further advantages with waiting for network

### DIFF
--- a/ansible/roles/nginx/templates/etc/systemd/system/nginx.service.d/wait-for-network.conf.j2
+++ b/ansible/roles/nginx/templates/etc/systemd/system/nginx.service.d/wait-for-network.conf.j2
@@ -8,6 +8,10 @@
 # before starting. This avoids an issue where 'nginx' might fail because remote
 # upstream servers defined by hostnames are unreachable.
 # Ref: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=943934
+#
+# This also fixes issues with IPv6 enabled hosts where IPv6 addresses might not
+# be configured at the time 'nginx' is started.
+# Ref: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=861261
 
 [Unit]
 After=network-online.target


### PR DESCRIPTION
The fix which was introduced with PR #2144 also addresses a separate
Debian bug. Document this fact so that the workaround isn't removed
unless and until both issues have been fixed.