### PR TITLE
[dovecot] Fix backslashes in regex_replace

### DIFF
--- a/ansible/roles/dovecot/defaults/main.yml
+++ b/ansible/roles/dovecot/defaults/main.yml
@@ -425,7 +425,7 @@ dovecot__default_configuration:
           {{ dovecot__features |
              intersect(['imap', 'imaps', 'pop3',
                         'pop3s', 'sieve', 'lmtp']) |
-             map('regex_replace', '^(imap|pop3)s$', '\\1') |
+             map("regex_replace", "^(imap|pop3)s$", "\1") |
              list | unique | join(' ') }}
 
   - section: 'authentication'


### PR DESCRIPTION
Commit ca2803e32de85b09ec1ebc87e16d5151031f708a removed the quoting around
the protocols parameter. The problem is that regex_replace is kind of wonky
and will behave differently depending on whether the var is quoted or not, see:
https://github.com/ansible/ansible/issues/33202

The result is that if there's a match (for e.g. "imaps"), the protocols
will contain a literal "\1" rather than "imap".