### PR TITLE
Remove warn argument from command and shell module

### DIFF
--- a/ansible/roles/apparmor/tasks/main.yml
+++ b/ansible/roles/apparmor/tasks/main.yml
@@ -150,9 +150,7 @@
   when: apparmor__fact_apparmor_enabled_and_loaded | bool and apparmor__register_tunables is changed
 
 - name: Unload AppArmor profiles
-  ansible.builtin.command: service apparmor teardown
-  args:
-    warn: False
+  ansible.builtin.command: service apparmor teardown  # noqa command-instead-of-module
   when: (not (apparmor__enabled | d() | bool))
 
 - name: Ensure AppArmor service is stopped

--- a/ansible/roles/apt_cacher_ng/tasks/main.yml
+++ b/ansible/roles/apt_cacher_ng/tasks/main.yml
@@ -70,14 +70,13 @@
          apt_cacher_ng__cache_dir_enforce_permissions == 'lazy')
 
 # Note: doing this using native Ansible tasks is too slow
-- name: Change cache directory permissions
+- name: Change cache directory permissions  # noqa deprecated-command-syntax
   ansible.builtin.shell: |
     chown --recursive {{ apt_cacher_ng__cache_dir_owner }}:{{ apt_cacher_ng__cache_dir_group }} .
     find . -type d -exec chmod {{ apt_cacher_ng__dir_perms }} {} \;
     find . -type f -exec chmod {{ apt_cacher_ng__file_perms }} {} \;
   args:
     chdir: '{{ apt_cacher_ng__cache_dir }}'
-    warn: False
   when: (apt_cacher_ng__deploy_state == 'present' and
          (apt_cacher_ng__cache_dir_enforce_permissions == "strict" or
           (apt_cacher_ng__cache_dir_enforce_permissions == "lazy" and

--- a/ansible/roles/cryptsetup/tasks/manage_devices.yml
+++ b/ansible/roles/cryptsetup/tasks/manage_devices.yml
@@ -305,7 +305,6 @@
                                + item.0.name + "_header_backup.raw") | quote }}
   args:
     executable: 'bash'
-    warn: False
   changed_when: False
   when: ((item.0.backup_header | d(cryptsetup__header_backup) | bool) and
           item.0.state | d(cryptsetup__state) in ['mounted', 'ansible_controller_mounted', 'unmounted', 'present'] and

--- a/ansible/roles/dokuwiki/tasks/main.yml
+++ b/ansible/roles/dokuwiki/tasks/main.yml
@@ -78,10 +78,9 @@
 - name: Get commit hash of target checkout
   environment:
     GIT_WORK_TREE: '{{ dokuwiki__git_checkout }}'
-  ansible.builtin.command: git rev-parse {{ dokuwiki__git_version }}
+  ansible.builtin.command: git rev-parse {{ dokuwiki__git_version }}  # noqa command-instead-of-module
   args:
     chdir: '{{ dokuwiki__git_dest }}'
-    warn: False
   become: True
   become_user: '{{ dokuwiki__user }}'
   register: dokuwiki__register_target_branch
@@ -90,10 +89,9 @@
 - name: Checkout DokuWiki
   environment:
     GIT_WORK_TREE: '{{ dokuwiki__git_checkout }}'
-  ansible.builtin.command: git checkout -f {{ dokuwiki__git_version }}
+  ansible.builtin.command: git checkout -f {{ dokuwiki__git_version }}   # noqa command-instead-of-module
   args:
     chdir: '{{ dokuwiki__git_dest }}'
-    warn: False
   become: True
   become_user: '{{ dokuwiki__user }}'
   register: dokuwiki__register_checkout

--- a/ansible/roles/etesync/tasks/main.yml
+++ b/ansible/roles/etesync/tasks/main.yml
@@ -67,10 +67,9 @@
   register: etesync__register_source
 
 - name: Verify git tag signature
-  ansible.builtin.shell: git verify-tag --raw "$(git describe)"
+  ansible.builtin.shell: git verify-tag --raw "$(git describe)"  # noqa command-instead-of-module
   args:
     chdir: '{{ etesync__git_checkout }}'
-    warn: False
   become: True
   become_user: '{{ etesync__user }}'
   changed_when: False

--- a/ansible/roles/etherpad/tasks/main.yml
+++ b/ansible/roles/etherpad/tasks/main.yml
@@ -97,10 +97,9 @@
   tags: [ 'role::etherpad:source' ]
 
 - name: Checkout Etherpad
-  ansible.builtin.command: 'git checkout --force {{ etherpad_version }}'  # noqa no-handler
+  ansible.builtin.command: 'git checkout --force {{ etherpad_version }}'  # noqa no-handler command-instead-of-module
   args:
     chdir: '{{ etherpad_src_dir + "/" + etherpad_repository }}'
-    warn: False
   environment:
     GIT_WORK_TREE: '{{ etherpad_home + "/" + etherpad_repository }}'
   become: True

--- a/ansible/roles/hashicorp/tasks/main.yml
+++ b/ansible/roles/hashicorp/tasks/main.yml
@@ -224,12 +224,10 @@
             (ansible_local.hashicorp.applications[item.0] != hashicorp__combined_version_map[item.0]))))))
   tags: [ 'role::hashicorp:install' ]
 
