### PR TITLE
Enable resources__files like in mount

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,6 +50,15 @@ New DebOps roles
 General
 '''''''
 
+:ref:`debops.mount` role
+'''''''''''''''''''''''''''''
+
+- The :ref:`debops.mount` role can now create a file with credentials before
+  trying to mount the network device.
+
+:ref:`debops.apache` role
+'''''''''''''''''''''''''''''
+
 - DebOps now includes a custom version of the
   ``community.general.apache2_module`` Ansible module, available as
   ``debops.debops.apache2_module``. The custom module includes a fixed

--- a/ansible/roles/mount/defaults/main.yml
+++ b/ansible/roles/mount/defaults/main.yml
@@ -98,6 +98,32 @@ mount__group_directories: []
 mount__host_directories: []
                                                                    # ]]]
                                                                    # ]]]
+# Manage custom files [[[
+# -----------------------
+
+# These variables can be used to create custom files that can be
+# hold credentials and be referenced in ``/etc/fstab``
+#
+# See :ref:`resources__ref_files` for more details.
+
+# .. envvar:: mount__files [[[
+#
+# Manage file contents on all hosts in Ansible inventory.
+mount__files: []
+
+                                                                   # ]]]
+# .. envvar:: mount__group_files [[[
+#
+# Manage file contents on hosts in a specific group in Ansible inventory.
+mount__group_files: []
+
+                                                                   # ]]]
+# .. envvar:: mount__host_files [[[
+#
+# Manage file contents on specific hosts in Ansible inventory.
+mount__host_files: []
+                                                                   # ]]]
+                                                                   # ]]]
 # Bind mounts [[[
 # ---------------
 

--- a/ansible/roles/mount/tasks/main.yml
+++ b/ansible/roles/mount/tasks/main.yml
@@ -40,6 +40,33 @@
          (((item.opts if (item.opts is string) else item.opts | join(','))
            if item.opts | d() else 'defaults') is match(".*x-systemd.automount.*")))
 
+# Manage custom files [[[1
+- name: Copy files to remote hosts
+  ansible.builtin.copy:
+    dest:     '{{ item.dest | d(item.path | d(item.name)) }}'
+    src:      '{{ item.src | d(omit) }}'
+    content:  '{{ item.content | d(omit) }}'
+    owner:    '{{ item.owner | d(omit) }}'
+    group:    '{{ item.group | d(omit) }}'
+    mode:     '{{ item.mode | d(omit) }}'
+    selevel:  '{{ item.selevel | d(omit) }}'
+    serole:   '{{ item.serole | d(omit) }}'
+    setype:   '{{ item.setype | d(omit) }}'
+    seuser:   '{{ item.seuser | d(omit) }}'
+    follow:   '{{ item.follow | d(omit) }}'
+    force:    '{{ item.force | d(omit) }}'
+    backup:   '{{ item.backup | d(omit) }}'
+    validate: '{{ item.validate | d(omit) }}'
+    remote_src: '{{ item.remote_src | d(omit) }}'
+    directory_mode: '{{ item.directory_mode | d(omit) }}'
+  loop: '{{ q("flattened", mount__files
+                           + mount__group_files
+                           + mount__host_files) }}'
+  when: (mount__enabled | bool and
+         (item.src | d() or item.content is defined) and
+         (item.dest | d() or item.path | d() or item.name | d()) and
+         (item.state | d('present') != 'absent'))
+
 - name: Manage device mounts
   ansible.posix.mount:
     src:    '{{ item.src }}'


### PR DESCRIPTION
Like discussed in chat, this PR enables the user to create a file before mount actually tries to mount anything.

Sample usage:
```
      mount__enabled: True
      mount__group_devices:
        - name: '/share'
          src:  '//nas-backup/foobar'
          fstype: 'cifs'
          opts: [ "rw", "_netdev", "x-systemd.automount", "credentials=/etc/cifs.credentials" ]

      mount__group_files:
        - dest: "/etc/cifs.credentials"
          mode: "0600"
          content: |
            username=foobar
            password=secret1234
```
