### PR TITLE
[ifupdown] Fix mismerge from cherry-pick

### DIFF
--- a/ansible/roles/ifupdown/templates/etc/network/interfaces.d/iface.j2
+++ b/ansible/roles/ifupdown/templates/etc/network/interfaces.d/iface.j2
@@ -11,6 +11,7 @@
 {% set ifupdown__tpl_addresses = [] %}
 {% set ifupdown__tpl_ipv4_addresses = [] %}
 {% set ifupdown__tpl_ipv6_addresses = [] %}
+{% if interface.no_addresses is undefined or not interface.no_addresses|bool %}
 {%   set ifupdown__tpl_addresses = (debops__tpl_macros.flattened(interface.address, interface.addresses) | from_yaml) | unique %}
 {%   set ifupdown__tpl_ipv4_addresses = ifupdown__tpl_addresses | ipv4 %}
 {%   set ifupdown__tpl_ipv6_addresses = ifupdown__tpl_addresses | ipv6 %}


### PR DESCRIPTION
When cherry-picking 8d23f1e7143732ae8d3ae873113feb22e47a8ec7 with 437cc2ee76a5bce192ecbb53515bbbc15097dde3 one line in iface.j2 was removed which should not have been removed.