### PR TITLE
[icinga] Add remote DB functionality and SSL support

### DIFF
--- a/ansible/playbooks/service/icinga_db.yml
+++ b/ansible/playbooks/service/icinga_db.yml
@@ -15,5 +15,17 @@
 
   roles:
 
+    - role: mariadb
+      tags: [ 'role::mariadb', 'skip::mariadb' ]
+      mariadb__dependent_databases: '{{ icinga_db__mariadb__dependent_databases }}'
+      mariadb__dependent_users: '{{ icinga_db__mariadb__dependent_users }}'
+      when: (icinga_db__type == 'mariadb')
+
+    - role: postgresql
+      tags: [ 'role::postgresql', 'skip::postgresql' ]
+      postgresql__dependent_roles: '{{ icinga_db__postgresql__dependent_roles }}'
+      postgresql__dependent_databases: '{{ icinga_db__postgresql__dependent_databases }}'
+      when: (icinga_db__type == 'postgresql')
+
     - role: icinga_db
       tags: [ 'role::icinga_db', 'skip::icinga_db' ]

--- a/ansible/playbooks/service/icinga_db.yml
+++ b/ansible/playbooks/service/icinga_db.yml
@@ -1,6 +1,7 @@
 ---
 # Copyright (C) 2018 Maciej Delmanowski <drybjed@gmail.com>
-# Copyright (C) 2018 DebOps <https://debops.org/>
+# Copyright (C) 2020 Gabriel Lewertowski <gabriel.lewertowski@trust-in-soft.com>
+# Copyright (C) 2018-2023 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-only
 
 - name: Configure Icinga database
@@ -19,13 +20,13 @@
       tags: [ 'role::mariadb', 'skip::mariadb' ]
       mariadb__dependent_databases: '{{ icinga_db__mariadb__dependent_databases }}'
       mariadb__dependent_users: '{{ icinga_db__mariadb__dependent_users }}'
-      when: (icinga_db__type == 'mariadb')
+      when: icinga_db__type == 'mariadb'
 
     - role: postgresql
       tags: [ 'role::postgresql', 'skip::postgresql' ]
       postgresql__dependent_roles: '{{ icinga_db__postgresql__dependent_roles }}'
       postgresql__dependent_databases: '{{ icinga_db__postgresql__dependent_databases }}'
-      when: (icinga_db__type == 'postgresql')
+      when: icinga_db__type == 'postgresql'
 
     - role: icinga_db
       tags: [ 'role::icinga_db', 'skip::icinga_db' ]

--- a/ansible/playbooks/service/icinga_web.yml
+++ b/ansible/playbooks/service/icinga_web.yml
@@ -99,6 +99,8 @@
         - '{{ icinga_web__postgresql__dependent_groups }}'
       postgresql__dependent_databases:
         - '{{ icinga_web__postgresql__dependent_databases }}'
+      postgresql__dependent_privileges:
+        - '{{ icinga_web__postgresql__dependent_privileges }}'
       postgresql__dependent_extensions:
         - '{{ icinga_web__postgresql__dependent_extensions }}'
       when: icinga_web__database_type == 'postgresql'

--- a/ansible/roles/icinga_db/COPYRIGHT
+++ b/ansible/roles/icinga_db/COPYRIGHT
@@ -1,7 +1,9 @@
 debops.icinga_db - Manage Icinga 2 database using Ansible
 
 Copyright (C) 2018 Maciej Delmanowski <drybjed@gmail.com>
-Copyright (C) 2018 DebOps <https://debops.org/>
+Copyright (C) 2020 Gabriel Lewertowski <gabriel.lewertowski@trust-in-soft.com>
+Copyright (C) 2023 David Härdeman <david@hardeman.nu>
+Copyright (C) 2018-2023 DebOps <https://debops.org/>
 SPDX-License-Identifier: GPL-3.0-only
 
 This Ansible role is part of DebOps.

--- a/ansible/roles/icinga_db/defaults/main.yml
+++ b/ansible/roles/icinga_db/defaults/main.yml
@@ -55,6 +55,130 @@ icinga_db__feature: '{{ "ido-pgsql"
                         else ("ido-mysql"
                               if (icinga_db__type == "mariadb")
                               else "unknown") }}'
+
+                                                                   # ]]]
+
+# .. envvar:: icinga_db__dbconfigs [[[
+#
+# Debconf questions and answers for the icinga2-ido-pgsql and icinga2-ido-mysql
+# packages, to install these packages without user interaction.
+icinga_db__dbconfigs:
+
+  - question: 'icinga2-{{ icinga_db__feature }}/dbconfig-install'
+    vtype: 'boolean'
+    value: 'false'
+
+  - question: 'icinga2-{{ icinga_db__feature }}/dbconfig-upgrade'
+    vtype: 'boolean'
+    value: '{{ icinga_db__host == "localhost" }}'
+
+  - question: 'icinga2-{{ icinga_db__feature }}/enable'
+    vtype: 'boolean'
+    value: 'true'
+
+  - question: 'icinga2-{{ icinga_db__feature }}/remote/host'
+    vtype: 'string'
+    value: '{{ icinga_db__host }}'
+
+  - question: 'icinga2-{{ icinga_db__feature }}/remote/port'
+    vtype: 'string'
+    value: '{{ icinga_db__port }}'
+
+  - question: 'icinga2-{{ icinga_db__feature }}/db/dbname'
+    vtype: 'string'
+    value: '{{ icinga_db__database }}'
+
+  - question: 'icinga2-{{ icinga_db__feature }}/db/app-user'
+    vtype: 'string'
+    value: '{{ icinga_db__user }}'
+
+  - question: 'icinga2-{{ icinga_db__feature }}/{{ "pgsql"
+                                                   if icinga_db__type == "postgresql"
+                                                   else ("mysql" if icinga_db__type == "mariadb"
+                                                                 else "")}}/app-pass'
+    vtype: 'password'
+    value: '{{ icinga_db__password }}'
+
+                                                                   # ]]]
+                                                                   # ]]]
+
+# Database configuration [[[
+# --------------------------
+# .. envvar:: icinga_db__host [[[
+#
+# The host where the Icinga 2 database will be installed.
+icinga_db__host: '{{ ansible_local.postgresql.server
+                     if (ansible_local.postgresql.server|d() and
+                         icinga_db__type == "postgresql")
+                     else (ansible_local.mariadb.server
+                           if (ansible_local.mariadb.server|d() and
+                               icinga_db__type == "mariadb")
+                           else "localhost") }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_db__port [[[
+#
+# The port used to connect to the Icinga 2 database.
+icinga_db__port: '{{ ansible_local.postgresql.port
+                     if (ansible_local.postgresql.port|d() and
+                         icinga_db__type == "postgresql")
+                     else (ansible_local.mariadb.port
+                           if (ansible_local.mariadb.server|d() and
+                               icinga_db__type == "mariadb")
+                           else "unknown") }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_db__user [[[
+#
+# Name of the database user for Icinga 2.
+icinga_db__user: 'icinga2'
+
+                                                                   # ]]]
+# .. envvar:: icinga_db__database [[[
+#
+# Name of the database for Icinga 2.
+icinga_db__database: 'icinga2'
+
+                                                                   # ]]]
+# .. envvar:: icinga_db__password_path [[[
+#
+# Path to database password file located on the Ansible Controller. See the
+# :ref:`debops.secret` role for more details.
+icinga_db__password_path: '{{ secret + "/" + icinga_db__type + "/" +
+                                        ansible_local[icinga_db__type].delegate_to }}{%
+                                         if icinga_db__type == "postgresql" %}/{{ ansible_local[icinga_db__type].port }}{% endif
+                                        %}{{ "/credentials/" + icinga_db__user +
+                                        "/password" }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_db__password [[[
+#
+# Password of the Icinga 2 database user.
+icinga_db__password: "{{ lookup('password', icinga_db__password_path
+                                   + ' length=48 chars=ascii_letters,digits,.-_') }}"
+
+                                                                   # ]]]
+# .. envvar:: icinga_db__init [[[
+#
+# Should the Icinga 2 database be initialized ? Per default, it should be
+# initialized only the first time this role runs.
+icinga_db__init: '{{ False if ansible_local.icinga_db.configured|d()
+                           else True }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_db__postgresql_schema [[[
+#
+# Path on the host where this role runs of the PostgreSQL schema. This schema
+# is used to populate the database when it is created.
+icinga_db__postgresql_schema: '/usr/share/icinga2-ido-pgsql/schema/pgsql.sql'
+
+                                                                   # ]]]
+# .. envvar:: icinga_db__mariadb_schema [[[
+#
+# Path on the host where this role runs of the MariaDB schema. This schema
+# is used to populate the database when it is created.
+icinga_db__mariadb_schema: '/usr/share/icinga2-ido-mysql/schema/mysql.sql'
+
                                                                    # ]]]
                                                                    # ]]]
 # APT packages [[[
@@ -79,3 +203,40 @@ icinga_db__base_packages:
 icinga_db__packages: []
                                                                    # ]]]
                                                                    # ]]]
+
+# Configuration for other Ansible roles [[[
+# -----------------------------------------
+
+# .. envvar:: icinga_db__postgresql__dependent_roles [[[
+#
+# Configuration of PostgreSQL roles for :ref:`debops.postgresql` Ansible role.
+icinga_db__postgresql__dependent_roles:
+  - name: '{{ icinga_db__user }}'
+    password: '{{ icinga_db__password }}'
+    db: '{{ icinga_db__database }}'
+    priv: ['ALL']
+
+                                                                   # ]]]
+# .. envvar:: icinga_db__postgresql__dependent_databases [[[
+#
+# Configuration of PostgreSQL databases for the :ref:`debops.postgresql` Ansible
+# role.
+icinga_db__postgresql__dependent_databases:
+  - name: '{{ icinga_db__database }}'
+    owner: '{{ icinga_db__user }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_db__mariadb__dependent_users [[[
+#
+# Configuration of MariaDB users for :ref:`debops.mariadb` Ansible role.
+icinga_db__mariadb__dependent_users:
+  - name: '{{ icinga_db__user }}'
+    password: '{{ icinga_db__password }}'
+    database: '{{ icinga_db__database }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_db__mariadb__dependent_databases [[[
+#
+# Configuration of MariaDB databases for :ref:`debops.mariadb` Ansible role.
+icinga_db__mariadb__dependent_databases:
+  - name: '{{ icinga_db__database }}'

--- a/ansible/roles/icinga_db/defaults/main.yml
+++ b/ansible/roles/icinga_db/defaults/main.yml
@@ -2,7 +2,9 @@
 # .. vim: foldmarker=[[[,]]]:foldmethod=marker
 
 # .. Copyright (C) 2018 Maciej Delmanowski <drybjed@gmail.com>
-# .. Copyright (C) 2018 DebOps <https://debops.org/>
+# .. Copyright (C) 2020 Gabriel Lewertowski <gabriel.lewertowski@trust-in-soft.com>
+# .. Copyright (C) 2023 David Härdeman <david@hardeman.nu>
+# .. Copyright (C) 2018-2023 DebOps <https://debops.org/>
 # .. SPDX-License-Identifier: GPL-3.0-only
 
 # .. _icinga_db__ref_defaults:
@@ -27,128 +29,90 @@
 # You should install Icinga with the :ref:`debops.icinga` role before
 # configuring a database for it. The default DebOps playbook should do that
 # automatically if the main Icinga role is enabled on a host.
-icinga_db__icinga_installed: '{{ True
-                                 if (ansible_local | d() and ansible_local.icinga | d() and
-                                     (ansible_local.icinga.installed | d()) | bool)
-                                 else False }}'
+icinga_db__icinga_installed: '{{ ansible_local.icinga.installed | d(False) | bool }}'
 
                                                                    # ]]]
+                                                                   # ]]]
+# Database configuration [[[
+# --------------------------
 # .. envvar:: icinga_db__type [[[
 #
 # The database type to configure for Icinga 2, either PostgreSQL (preferred) or
 # MariaDB/MySQL. Debian installation supports only one database type at a time.
 icinga_db__type: '{{ ansible_local.icinga_db.type
-                     if (ansible_local.icinga_db.type | d())
-                     else ("postgresql"
-                           if (ansible_local | d() and ansible_local.postgresql is defined)
-                           else ("mariadb"
-                                 if (ansible_local | d() and ansible_local.mariadb is defined)
-                                 else "unknown")) }}'
+                     | d("postgresql" if ansible_local.postgresql is defined else "", true)
+                     | d("mariadb" if ansible_local.mariadb is defined else "", true) }}'
 
                                                                    # ]]]
