### PR TITLE
[ci] Pin setuptools package to specific version

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Prepare test environment
         run: |
-          pip3 install --user --upgrade pip wheel setuptools
+          pip3 install --user --upgrade pip wheel "setuptools==65.7.0"
           pip3 install --user --upgrade reuse
 
       - name: Check codebase with REUSE linter
@@ -42,7 +42,7 @@ jobs:
         run: |
           sudo apt-get remove --purge -yq ansible
           sudo apt-get install python3-netaddr
-          pip3 install --upgrade pip wheel setuptools
+          pip3 install --upgrade pip wheel "setuptools==65.7.0"
           pip3 install --user --upgrade Jinja2 ansible ansible-lint
 
       - name: Verify playbook with ansible-lint
@@ -64,7 +64,7 @@ jobs:
       - name: Prepare test environment
         run: |
           sudo apt-get remove --purge -yq ansible
-          pip3 install --user --upgrade pip wheel setuptools
+          pip3 install --user --upgrade pip wheel "setuptools==65.7.0"
           pip3 install --user --upgrade Jinja2 ansible
 
       - name: Check playbook syntax with ansible-playbook
@@ -90,7 +90,7 @@ jobs:
           sudo apt-get -qq update
           sudo apt-get -yq install pandoc pandoc-data
           sudo apt-get remove --purge -yq ansible
-          pip3 install --user --upgrade pip wheel setuptools
+          pip3 install --user --upgrade pip wheel "setuptools==65.7.0"
           pip3 install --user --upgrade Jinja2 ansible ansible-lint yamllint galaxy-importer reuse
 
       - name: Build DebOps Collections for Ansible Galaxy
@@ -115,7 +115,7 @@ jobs:
 
       - name: Prepare test environment
         run: |
-          pip3 install --user --upgrade pip wheel setuptools
+          pip3 install --user --upgrade pip wheel "setuptools==65.7.0"
           pip3 install --user --upgrade yamllint
 
       - name: Check codebase with yamllint
@@ -136,7 +136,7 @@ jobs:
 
       - name: Prepare test environment
         run: |
-          pip3 install --user --upgrade pip wheel setuptools
+          pip3 install --user --upgrade pip wheel "setuptools==65.7.0"
           pip3 install --user --upgrade pycodestyle
 
       - name: Check codebase with pycodestyle
@@ -194,7 +194,7 @@ jobs:
         run: |
           sudo apt-get -qq update
           sudo apt-get -yq install python3-nose2
-          pip3 install --user --upgrade pip wheel setuptools pypandoc
+          pip3 install --user --upgrade pip wheel "setuptools==65.7.0" pypandoc
           pip3 install --user --upgrade cov-core future unittest2 pyyaml python-dotenv toml pyxdg jinja2
 
       - name: Run DebOps unit tests
@@ -220,7 +220,7 @@ jobs:
         run: |
           sudo apt-get -qq update
           sudo apt-get -yq install pandoc pandoc-data graphviz
-          pip3 install --user --upgrade pip wheel setuptools pypandoc
+          pip3 install --user --upgrade pip wheel "setuptools==65.7.0" pypandoc
           pip3 install --user --upgrade sphinx sphinx-autobuild sphinx_rtd_theme
 
       - name: Build DebOps Python wheel package
@@ -247,7 +247,7 @@ jobs:
         run: |
           sudo apt-get -qq update
           sudo apt-get -yq install pandoc pandoc-data graphviz
-          pip3 install --user --upgrade pip wheel setuptools pypandoc
+          pip3 install --user --upgrade pip wheel "setuptools==65.7.0" pypandoc
           pip3 install --user --upgrade sphinx sphinx-autobuild sphinx_rtd_theme
 
       - name: Build DebOps Python sdist package
@@ -272,7 +272,7 @@ jobs:
         run: |
           sudo apt-get -qq update
           sudo apt-get install -yq graphviz
-          pip3 install --user --upgrade pip wheel setuptools
+          pip3 install --user --upgrade pip wheel "setuptools==65.7.0"
           pip3 install --user --upgrade sphinx sphinx-autobuild sphinx_rtd-theme
 
       - name: Build documentation site

--- a/.github/workflows/prepare-ci-pipeline/action.yml
+++ b/.github/workflows/prepare-ci-pipeline/action.yml
@@ -18,7 +18,7 @@ runs:
       run: |
         sudo apt-get -qq update
         sudo apt-get remove --purge -yq ansible python python2.7 python2.7-minimal
-        pip3 install --user --upgrade pip wheel setuptools
+        pip3 install --user --upgrade pip wheel "setuptools==65.7.0"
         pip3 install --user --upgrade Jinja2 ansible
         pip3 install --user .
         debops-init ~/src/controller


### PR DESCRIPTION
The setuptools v66.0.0 package has removed support for legacy version strings that don't conform to PEP 440.

Due to a wrong version number used in 'python3-distro-info' and 'python-debian' Ubuntu packages, the installation of packages from PyPI is broken by the above change. To mitigate this before the Ubuntu packages are fixed, the 'setuptools' PyPI package will be installed using the latest known version to support legacy version numbers.

Ref: https://github.com/pypa/setuptools/issues/3772