### PR TITLE
[keyring] Make keyring path configurable

### DIFF
--- a/ansible/roles/keyring/tasks/main.yml
+++ b/ansible/roles/keyring/tasks/main.yml
@@ -52,6 +52,7 @@
                                       if (keyring__keyserver | d() and item.url is undefined and item.keybase is undefined and
                                           ((item.id | d(item)) | replace(" ","")) not in keyring__fact_local_keys)
                                       else omit) }}'
+    keyring: '{{ item.keyring | d(omit) }}'
     url: '{{ item.url | d((keyring__keybase_api + item.keybase
                            + "/pgp_keys.asc?fingerprint=" + ((item.id | d(item)) | replace(" ","")))
                           if item.keybase | d() else omit) }}'

--- a/docs/ansible/roles/keyring/defaults-detailed.rst
+++ b/docs/ansible/roles/keyring/defaults-detailed.rst
@@ -190,6 +190,11 @@ The YAML dictionaries are defined using specific parameters:
   .. __: https://keybase.io/
   .. __: https://keybase.io/docs/api/1.0/call/user/pgp_keys.asc
 
+``keyring``
+  Optional. Absolute path for the keyring where the GPG key should be stored.
+  If omitted, the key will be stored in the system-wide keyring
+  (:file:`/etc/apt/trusted.gpg`).
+
 ``keyserver``
   Optional. Override the default GPG keyserver URL specified in the
   :envvar:`keyring__keyserver` variable.


### PR DESCRIPTION
This is useful e.g. when configuring third-party repos, since the GPG
key can be stored in a separate file and referenced in the
/etc/apt/sources.list.d/* entry like this:

deb [signed-by=/usr/share/keyrings/example.gpg] https://example.com/debian/ stable main

Which means that example.gpg won't be trusted to sign *any* package.