-# .. envvar:: icinga_db__feature [[[
+# .. envvar:: icinga_db__database_map [[[
 #
-# Name of the IDO feature to enable for Icinga 2. This should correspond with
-# the selected database type.
-icinga_db__feature: '{{ "ido-pgsql"
-                        if (icinga_db__type == "postgresql")
-                        else ("ido-mysql"
-                              if (icinga_db__type == "mariadb")
-                              else "unknown") }}'
+# A map containing per-database settings for the Icinga 2 database.
+icinga_db__database_map:
+  postgresql:
+    ido:       'pgsql'
+    db_name:   'icinga2'
+    db_user:   'icinga2'
+    db_host:   '{{ ansible_local.postgresql.server | d("localhost") }}'
+    db_port:   '{{ ansible_local.postgresql.port | d(5432) }}'
+    db_schema: '/usr/share/icinga2-ido-pgsql/schema/pgsql.sql'
+    pw_path:   '{{ secret + "/postgresql/"
+                   + ansible_local.postgresql.delegate_to | d(inventory_hostname)
+                   + "/" + ansible_local.postgresql.port | d("5432")
+                   + "/credentials/icinga2/password" }}'
+  mariadb:
+    ido:       'mysql'
+    db_name:   'icinga2'
+    db_user:   'icinga2'
+    db_host:   '{{ ansible_local.mariadb.server | d("localhost") }}'
+    db_port:   '{{ ansible_local.mariadb.port | d() }}'
+    db_schema: '/usr/share/icinga2-ido-mysql/schema/mysql.sql'
+    pw_path:   '{{ secret + "/mariadb/"
+                   + ansible_local.mariadb.delegate_to | d(inventory_hostname)
+                   + "/credentials/icinga2/password" }}'
 
                                                                    # ]]]
-
-# .. envvar:: icinga_db__dbconfigs [[[
+# .. envvar:: icinga_db__ido [[[
 #
-# Debconf questions and answers for the icinga2-ido-pgsql and icinga2-ido-mysql
-# packages, to install these packages without user interaction.
-icinga_db__dbconfigs:
-
-  - question: 'icinga2-{{ icinga_db__feature }}/dbconfig-install'
-    vtype: 'boolean'
-    value: 'false'
-
-  - question: 'icinga2-{{ icinga_db__feature }}/dbconfig-upgrade'
-    vtype: 'boolean'
-    value: '{{ icinga_db__host == "localhost" }}'
-
-  - question: 'icinga2-{{ icinga_db__feature }}/enable'
-    vtype: 'boolean'
-    value: 'true'
-
-  - question: 'icinga2-{{ icinga_db__feature }}/remote/host'
-    vtype: 'string'
-    value: '{{ icinga_db__host }}'
-
-  - question: 'icinga2-{{ icinga_db__feature }}/remote/port'
-    vtype: 'string'
-    value: '{{ icinga_db__port }}'
-
-  - question: 'icinga2-{{ icinga_db__feature }}/db/dbname'
-    vtype: 'string'
-    value: '{{ icinga_db__database }}'
-
-  - question: 'icinga2-{{ icinga_db__feature }}/db/app-user'
-    vtype: 'string'
-    value: '{{ icinga_db__user }}'
-
-  - question: 'icinga2-{{ icinga_db__feature }}/{{ "pgsql"
-                                                   if icinga_db__type == "postgresql"
-                                                   else ("mysql" if icinga_db__type == "mariadb"
-                                                                 else "")}}/app-pass'
-    vtype: 'password'
-    value: '{{ icinga_db__password }}'
+# The IDO driver to use for the Icinga 2 database.
+icinga_db__ido: '{{ icinga_db__database_map[icinga_db__type].ido }}'
 
                                                                    # ]]]
-                                                                   # ]]]
-
-# Database configuration [[[
-# --------------------------
 # .. envvar:: icinga_db__host [[[
 #
 # The host where the Icinga 2 database will be installed.
-icinga_db__host: '{{ ansible_local.postgresql.server
-                     if (ansible_local.postgresql.server|d() and
-                         icinga_db__type == "postgresql")
-                     else (ansible_local.mariadb.server
-                           if (ansible_local.mariadb.server|d() and
-                               icinga_db__type == "mariadb")
-                           else "localhost") }}'
+icinga_db__host: '{{ icinga_db__database_map[icinga_db__type].db_host }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_db__port [[[
 #
 # The port used to connect to the Icinga 2 database.
-icinga_db__port: '{{ ansible_local.postgresql.port
-                     if (ansible_local.postgresql.port|d() and
-                         icinga_db__type == "postgresql")
-                     else (ansible_local.mariadb.port
-                           if (ansible_local.mariadb.server|d() and
-                               icinga_db__type == "mariadb")
-                           else "unknown") }}'
+icinga_db__port: '{{ icinga_db__database_map[icinga_db__type].db_port }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_db__ssl [[[
+#
+# Whether to use SSL when communicating with the Icinga 2 database.
+icinga_db__ssl: '{{ False if icinga_db__host == "localhost"
+                    else ansible_local.pki.enabled | d(False) | bool }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_db__user [[[
 #
 # Name of the database user for Icinga 2.
-icinga_db__user: 'icinga2'
+icinga_db__user: '{{ icinga_db__database_map[icinga_db__type].db_user }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_db__database [[[
 #
 # Name of the database for Icinga 2.
-icinga_db__database: 'icinga2'
+icinga_db__database: '{{ icinga_db__database_map[icinga_db__type].db_name }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_db__password_path [[[
 #
 # Path to database password file located on the Ansible Controller. See the
 # :ref:`debops.secret` role for more details.
-icinga_db__password_path: '{{ secret + "/" + icinga_db__type + "/" +
-                                        ansible_local[icinga_db__type].delegate_to }}{%
-                                         if icinga_db__type == "postgresql" %}/{{ ansible_local[icinga_db__type].port }}{% endif
-                                        %}{{ "/credentials/" + icinga_db__user +
-                                        "/password" }}'
+icinga_db__password_path: '{{ icinga_db__database_map[icinga_db__type].pw_path }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_db__password [[[
@@ -162,24 +126,102 @@ icinga_db__password: "{{ lookup('password', icinga_db__password_path
 #
 # Should the Icinga 2 database be initialized ? Per default, it should be
 # initialized only the first time this role runs.
-icinga_db__init: '{{ False if ansible_local.icinga_db.configured|d()
-                           else True }}'
+icinga_db__init: '{{ not (ansible_local.icinga_db.configured | d(False) | bool) }}'
 
                                                                    # ]]]
-# .. envvar:: icinga_db__postgresql_schema [[[
+# .. envvar:: icinga_db__schema [[[
 #
-# Path on the host where this role runs of the PostgreSQL schema. This schema
-# is used to populate the database when it is created.
-icinga_db__postgresql_schema: '/usr/share/icinga2-ido-pgsql/schema/pgsql.sql'
+# Absolute path to the Icinga 2 database schema which will be imported during
+# initialization. The schema needs to be located on the remote host where
+# Icinga 2 is being configured.
+icinga_db__schema: '{{ icinga_db__database_map[icinga_db__type].db_schema }}'
 
                                                                    # ]]]
-# .. envvar:: icinga_db__mariadb_schema [[[
+# .. envvar:: icinga_db__default_configuration [[[
 #
-# Path on the host where this role runs of the MariaDB schema. This schema
-# is used to populate the database when it is created.
-icinga_db__mariadb_schema: '/usr/share/icinga2-ido-mysql/schema/mysql.sql'
+# The default database configuration applied by the role.
+icinga_db__default_configuration:
+
+  - name: 'library'
+    raw: 'library "db_ido_{{ icinga_db__ido }}"'
+
+  - name: 'connection'
+    option: 'object Ido{{ icinga_db__ido | capitalize }}Connection "ido-{{ icinga_db__ido }}"'
+    options:
+
+      - name: 'user'
+        value: '{{ icinga_db__user }}'
+
+      - name: 'password'
+        value: '{{ icinga_db__password }}'
+
+      - name: 'host'
+        value: '{{ icinga_db__host }}'
+
+      - name: 'database'
+        value: '{{ icinga_db__database }}'
+
+      - name: 'port'
+        value: '{{ icinga_db__port | d("") }}'
+        state: '{{ "present" if icinga_db__port | d() else "ignore" }}'
+
+      - name: 'ssl_mode'
+        value: '{{ "verify-full" if icinga_db__ssl | d(False) | bool else "disable" }}'
+        state: '{{ "present" if icinga_db__type | d() == "postgresql" else "ignore" }}'
+
+      - name: 'enable_ssl'
+        value: '{{ True if icinga_db__ssl | d(False) | bool else False }}'
+        state: '{{ "present" if icinga_db__type | d() == "mariadb" else "ignore" }}'
+
+      - name: 'ssl_ca'
+        value: '{{ icinga_db__ssl_ca_certificate }}'
 
                                                                    # ]]]