-- name: Synchronize Consul Web UI public directory
+- name: Synchronize Consul Web UI public directory  # noqa command-instead-of-module
   ansible.builtin.shell: 'rsync --delete --recursive --prune-empty-dirs
          {{ hashicorp__lib + "/" + item + "/" + hashicorp__combined_version_map[item] + "/web_ui/" }}
          {{ hashicorp__consul_webui_path }} && chown -R root:root {{ hashicorp__consul_webui_path }}'
-  args:  # noqa no-handler
-    warn: False
   with_items: '{{ (hashicorp__applications + hashicorp__dependent_applications) | unique }}'
   when: (hashicorp__consul_webui | bool and item == 'consul' and hashicorp__register_unpack_webui is changed)
 

--- a/ansible/roles/netbox/tasks/main.yml
+++ b/ansible/roles/netbox/tasks/main.yml
@@ -99,10 +99,9 @@
 - name: Get commit hash of target checkout
   environment:
     GIT_WORK_TREE: '{{ netbox__git_checkout }}'
-  ansible.builtin.command: git rev-parse {{ netbox__git_version }}
+  ansible.builtin.command: git rev-parse {{ netbox__git_version }}  # noqa command-instead-of-module
   args:
     chdir: '{{ netbox__git_dest }}'
-    warn: False
   become: True
   become_user: '{{ netbox__user }}'
   register: netbox__register_target_branch
@@ -111,10 +110,9 @@
 - name: Checkout NetBox
   environment:  # noqa no-handler
     GIT_WORK_TREE: '{{ netbox__git_checkout }}'
-  ansible.builtin.command: git checkout -f {{ netbox__git_version }}
+  ansible.builtin.command: git checkout -f {{ netbox__git_version }}  # noqa command-instead-of-module
   args:
     chdir: '{{ netbox__git_dest }}'
-    warn: False
   become: True
   become_user: '{{ netbox__user }}'
   register: netbox__register_checkout

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -229,11 +229,10 @@
   # is being reset and move all symlinks out of the way to prevent
   # accidental failures because of old wrong configuration files
 - name: Remove all configuration symlinks during config reset
-  ansible.builtin.shell: rm -f /etc/nginx/sites-enabled/*
+  ansible.builtin.shell: rm -f /etc/nginx/sites-enabled/*  # noqa deprecated-command-syntax
   args:
     executable: 'sh'
     creates: '/etc/ansible/facts.d/nginx.fact'
-    warn: False
   when: (nginx__deploy_state in ['present', 'config'])
 
 - name: Configure htpasswd files

--- a/ansible/roles/owncloud/tasks/tarball.yml
+++ b/ansible/roles/owncloud/tasks/tarball.yml
@@ -50,12 +50,11 @@
 
     # Get latest patch version for release [[[2
 
-    - name: Query for the full version string of the current release
+    - name: Query for the full version string of the current release  # noqa command-instead-of-module
       ansible.builtin.shell: curl -s -m 900 {{ (owncloud__variant_download_url_map[owncloud__variant] + "/") | quote }}
              | sed --silent 's/.*href="nextcloud-\({{ owncloud__release | regex_escape() }}[^"]\+\).zip.asc".*/\1/p'
              | sort --version-sort --reverse
       args:
-        warn: False
         executable: 'sh'
       register: owncloud__register_full_version
       changed_when: False

--- a/ansible/roles/phpipam/tasks/phpipam.yml
+++ b/ansible/roles/phpipam/tasks/phpipam.yml
@@ -66,10 +66,9 @@
 - name: Get commit hash of target checkout
   environment:
     GIT_WORK_TREE: '{{ phpipam__git_checkout }}'
-  ansible.builtin.command: git rev-parse {{ phpipam__git_version }}
+  ansible.builtin.command: git rev-parse {{ phpipam__git_version }}  # noqa command-instead-of-module
   args:
     chdir: '{{ phpipam__git_dest }}'
