### PR TITLE
[nginx] Disable servers using `enabled` var

### DIFF
--- a/ansible/roles/nginx/tasks/nginx_servers.yml
+++ b/ansible/roles/nginx/tasks/nginx_servers.yml
@@ -193,7 +193,7 @@
   notify: [ 'Test nginx and restart' ]
   when: (item.name is defined and
          ((item.state | d("present") == 'absent') or
-          (item.enabled | d() and not item.enabled | bool) or
+          (item.enabled is defined | d() and not item.enabled | bool) or
           (item.delete | d() | bool)))
 
   ## https://stackoverflow.com/a/28888474


### PR DESCRIPTION
Disabling nginx servers by using `enabled: False` is fixed
in the task 'when' condition.  The removal of symlinks
in `/etc/nginx/sites-enabled` is controlled by this variable, but
the check did not work when the variable is defined and is false.