### PR TITLE
Take avantage of Sphinx build cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@
 # Use the Bash shell by default
 SHELL := /bin/bash
 
+SPHINXFLAGS ?= -n -W
+
 .PHONY: all
 all: help
 
@@ -157,7 +159,7 @@ check-versions:
 .PHONY: test-docs
 test-docs:
 	@printf "%s\n" "Testing HTML documentation generation..."
-	@cd docs && sphinx-build -n -W -b html -d _build/doctrees . _build/html
+	@cd docs && sphinx-build $(SPHINXFLAGS) -b html -d _build/doctrees . _build/html
 
 .PHONY: test-man
 test-man:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,6 +48,17 @@ for element in os.listdir(rst_ansible_roles):
                             print("Creation of the directory %s failed"
                                   % defaults_dir)
 
+                    # Only rebuild files that have changed, thus
+                    # taking avantage of the sphinx cache
+                    dst_file = (
+                            os.path.splitext(defaults_file)[0] + '.rst'
+                        ).lstrip('../')
+                    if os.path.exists(dst_file):
+                        src_stat = os.stat(defaults_file)
+                        dst_stat = os.stat(dst_file)
+                        if dst_stat.st_mtime_ns >= src_stat.st_mtime_ns:
+                            continue
+
                     yaml2rst.convert_file(
                         defaults_file,
                         (os.path.splitext(defaults_file)[0]


### PR DESCRIPTION
Enables a user to `export SPHINXFLAGS` to any value and then build without blocking on errors for example, while retaining the default behavior is `SPHINXFLAGS` is unset

The cache is no longer forcibly re-created and will compare modified times of files before rebuilding the rst (from yaml)
