### PR TITLE
[ntp] Do not purge any ntp daemon if ntp support is not enabled

### DIFF
--- a/ansible/roles/ntp/tasks/main.yml
+++ b/ansible/roles/ntp/tasks/main.yml
@@ -19,6 +19,7 @@
     purge: True
   register: ntp__register_apt_purge
   until: ntp__register_apt_purge is succeeded
+  when: ntp__daemon_enabled | bool
 
   # Installs either ntpdate, NTPd, chrony or OpenNTPd on all hosts except inside containers
 - name: Install NTP service


### PR DESCRIPTION
Allow leaving the current target ntpd daemon untouched if ntpd daemon support is not enabled.