+# .. envvar:: icinga_db__configuration [[[
+#
+# Custom database configuration defined in the Ansible inventory.
+icinga_db__configuration: []
+
+                                                                   # ]]]
+# .. envvar:: icinga_db__combined_configuration [[[
+#
+# A variable which combines the database configuration from different
+# source variables and is used by the role to generate the actual
+# configuration file.
+icinga_db__combined_configuration: '{{ icinga_db__default_configuration
+                                       + icinga_db__configuration }}'
+
+                                                                   # ]]]
+                                                                   # ]]]
+# Support for DebOps PKI and TLS [[[
+# ----------------------------------
+
+# .. envvar:: icinga_db__pki_path [[[
+#
+# Absolute path to the directory that contains PKI realms.
+icinga_db__pki_path: '{{ ansible_local.pki.base_path | d("/etc/pki/realms") }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_db__pki_realm [[[
+#
+# Default PKI realm used by the Icinga database server.
+icinga_db__pki_realm: '{{ ansible_local.pki.realm | d("domain") }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_db__pki_ca [[[
+#
+# Name of the Root CA certificate file, relative to the PKI realm directory.
+icinga_db__pki_ca: 'CA.crt'
+
+                                                                   # ]]]
+# .. envvar:: icinga_db__ssl_ca_certificate [[[
+#
+# Absolute path to the Root CA certificate used by the Icinga 2 master to
+# authenticate database server certificates.
+icinga_db__ssl_ca_certificate: '{{ icinga_db__pki_path + "/"
+                                   + icinga_db__pki_realm + "/"
+                                   + icinga_db__pki_ca }}'
+
                                                                    # ]]]
 # APT packages [[[
 # ----------------
@@ -188,13 +230,7 @@ icinga_db__mariadb_schema: '/usr/share/icinga2-ido-mysql/schema/mysql.sql'
 #
 # The list of APT packages to install for Icinga 2 database support. The
 # database configuration will be performed by the ``dbconfig`` infrastructure.
-icinga_db__base_packages:
-
-  - '{{ "icinga2-ido-pgsql"
-        if (icinga_db__type == "postgresql")
-        else ("icinga2-ido-mysql"
-              if (icinga_db__type == "mariadb")
-              else []) }}'
+icinga_db__base_packages: [ '{{ "icinga2-ido-" + icinga_db__ido }}' ]
 
                                                                    # ]]]
 # .. envvar:: icinga_db__packages [[[

--- a/ansible/roles/icinga_db/tasks/main.yml
+++ b/ansible/roles/icinga_db/tasks/main.yml
@@ -1,71 +1,84 @@
 ---
 # Copyright (C) 2018 Maciej Delmanowski <drybjed@gmail.com>
-# Copyright (C) 2018 DebOps <https://debops.org/>
+# Copyright (C) 2020 Gabriel Lewertowski <gabriel.lewertowski@trust-in-soft.com>
+# Copyright (C) 2023 David Härdeman <david@hardeman.nu>
+# Copyright (C) 2018-2023 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-only
 
 - name: Import DebOps global handlers
   ansible.builtin.import_role:
     name: 'global_handlers'
 
-- import_role:
+- name: Import DebOps secret role
+  ansible.builtin.import_role:
     name: 'secret'
 
-- name: Set dbconfig configuration for Icinga database
-  ansible.builtin.debconf:
-    name: 'icinga2-{{ icinga_db__feature }}'
-    question: '{{ item.question }}'
-    vtype: '{{ item.vtype }}'
-    value: '{{ item.value }}'
-  with_items: '{{ icinga_db__dbconfigs }}'
-  when: icinga_db__icinga_installed|bool and
-        icinga_db__type != 'unknown' and
-        item.state|d('present') == 'present'
-  no_log: '{{ item.vtype == "password" }}'
-  changed_when: False
+- name: Assert that the DB type is valid
+  ansible.builtin.assert:
+    that:
+      - 'icinga_db__database_map[icinga_db__type] is defined'
+  become: False
+  run_once: True
+  delegate_to: 'localhost'
 
 - name: Install required packages
   ansible.builtin.package:
-    name: '{{ lookup("flattened",
-                     (icinga_db__base_packages + icinga_db__packages),
-                     wantlist=True) }}'
+    name: '{{ q("flattened", icinga_db__base_packages + icinga_db__packages) }}'
     state: 'present'
   register: icinga_db__register_packages
   until: icinga_db__register_packages is succeeded
   notify: [ 'Check icinga2 configuration and restart' ]
-  when: icinga_db__icinga_installed | bool and
-        icinga_db__type != 'unknown'
+  when: icinga_db__icinga_installed | bool
 
-- name: Import Icinga IDO database on installation into PostgreSQL
-  postgresql_db:
+- name: Create Icinga PostgreSQL tables
+  community.postgresql.postgresql_db:
     name: '{{ icinga_db__database }}'
     state: 'restore'
+    target: '{{ icinga_db__schema }}'
     login_host: '{{ icinga_db__host }}'
-    login_password: '{{ icinga_db__password }}'
     login_user: '{{ icinga_db__user }}'
-    target: '{{ icinga_db__postgresql_schema }}'
+    login_password: '{{ icinga_db__password }}'
+    ssl_mode: '{{ "verify-full" if icinga_db__ssl | d(False) | bool else "disable" }}'
+  no_log: '{{ debops__no_log | d(True) }}'
   when: icinga_db__type == 'postgresql' and
-        icinga_db__init|bool
+        icinga_db__init | bool
 
-- name: Import Icinga IDO database on installation into MariaDB
-  mysql_db:
+- name: Create Icinga MariaDB tables
+  community.mysql.mysql_db:
     name: '{{ icinga_db__database }}'
     state: 'import'
+    target: '{{ icinga_db__schema }}'
     login_host: '{{ icinga_db__host }}'
-    login_password: '{{ icinga_db__password }}'
     login_user: '{{ icinga_db__user }}'
-    target: '{{ icinga_db__mariadb_schema }}'
+    login_password: '{{ icinga_db__password }}'
+    check_hostname: '{{ icinga_db__ssl | d(False) | bool }}'
+  no_log: '{{ debops__no_log | d(True) }}'
   when: icinga_db__type == 'mariadb' and
-        icinga_db__init|bool
+        icinga_db__init | bool
 
-- name: Ensure that IDO feature is enabled
-  ansible.builtin.file:
-    path: '/etc/icinga2/features-enabled/{{ icinga_db__feature }}.conf'
-    src: '../features-available/{{ icinga_db__feature }}.conf'
-    state: 'link'
-    mode: '0600'
+- name: Add Icinga database configuration file diversion
+  debops.debops.dpkg_divert:
+    path: '/etc/icinga2/features-available/ido-{{ icinga_db__ido }}.conf'
+    state: 'present'
+  when: icinga_db__icinga_installed | bool
+
+- name: Create Icinga database configuration file
+  ansible.builtin.template:
+    src: 'etc/icinga2/features-available/ido-db.conf.j2'
+    dest: '/etc/icinga2/features-available/ido-{{ icinga_db__ido }}.conf'
+    owner: 'root'
+    group: 'nagios'
+    mode: '0640'
   notify: [ 'Check icinga2 configuration and restart' ]
-  when: icinga_db__icinga_installed | bool and
-        icinga_db__feature != 'unknown'
+  when: icinga_db__icinga_installed | bool
+
+- name: Enable Icinga database support
+  ansible.builtin.file:
+    path: '/etc/icinga2/features-enabled/ido-{{ icinga_db__ido }}.conf'
+    src: '../features-available/ido-{{ icinga_db__ido }}.conf'
+    state: 'link'
+  notify: [ 'Check icinga2 configuration and restart' ]
+  when: icinga_db__icinga_installed | bool
 
 - name: Make sure that Ansible local facts directory exists
   ansible.builtin.file:

--- a/ansible/roles/icinga_db/tasks/main.yml
+++ b/ansible/roles/icinga_db/tasks/main.yml
@@ -7,17 +7,21 @@
   ansible.builtin.import_role:
     name: 'global_handlers'
 
+- import_role:
+    name: 'secret'
+
 - name: Set dbconfig configuration for Icinga database
   ansible.builtin.debconf:
     name: 'icinga2-{{ icinga_db__feature }}'
-    question: '{{ item }}'
-    vtype: 'boolean'
-    value: 'true'
-  with_items:
-    - 'icinga2-{{ icinga_db__feature }}/dbconfig-install'
-    - 'icinga2-{{ icinga_db__feature }}/dbconfig-upgrade'
-  when: icinga_db__icinga_installed | bool and
-        icinga_db__type != 'unknown'
+    question: '{{ item.question }}'
+    vtype: '{{ item.vtype }}'
+    value: '{{ item.value }}'
+  with_items: '{{ icinga_db__dbconfigs }}'
+  when: icinga_db__icinga_installed|bool and
+        icinga_db__type != 'unknown' and
+        item.state|d('present') == 'present'
+  no_log: '{{ item.vtype == "password" }}'
+  changed_when: False
 
 - name: Install required packages
   ansible.builtin.package:
@@ -30,6 +34,28 @@
   notify: [ 'Check icinga2 configuration and restart' ]
   when: icinga_db__icinga_installed | bool and
         icinga_db__type != 'unknown'
+
+- name: Import Icinga IDO database on installation into PostgreSQL
+  postgresql_db:
+    name: '{{ icinga_db__database }}'
+    state: 'restore'
+    login_host: '{{ icinga_db__host }}'
+    login_password: '{{ icinga_db__password }}'
+    login_user: '{{ icinga_db__user }}'
+    target: '{{ icinga_db__postgresql_schema }}'
+  when: icinga_db__type == 'postgresql' and
+        icinga_db__init|bool
+
+- name: Import Icinga IDO database on installation into MariaDB
+  mysql_db:
+    name: '{{ icinga_db__database }}'
+    state: 'import'
+    login_host: '{{ icinga_db__host }}'
+    login_password: '{{ icinga_db__password }}'
+    login_user: '{{ icinga_db__user }}'
+    target: '{{ icinga_db__mariadb_schema }}'
+  when: icinga_db__type == 'mariadb' and
+        icinga_db__init|bool
 
 - name: Ensure that IDO feature is enabled
   ansible.builtin.file:

--- a/ansible/roles/icinga_db/templates/etc/ansible/facts.d/icinga_db.fact.j2
+++ b/ansible/roles/icinga_db/templates/etc/ansible/facts.d/icinga_db.fact.j2
@@ -2,34 +2,146 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (C) 2018 Maciej Delmanowski <drybjed@gmail.com>
-# Copyright (C) 2018 DebOps <https://debops.org/>
+# Copyright (C) 2023 David Härdeman <david@hardeman.nu>
+# Copyright (C) 2018-2023 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-only
 
 # {{ ansible_managed }}
 
 from __future__ import print_function
-from json import loads, dumps
+from json import dumps
 from sys import exit
 import os
