### PR TITLE
[sshd] Fix molly-guard when using dracut

### DIFF
--- a/ansible/roles/sshd/defaults/main.yml
+++ b/ansible/roles/sshd/defaults/main.yml
@@ -61,6 +61,17 @@ sshd__packages: []
 # Ansible local facts.
 sshd__version: '{{ ansible_local.sshd.version | d("0.0") }}'
                                                                    # ]]]
+# .. envvar:: sshd__combined_packages [[[
+#
+# Combined list of packages to install. This variable is used in the role
+# tasks.
+sshd__combined_packages: '{{ sshd__base_packages
+                             + sshd__recommended_packages
+                             + sshd__optional_packages
+                             + sshd__ldap_packages
+                             + sshd__packages }}'
+
+                                                                   # ]]]
                                                                    # ]]]
 # Host whitelists and allow lists [[[
 # -----------------------------------

--- a/ansible/roles/sshd/tasks/main.yml
+++ b/ansible/roles/sshd/tasks/main.yml
@@ -90,14 +90,31 @@
     state: 'directory'
     mode: '0755'
 
+  # molly-guard + dracut means that the system can't reboot anymore, see:
+  # https://bugs.debian.org/992351
+- name: Ensure that dracut directory exists before installing molly-guard fix
+  ansible.builtin.file:
+    path: '/etc/dracut.conf.d'
+    state: 'directory'
+    mode: '0755'
+  when: '"molly-guard" in q("flattened", sshd__combined_packages)'
+
+- name: Install molly-guard fix for dracut
+  ansible.builtin.template:
+    src: 'etc/dracut.conf.d/20-debops-molly-guard.conf.j2'
+    dest: '/etc/dracut.conf.d/20-debops-molly-guard.conf'
+    mode: '0644'
+  when: '"molly-guard" in q("flattened", sshd__combined_packages)'
+
+- name: Remove molly-guard fix for dracut
+  ansible.builtin.file:
+    path: '/etc/dracut.conf.d/20-debops-molly-guard.conf'
+    state: 'absent'
+  when: '"molly-guard" not in q("flattened", sshd__combined_packages)'
+
 - name: Ensure OpenSSH support is installed
   ansible.builtin.apt:
-    name: '{{ (sshd__base_packages
-             + sshd__recommended_packages
-             + sshd__optional_packages
-             + sshd__ldap_packages
-             + sshd__packages)
-             | flatten }}'
+    name: '{{ q("flattened", sshd__combined_packages) }}'
     state: '{{ "present"
                if (ansible_local | d() and ansible_local.sshd | d())
                else "latest" }}'

--- a/ansible/roles/sshd/templates/etc/dracut.conf.d/20-debops-molly-guard.conf.j2
+++ b/ansible/roles/sshd/templates/etc/dracut.conf.d/20-debops-molly-guard.conf.j2
@@ -1,0 +1,12 @@
+{# Copyright (C) 2022 David Härdeman <david@hardeman.nu>
+ # Copyright (C) 2021 Anton Lundin <glance@acc.umu.se>
+ # Copyright (C) 2022 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-only
+ #}
+#
+# {{ ansible_managed }}
+#
+# Fix for Debian bug #992351:
+# https://bugs.debian.org/992351
+
+install_items+=" /lib/molly-guard/poweroff /lib/molly-guard/reboot /lib/molly-guard/halt /lib/molly-guard/shutdown "


### PR DESCRIPTION
molly-guard is currently installed by default by the sshd role.

On machines using dracut (not default), molly-guard will unfortunately mean
that a reboot is no longer possible, see:
https://bugs.debian.org/992351

This patch ensures that a workaround is in place (noop on systems not
using dracut). Also, I've defined the new variable sshd__combined_packages
to make the resulting tasks/main.yml look a bit nicer.

Not 100% happy about adding three more task steps for this corner-case, but
a non-working reboot is on the other hand a pretty nasty scenario.