### PR TITLE
Add log-driver to docker_server

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,6 +47,9 @@ New DebOps roles
 - The :ref:`debops.miniflux` role can install and manage Miniflux, a web-based,
   minimalistic feed reader written in Go.
 
+- The :ref:`debops.docker_server` role can now directly handle the daemon
+  log-driver parameter.
+
 General
 '''''''
 

--- a/ansible/roles/docker_server/defaults/main.yml
+++ b/ansible/roles/docker_server/defaults/main.yml
@@ -375,6 +375,13 @@ docker_server__storage_driver: '{{ ansible_local.docker_server.storage_driver
 docker_server__storage_options: {}
 
                                                                    # ]]]
+# .. envvar:: docker_server__log_driver [[[
+#
+# Log driver for Docker volumes (default: "json-file").
+docker_server__log_driver: '{{ ansible_local.docker_server.log_driver
+                                    | d("json-file") }}'
+
+                                                                   # ]]]
 # .. envvar:: docker_server__custom_daemon_options [[[
 #
 # Allows passing of arbitrary/unsupported configuration options to

--- a/ansible/roles/docker_server/templates/etc/docker/daemon.json.j2
+++ b/ansible/roles/docker_server/templates/etc/docker/daemon.json.j2
@@ -62,6 +62,9 @@
 {%-   endfor %}
 {%    set _ = docker_server__tpl_options.update({"labels": docker_server__tpl_labels}) %}
 {%- endif %}
+{%  if docker_server__log_driver | d() -%}
+{%    set _ = docker_server__tpl_options.update({"log-driver": docker_server__log_driver}) %}
+{%- endif %}
 {%  if docker_server__storage_driver | d() -%}
 {%    set _ = docker_server__tpl_options.update({"storage-driver": docker_server__storage_driver}) %}
 {%- endif %}


### PR DESCRIPTION
Quick and dirty addition so that "none" can be specified as the log-driver in an easy way, like for the storage option.