+import re
 
 
-output = loads('''{{ {"configured": False,
-                      "type": icinga_db__type,
-                      "ido": icinga_db__database_map[icinga_db__type].ido,
-                      "db_name": icinga_db__database,
-                      "db_host": icinga_db__host,
-                      "db_port": icinga_db__port,
-                      "db_ssl": icinga_db__ssl,
-                      "db_user": icinga_db__user,
-                      "db_password": icinga_db__password}
-                     | to_nice_json }}''')
+# https://stackoverflow.com/questions/241327/remove-c-and-c-comments-using-python
+def remove_comments(text):
+    def replacer(match):
+        s = match.group(0)
+        if s.startswith('/'):
+            return " "
+        else:
+            return s
+    pattern = re.compile(
+        r'//.*?$|/\*.*?\*/|\'(?:\\.|[^\\\'])*\'|"(?:\\.|[^\\"])*"',
+        re.DOTALL | re.MULTILINE
+    )
+    return re.sub(pattern, replacer, text)
+
+
+def splitlines_and_cleanup(text):
+    return [line.strip() for line in text.splitlines() if line.strip()]
+
+
+def parse(it):
+    result = []
+
+    while True:
+        try:
+            line = next(it)
+        except StopIteration:
+            break
+
+        tokens = line.split()
+        cfg_entry = {
+            "raw": line,
+            "tokens": tokens,
+            "parameters": {},
+            "children": []
+        }
+        if len(tokens) == 3 and tokens[1] == '=' and tokens[2] != '{':
+            cfg_entry["parameters"][tokens[0]] = tokens[2]
+
+        token_iter = iter(tokens)
+        while True:
+            try:
+                tk = next(token_iter)
+            except StopIteration:
+                result.append(cfg_entry)
+                break
+
+            if tk == '}':
+                break
+            elif tk == '{':
+                cfg_entry["children"] = parse(it)
+                for child in cfg_entry["children"]:
+                    cfg_entry["parameters"].update(child["parameters"])
+                result.append(cfg_entry)
+                break
+
+    return result
+
+
+parameter_map = {
+    'host': 'db_host',
+    'database': 'db_name',
+    'user': 'db_user',
+    'password': 'db_password',
+    'port': 'db_port',
+    'enable_ssl': 'db_ssl',
+    'ssl_mode': 'db_ssl',
+    'ssl_ca': 'db_ssl_ca'
+}
+
+
+def parse_cfg(txt):
+    result = {'configured': False}
+
+    txt = remove_comments(txt)
+    txt = splitlines_and_cleanup(txt)
+    cfg = parse(iter(txt))
+
+    for entry in cfg:
+        if 'tokens' not in entry or len(entry['tokens']) < 3:
+            continue
+        elif entry['tokens'][0].lower() != "object":
+            continue
+        elif entry['tokens'][1].lower() == 'idopgsqlconnection':
+            result = {
+                'configured': True,
+                'ido': 'pgsql',
+                'type': 'postgresql',
+            }
+        elif entry['tokens'][1].lower() == 'idomysqlconnection':
+            result = {
+                'configured': True,
+                'ido': 'mysql',
+                'type': 'mariadb',
+            }
+        else:
+            continue
+
+        for input_key, output_key in parameter_map.items():
+            if input_key not in entry['parameters']:
+                continue
+            val = entry['parameters'][input_key]
+            if val.startswith('"') and val.endswith('"') and len(val) > 1:
+                val = val.strip('"')
+            result[output_key] = val
+
+    return result
+
+
+output = {'configured': True}
 
 db_config_files = [
-    '/etc/icinga2/features-available/ido-{{ icinga_db__database_map[icinga_db__type].ido }}.conf'
+    ('/etc/icinga2/features-available/'
+     'ido-{{ icinga_db__database_map[icinga_db__type].ido }}.conf')
 ]
 
 for config_file in db_config_files:
-    if os.path.exists(config_file) and os.path.isfile(config_file):
-        output['configured'] = True
+    if not os.path.exists(config_file) or not os.path.isfile(config_file):
+        output['configured'] = False
+        break
+
+    try:
+        with open(config_file, 'r') as f:
+            cfg = f.read()
+            output.update(parse_cfg(cfg))
+
+    except Exception:
+        output['configured'] = False
+        break
 
 print(dumps(output, sort_keys=True, indent=4))

--- a/ansible/roles/icinga_db/templates/etc/ansible/facts.d/icinga_db.fact.j2
+++ b/ansible/roles/icinga_db/templates/etc/ansible/facts.d/icinga_db.fact.j2
@@ -12,56 +12,24 @@ from json import loads, dumps
 from sys import exit
 import os
 
-try:
-    from configparser import ConfigParser
-except ImportError:
-    from ConfigParser import ConfigParser
-
-# Python 2 compatibility
-try:
-    from StringIO import StringIO
-except ImportError:
-    pass
-
-
-def get_config(config_file):
-    config_data = []
-    if os.path.isfile(config_file):
-        with open(config_file, 'r') as f:
-            config_string = '[global]\n' + f.read()
-            config = ConfigParser()
-            try:
-                config.read_string(config_string.decode('utf-8'))
-            except AttributeError:
-                try:
-                    config.read_string(config_string)
-                except AttributeError:
-                    # Python 2 compatibility
-                    sbuffer = StringIO(config_string)
-                    config.readfp(sbuffer)
-
-            for section in config.sections():
-
-                section_options = {}
-                for name, value in config.items(section):
-                    section_options[name] = value.strip("'")
-
-    return section_options
-
 
 output = loads('''{{ {"configured": False,
-                      "type": icinga_db__type}
+                      "type": icinga_db__type,
+                      "ido": icinga_db__database_map[icinga_db__type].ido,
+                      "db_name": icinga_db__database,
+                      "db_host": icinga_db__host,
+                      "db_port": icinga_db__port,
+                      "db_ssl": icinga_db__ssl,
+                      "db_user": icinga_db__user,
+                      "db_password": icinga_db__password}
                      | to_nice_json }}''')
 
 db_config_files = [
-    '/etc/dbconfig-common/icinga2-ido-pgsql.conf',
-    '/etc/dbconfig-common/icinga2-ido-mysql.conf'
+    '/etc/icinga2/features-available/ido-{{ icinga_db__database_map[icinga_db__type].ido }}.conf'
 ]
 
 for config_file in db_config_files:
     if os.path.exists(config_file) and os.path.isfile(config_file):
         output['configured'] = True
-        if os.access(config_file, os.R_OK):
-            output.update(get_config(config_file))
 
 print(dumps(output, sort_keys=True, indent=4))

--- a/ansible/roles/icinga_db/templates/etc/icinga2/features-available/ido-db.conf.j2
+++ b/ansible/roles/icinga_db/templates/etc/icinga2/features-available/ido-db.conf.j2
@@ -1,0 +1,64 @@
+{# Copyright (C) 2023 David Härdeman <david@hardeman.nu>
+ # Copyright (C) 2023 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-only
+ #}
+/**
+ * The db_ido_{{ icinga_db__ido }} library implements IDO functionality
+ * for {{ icinga_db__ido }}.
+ *
+ * {{ ansible_managed }}
+ */
+
+{% macro print_element(element, commented, loop_first, indent) %}
+{%   set prefix = ("{:^" + indent | string + "}").format('') %}
+{%   set comment_prefix = (prefix + "# ") %}
+{%   if commented or element.state | d('present') == 'comment' %}
+{%     set commented = True %}
+{%     set prefix = comment_prefix %}
+{%   else %}
+{%     set commented = False %}
+{%   endif %}
+{%   if element.options | d() and not loop_first %}
+{{     '' }}
+{%   endif %}
+{%   if element.comment | d() %}
+{{     element.comment | regex_replace('\n$', '') | comment(prefix='', decoration=comment_prefix, postfix='') -}}
+{%   endif %}
+{%   if element.raw | d() %}
+{%     if commented %}
+{{       '{}'.format(element.raw | regex_replace('\n$', '') | comment(prefix='', decoration=comment_prefix, postfix='')) -}}
+{%     else %}
+{{       '{}'.format(element.raw | regex_replace('\n$', '')) }}
+{%     endif %}
+{%   elif element.options | d() %}
+{{     '{}{} {{'.format(prefix, element.option | d(element.name) | regex_replace('\n$', '')) }}
+{%     for element in element.options %}
+{%       if element.state | d('present') not in [ 'absent', 'ignore', 'init' ] %}
+{{         print_element(element, commented, loop.first, indent + 8) -}}
+{%       endif %}
+{%     endfor %}
+{{     '{}}}'.format(prefix) }}
+{%   else %}
+{%     if element.value is not string and element.value is not mapping and element.value is iterable %}
+{%       set element_value = [] %}
+{%       for option in element.value %}
+{%         if option.state | d('present') != 'absent' and option.name | d("") | length > 0 %}
+{%           set _ = element_value.append(option.name) %}
+{%         endif %}
+{%       endfor %}
+{%     elif element.value is string %}
+{%       set element_value = '"' + element.value + '"' %}
+{%     elif element.value is boolean %}
+{%       set element_value = element.value | string | lower %}
+{%     else %}
+{%       set element_value = element.value | d("") | to_json %}
+{%     endif %}
+{{     '{}{} = {}'.format(prefix, element.option | d(element.name), element_value) }}
+{%   endif %}
+{% endmacro %}
+{##}
+{% for item in icinga_db__combined_configuration | debops.debops.parse_kv_config %}
+{%   if item.state | d('present') not in [ 'absent', 'init', 'ignore' ] %}
+{{     print_element(item, item.state | d('present') == 'comment', loop.first, 0) -}}
+{%   endif %}
+{% endfor %}

--- a/ansible/roles/icinga_web/COPYRIGHT
+++ b/ansible/roles/icinga_web/COPYRIGHT
@@ -1,6 +1,8 @@
 debops.icinga_web - Manage Icinga 2 Webservice using Ansible
 
 Copyright (C) 2018 Maciej Delmanowski <drybjed@gmail.com>
+Copyright (C) 2020 Gabriel Lewertowski <gabriel.lewertowski@trust-in-soft.com>
+Copyright (C) 2023 David Härdeman <david@hardeman.nu>
 Copyright (C) 2018 DebOps <https://debops.org/>
 SPDX-License-Identifier: GPL-3.0-only
 

--- a/ansible/roles/icinga_web/defaults/main.yml
+++ b/ansible/roles/icinga_web/defaults/main.yml
@@ -2,7 +2,9 @@
 # .. vim: foldmarker=[[[,]]]:foldmethod=marker
 
 # .. Copyright (C) 2018 Maciej Delmanowski <drybjed@gmail.com>
-# .. Copyright (C) 2018 DebOps <https://debops.org/>
+# .. Copyright (C) 2020 Gabriel Lewertowski <gabriel.lewertowski@trust-in-soft.com>
+# .. Copyright (C) 2023 David Härdeman <david@hardeman.nu>
+# .. Copyright (C) 2018-2023 DebOps <https://debops.org/>
 # .. SPDX-License-Identifier: GPL-3.0-only
 
 # .. _icinga_web__ref_defaults:
@@ -184,104 +186,105 @@ icinga_web__default_modules:
 icinga_web__modules: []
                                                                    # ]]]
                                                                    # ]]]
-# Icinga 2 Web internal database [[[
-# ----------------------------------
+# Icinga 2 Web database [[[
+# -------------------------
 
 # .. envvar:: icinga_web__database_type [[[
 #
-# Specify the type of the database to use for Icinga 2 Web internal database,
-# either ``postgresql`` (preferred) or ``mariadb``. The role will try to detect
-# the available databases automatically based on the Ansible local facts.
+# Specify the type of the Icinga 2 Web database, either ``postgresql``
+# (preferred) or ``mariadb``. The role will try to detect the available
+# databases automatically based on the Ansible local facts.
 icinga_web__database_type: '{{ ansible_local.icinga_web.database_type
-                               if (ansible_local.icinga_web.database_type | d())
-                               else ("postgresql"
-                                     if (ansible_local | d() and ansible_local.postgresql is defined)
-                                     else ("mariadb"
-                                           if (ansible_local | d() and ansible_local.mariadb is defined)
-                                           else "Icinga Web requires a database")) }}'
+                               | d(ansible_local.icinga_db.type | d(""), true)
+                               | d("postgresql" if ansible_local.postgresql is defined else "", true)
+                               | d("mariadb" if ansible_local.mariadb is defined else "", true) }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__database_map [[[
+#
+# A map containing per-database settings for the Icinga 2 Web database.
+icinga_web__database_map:
+  postgresql:
+    ido:     'pgsql'
+    db_name: 'icingaweb2_production'
+    db_user: 'icingaweb2'
+    db_host: '{{ ansible_local.postgresql.server | d("localhost") }}'
+    db_port: '{{ ansible_local.postgresql.port | d(5432) }}'
+    db_schema: '/usr/share/icingaweb2/etc/schema/pgsql.schema.sql'
+    pw_path: '{{ secret + "/postgresql/"
+                 + ansible_local.postgresql.delegate_to | d(inventory_hostname)
+                 + "/" + ansible_local.postgresql.port | d("5432")
+                 + "/credentials/icingaweb2/password" }}'
+  mariadb:
+    ido:     'mysql'
+    db_name: 'icingaweb2'
+    db_user: 'icingaweb2'
+    db_host: '{{ ansible_local.mariadb.server | d("localhost") }}'
+    db_port: '{{ ansible_local.mariadb.port | d(3306) }}'
+    db_schema: '/usr/share/icingaweb2/etc/schema/mysql.schema.sql'
+    pw_path: '{{ secret + "/mariadb/"
+                 + ansible_local.mariadb.delegate_to | d(inventory_hostname)
+                 + "/credentials/icingaweb2/password" }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__database_name [[[
 #
-# Name of the Icinga 2 Web internal database.
-icinga_web__database_name: '{{ "icingaweb2_production"
-                               if (icinga_web__database_type == "postgresql")
-                               else ("icingaweb2"
-                                     if (icinga_web__database_type == "mariadb")
-                                     else "") }}'
+# Name of the Icinga 2 Web database.
+icinga_web__database_name: '{{ icinga_web__database_map[icinga_web__database_type].db_name }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__database_user [[[
 #
-# Name of the Icinga 2 Web internal database user.
-icinga_web__database_user: 'icingaweb2'
+# Name of the Icinga 2 Web database user.
+icinga_web__database_user: '{{ icinga_web__database_map[icinga_web__database_type].db_user }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__database_password_path [[[
 #
 # Path to database password file located on the Ansible Controller. See the
 # :ref:`debops.secret` role for more details.
-icinga_web__database_password_path: '{{ secret + "/" + icinga_web__database_type + "/" +
-                                        ansible_local[icinga_web__database_type].delegate_to }}{%
-                                          if icinga_web__database_type == "postgresql" %}/{{ ansible_local[icinga_web__database_type].port }}{% endif
-                                        %}{{ "/credentials/" + icinga_web__database_user +
-                                        "/password" }}'
+icinga_web__database_password_path: '{{ icinga_web__database_map[icinga_web__database_type].pw_path }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__database_password [[[
 #
