### PR TITLE
Update OpenSearch to 2.2.1, fix permission issue

### DIFF
--- a/ansible/roles/opensearch/defaults/main.yml
+++ b/ansible/roles/opensearch/defaults/main.yml
@@ -22,7 +22,7 @@
 # .. envvar:: opensearch__version [[[
 #
 # The OpenSearch version to install.
-opensearch__version: '2.2.0'
+opensearch__version: '2.2.1'
 
                                                                    # ]]]
 # .. envvar:: opensearch__tarball [[[

--- a/ansible/roles/opensearch/meta/watch-opensearch
+++ b/ansible/roles/opensearch/meta/watch-opensearch
@@ -4,7 +4,7 @@
 
 # Role: opensearch
 # Package: opensearch
-# Version: 2.2.0
+# Version: 2.2.1
 
 version=4
 https://github.com/opensearch-project/OpenSearch/tags \/opensearch-project\/OpenSearch\/releases\/tag\/(\d+\.\d+\.\d+)

--- a/ansible/roles/opensearch/tasks/main.yml
+++ b/ansible/roles/opensearch/tasks/main.yml
@@ -7,7 +7,7 @@
   ansible.builtin.import_role:
     name: 'global_handlers'
 
-- name: Create directories
+- name: Create data directories
   ansible.builtin.file:
     path: '{{ item }}'
     state: 'directory'
@@ -15,7 +15,6 @@
     group: '{{ opensearch__group }}'
     mode: '0750'
   loop:
-    - '/etc/opensearch'
     - '/var/local/opensearch'
     - '/var/log/opensearch'
 
@@ -61,7 +60,7 @@
         remote_src: True
         owner: 'root'
         group: 'root'
-        mode: 'u=rwX,g=rX,o=rX'
+        mode: '0755'
         extra_opts:
           - '--strip-components=1'
       notify: [ 'Refresh host facts', 'Restart opensearch' ]
@@ -71,15 +70,15 @@
         src: '{{ opensearch__installation_directory }}/config/'
         dest: '/etc/opensearch'
         remote_src: True
-        owner: 'root'
+        owner: '{{ opensearch__user }}'
         group: '{{ opensearch__group }}'
-        mode: '0640'
+        mode: '0755'
 
 - name: Configure OpenSearch and the JVM
   ansible.builtin.template:
     src: 'etc/opensearch/{{ item }}.j2'
     dest: '/etc/opensearch/{{ item }}'
-    owner: 'root'
+    owner: '{{ opensearch__user }}'
     group: '{{ opensearch__group }}'
     mode: '0640'
   loop:
@@ -103,8 +102,6 @@
   ansible.builtin.template:
     src: 'etc/systemd/system/opensearch.service.j2'
     dest: '/etc/systemd/system/opensearch.service'
-    owner: 'root'
-    group: 'root'
     mode: '0644'
   notify: [ 'Reload service manager' ]
 
@@ -112,16 +109,12 @@
   ansible.builtin.file:
     path: '/etc/ansible/facts.d'
     state: 'directory'
-    owner: 'root'
-    group: 'root'
     mode: '0755'
 
 - name: Save local facts
   ansible.builtin.template:
     src: 'etc/ansible/facts.d/opensearch.fact.j2'
     dest: '/etc/ansible/facts.d/opensearch.fact'
-    owner: 'root'
-    group: 'root'
     mode: '0755'
   notify: [ 'Refresh host facts' ]
   tags: [ 'meta::facts' ]


### PR DESCRIPTION
Update OpenSearch to 2.2.1

The /etc/opensearch directory permissions would be set to 0640 on every
update, which caused OpenSearch startup failures. This commit fixes that
issue and makes the applied ownership and permissions more visible.