### PR TITLE
Handle change in extrepo Enabled/Disabled sources file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -334,6 +334,9 @@ Fixed
 General
 '''''''
 
+- Extrepo facts file did not detect a disabled repository as being disabled
+  due to a change in the extrepo file format.
+
 - Ensure that the custom Ansible plugins included in DebOps are present in the
   Ansible Collection build from the DebOps repository.
 

--- a/ansible/roles/extrepo/templates/etc/ansible/facts.d/extrepo.fact.j2
+++ b/ansible/roles/extrepo/templates/etc/ansible/facts.d/extrepo.fact.j2
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (C) 2021 Maciej Delmanowski <drybjed@gmail.com>
-# Copyright (C) 2021 DebOps <https://debops.org/>
+# Copyright (C) 2021-2023 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 # {{ ansible_managed }}
@@ -33,14 +33,20 @@ except Exception:
 
 sources_path = '/etc/apt/sources.list.d'
 
-sources_files = [f for f in os.listdir(sources_path)
+sources_files = [sources_path + "/" + f for f in os.listdir(sources_path)
                  if os.path.isfile(os.path.join(sources_path, f))]
 
 sources = []
 
 for item in sources_files:
-    if item.startswith('extrepo_') and item.endswith('.sources'):
-        sources.append(item[8:-8])
+    with open(item, mode="r") as fd:
+        lines = fd.readlines()
+    # Missing, or 'Enabled: yes\n' means enabled
+    disabled = 'Enabled: no\n' in lines
+    if not disabled:
+        item = os.path.basename(item)
+        if item.startswith('extrepo_') and item.endswith('.sources'):
+            sources.append(item[8:-8])
 
 output['sources'] = sources
 


### PR DESCRIPTION
Extrepo facts file did not detect a disabled repository as being disabled
due to a change in the extrepo file format.
