### PR TITLE
Add ansible.netcommon to requirements

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -8,6 +8,7 @@
 # detect it correctly.
 
 collections:
+  - 'ansible.netcommon'
   - 'ansible.posix'
   - 'community.crypto'
   - 'community.general'


### PR DESCRIPTION
I've just had an incident where hosts file templating failed because ansible.netcommon wasn't available in my environment. This dependency appears to be missing from requirements.yml so those installing direct from git will be left without.
As in #2067, 'ansible.utils.ipaddr' appears to be recommended now but I'm unsure if there are compatibility reasons for remaining with netcommon which would preclude changing dependency.