-    warn: False
   become: True
   become_user: '{{ phpipam__user }}'
   register: phpipam__register_target_branch
@@ -78,10 +77,9 @@
 - name: Checkout phpIPAM
   environment:
     GIT_WORK_TREE: '{{ phpipam__git_checkout }}'
-  ansible.builtin.command: git checkout -f {{ phpipam__git_version }}
+  ansible.builtin.command: git checkout -f {{ phpipam__git_version }}  # noqa command-instead-of-module
   args:
     chdir: '{{ phpipam__git_dest }}'
-    warn: False
   become: True
   become_user: '{{ phpipam__user }}'
   register: phpipam__register_checkout

--- a/ansible/roles/postgresql_server/tasks/manage_clusters.yml
+++ b/ansible/roles/postgresql_server/tasks/manage_clusters.yml
@@ -7,7 +7,6 @@
   ansible.builtin.shell: set -o nounset -o pipefail -o errexit && mount | grep /dev/shm || true
   args:
     executable: 'bash'
-    warn: False
   register: postgresql_server__register_shm
   changed_when: False
   check_mode: False

--- a/ansible/roles/rails_deploy/tasks/deploy_keys.yml
+++ b/ansible/roles/rails_deploy/tasks/deploy_keys.yml
@@ -20,12 +20,10 @@
         rails_deploy_register_deploy_key is defined
 
   # FIXME: Use a proper Ansible module instead of the 'command' module
-- name: Transfer the deploy key to Github
+- name: Transfer the deploy key to Github  # noqa command-instead-of-module
   ansible.builtin.command: "curl --silent --header 'Authorization: token {{ rails_deploy_git_access_token }}'
                  --data '{{ rails_deploy_key_data | to_nice_json }}'
                  https://api.github.com/repos/{{ rails_deploy_git_account }}/{{ rails_deploy_git_repo }}/keys"
-  args:
-    warn: False
   changed_when: False
   when: rails_deploy_git_access_token and
         'file://' not in rails_deploy_git_location and
@@ -44,13 +42,11 @@
         not 'github' in rails_deploy_git_host
 
   # FIXME: Use a proper Ansible module instead of the 'command' module
-- name: Transfer the deploy key to Gitlab
+- name: Transfer the deploy key to Gitlab  # noqa command-instead-of-module
   ansible.builtin.command: "curl --insecure --header 'PRIVATE-TOKEN: {{ rails_deploy_git_access_token }}'
                  --data '{{ rails_deploy_key_data | to_nice_json }}'
                  https://{{ rails_deploy_git_host }}/api/v3/projects/{{
                    rails_deploy_register_gitlab_response.json.id }}/keys"
-  args:
-    warn: False
   changed_when: False
   register: foo
   when: rails_deploy_git_access_token and

--- a/ansible/roles/roundcube/tasks/main.yml
+++ b/ansible/roles/roundcube/tasks/main.yml
@@ -21,11 +21,9 @@
 
 # ---- Environment ----
 
-- name: Get version of current Roundcube installation
+- name: Get version of current Roundcube installation  # noqa command-instead-of-module
   ansible.builtin.command: sed -n "s/^define('RCMAIL_VERSION', '\(.*\)');/\1/p" \
            {{ roundcube__git_dest }}/program/include/iniset.php
-  args:
-    warn: False
   changed_when: False
   failed_when: False
   register: roundcube__register_version

--- a/ansible/roles/rsnapshot/tasks/main.yml
+++ b/ansible/roles/rsnapshot/tasks/main.yml
@@ -65,7 +65,6 @@
   ansible.builtin.command: touch /root/.ssh/known_hosts
   args:
     creates: '/root/.ssh/known_hosts'
-    warn: False
 
 - name: Make sure that Ansible local facts directory exists
   ansible.builtin.file:

--- a/ansible/roles/sshd/tasks/main.yml
+++ b/ansible/roles/sshd/tasks/main.yml
@@ -178,7 +178,6 @@
   ansible.builtin.command: touch {{ sshd__known_hosts_file }}
   args:
     creates: '{{ sshd__known_hosts_file }}'
-    warn: False
   tags: [ 'role::sshd:known_hosts' ]
 
 - name: Get list of already scanned host fingerprints


### PR DESCRIPTION
The `warn` argument to the command and shell modules was deprecated in Ansible 2.11 and removed in 2.14. This argument is no longer needed as no warnings are issued anymore if these modules are used in ways which could be replaced by an Ansible module. For cases where ansible-lint reports an error without the argument, appropriate `noqa` comments are added.

See https://github.com/ansible/ansible/pull/70504.