### PR TITLE
[rspamd] Fix PEP632 deprecation of distutils

### DIFF
--- a/ansible/roles/rspamd/files/usr/local/sbin/rspamd-dkim-keygen
+++ b/ansible/roles/rspamd/files/usr/local/sbin/rspamd-dkim-keygen
@@ -42,11 +42,11 @@ import logging
 import tempfile
 import argparse
 import subprocess
-import distutils.spawn
+import shutil
 
 __license__ = 'GPL-2.0 OR Apache-2.0'
 __author__ = 'David Härdeman <david@hardeman.nu>'
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 
 LOG = logging.getLogger(__name__)
 
@@ -628,7 +628,7 @@ def main():
     if args.print_config:
         print_example_config()
 
-    if distutils.spawn.find_executable("rspamadm") is None:
+    if shutil.which("rspamadm") is None:
         die("rspamadm executable not found")
 
     if args.month == 0:

--- a/ansible/roles/rspamd/files/usr/local/sbin/rspamd-dkim-update
+++ b/ansible/roles/rspamd/files/usr/local/sbin/rspamd-dkim-update
@@ -21,11 +21,11 @@ import smtplib
 import argparse
 import datetime
 import subprocess
-import distutils.spawn
+import shutil
 
 __license__ = 'GPL-2.0 OR Apache-2.0'
 __author__ = 'David Härdeman <david@hardeman.nu>'
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 
 LOG = logging.getLogger(__name__)
 
@@ -219,7 +219,7 @@ def get_keys(key_list):
 
 def do_nsupdate(config, keys):
     # First, prepare the commands and make sure all executables are present
-    if distutils.spawn.find_executable("nsupdate") is None:
+    if shutil.which("nsupdate") is None:
         die("nsupdate executable not found")
 
     pre_cmd = []
@@ -236,7 +236,7 @@ def do_nsupdate(config, keys):
     elif config["method"] == "nsupdate_gsstsig":
         main_cmd += ["-g"]
 
-        if distutils.spawn.find_executable("kinit") is None:
+        if shutil.which("kinit") is None:
             die("kinit executable not found")
         pre_cmd = [
             "kinit", "-k",
@@ -244,7 +244,7 @@ def do_nsupdate(config, keys):
             "-p", config["nsupdate_gsstsig_princ"]
         ]
 
-        if distutils.spawn.find_executable("kdestroy") is None:
+        if shutil.which("kdestroy") is None:
             die("kdestroy executable not found")
         post_cmd = ["kdestroy"]
 


### PR DESCRIPTION
The alternative, ``shutil.which``, was introduced with Python 3.3, which
predates Debian stretch, so it should be safe to use without any
fallback to ``distutils``.

Closes: #2147 