### PR TITLE
[sshd] Fix typos in original configuration

### DIFF
--- a/ansible/roles/sshd/defaults/main.yml
+++ b/ansible/roles/sshd/defaults/main.yml
@@ -299,7 +299,7 @@ sshd__original_configuration:
     value: 'prohibit-password'
     state: 'init'
 
-  - name: 'StrictMode'
+  - name: 'StrictModes'
     value: True
     state: 'init'
 
@@ -372,7 +372,7 @@ sshd__original_configuration:
     value: True
     state: 'init'
 
-  - name: 'KerberosTicketClenaup'
+  - name: 'KerberosTicketCleanup'
     value: True
     state: 'init'
 


### PR DESCRIPTION
Both configuration options are not present, so the typos don't matter by default. Still good to avoid potential footguns though.