### PR TITLE
[gitlab_runner] Fix templating type error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -331,6 +331,8 @@ debops.boxbackup role
   task on systems other than Debian 9 or 10. The patch is not required since
   the ``vagrant-libvirt`` v0.1.0 package.
 
+- Fixed a templating type error in the task that creates required Unix groups.
+
 :ref:`debops.grub` role
 '''''''''''''''''''''''
 

--- a/ansible/roles/gitlab_runner/tasks/main.yml
+++ b/ansible/roles/gitlab_runner/tasks/main.yml
@@ -12,7 +12,7 @@
     name: '{{ item.name if item.name | d() else item }}'
     system: '{{ item.system | bool if item.system is defined else gitlab_runner__system | bool }}'
     state: 'present'
-  loop: '{{ q("flattened", gitlab_runner__group
+  loop: '{{ q("flattened", [ gitlab_runner__group ]
                            + gitlab_runner__additional_groups) }}'
 
 - name: Create gitlab-runner user


### PR DESCRIPTION
This error occurs on ansible 6.3.0 with Jinja2 3.1.2:

```
TASK [debops.debops.gitlab_runner : Create required groups] ********************
fatal: [runner11.ciphermail.com]: FAILED! =>
  msg: 'Unexpected templating type error occurred on ({{ q("flattened", gitlab_runner__group + gitlab_runner__additional_groups) }}): can only concatenate str (not "list") to str'
```

It does not appear to be an issue on ansible 2.10 with Jinja2 2.11 (in
Debian Bullseye).