-# Password for Icinga 2 Web internal database.
+# Password for Icinga 2 Web database.
 icinga_web__database_password: "{{ lookup('password', icinga_web__database_password_path
                                    + ' length=48 chars=ascii_letters,digits,.-_') }}"
 
                                                                    # ]]]
 # .. envvar:: icinga_web__database_host [[[
 #
-# The address of the Icinga 2 Web internal database server.
-icinga_web__database_host: '{{ ansible_local[icinga_web__database_type].server
-                               if (ansible_local | d() and ansible_local[icinga_web__database_type] | d() and
-                                   ansible_local[icinga_web__database_type].server | d())
-                               else "localhost" }}'
+# The address of the Icinga 2 Web database server.
+icinga_web__database_host: '{{ icinga_web__database_map[icinga_web__database_type].db_host }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__database_port [[[
 #
-# The port on which the Icinga 2 Web internal database server listens for
-# connections.
-icinga_web__database_port: '{{ ansible_local[icinga_web__database_type].port
-                               if (ansible_local | d() and ansible_local[icinga_web__database_type] | d() and
-                                   ansible_local[icinga_web__database_type].port | d())
-                               else "" }}'
+# The port on which the Icinga 2 Web database server listens for connections.
+icinga_web__database_port: '{{ icinga_web__database_map[icinga_web__database_type].db_port }}'
 
                                                                    # ]]]
-# .. envvar:: icinga_web__database_delegate_to [[[
+# .. envvar:: icinga_web__database_ssl [[[
 #
-# The Ansible inventory name of the host to which the database tasks will be
-# delegated to.
-icinga_web__database_delegate_to: '{{ ansible_local[icinga_web__database_type].delegate_to
-                                      if (ansible_local | d() and ansible_local[icinga_web__database_type] | d() and
-                                          ansible_local[icinga_web__database_type].delegate_to | d())
-                                      else inventory_hostname }}'
+# Whether to use SSL when communicating with the Icinga 2 Web database.
+icinga_web__database_ssl: '{{ False if icinga_web__database_host == "localhost"
+                              else ansible_local.pki.enabled | d(False) | bool }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__database_schema [[[
 #
-# Absolute path to the Icinga 2 Web internal database schema which will be
-# imported during initialization. The schema needs to be located on the remote
-# host with the database.
-icinga_web__database_schema: '{{ "/usr/share/icingaweb2/etc/schema/"
-                                 + ("pgsql.schema.sql"
-                                    if (icinga_web__database_type == "postgresql")
-                                    else "mysql.schema.sql") }}'
+# Absolute path to the Icinga 2 Web database schema which will be imported
+# during initialization. The schema needs to be located on the remote host
+# where Icinga 2 Web is being configured.
+icinga_web__database_schema: '{{ icinga_web__database_map[icinga_web__database_type].db_schema }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__database_init [[[
 #
-# Enable or disable initialization of the Icinga 2 Web internal database.
-icinga_web__database_init: '{{ False
-                               if (ansible_local | d() and ansible_local.icinga_web | d() and
-                                   (ansible_local.icinga_web.installed | d()) | bool)
-                               else True }}'
+# Enable or disable initialization of the Icinga 2 Web database.
+icinga_web__database_init: '{{ not (ansible_local.icinga_web.installed | d(False) | bool) }}'
+
                                                                    # ]]]
                                                                    # ]]]
 # Icinga 2 master database [[[
@@ -298,10 +301,7 @@ icinga_web__database_init: '{{ False
 # the Icinga 2 Web interface.
 # This does not control the configuration of the actual database, see
 # :ref:`debops.icinga_db` role for that.
-icinga_web__master_database_enabled: '{{ True
-                                         if (ansible_local | d() and ansible_local.icinga_db | d() and
-                                             (ansible_local.icinga_db.configured | d()) | bool)
-                                         else False }}'
+icinga_web__master_database_enabled: '{{ ansible_local.icinga_db.configured | d(False) | bool }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__master_database_type [[[
@@ -311,34 +311,48 @@ icinga_web__master_database_enabled: '{{ True
 icinga_web__master_database_type: '{{ ansible_local.icinga_db.type | d("") }}'
 
                                                                    # ]]]
+# .. envvar:: icinga_web__master_database_ido [[[
+#
+# Specify the IDO driver of the Icinga 2 master database, either ``pgsql`` or
+# ``mysql``.
+icinga_web__master_database_ido: '{{ ansible_local.icinga_db.ido | d("") }}'
+
+                                                                   # ]]]
 # .. envvar:: icinga_web__master_database_name [[[
 #
 # Name of the Icinga 2 master database.
-icinga_web__master_database_name: '{{ ansible_local.icinga_db.dbc_dbname | d("icinga2") }}'
+icinga_web__master_database_name: '{{ ansible_local.icinga_db.db_name | d("icinga2") }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__master_database_user [[[
 #
 # Name of the Icinga 2 master database user.
-icinga_web__master_database_user: '{{ ansible_local.icinga_db.dbc_dbuser | d("icinga2") }}'
+icinga_web__master_database_user: '{{ ansible_local.icinga_db.db_user | d("icinga2") }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__master_database_password [[[
 #
 # Password for the Icinga 2 master database.
-icinga_web__master_database_password: '{{ ansible_local.icinga_db.dbc_dbpass | d("") }}'
+icinga_web__master_database_password: '{{ ansible_local.icinga_db.db_password | d("") }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__master_database_host [[[
 #
 # The address of the Icinga 2 master database host.
-icinga_web__master_database_host: '{{ ansible_local.icinga_db.dbc_dbserver | d("localhost") }}'
+icinga_web__master_database_host: '{{ ansible_local.icinga_db.db_host | d("localhost") }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__master_database_port [[[
 #
 # The port on which the Icinga 2 master database listens for connections.
-icinga_web__master_database_port: '{{ ansible_local.icinga_db.dbc_dbport | d("") }}'
+icinga_web__master_database_port: '{{ ansible_local.icinga_db.db_port | d("") }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__master_database_ssl [[[
+#
+# Whether to use SSL when communicating with the Icinga 2 master database.
+icinga_web__master_database_ssl: '{{ ansible_local.icinga_db.db_ssl | d(False) }}'
+
                                                                    # ]]]
                                                                    # ]]]
 # Icinga 2 Director support [[[
@@ -411,45 +425,57 @@ icinga_web__director_api_password: '{{ lookup("password", secret + "/icinga_web/
                                        + icinga_web__director_api_user + "/password") }}'
 
                                                                    # ]]]
+
 # .. envvar:: icinga_web__director_database_type [[[
 #
