### PR TITLE
pki: convert intermediate to PEM

### DIFF
--- a/ansible/roles/pki/files/usr/local/lib/pki/pki-realm
+++ b/ansible/roles/pki/files/usr/local/lib/pki/pki-realm
@@ -1071,8 +1071,8 @@ convert_der_to_pem () {
     local input_file="${1}"
 
     if [ -n "${input_file}" ] && [ -r "${input_file}" ] ; then
-        if ! openssl x509 -in "${input_file}" -noout 2>/dev/null ; then
-            openssl x509 -inform DER -in "${input_file}" -out "${input_file}.tmp"
+        if ! openssl x509 -inform PEM -in "${input_file}" -noout 2>/dev/null ; then
+            openssl x509 -in "${input_file}" -outform PEM -out "${input_file}.tmp"
             mv "${input_file}.tmp" "${input_file}"
         fi
     fi


### PR DESCRIPTION
The pki-realm script tried to convert the intermediate certificate by running openssl to see whether it could read the file. Ubuntu's OpenSSL 3.0.2 15 Mar 2022 (Library: OpenSSL 3.0.2 15 Mar 2022) will happily read a DER file, though, and thus, the test passes which causes the conversion to be skipped.

This change explicitly requests openssl to read a PEM format. If that fails, the conversion will be pursued.