### PR TITLE
New GPG keys for InfluxData repos.

### DIFF
--- a/ansible/roles/influxdata/defaults/main.yml
+++ b/ansible/roles/influxdata/defaults/main.yml
@@ -23,7 +23,8 @@
 # .. envvar:: influxdata__key_id [[[
 #
 # The fingerprint of the APT repository GPG key to configure.
-influxdata__key_id: '05CE 1508 5FC0 9D18 E99E FB22 684A 14CF 2582 E0C5'
+# from: https://portal.influxdata.com/downloads/
+influxdata__key_id: '9D53 9D90 D332 8DC7 D6C8 D3B9 D8FF 8E1F 7DF8 B07E'
 
                                                                    # ]]]
 # .. envvar:: influxdata__repository [[[


### PR DESCRIPTION
Current GPG key for InfluxData repositories. 

Important as previous one does not work anymore! 