### PR TITLE
chore(command/shell): remove warn removed in Ansible 7

### DIFF
--- a/ansible/roles/apparmor/tasks/main.yml
+++ b/ansible/roles/apparmor/tasks/main.yml
@@ -151,8 +151,6 @@
 
 - name: Unload AppArmor profiles
   ansible.builtin.command: service apparmor teardown
-  args:
-    warn: False
   when: (not (apparmor__enabled | d() | bool))
 
 - name: Ensure AppArmor service is stopped

--- a/ansible/roles/apt_cacher_ng/tasks/main.yml
+++ b/ansible/roles/apt_cacher_ng/tasks/main.yml
@@ -77,7 +77,6 @@
     find . -type f -exec chmod {{ apt_cacher_ng__file_perms }} {} \;
   args:
     chdir: '{{ apt_cacher_ng__cache_dir }}'
-    warn: False
   when: (apt_cacher_ng__deploy_state == 'present' and
          (apt_cacher_ng__cache_dir_enforce_permissions == "strict" or
           (apt_cacher_ng__cache_dir_enforce_permissions == "lazy" and

--- a/ansible/roles/cryptsetup/tasks/manage_devices.yml
+++ b/ansible/roles/cryptsetup/tasks/manage_devices.yml
@@ -305,7 +305,6 @@
                                + item.0.name + "_header_backup.raw") | quote }}
   args:
     executable: 'bash'
-    warn: False
   changed_when: False
   when: ((item.0.backup_header | d(cryptsetup__header_backup) | bool) and
           item.0.state | d(cryptsetup__state) in ['mounted', 'ansible_controller_mounted', 'unmounted', 'present'] and

--- a/ansible/roles/dokuwiki/tasks/main.yml
+++ b/ansible/roles/dokuwiki/tasks/main.yml
@@ -81,7 +81,6 @@
   ansible.builtin.command: git rev-parse {{ dokuwiki__git_version }}
   args:
     chdir: '{{ dokuwiki__git_dest }}'
-    warn: False
   become: True
   become_user: '{{ dokuwiki__user }}'
   register: dokuwiki__register_target_branch
@@ -93,7 +92,6 @@
   ansible.builtin.command: git checkout -f {{ dokuwiki__git_version }}
   args:
     chdir: '{{ dokuwiki__git_dest }}'
-    warn: False
   become: True
   become_user: '{{ dokuwiki__user }}'
   register: dokuwiki__register_checkout

--- a/ansible/roles/etesync/tasks/main.yml
+++ b/ansible/roles/etesync/tasks/main.yml
@@ -70,7 +70,6 @@
   ansible.builtin.shell: git verify-tag --raw "$(git describe)"
   args:
     chdir: '{{ etesync__git_checkout }}'
-    warn: False
   become: True
   become_user: '{{ etesync__user }}'
   changed_when: False

--- a/ansible/roles/etherpad/tasks/main.yml
+++ b/ansible/roles/etherpad/tasks/main.yml
@@ -100,7 +100,6 @@
   ansible.builtin.command: 'git checkout --force {{ etherpad_version }}'  # noqa no-handler
   args:
     chdir: '{{ etherpad_src_dir + "/" + etherpad_repository }}'
-    warn: False
   environment:
     GIT_WORK_TREE: '{{ etherpad_home + "/" + etherpad_repository }}'
   become: True

--- a/ansible/roles/hashicorp/tasks/main.yml
+++ b/ansible/roles/hashicorp/tasks/main.yml
@@ -229,7 +229,6 @@
          {{ hashicorp__lib + "/" + item + "/" + hashicorp__combined_version_map[item] + "/web_ui/" }}
          {{ hashicorp__consul_webui_path }} && chown -R root:root {{ hashicorp__consul_webui_path }}'
   args:  # noqa no-handler
-    warn: False
   with_items: '{{ (hashicorp__applications + hashicorp__dependent_applications) | unique }}'
   when: (hashicorp__consul_webui | bool and item == 'consul' and hashicorp__register_unpack_webui is changed)
 

--- a/ansible/roles/netbox/tasks/main.yml
+++ b/ansible/roles/netbox/tasks/main.yml
@@ -102,7 +102,6 @@
   ansible.builtin.command: git rev-parse {{ netbox__git_version }}
   args:
     chdir: '{{ netbox__git_dest }}'
-    warn: False
   become: True
   become_user: '{{ netbox__user }}'
   register: netbox__register_target_branch
@@ -114,7 +113,6 @@
   ansible.builtin.command: git checkout -f {{ netbox__git_version }}
   args:
     chdir: '{{ netbox__git_dest }}'
-    warn: False
   become: True
   become_user: '{{ netbox__user }}'
   register: netbox__register_checkout

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -233,7 +233,6 @@
   args:
     executable: 'sh'
     creates: '/etc/ansible/facts.d/nginx.fact'
-    warn: False
   when: (nginx__deploy_state in ['present', 'config'])
 
 - name: Configure htpasswd files

--- a/ansible/roles/owncloud/tasks/tarball.yml
+++ b/ansible/roles/owncloud/tasks/tarball.yml
@@ -55,7 +55,6 @@
              | sed --silent 's/.*href="nextcloud-\({{ owncloud__release | regex_escape() }}[^"]\+\).zip.asc".*/\1/p'
              | sort --version-sort --reverse
       args:
-        warn: False
         executable: 'sh'
       register: owncloud__register_full_version
       changed_when: False

--- a/ansible/roles/phpipam/tasks/phpipam.yml
+++ b/ansible/roles/phpipam/tasks/phpipam.yml
@@ -69,7 +69,6 @@
   ansible.builtin.command: git rev-parse {{ phpipam__git_version }}
   args:
     chdir: '{{ phpipam__git_dest }}'
-    warn: False
   become: True
   become_user: '{{ phpipam__user }}'
   register: phpipam__register_target_branch
@@ -81,7 +80,6 @@
   ansible.builtin.command: git checkout -f {{ phpipam__git_version }}
   args:
     chdir: '{{ phpipam__git_dest }}'
-    warn: False
   become: True
   become_user: '{{ phpipam__user }}'
   register: phpipam__register_checkout

--- a/ansible/roles/postgresql_server/tasks/manage_clusters.yml
+++ b/ansible/roles/postgresql_server/tasks/manage_clusters.yml
@@ -7,7 +7,6 @@
   ansible.builtin.shell: set -o nounset -o pipefail -o errexit && mount | grep /dev/shm || true
   args:
     executable: 'bash'
-    warn: False
   register: postgresql_server__register_shm
   changed_when: False
   check_mode: False

--- a/ansible/roles/rails_deploy/tasks/deploy_keys.yml
+++ b/ansible/roles/rails_deploy/tasks/deploy_keys.yml
@@ -25,7 +25,6 @@
                  --data '{{ rails_deploy_key_data | to_nice_json }}'
                  https://api.github.com/repos/{{ rails_deploy_git_account }}/{{ rails_deploy_git_repo }}/keys"
   args:
-    warn: False
   changed_when: False
   when: rails_deploy_git_access_token and
         'file://' not in rails_deploy_git_location and
@@ -50,7 +49,6 @@
                  https://{{ rails_deploy_git_host }}/api/v3/projects/{{
                    rails_deploy_register_gitlab_response.json.id }}/keys"
   args:
