### PR TITLE
feat(netbox): Upgrade from NetBox v3.3.8 to v3.4.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -137,7 +137,7 @@ Updates of upstream application versions
   updated to the next point release as well, 11.4.
 
 - In the :ref:`debops.netbox` role, the NetBox version has been updated to
-  ``v3.3.8``.
+  ``v3.4.2``.
 
 - In the :ref:`debops.owncloud` role, the ownCloud support has been updated to
   ``v10.10``.

--- a/ansible/roles/netbox/defaults/main.yml
+++ b/ansible/roles/netbox/defaults/main.yml
@@ -143,7 +143,7 @@ netbox__git_repo: 'https://github.com/netbox-community/netbox.git'
 # .. envvar:: netbox__git_version [[[
 #
 # The :command:`git` branch or tag which will be installed.
-netbox__git_version: 'v3.3.8'
+netbox__git_version: 'v3.4.2'
 
                                                                    # ]]]
 # .. envvar:: netbox__git_dest [[[

--- a/ansible/roles/netbox/meta/watch-netbox
+++ b/ansible/roles/netbox/meta/watch-netbox
@@ -4,7 +4,7 @@
 
 # Role: netbox
 # Package: netbox
-# Version: 3.3.8
+# Version: 3.4.2
 
 version=4
 https://github.com/netbox-community/netbox/tags .*/v?(\d\S+)\.tar\.gz


### PR DESCRIPTION
No other changes are needed. I checked all the release notes and even gone though this in the NetBox git repo:

```Shell
git wd 'v3.3.8..v3.4.2' -- upgrade.sh netbox/netbox/configuration.example.py docs
```

to stay up-to-date.

I first thought the new search feature would use something like Elasticsearch but that was only my own bias. It uses a single database table and works great from my bit of testing.