### PR TITLE
[sshd] Don't use "Include" on pre-Bullseye releases

### DIFF
--- a/ansible/roles/sshd/defaults/main.yml
+++ b/ansible/roles/sshd/defaults/main.yml
@@ -247,6 +247,7 @@ sshd__original_configuration:
   - name: 'Include_sshd_config.d'
     option: 'Include'
     value: '/etc/ssh/sshd_config.d/*.conf'
+    state: '{{ "absent" if ansible_distribution_release in [ "stretch", "buster" ] else "present" }}'
 
   - name: 'Port'
     value: 22


### PR DESCRIPTION
The "Include" directive is only supported from Bullseye onwards.

Resolves: https://github.com/debops/debops/issues/2293