-# Specify the database type for the Icinga 2 Director database, either
-# ``postgresql`` (preferred) or ``mariadb``. It's usually the same type as the
-# main Icinga 2 Web database.
-icinga_web__director_database_type: '{{ ansible_local.icinga_web.database_type
-                                        if (ansible_local.icinga_web.database_type | d())
-                                        else ("postgresql"
-                                              if (ansible_local | d() and ansible_local.postgresql is defined)
-                                              else ("mariadb"
-                                                    if (ansible_local | d() and ansible_local.mariadb is defined)
-                                                    else "Icinga Director requires a database")) }}'
+# Specify the type of the Icinga 2 Director database, either ``postgresql``
+# (preferred) or ``mariadb``. It's usually the same type as the main Icinga 2
+# Web database.
+icinga_web__director_database_type: '{{ icinga_web__database_type | d("invalid") }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__director_database_map [[[
+#
+# A map containing per-database settings for the Icinga 2 Director database.
+icinga_web__director_database_map:
+  postgresql:
+    ido:     'pgsql'
+    db_name: 'icinga2_director_production'
+    db_user: 'icinga2_director'
+    db_host: '{{ ansible_local.postgresql.server | d("localhost") }}'
+    db_port: '{{ ansible_local.postgresql.port | d(5432) }}'
+    pw_path: '{{ secret + "/postgresql/"
+                 + ansible_local.postgresql.delegate_to | d(inventory_hostname)
+                 + "/" + ansible_local.postgresql.port | d("5432")
+                 + "/credentials/icinga2_director/password" }}'
+  mariadb:
+    ido:     'mysql'
+    db_name: 'icinga2_director'
+    db_user: 'icinga2_director'
+    db_host: '{{ ansible_local.mariadb.server | d("localhost") }}'
+    db_port: '{{ ansible_local.mariadb.port | d() }}'
+    pw_path: '{{ secret + "/mariadb/"
+                 + ansible_local.mariadb.delegate_to | d(inventory_hostname)
+                 + "/credentials/icinga2_director/password" }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__director_database_name [[[
 #
 # Name of the Icinga 2 Director database.
-icinga_web__director_database_name: '{{ "icinga2_director_production"
-                                        if (icinga_web__director_database_type == "postgresql")
-                                        else ("icinga2_director"
-                                              if (icinga_web__director_database_type == "mariadb")
-                                              else "") }}'
+icinga_web__director_database_name: '{{ icinga_web__director_database_map[icinga_web__director_database_type].db_name }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__director_database_user [[[
 #
 # Name of the Icinga 2 Director database user.
-icinga_web__director_database_user: 'icinga2_director'
+icinga_web__director_database_user: '{{ icinga_web__director_database_map[icinga_web__director_database_type].db_user }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__director_database_password_path [[[
 #
 # Path to database password file located on the Ansible Controller for the
 # Icinga 2 Director database.
-icinga_web__director_database_password_path: '{{ secret + "/" + icinga_web__director_database_type + "/" +
-                                                 ansible_local[icinga_web__director_database_type].delegate_to }}{%
-                                                   if icinga_web__director_database_type == "postgresql" %}/{{ ansible_local[icinga_web__director_database_type].port }}{% endif
-                                                 %}{{ "/credentials/" + icinga_web__director_database_user +
-                                                 "/password" }}'
+icinga_web__director_database_password_path: '{{ icinga_web__director_database_map[icinga_web__director_database_type].pw_path }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__director_database_password [[[
@@ -462,49 +488,34 @@ icinga_web__director_database_password: "{{ lookup('password', icinga_web__direc
 # .. envvar:: icinga_web__director_database_host [[[
 #
 # Address of the Icinga 2 Director database server.
-icinga_web__director_database_host: '{{ ansible_local[icinga_web__director_database_type].server
-                                        if (ansible_local | d() and ansible_local[icinga_web__director_database_type] | d() and
-                                            ansible_local[icinga_web__director_database_type].server | d())
-                                        else "localhost" }}'
+icinga_web__director_database_host: '{{ icinga_web__director_database_map[icinga_web__director_database_type].db_host }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__director_database_port [[[
 #
 # The port on which the Icinga 2 Director database server listens for
 # connections.
-icinga_web__director_database_port: '{{ ansible_local[icinga_web__director_database_type].port
-                                        if (ansible_local | d() and ansible_local[icinga_web__director_database_type] | d() and
-                                            ansible_local[icinga_web__director_database_type].port | d())
-                                        else "" }}'
+icinga_web__director_database_port: '{{ icinga_web__director_database_map[icinga_web__director_database_type].db_port }}'
 
                                                                    # ]]]
-# .. envvar:: icinga_web__director_database_delegate_to [[[
+# .. envvar:: icinga_web__director_database_ssl [[[
 #
-# The Ansible inventory hostname of the host where the database-related role
-# tasks will be delegated to.
-icinga_web__director_database_delegate_to: '{{ ansible_local[icinga_web__director_database_type].delegate_to
-                                               if (ansible_local | d() and ansible_local[icinga_web__director_database_type] | d() and
-                                                   ansible_local[icinga_web__director_database_type].delegate_to | d())
-                                               else inventory_hostname }}'
+# Whether to use SSL when communicating with the Icinga 2 Director database.
+icinga_web__director_database_ssl: '{{ False if icinga_web__director_database_host == "localhost"
+                                       else ansible_local.pki.enabled | d(False) | bool }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__director_database_init [[[
 #
 # Enable or disable initialization of the Icinga 2 Director database.
-icinga_web__director_database_init: '{{ False
-                                        if (ansible_local | d() and ansible_local.icinga_web | d() and
-                                            (ansible_local.icinga_web.installed | d()) | bool)
-                                        else True }}'
+icinga_web__director_database_init: '{{ not (ansible_local.icinga_web.installed | d(False) | bool) }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__director_kickstart_enabled [[[
 #
 # Enable or disable initial import (kickstart) of the Icinga 2 configuration
 # into the Director database.
-icinga_web__director_kickstart_enabled: '{{ True
-                                            if (ansible_local | d() and ansible_local.icinga | d() and
-                                                (ansible_local.icinga.installed | d()) | bool)
-                                            else False }}'
+icinga_web__director_kickstart_enabled: '{{ ansible_local.icinga.installed | d(False) | bool }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__director_default_templates [[[
@@ -576,56 +587,106 @@ icinga_web__director_combined_templates: '{{ icinga_web__director_default_templa
 
 # .. envvar:: icinga_web__x509_enabled [[[
 #
-# Enable or disable support for Icinga 2 Web x509 module. It requires
-# MariaDB/MySQL.
+# Enable or disable support for Icinga 2 Web x509 module. It currently only
+# supports MariaDB.
 # See https://github.com/icinga/icingaweb2-module-x509 for more details
-icinga_web__x509_enabled: '{{ ansible_local.mariadb is defined }}'
+icinga_web__x509_enabled: '{{ icinga_web__director_database_type == "mariadb"
+                              and ansible_local.mariadb is defined }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__x509_database_type [[[
+#
+# Specify the type of the Icinga 2 Web x509 module database. Either
+# ``postgresql`` (under development) or ``mariadb``. It's usually the same type
+# as the main Icinga 2 Web database.
+icinga_web__x509_database_type: '{{ icinga_web__database_type | d("invalid") }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__x509_database_map [[[
+#
+# A map containing per-database settings for the Icinga 2 Web x509 module
+# database.
+icinga_web__x509_database_map:
+  postgresql:
+    ido:     'pgsql'
+    db_name: 'icingaweb2_x509'
+    db_user: 'icingaweb2_x509'
+    db_host: '{{ ansible_local.postgresql.server | d("localhost") }}'
+    db_port: '{{ ansible_local.postgresql.port | d(5432) }}'
+    db_schema: '/usr/share/icingaweb2/modules/x509/etc/schema/pgsql.schema.sql'
+    pw_path: '{{ secret + "/postgresql/"
+                 + ansible_local.postgresql.delegate_to | d(inventory_hostname)
+                 + "/" + ansible_local.postgresql.port | d("5432")
+                 + "/credentials/icingaweb2_x509/password" }}'
+  mariadb:
+    ido:     'mysql'
+    db_name: 'icingaweb2_x509'
+    db_user: 'icingaweb2_x509'
+    db_host: '{{ ansible_local.mariadb.server | d("localhost") }}'
+    db_port: '{{ ansible_local.mariadb.port | d(3306) }}'
+    db_schema: '/usr/share/icingaweb2/modules/x509/etc/schema/mysql.schema.sql'
+    pw_path: '{{ secret + "/mariadb/"
+                 + ansible_local.mariadb.delegate_to | d(inventory_hostname)
+                 + "/credentials/icingaweb2_x509/password" }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__x509_database_name [[[
 #
-# Name of the Icinga 2 Web database used for the X509 module
-icinga_web__x509_database_name: 'icingaweb2_x509'
+# Name of the Icinga 2 Web x509 module database.
+icinga_web__x509_database_name: '{{ icinga_web__x509_database_map[icinga_web__x509_database_type].db_name }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__x509_database_user [[[
 #
-# Name of the Icinga 2 Web x509 database user.
-icinga_web__x509_database_user: 'icingaweb2_x509'
+# Name of the Icinga 2 Web x509 module database user.
+icinga_web__x509_database_user: '{{ icinga_web__x509_database_map[icinga_web__x509_database_type].db_user }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__x509_database_password_path [[[
+#
+# Path to the database password file located on the Ansible Controller. See the
+# :ref:`debops.secret` role for more details.
+icinga_web__x509_database_password_path: '{{ icinga_web__x509_database_map[icinga_web__x509_database_type].pw_path }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__x509_database_password [[[
 #
-# Password for Icinga 2 Web x509 database.
-icinga_web__x509_database_password: '{{ lookup("password", secret + "/mariadb/"
-                                        + ansible_local.mariadb.delegate_to | d(inventory_hostname)
-                                        + "/credentials/" + icinga_web__x509_database_user + "/password"
+# Password for the Icinga 2 Web x509 module database.
+icinga_web__x509_database_password: '{{ lookup("password", icinga_web__x509_database_password_path
                                         + " length=48 chars=ascii_letters,digits,.-_") }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__x509_database_host [[[
 #
-# Address of the Icinga 2 X509 database server.
-icinga_web__x509_database_host: '{{ ansible_local.mariadb.server | d("localhost") }}'
+# The address of the Icinga 2 Web x509 module database server.
+icinga_web__x509_database_host: '{{ icinga_web__x509_database_map[icinga_web__x509_database_type].db_host }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__x509_database_port [[[
 #
-# The port on which the Icinga 2 x509 database server listens for
+# The port on which the Icinga 2 Web x509 module database server listens for
 # connections.
-icinga_web__x509_database_port: '{{ ansible_local.mariadb.port | d("3306") }}'
+icinga_web__x509_database_port: '{{ icinga_web__x509_database_map[icinga_web__x509_database_type].db_port }}'
 
                                                                    # ]]]
-# .. envvar:: icinga_web__x5609_database_schema [[[
+# .. envvar:: icinga_web__x509_database_schema [[[
 #
-# Absolute path to the Icinga 2 Web internal database schema which will be
+# Absolute path to the Icinga 2 Web x509 module database scheme which will be
 # imported during initialization.
-icinga_web__x509_database_schema: '/usr/share/icingaweb2/modules/x509/etc/schema/mysql.schema.sql'
+icinga_web__x509_database_schema: '{{ icinga_web__x509_database_map[icinga_web__x509_database_type].db_schema }}'
+
+                                                                   # ]]]
+# .. envvar:: icinga_web__x509_database_ssl [[[
+#
+# Whether to use SSL when communicating with the Icinga 2 Web x509 module
+# database.
+icinga_web__x509_database_ssl: '{{ False if icinga_web__x509_database_host == "localhost"
+                                   else ansible_local.pki.enabled | d(False) | bool }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__x509_database_init [[[
 #
-# Enable or disable initialization of the Icinga 2 Web x509 database.
+# Enable or disable initialization of the Icinga 2 Web x509 module database.
 icinga_web__x509_database_init: '{{ not ansible_local.icinga_web.x509_installed | d(False) }}'
 
                                                                    # ]]]
@@ -1113,11 +1174,7 @@ icinga_web__default_resources:
         value: 'db'
 
       - name: 'db'
-        value: '{{ "pgsql"
-                   if (icinga_web__database_type == "postgresql")
-                   else ("mysql"
-                         if (icinga_web__database_type == "mariadb")
-                         else "unknown") }}'
+        value: '{{ icinga_web__database_map[icinga_web__database_type].ido }}'
 
       - name: 'host'
         value: '{{ icinga_web__database_host }}'
@@ -1142,23 +1199,17 @@ icinga_web__default_resources:
         value: '0'
 
       - name: 'use_ssl'
-        value: '0'
+        value: '{{ "1" if icinga_web__database_ssl | d(False) | bool else "0" }}'
 
   - name: 'icinga2'
-    state: '{{ "present"
-               if (icinga_web__master_database_enabled | bool)
-               else "ignore" }}'
+    state: '{{ "present" if icinga_web__master_database_enabled | bool else "ignore" }}'
     options:
 
       - name: 'type'
         value: 'db'
 
       - name: 'db'
-        value: '{{ "pgsql"
-                   if (icinga_web__master_database_type == "postgresql")
-                   else ("mysql"
-                         if (icinga_web__master_database_type == "mariadb")
-                         else "unknown") }}'
+        value: '{{ icinga_web__master_database_ido }}'
 
       - name: 'host'
         value: '{{ icinga_web__master_database_host }}'
