### PR TITLE
[Stable-2.3] Fix two missing conversions to string

### DIFF
--- a/ansible/roles/ferm/templates/etc/ferm/rules.d/rule.conf.j2
+++ b/ansible/roles/ferm/templates/etc/ferm/rules.d/rule.conf.j2
@@ -448,7 +448,7 @@
                          hashlimit-mode {{ config.hashlimit_mode | d("srcip") }}
                          hashlimit-name {{ config.hashlimit_name | d(config.name | d(rule_name)) }}
 {%       if config.hashlimit_expire is undefined or config.hashlimit_expire %}
-                         hashlimit-htable-expire {{ ((config.hashlimit_expire|d("1800")) | int * 1000) }}
+                         hashlimit-htable-expire {{ (((config.hashlimit_expire|d("1800")) | int * 1000) | string ) }}
 {%       endif %}
 {%       if ferm__tpl_config['hashlimit_target'] not in [ 'ACCEPT', 'DROP', 'REJECT', 'RETURN', 'NOP' ] %}
 {%         if config.include|d() %}

--- a/ansible/roles/sysctl/templates/etc/sysctl.d/parameters.conf.j2
+++ b/ansible/roles/sysctl/templates/etc/sysctl.d/parameters.conf.j2
@@ -11,7 +11,7 @@
 {%   elif not value | bool and value is not iterable %}
 {%     if value is not none %}
 {%       if value | int or value | string == '0' %}
-{{ value -}}
+{{ value | string -}}
 {%       else %}
 {{ '0' -}}
 {%       endif %}


### PR DESCRIPTION
These two missing conversions cause templating errors in my build

related traceback : https://pastebin.com/gh2QL3b5

(this is only one of the error, the other ones were similar

Note that I did not figure out why this breaks for me and not for others. Also note that I only tested on Stable-2.3 but other branches might have similar problems

Related-to: https://github.com/debops/debops/issues/2201
Related-to: https://github.com/debops/debops/pull/2212