### PR TITLE
[nginx] Add support for toplevel options to the default template

### DIFF
--- a/ansible/roles/nginx/templates/etc/nginx/sites-available/default.conf.j2
+++ b/ansible/roles/nginx/templates/etc/nginx/sites-available/default.conf.j2
@@ -489,6 +489,10 @@
 {%     endif                                                                %}
 
 {% endif                                                                    %}
+{% if item.toplevel_options | d() %}
+{{   item.toplevel_options | regex_replace("(?m)^\s*$", "") | regex_replace("\n$", "") }}
+
+{% endif %}
 {% set nginx__tpl_hostname_domain = item.hostname_domain | d(((item.name if item.name is string else item.name[0]) if item.name | d() else ansible_fqdn).split('.')[1:] | join('.')) %}
 {% set nginx__tpl_final_hostname_domain = [] %}
 {% if item.hostname_domain is undefined %}

--- a/docs/ansible/roles/nginx/defaults-detailed.rst
+++ b/docs/ansible/roles/nginx/defaults-detailed.rst
@@ -210,9 +210,15 @@ Common webserver options
   List of files that will be included at the end of the server
   configuration using `include`.
 
+``toplevel_options``
+  Optional, String or YAML text block with top-level options (i.e. before any
+  ``server`` blocks in the generated configuration) for this server
+  configuration. Semicolons at the end of each line are required.
+
 ``options``
-  Optional, String or YAML text block with options for this server configuration.
-  Semicolons at the end of each line are required.
+  Optional, String or YAML text block with options (included inside the
+  relevant ``server`` block) for this server configuration. Semicolons at the
+  end of each line are required.
 
 Redirects
 ~~~~~~~~~


### PR DESCRIPTION
Some configurations require options to be defined at the toplevel, i.e. outside any "server" blocks. This adds support for such configurations to the default template (which is included by the other templates except custom).