@@ -1183,20 +1234,17 @@ icinga_web__default_resources:
         value: '0'
 
       - name: 'use_ssl'
-        value: '0'
+        value: '{{ "1" if icinga_web__master_database_ssl | d(False) | bool else "0" }}'
 
   - name: 'icinga2_director'
+    state: '{{ "present" if icinga_web__director_enabled | bool else "ignore" }}'
     options:
 
       - name: 'type'
         value: 'db'
 
       - name: 'db'
-        value: '{{ "pgsql"
-                   if (icinga_web__director_database_type == "postgresql")
-                   else ("mysql"
-                         if (icinga_web__director_database_type == "mariadb")
-                         else "unknown") }}'
+        value: '{{ icinga_web__director_database_map[icinga_web__director_database_type].ido }}'
 
       - name: 'host'
         value: '{{ icinga_web__director_database_host }}'
@@ -1221,11 +1269,10 @@ icinga_web__default_resources:
         value: '0'
 
       - name: 'use_ssl'
-        value: '0'
-
-    state: '{{ "present" if icinga_web__director_enabled | bool else "ignore" }}'
+        value: '{{ "1" if icinga_web__director_database_ssl | d(False) | bool else "0" }}'
 
   - name: 'ldap_db'
+    state: '{{ "present" if icinga_web__ldap_enabled | bool else "ignore" }}'
     options:
 
       - name: 'type'
@@ -1249,16 +1296,15 @@ icinga_web__default_resources:
       - name: 'encryption'
         value: '{{ icinga_web__ldap_encryption }}'
 
-    state: '{{ "present" if icinga_web__ldap_enabled | bool else "ignore" }}'
-
   - name: 'icingaweb2_x509'
+    state: '{{ "present" if icinga_web__x509_enabled | bool else "ignore" }}'
     options:
 
       - name: 'type'
         value: 'db'
 
       - name: 'db'
-        value: 'mysql'
+        value: '{{ icinga_web__x509_database_map[icinga_web__x509_database_type].ido }}'
 
       - name: 'host'
         value: '{{ icinga_web__x509_database_host }}'
@@ -1278,7 +1324,8 @@ icinga_web__default_resources:
       - name: 'charset'
         value: 'utf8'
 
-    state: '{{ "present" if icinga_web__x509_enabled | bool else "ignore" }}'
+      - name: 'use_ssl'
+        value: '{{ "1" if icinga_web__x509_database_ssl | d(False) | bool else "0" }}'
 
                                                                    # ]]]
 # .. envvar:: icinga_web__resources [[[

--- a/ansible/roles/icinga_web/defaults/main.yml
+++ b/ansible/roles/icinga_web/defaults/main.yml
@@ -1707,10 +1707,12 @@ icinga_web__mariadb__dependent_users:
 
   - database: '{{ icinga_web__database_name }}'
     user: '{{ icinga_web__database_user }}'
+    password: '{{ icinga_web__database_password }}'
     state: '{{ "present" if icinga_web__database_type == "mariadb" else "ignore" }}'
 
   - database: '{{ icinga_web__director_database_name }}'
     user: '{{ icinga_web__director_database_user }}'
+    password: '{{ icinga_web__director_database_password }}'
     state: '{{ "present"
                 if (icinga_web__director_enabled | bool and icinga_web__director_database_type == "mariadb")
                 else "ignore" }}'

--- a/ansible/roles/icinga_web/defaults/main.yml
+++ b/ansible/roles/icinga_web/defaults/main.yml
@@ -1672,6 +1672,19 @@ icinga_web__postgresql__dependent_groups:
     state: '{{ "present" if icinga_web__director_enabled | bool else "ignore" }}'
 
                                                                    # ]]]
+# .. envvar:: icinga_web__postgresql__dependent_privileges [[[
+#
+# Configuration of PostgreSQL privileges for the :ref:`debops.postgresql`
+# Ansible role.
+icinga_web__postgresql__dependent_privileges:
+
+  - roles:  [ '{{ icinga_web__database_user }}' ]
+    database: '{{ icinga_web__database_name }}'
+    objs:   [ 'ALL_DEFAULT' ]
+    privs:  [ 'SELECT', 'INSERT', 'UPDATE', 'DELETE' ]
+    type:     'default_privs'
+
+                                                                   # ]]]
 # .. envvar:: icinga_web__postgresql__dependent_extensions [[[
 #
 # Configuration of PostgreSQL extensions for the :ref:`debops.postgresql` Ansible

--- a/ansible/roles/icinga_web/tasks/main.yml
+++ b/ansible/roles/icinga_web/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 # Copyright (C) 2018 Maciej Delmanowski <drybjed@gmail.com>
-# Copyright (C) 2018 DebOps <https://debops.org/>
+# Copyright (C) 2020 Gabriel Lewertowski <gabriel.lewertowski@trust-in-soft.com>
+# Copyright (C) 2023 David Härdeman <david@hardeman.nu>
+# Copyright (C) 2018-2023 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-only
 
 - name: Import custom Ansible plugins
@@ -15,11 +17,21 @@
   ansible.builtin.import_role:
     name: 'secret'
 
+- name: Assert that the DB types are valid
+  ansible.builtin.assert:
+    that:
+      - 'icinga_web__database_map[icinga_web__database_type].db_name is defined'
+      - 'icinga_web__director_enabled | d(False) | bool == False or
+         icinga_web__director_database_map[icinga_web__director_database_type].db_name is defined'
+      - 'icinga_web__x509_enabled | d(False) | bool == False or
+         icinga_web__x509_database_map[icinga_web__x509_database_type].db_name is defined'
+  become: False
+  run_once: True
+  delegate_to: 'localhost'
+
 - name: Install required Icinga Web packages
   ansible.builtin.package:
-    name: '{{ lookup("flattened",
-                     (icinga_web__base_packages + icinga_web__packages),
-                     wantlist=True) }}'
+    name: '{{ q("flattened", icinga_web__base_packages + icinga_web__packages) }}'
     state: 'present'
   register: icinga_web__register_packages
   until: icinga_web__register_packages is succeeded
@@ -38,16 +50,11 @@
     group: '{{ icinga_web__group }}'
     mode: '{{ item.mode | d("02770") }}'
   with_items:
-
     - name: 'enabledModules'
       mode: '02750'
-
     - name: 'modules/monitoring'
-
     - name: 'modules/director'
-
     - name: 'modules/x509'
-
   when: item.state | d('present') not in ['absent', 'ignore', 'init']
 
 - name: Download and install Icinga upstream modules
@@ -90,38 +97,27 @@
     mode: '0660'
   no_log: '{{ debops__no_log | d(item.no_log) | d(False) }}'
   with_items:
-
     - filename: 'authentication.ini'
       config: '{{ icinga_web__combined_authentication }}'
-
     - filename: 'config.ini'
       config: '{{ icinga_web__combined_config }}'
-
     - filename: 'groups.ini'
       config: '{{ icinga_web__combined_groups }}'
-
     - filename: 'resources.ini'
       config: '{{ icinga_web__combined_resources }}'
       no_log: '{{ debops__no_log | d(True) }}'
-
     - filename: 'roles.ini'
       config: '{{ icinga_web__combined_roles }}'
-
     - filename: 'modules/monitoring/backends.ini'
       config: '{{ icinga_web__combined_backends }}'
-
     - filename: 'modules/monitoring/commandtransports.ini'
       config: '{{ icinga_web__combined_commandtransports }}'
-
     - filename: 'modules/director/config.ini'
       config: '{{ icinga_web__combined_director_cfg }}'
-
     - filename: 'modules/director/kickstart.ini'
       config: '{{ icinga_web__combined_director_kickstart_cfg }}'
-
     - filename: 'modules/x509/config.ini'
       config: '{{ icinga_web__combined_x509_cfg }}'
-
   when: item.state | d('present') not in ['absent', 'ignore', 'init']
 
 - name: Generate initial data file
@@ -134,36 +130,53 @@
   when: icinga_web__database_init | bool
   no_log: '{{ debops__no_log | d(True) }}'
 
-- name: Import Icinga Web database on installation into PostgreSQL
+- name: Create Icinga Web PostgreSQL tables
   community.general.postgresql_db:
     name: '{{ icinga_web__database_name }}'
     state: 'restore'
+    target: '{{ item }}'
     login_host: '{{ icinga_web__database_host }}'
     login_user: '{{ icinga_web__database_user }}'
     login_password: '{{ icinga_web__database_password }}'
-    target: '{{ item }}'
+    ssl_mode: '{{ "verify-full" if icinga_web__database_ssl | d(False) | bool else "disable" }}'
   with_items:
     - '{{ icinga_web__database_schema }}'
     - '/tmp/icingaweb-initial-data.sql'
