### PR TITLE
[python] Allow overriding /etc/pip.conf template

### DIFF
--- a/ansible/roles/python/tasks/main.yml
+++ b/ansible/roles/python/tasks/main.yml
@@ -34,7 +34,7 @@
 
 - name: Generate pip configuration
   ansible.builtin.template:
-    src: 'etc/pip.conf.j2'
+    src: '{{ lookup("debops.debops.template_src", "etc/pip.conf.j2") }}'
     dest: '/etc/pip.conf'
     mode: '0644'
 


### PR DESCRIPTION
In our environment we need a custom /etc/pip.conf 

This change would allow us to use a custom template without modifying the default DebOps roles