### PR TITLE
[proc_hidepid] Optimise /etc/ansible/facts.d/proc_hidepid.fact for hosts joined to active-directory domain

### DIFF
--- a/ansible/roles/proc_hidepid/templates/etc/ansible/facts.d/proc_hidepid.fact.j2
+++ b/ansible/roles/proc_hidepid/templates/etc/ansible/facts.d/proc_hidepid.fact.j2
@@ -10,7 +10,7 @@
 from __future__ import print_function
 from json import dumps
 from pwd import getpwuid
-from grp import getgrall
+from grp import getgrgid
 from os import stat
 
 
@@ -44,9 +44,9 @@ with open('/proc/mounts', 'r') as mounts:
                             output['gid'] = option.split('=')[1]
 
 if output['gid']:
-    groups = getgrall()
-    for group in groups:
-        if str(group.gr_gid) == output['gid']:
-            output['group'] = group.gr_name
+    try:
+        output['group'] = getgrgid(output['gid']).gr_name
+    except KeyError:
+        pass
 
 print(dumps(output, sort_keys=True, indent=4))


### PR DESCRIPTION
Avoid retrieving all system groups which is very slow if the host is joined to a large AD domain, has winbindd running, and uses winbindd in /etc/nsswitch.conf. It can take several minutes depending on number of domain users. Like 4 minutes for 6k groups in AD.