-    warn: False
   changed_when: False
   register: foo
   when: rails_deploy_git_access_token and

--- a/ansible/roles/roundcube/tasks/main.yml
+++ b/ansible/roles/roundcube/tasks/main.yml
@@ -25,7 +25,6 @@
   ansible.builtin.command: sed -n "s/^define('RCMAIL_VERSION', '\(.*\)');/\1/p" \
            {{ roundcube__git_dest }}/program/include/iniset.php
   args:
-    warn: False
   changed_when: False
   failed_when: False
   register: roundcube__register_version

--- a/ansible/roles/rsnapshot/tasks/main.yml
+++ b/ansible/roles/rsnapshot/tasks/main.yml
@@ -65,7 +65,6 @@
   ansible.builtin.command: touch /root/.ssh/known_hosts
   args:
     creates: '/root/.ssh/known_hosts'
-    warn: False
 
 - name: Make sure that Ansible local facts directory exists
   ansible.builtin.file:

--- a/ansible/roles/sshd/tasks/main.yml
+++ b/ansible/roles/sshd/tasks/main.yml
@@ -178,7 +178,6 @@
   ansible.builtin.command: touch {{ sshd__known_hosts_file }}
   args:
     creates: '{{ sshd__known_hosts_file }}'
-    warn: False
   tags: [ 'role::sshd:known_hosts' ]
 
 - name: Get list of already scanned host fingerprints


### PR DESCRIPTION
This commit removes the `warn` argument that has been deprecated and was removed with Ansible 7.0.0, released 2022-11-22.

See:

* [Changelog](https://github.com/ansible-community/ansible-build-data/blob/main/7/CHANGELOG-v7.rst#ansible-core-5), look for “command/shell - remove deprecated `warn` module param”
* [PR](https://github.com/ansible/ansible/pull/77411)

I would appreciate this being released as 3.0.4 soon so that I can upgrade to Ansible 7.