+  no_log: '{{ debops__no_log | d(True) }}'
   when: icinga_web__database_type == 'postgresql' and
         icinga_web__database_init | bool
 
-- name: Import Icinga Web database on installation into MariaDB
+- name: Create Icinga Web x509 PostgreSQL tables
+  community.general.postgresql_db:
+    name: '{{ icinga_web__x509_database_name }}'
+    state: 'restore'
+    target: '{{ icinga_web__x509_database_schema }}'
+    login_host: '{{ icinga_web__x509_database_host }}'
+    login_user: '{{ icinga_web__x509_database_user }}'
+    login_password: '{{ icinga_web__x509_database_password }}'
+    ssl_mode: '{{ "verify-full" if icinga_web__x509_database_ssl | d(False) | bool else "disable" }}'
+  no_log: '{{ debops__no_log | d(True) }}'
+  when: icinga_web__x509_enabled | bool and
+        icinga_web__x509_database_type == 'postgresql' and
+        icinga_web__x509_database_init | bool
+
+- name: Create Icinga Web MariaDB tables
   community.mysql.mysql_db:
     name: '{{ icinga_web__database_name }}'
     state: 'import'
+    target: '{{ item }}'
     login_host: '{{ icinga_web__database_host }}'
     login_user: '{{ icinga_web__database_user }}'
     login_password: '{{ icinga_web__database_password }}'
-    target: '{{ item }}'
-    login_unix_socket: '/run/mysqld/mysqld.sock'
+    check_hostname: '{{ icinga_web__database_ssl | d(False) | bool }}'
   with_items:
     - '{{ icinga_web__database_schema }}'
     - '/tmp/icingaweb-initial-data.sql'
+  no_log: '{{ debops__no_log | d(True) }}'
   when: icinga_web__database_type == 'mariadb' and
         icinga_web__database_init | bool
 
-- name: Import Icinga Web x509 database on installation into MariaDB
+- name: Create Icinga Web x509 MariaDB tables
   community.mysql.mysql_db:
     name: '{{ icinga_web__x509_database_name }}'
     state: 'import'
@@ -172,10 +185,11 @@
     login_port: '{{ icinga_web__x509_database_port }}'
     login_user: '{{ icinga_web__x509_database_user }}'
     login_password: '{{ icinga_web__x509_database_password }}'
-    login_unix_socket: '/run/mysqld/mysqld.sock'
-  when: icinga_web__x509_enabled | bool and
-        icinga_web__x509_database_init | bool
+    check_hostname: '{{ icinga_web__x509_database_ssl | d(False) | bool }}'
   no_log: '{{ debops__no_log | d(True) }}'
+  when: icinga_web__x509_enabled | bool and
+        icinga_web__x509_database_type == 'mariadb' and
+        icinga_web__x509_database_init | bool
 
 - name: Ensure that initial data schema is removed
   ansible.builtin.file:

--- a/ansible/roles/icinga_web/tasks/main.yml
+++ b/ansible/roles/icinga_web/tasks/main.yml
@@ -148,19 +148,6 @@
   when: icinga_web__database_type == 'postgresql' and
         icinga_web__database_init | bool
 
-  # Without this, Icinga Web cannot access the database, with error:
-  # permission denied for relation icingaweb_user
-- name: Ensure that PostgreSQL database tables are accessible
-  community.general.postgresql_privs:
-    db: '{{ icinga_web__database_name }}'
-    role: '{{ icinga_web__database_user }}'
-    objs: 'ALL_IN_SCHEMA'
-    privs: 'SELECT,INSERT,UPDATE,DELETE'
-  delegate_to: '{{ icinga_web__database_delegate_to }}'
-  when: icinga_web__database_type == 'postgresql' and
-        icinga_web__database_host == 'localhost' and
-        icinga_web__database_init | bool
-
 - name: Import Icinga Web database on installation into MariaDB
   community.mysql.mysql_db:
     name: '{{ icinga_web__database_name }}'

--- a/ansible/roles/icinga_web/tasks/main.yml
+++ b/ansible/roles/icinga_web/tasks/main.yml
@@ -131,21 +131,21 @@
     owner: 'root'
     group: 'root'
     mode: '0600'
-  when: icinga_web__database_host == 'localhost' and
-      icinga_web__database_init | bool
+  when: icinga_web__database_init | bool
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Import Icinga Web database on installation into PostgreSQL
   community.general.postgresql_db:
     name: '{{ icinga_web__database_name }}'
     state: 'restore'
+    login_host: '{{ icinga_web__database_host }}'
+    login_user: '{{ icinga_web__database_user }}'
+    login_password: '{{ icinga_web__database_password }}'
     target: '{{ item }}'
   with_items:
     - '{{ icinga_web__database_schema }}'
     - '/tmp/icingaweb-initial-data.sql'
-  delegate_to: '{{ icinga_web__database_delegate_to }}'
   when: icinga_web__database_type == 'postgresql' and
-        icinga_web__database_host == 'localhost' and
         icinga_web__database_init | bool
 
   # Without this, Icinga Web cannot access the database, with error:
@@ -165,14 +165,15 @@
   community.mysql.mysql_db:
     name: '{{ icinga_web__database_name }}'
     state: 'import'
+    login_host: '{{ icinga_web__database_host }}'
+    login_user: '{{ icinga_web__database_user }}'
+    login_password: '{{ icinga_web__database_password }}'
     target: '{{ item }}'
     login_unix_socket: '/run/mysqld/mysqld.sock'
   with_items:
     - '{{ icinga_web__database_schema }}'
     - '/tmp/icingaweb-initial-data.sql'
-  delegate_to: '{{ icinga_web__database_delegate_to }}'
   when: icinga_web__database_type == 'mariadb' and
-        icinga_web__database_host == 'localhost' and
         icinga_web__database_init | bool
 
 - name: Import Icinga Web x509 database on installation into MariaDB

--- a/ansible/roles/postgresql/defaults/main.yml
+++ b/ansible/roles/postgresql/defaults/main.yml
@@ -203,6 +203,21 @@ postgresql__databases: []
 postgresql__dependent_databases: []
 
                                                                    # ]]]
+# .. envvar:: postgresql__privileges [[[
+#
+# List of PostgreSQL privileges, specified as YAML dicts. See
+# :ref:`postgresql__ref_privileges` for more details.
+postgresql__privileges: []
+
+                                                                   # ]]]
+# .. envvar:: postgresql__dependent_privileges [[[
+#
+# List of PostgreSQL privileges, specified as a YAML dicts, defined by other
+# roles via dependency variables. See :ref:`postgresql__ref_privileges` for
+# more details.
+postgresql__dependent_privileges: []
+
+                                                                   # ]]]
 # .. envvar:: postgresql__extensions [[[
 #
 # List of PostgreSQL extensions enabled in specific databases, each extension

--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -215,6 +215,26 @@
         (item.db | d() and item.priv | d())
   no_log: '{{ debops__no_log | d(True) }}'
 
+- name: Grant or revoke extra privileges
+  community.postgresql.postgresql_privs:
+    database: '{{ item.database }}'
+    port: '{{ item.port | d(postgresql__port if postgresql__port else omit) }}'
+    grant_option: '{{ item.grant_option | d(omit) }}'
+    objs: '{{ item.objs | join(",") }}'
+    privs: '{{ item.public_privs | d(["ALL"]) | join(",") }}'
+    roles: '{{ item.roles | join(",") }}'
+    schema: '{{ item.schema | d(omit) }}'
+    state: '{{ item.state | d("present") }}'
+    target_roles: '{{ item.target_roles | d(omit) }}'
+    type: '{{ item.type }}'
+  loop: '{{ q("flattened", postgresql__privileges
+                           + postgresql__dependent_privileges) }}'
+  become: True
+  become_user: '{{ postgresql__user }}'
+  delegate_to: '{{ postgresql__delegate_to }}'
+  when: (item.state | d('present') == 'present') and
+        item.enabled | d(True) | bool
+
 - name: Make sure required system groups exist
   ansible.builtin.group:
     name: '{{ item.group | d(item.owner) }}'

--- a/docs/ansible/roles/postgresql/defaults-detailed.rst
+++ b/docs/ansible/roles/postgresql/defaults-detailed.rst
@@ -286,6 +286,79 @@ Create database owned by a specified role and grant select privilege on all tabl
        public_privs: [ 'SELECT' ]
        grant_option: 'no'
 
+.. _postgresql__ref_privileges:
+
+postgresql__privileges
+----------------------
+
+List of additional privileges to grant or revoke on a PostgreSQL server. The
+parameters closely match those of the `PostgreSQL Ansible module`__. Known
+parameters:
+
+.. __: https://docs.ansible.com/ansible/latest/collections/community/postgresql/postgresql_privs_module.html
+
+``database``
+  Required. Database name.
+
+``roles``
+  Required. List of role (user/group) names to set permissions for.
+
+``port``
+  Optional. TCP port to use when connecting to the PostgreSQL server.
+
+``objs``
+  Optional. List of database objects to set privileges on. Default: public.
+
+``privs``
+  Optional. Comma separated list of privileges to grant. Default: ALL.
+
+``state``
+  Optional. If ``present``, the specified privileges are granted, if ``absent``
+  they are revoked. Default: ``present``.
+
+``type``
+  Optional. Type of database object to set privileges on. Default: table.
+
+``schema``
+  Optional. Schema that contains the database objects specified via ``objs``.
+
+``target_roles``
+  Optional. A list of existing role (user/group) names for which to set the
+  default permissions for database objects subsequently created by them. Only
+  relevant when ``type=default_privs``.
+
+``grant_option``
+  Optional. Whether role (``owner``) may grant/revoke the specified privileges
+  to others.
+
+Examples
+~~~~~~~~
+
+Give the role ``reader`` default rights to any default objects created in the
+database ``library`` (e.g. tables created by another user).
+
+.. code-block:: yaml
+
+   postgresql__privileges:
+     - roles: [ 'reader' ]
+       database: 'library'
+       objs: [ 'ALL_DEFAULT' ]
+       privs: [ 'SELECT', 'INSERT', 'UPDATE', 'DELETE' ]
+       type: 'default_privs'
+
+Give ``SELECT`` privileges to the role ``reader`` for any tables created by
+``librarian`` in database ``library``.
+
+.. code-block:: yaml
+
+   postgresql__privileges:
+     - roles: [ 'reader' ]
+       database: 'library'
+       objs: [ 'TABLES' ]
+       privs: [ 'SELECT' ]
+       target_roles: [ 'librarian' ]
+       type: 'default_privs'
+
 .. _postgresql__ref_extensions:
 
 postgresql__extensions


### PR DESCRIPTION
This PR builds on the two separate PRs submitted by @lewer back in 2020 (#1443 and #1466),
but they've been substantially refresh. adapted to the current coding standards and I've also taken
the opportunity to add SSL support (seems like a good idea for remote DB access).

In addition, the x509 module in `icinga_web` is now prepared to support PostgreSQL once a new
upstream version is released.

Closes: #1443, #1466, #2206