### PR TITLE
[ansible] Use fully-qualified names for ipv4/ipv6/ipaddr/ipwrap

### DIFF
--- a/ansible/playbooks/tools/6to4.yml
+++ b/ansible/playbooks/tools/6to4.yml
@@ -26,7 +26,7 @@
     debops_6to4_var_ipv4_interface: '{{ debops_6to4_ipv4_interface | default(ansible_default_ipv4.interface) }}'
 
     # IPv6 address converted from IPv4 public address
-    debops_6to4_var_ipv6_address: '{{ hostvars[inventory_hostname]["ansible_" + debops_6to4_var_ipv4_interface].ipv4.address | ipv4("6to4") }}'
+    debops_6to4_var_ipv6_address: '{{ hostvars[inventory_hostname]["ansible_" + debops_6to4_var_ipv4_interface].ipv4.address | ansible.utils.ipv4("6to4") }}'
 
 
   pre_tasks:

--- a/ansible/roles/avahi/defaults/main.yml
+++ b/ansible/roles/avahi/defaults/main.yml
@@ -60,7 +60,8 @@ avahi__use_ipv4: True
 # disabled if there are no IPv6 addresses present.
 avahi__use_ipv6: '{{ True
                      if (ansible_all_ipv6_addresses
-                         | difference(ansible_all_ipv6_addresses | ipv6("link-local")))
+                         | difference(ansible_all_ipv6_addresses
+                         | ansible.utils.ipv6("link-local")))
                      else False }}'
 
                                                                    # ]]]

--- a/ansible/roles/dhcpd/templates/etc/dhcp/dhcpd.conf.j2
+++ b/ansible/roles/dhcpd/templates/etc/dhcp/dhcpd.conf.j2
@@ -32,15 +32,15 @@ option domain-name "{{ dhcpd__domain_name }}";
 {%      if dhcpd__domain_search %}
 option domain-search "{{ dhcpd__domain_search | join('", "') }}";
 {%      endif %}
-{%      if dhcpd__name_servers|ipv4 %}
-option domain-name-servers {{ dhcpd__name_servers|ipv4 | join(', ') }};
+{%      if dhcpd__name_servers | ansible.utils.ipv4 %}
+option domain-name-servers {{ dhcpd__name_servers | ansible.utils.ipv4 | join(', ') }};
 {%      endif %}
 {%  elif dhcpd__protocol == 'DHCPv6' %}
 {%      if dhcpd__domain_search %}
 option dhcp6.domain-search "{{ dhcpd__domain_search | join('", "') }}";
 {%      endif %}
-{%      if dhcpd__name_servers|ipv6 %}
-option dhcp6.name-servers {{ dhcpd__name_servers|ipv6 | join(', ') }};
+{%      if dhcpd__name_servers | ansible.utils.ipv6 %}
+option dhcp6.name-servers {{ dhcpd__name_servers | ansible.utils.ipv6 | join(', ') }};
 {%      endif %}
 {%  endif %}
 {%  if dhcpd__global_options_map[dhcpd__protocol] | d() %}

--- a/ansible/roles/dhcpd/templates/etc/dhcp/macro_subnet.j2
+++ b/ansible/roles/dhcpd/templates/etc/dhcp/macro_subnet.j2
@@ -4,16 +4,16 @@
  #}
 {% from 'macro_pool.j2' import print_pool %}
 {% macro print_subnet(subnet, protocol) %}
-{%  if ((protocol == 'DHCPv4' and subnet.subnet | d()|ipv4) or
-        (protocol == 'DHCPv6' and subnet.subnet | d()|ipv6)) and
+{%  if ((protocol == 'DHCPv4' and subnet.subnet | d() | ansible.utils.ipv4) or
+        (protocol == 'DHCPv6' and subnet.subnet | d() | ansible.utils.ipv6)) and
        subnet.state | d('present') == 'present' %}
 {%      if subnet.comment | d() %}
 # {{ subnet.comment }}
 {%      endif %}
 {%      if protocol == 'DHCPv4' %}
-subnet {{ subnet.subnet|ipaddr('network') }} netmask {{ subnet.subnet|ipaddr('netmask') }} {
+subnet {{ subnet.subnet | ansible.utils.ipaddr('network') }} netmask {{ subnet.subnet | ansible.utils.ipaddr('netmask') }} {
 {%      elif protocol == 'DHCPv6' %}
-subnet6 {{ subnet.subnet|ipaddr('network/prefix') }} {
+subnet6 {{ subnet.subnet | ansible.utils.ipaddr('network/prefix') }} {
 {%      endif %}
 {%      if subnet.options | d() %}
 

--- a/ansible/roles/dnsmasq/defaults/main.yml
+++ b/ansible/roles/dnsmasq/defaults/main.yml
@@ -403,7 +403,8 @@ dnsmasq__default_configuration:
         state: '{{ "comment"
                    if ((ansible_local.lxc.net_domain | d()) or
                        (ansible_local.resolvconf.upstream_nameservers
-                          | d(ansible_dns.nameservers) | ipaddr("private")))
+                        | d(ansible_dns.nameservers)
+                        | ansible.utils.ipaddr("private")))
                    else "present" }}'
 
       - name: 'resolv-file'

--- a/ansible/roles/dnsmasq/templates/etc/dnsmasq.d/dhcp-dns-options.conf.j2
+++ b/ansible/roles/dnsmasq/templates/etc/dnsmasq.d/dhcp-dns-options.conf.j2
@@ -30,11 +30,11 @@
 {%       set _ = dhcp_host.append('set:' + entry.tag) %}
 {%     endif %}
 {%     if entry.ip | d() and (entry.host is undefined and entry.a is undefined and entry.aaaa is undefined) %}
-{%       set _ = dhcp_host.extend( ([ entry.ip ] if (entry.ip is string) else entry.ip) | ipwrap ) %}
+{%       set _ = dhcp_host.extend( ([ entry.ip ] if (entry.ip is string) else entry.ip) | ansible.utils.ipwrap ) %}
 {%     elif entry.ipaddr | d() and (entry.host is undefined and entry.a is undefined and entry.aaaa is undefined) %}
-{%       set _ = dhcp_host.extend( ([ entry.ipaddr ] if (entry.ipaddr is string) else entry.ipaddr) | ipwrap ) %}
+{%       set _ = dhcp_host.extend( ([ entry.ipaddr ] if (entry.ipaddr is string) else entry.ipaddr) | ansible.utils.ipwrap ) %}
 {%     elif entry.address | d() and (entry.host is undefined and entry.a is undefined and entry.aaaa is undefined) %}
-{%       set _ = dhcp_host.extend( ([ entry.address ] if (entry.address is string) else entry.address) | ipwrap ) %}
+{%       set _ = dhcp_host.extend( ([ entry.address ] if (entry.address is string) else entry.address) | ansible.utils.ipwrap ) %}
 {%     endif %}
 {%     if entry.name | d() %}
 {%       set _ = dhcp_host.append(entry.name) %}
@@ -57,11 +57,11 @@
 {%       endif %}
 {%       set _ = host_record.append(host_name + '.' + entry.domain) %}
 {%       if entry.ip | d() %}
-{%         set _ = host_record.extend( ([ entry.ip ] if (entry.ip is string) else entry.ip) | ipwrap ) %}
+{%         set _ = host_record.extend( ([ entry.ip ] if (entry.ip is string) else entry.ip) | ansible.utils.ipwrap ) %}
 {%       elif entry.ipaddr | d() %}
-{%         set _ = host_record.extend( ([ entry.ipaddr ] if (entry.ipaddr is string) else entry.ipaddr) | ipwrap ) %}
+{%         set _ = host_record.extend( ([ entry.ipaddr ] if (entry.ipaddr is string) else entry.ipaddr) | ansible.utils.ipwrap ) %}
 {%       elif entry.address | d() %}
-{%         set _ = host_record.extend( ([ entry.address ] if (entry.address is string) else entry.address) | ipwrap ) %}
+{%         set _ = host_record.extend( ([ entry.address ] if (entry.address is string) else entry.address) | ansible.utils.ipwrap ) %}
 {%       endif %}
 {%     endif %}
 {%     if (entry.host | d() or entry.a | d() or entry.aaaa | d()) and (entry.ip | d() or entry.ipaddr | d() or entry.address | d() or entry.target | d()) %}

--- a/ansible/roles/dnsmasq/templates/lookup/dnsmasq__interface_configuration.j2
+++ b/ansible/roles/dnsmasq/templates/lookup/dnsmasq__interface_configuration.j2
@@ -11,16 +11,16 @@
 {%     if hostvars[inventory_hostname]["ansible_" + interface.name].ipv4 | d() %}
 {%       set _ = dnsmasq__tpl_ipv4.append(hostvars[inventory_hostname]["ansible_" + interface.name].ipv4.address + '/'
                                           + (hostvars[inventory_hostname]["ansible_" + interface.name].ipv4.address + '/'
-                                             + hostvars[inventory_hostname]["ansible_" + interface.name].ipv4.netmask) | ipaddr('prefix') | string) %}
+                                             + hostvars[inventory_hostname]["ansible_" + interface.name].ipv4.netmask) | ansible.utils.ipaddr('prefix') | string) %}
 {%       if hostvars[inventory_hostname]["ansible_" + interface.name].ipv4_secondaries | d() %}
 {%         for element in hostvars[inventory_hostname]["ansible_" + interface.name].ipv4_secondaries %}
-{%           set _ = dnsmasq__tpl_ipv4.append(element.address + '/' + (element.address + '/' + element.netmask) | ipaddr('prefix') | string) %}
+{%           set _ = dnsmasq__tpl_ipv4.append(element.address + '/' + (element.address + '/' + element.netmask) | ansible.utils.ipaddr('prefix') | string) %}
 {%         endfor %}
 {%       endif %}
 {%     endif %}
 {%     if hostvars[inventory_hostname]["ansible_" + interface.name].ipv6 | d() %}
 {%       for element in hostvars[inventory_hostname]["ansible_" + interface.name].ipv6 %}
-{%         if not element.address | ipv6('link-local') %}
+{%         if not element.address | ansible.utils.ipv6('link-local') %}
 {%           set _ = dnsmasq__tpl_ipv6.append(element.address + '/' + element.prefix) %}
 {%         endif %}
 {%       endfor %}
@@ -28,18 +28,18 @@
 {%   endif %}
 {%   if interface.address | d() %}
 {%     for element in ([ interface.address ] if interface.address is string else interface.address) %}
-{%       if element | ipv4('host/prefix') %}
+{%       if element | ansible.utils.ipv4('host/prefix') %}
 {%         set _ = dnsmasq__tpl_ipv4.append(element) %}
-{%       elif element | ipv6('host/prefix') and not element | ipv6('link-local') %}
+{%       elif element | ansible.utils.ipv6('host/prefix') and not element | ansible.utils.ipv6('link-local') %}
 {%         set _ = dnsmasq__tpl_ipv6.append(element) %}
 {%       endif %}
 {%     endfor %}
 {%   endif %}
 {%   if interface.addresses | d() %}
 {%     for element in ([ interface.addresses ] if interface.addresses is string else interface.addresses) %}
-{%       if element | ipv4('host/prefix') %}
+{%       if element | ansible.utils.ipv4('host/prefix') %}
 {%         set _ = dnsmasq__tpl_ipv4.append(element) %}
-{%       elif element | ipv6('host/prefix') and not element | ipv6('link-local') %}
+{%       elif element | ansible.utils.ipv6('host/prefix') and not element | ansible.utils.ipv6('link-local') %}
 {%         set _ = dnsmasq__tpl_ipv6.append(element) %}
 {%       endif %}
 {%     endfor %}
@@ -77,14 +77,14 @@
   "name": ("dhcp_range_" + (host_address | replace('.','_') | replace('/','_'))),
   "option": "dhcp-range",
   "separator": True,
-  "value": ("set:" + interface_tag + "," + host_address | ipv4(interface.dhcp_range_start | d(10) | int) | ipv4('address') + ',' + host_address | ipv4(interface.dhcp_range_end | d(-10) | int) | ipv4('address') + ',' + host_address | ipv4('netmask') + ',' + interface.dhcp_lease | d('24h'))
+  "value": ("set:" + interface_tag + "," + host_address | ansible.utils.ipv4(interface.dhcp_range_start | d(10) | int) | ansible.utils.ipv4('address') + ',' + host_address | ansible.utils.ipv4(interface.dhcp_range_end | d(-10) | int) | ansible.utils.ipv4('address') + ',' + host_address | ansible.utils.ipv4('netmask') + ',' + interface.dhcp_lease | d('24h'))
 }) %}
 {%       endfor %}
 {%       for host_address in dnsmasq__tpl_ipv6 %}
 {%         set _ = interface_options.append({
   "name": ("dhcp_range_" + (host_address | replace(':','_') | replace('/','_'))),
   "option": "dhcp-range",
-  "value": ("set:" + interface_tag + "," + host_address | ipv6(interface.dhcp_range_start | d(10) | int) | ipv6('address') + ',' + host_address | ipv6(interface.dhcp_range_end | d(-10) | int) | ipv6('address') + ',' + interface.dhcp_ipv6_mode | d("ra-names,ra-stateless,slaac") + "," + host_address | ipv6('prefix') | string + ',' + interface.dhcp_lease | d('24h'))
+  "value": ("set:" + interface_tag + "," + host_address | ansible.utils.ipv6(interface.dhcp_range_start | d(10) | int) | ansible.utils.ipv6('address') + ',' + host_address | ansible.utils.ipv6(interface.dhcp_range_end | d(-10) | int) | ansible.utils.ipv6('address') + ',' + interface.dhcp_ipv6_mode | d("ra-names,ra-stateless,slaac") + "," + host_address | ansible.utils.ipv6('prefix') | string + ',' + interface.dhcp_lease | d('24h'))
 }) %}
 {%       endfor %}
 {%     endif %}
@@ -116,7 +116,7 @@
   "name": "dhcp_option6_dns_server",
   "option": "dhcp-option",
   "comment": "Advertise RDNSS servers for local IPv6 network",
-  "value": ("tag:" + interface_tag + ",option6:dns-server," + dnsmasq__tpl_ipv6 | ipv6("address") | ipwrap | join(","))
+  "value": ("tag:" + interface_tag + ",option6:dns-server," + dnsmasq__tpl_ipv6 | ansible.utils.ipv6("address") | ansible.utils.ipwrap | join(","))
 }) %}
 {%   endif %}
 {%   set _ = interface_options.append({
@@ -133,7 +133,7 @@
 {%     set _ = interface_options.append({
   "name": ("domain_" + (host_address | replace('.','_') | replace('/','_'))),
   "option": "domain",
-  "value": (interface_domain + "," + host_address | ipaddr('subnet') + (",local" if (host_address | ipaddr('prefix') in [ 8, 16, 24 ]) else ""))
+  "value": (interface_domain + "," + host_address | ansible.utils.ipaddr('subnet') + (",local" if (host_address | ansible.utils.ipaddr('prefix') in [ 8, 16, 24 ]) else ""))
 }) %}
 {%   endfor %}
 {%   if (interface.boot_enabled | d(dnsmasq__boot_enabled)) | bool %}

--- a/ansible/roles/dnsmasq/templates/lookup/dnsmasq__tcpwrappers__dependent_allow.j2
+++ b/ansible/roles/dnsmasq/templates/lookup/dnsmasq__tcpwrappers__dependent_allow.j2
@@ -12,16 +12,16 @@
 {%     if hostvars[inventory_hostname]["ansible_" + interface.name].ipv4 | d() %}
 {%       set _ = dnsmasq__tpl_ipv4.append(hostvars[inventory_hostname]["ansible_" + interface.name].ipv4.address + '/'
                                           + (hostvars[inventory_hostname]["ansible_" + interface.name].ipv4.address + '/'
-                                             + hostvars[inventory_hostname]["ansible_" + interface.name].ipv4.netmask) | ipaddr('prefix') | string) %}
+                                             + hostvars[inventory_hostname]["ansible_" + interface.name].ipv4.netmask) | ansible.utils.ipaddr('prefix') | string) %}
 {%       if hostvars[inventory_hostname]["ansible_" + interface.name].ipv4_secondaries | d() %}
 {%         for element in hostvars[inventory_hostname]["ansible_" + interface.name].ipv4_secondaries %}
-{%           set _ = dnsmasq__tpl_ipv4.append(element.address + '/' + (element.address + '/' + element.netmask) | ipaddr('prefix') | string) %}
+{%           set _ = dnsmasq__tpl_ipv4.append(element.address + '/' + (element.address + '/' + element.netmask) | ansible.utils.ipaddr('prefix') | string) %}
 {%         endfor %}
 {%       endif %}
 {%     endif %}
 {%     if hostvars[inventory_hostname]["ansible_" + interface.name].ipv6 | d() %}
 {%       for element in hostvars[inventory_hostname]["ansible_" + interface.name].ipv6 %}
-{%         if not element.address | ipv6('link-local') %}
+{%         if not element.address | ansible.utils.ipv6('link-local') %}
 {%           set _ = dnsmasq__tpl_ipv6.append(element.address + '/' + element.prefix) %}
 {%         endif %}
 {%       endfor %}
@@ -29,18 +29,18 @@
 {%   endif %}
 {%   if interface.address | d() %}
 {%     for element in ([ interface.address ] if interface.address is string else interface.address) %}
-{%       if element | ipv4('host/prefix') %}
+{%       if element | ansible.utils.ipv4('host/prefix') %}
 {%         set _ = dnsmasq__tpl_ipv4.append(element) %}
-{%       elif element | ipv6('host/prefix') and not element | ipv6('link-local') %}
+{%       elif element | ansible.utils.ipv6('host/prefix') and not element | ansible.utils.ipv6('link-local') %}
 {%         set _ = dnsmasq__tpl_ipv6.append(element) %}
 {%       endif %}
 {%     endfor %}
 {%   endif %}
 {%   if interface.addresses | d() %}
 {%     for element in ([ interface.addresses ] if interface.addresses is string else interface.addresses) %}
-{%       if element | ipv4('host/prefix') %}
+{%       if element | ansible.utils.ipv4('host/prefix') %}
 {%         set _ = dnsmasq__tpl_ipv4.append(element) %}
-{%       elif element | ipv6('host/prefix') and not element | ipv6('link-local') %}
+{%       elif element | ansible.utils.ipv6('host/prefix') and not element | ansible.utils.ipv6('link-local') %}
 {%         set _ = dnsmasq__tpl_ipv6.append(element) %}
 {%       endif %}
 {%     endfor %}
@@ -51,7 +51,7 @@
 {% endfor %}
 {% set _ = dnsmasq__tpl_tcpwrappers__dependent_allow.append({
   "daemon": "in.tftpd",
-  "client": (dnsmasq__tpl_subnets | ipaddr('subnet')),
+  "client": (dnsmasq__tpl_subnets | ansible.utils.ipaddr('subnet')),
   "weight": 50,
   "filename": "dnsmasq_dependent_allow",
   "comment": "Allow remote connections to TFTP server",

--- a/ansible/roles/dropbear_initramfs/defaults/main.yml
+++ b/ansible/roles/dropbear_initramfs/defaults/main.yml
@@ -105,8 +105,8 @@ dropbear_initramfs__network_gateway: '{{ ansible_default_ipv4.gateway }}'
 # The `ipwrap` filter causes IPv6 address to work on some platforms.
 # Refer to: https://serverfault.com/questions/445296/is-there-a-linux-kernel-boot-parameter-to-configure-an-ipv6-address/701451#701451
 dropbear_initramfs__network_manual: '{{
-  (dropbear_initramfs__network_address | ipwrap) + "::" +
-  (dropbear_initramfs__network_gateway | ipwrap) + ":" +
+  (dropbear_initramfs__network_address | ansible.utils.ipwrap) + "::" +
+  (dropbear_initramfs__network_gateway | ansible.utils.ipwrap) + ":" +
   dropbear_initramfs__network_netmask + "::" +
   dropbear_initramfs__network_device + ":none" }}'
 

--- a/ansible/roles/dropbear_initramfs/templates/etc/initramfs-tools/scripts/local-top/debops_dropbear_initramfs.j2
+++ b/ansible/roles/dropbear_initramfs/templates/etc/initramfs-tools/scripts/local-top/debops_dropbear_initramfs.j2
@@ -21,11 +21,11 @@ esac
 {% for name, interface in dropbear_initramfs__combined_interfaces | dictsort %}
 {%   set interface_name = (interface.iface | d(name)) %}
 {%   set addresses = (debops__tpl_macros.flattened(interface.address, interface.addresses) | from_yaml) | unique %}
-{%   set ipv4_addresses = addresses | ipv4 %}
-{%   set ipv6_addresses = addresses | ipv6 %}
+{%   set ipv4_addresses = addresses | ansible.utils.ipv4 %}
+{%   set ipv6_addresses = addresses | ansible.utils.ipv6 %}
 {%   set gateways = (debops__tpl_macros.flattened(interface.gateway, interface.gateways) | from_yaml) | unique %}
-{%   set ipv4_gateways = gateways | ipv4 %}
-{%   set ipv6_gateways = gateways | ipv6 %}
+{%   set ipv4_gateways = gateways | ansible.utils.ipv4 %}
+{%   set ipv6_gateways = gateways | ansible.utils.ipv6 %}
 
 ip link set dev {{ interface_name | quote }} up
 {%   if interface.inet6 in ['static'] %}

--- a/ansible/roles/ferm/templates/etc/ferm/rules.d/rule.conf.j2
+++ b/ansible/roles/ferm/templates/etc/ferm/rules.d/rule.conf.j2
@@ -384,12 +384,12 @@
     @def $PRIVATE_IP = ( @ipfilter( ({{ ferm__tpl_config['private_ip'] | unique | join(' ') }}) ) );
 
 {%       if ferm__tpl_config['public_ip'] | d() %}
-    @def $PUBLIC_IPV4 = "{{ ferm__tpl_config['public_ip'] | unique | ipv4 | first | d('') }}";
-    @def $PUBLIC_IPV6 = "{{ ferm__tpl_config['public_ip'] | unique | ipv6 | first | d('') }}";
+    @def $PUBLIC_IPV4 = "{{ ferm__tpl_config['public_ip'] | unique | ansible.utils.ipv4 | first | d('') }}";
+    @def $PUBLIC_IPV6 = "{{ ferm__tpl_config['public_ip'] | unique | ansible.utils.ipv6 | first | d('') }}";
 
 {%       endif %}
-    @def $PRIVATE_IPV4 = "{{ ferm__tpl_config['private_ip'] | unique | ipv4 | first | d('') }}";
-    @def $PRIVATE_IPV6 = "{{ ferm__tpl_config['private_ip'] | unique | ipv6 | first | d('') }}";
+    @def $PRIVATE_IPV4 = "{{ ferm__tpl_config['private_ip'] | unique | ansible.utils.ipv4 | first | d('') }}";
+    @def $PRIVATE_IPV6 = "{{ ferm__tpl_config['private_ip'] | unique | ansible.utils.ipv6 | first | d('') }}";
 
     {% if ferm__tpl_config['interface'] | d() %}@if @ne($PUBLIC_IF,""){% endif %}{% if ferm__tpl_config['public_ip'] | d() %} @if @ne($PUBLIC_IP,""){% endif %} @if @ne($PRIVATE_IP,"") {
         table filter chain FORWARD {

--- a/ansible/roles/ifupdown/templates/etc/network/interfaces.d/iface.j2
+++ b/ansible/roles/ifupdown/templates/etc/network/interfaces.d/iface.j2
@@ -13,11 +13,11 @@
 {% set ifupdown__tpl_ipv6_addresses = [] %}
 {% if interface.no_addresses is undefined or not interface.no_addresses | bool %}
 {%   set ifupdown__tpl_addresses = (debops__tpl_macros.flattened(interface.address, interface.addresses) | from_yaml) | unique %}
-{%   set ifupdown__tpl_ipv4_addresses = ifupdown__tpl_addresses | ipv4 %}
-{%   set ifupdown__tpl_ipv6_addresses = ifupdown__tpl_addresses | ipv6 %}
+{%   set ifupdown__tpl_ipv4_addresses = ifupdown__tpl_addresses | ansible.utils.ipv4 %}
+{%   set ifupdown__tpl_ipv6_addresses = ifupdown__tpl_addresses | ansible.utils.ipv6 %}
 {%   set ifupdown__tpl_gateways = (debops__tpl_macros.flattened(interface.gateway, interface.gateways) | from_yaml) | unique %}
-{%   set ifupdown__tpl_ipv4_gateways = ifupdown__tpl_gateways | unique | ipv4 %}
-{%   set ifupdown__tpl_ipv6_gateways = ifupdown__tpl_gateways | unique | ipv6 %}
+{%   set ifupdown__tpl_ipv4_gateways = ifupdown__tpl_gateways | unique | ansible.utils.ipv4 %}
+{%   set ifupdown__tpl_ipv6_gateways = ifupdown__tpl_gateways | unique | ansible.utils.ipv6 %}
 {% endif %}
 {% if interface.inet | d() and interface.inet in [ 'static', 'tunnel' ] and not ifupdown__tpl_ipv4_addresses %}
 {%   set _ = interface.update({"inet":"manual"}) %}
@@ -62,8 +62,8 @@ allow-{{ thing }} {{ interface_name }}
 {%     endif %}
 iface {{ interface_name }} inet {{ interface.inet }}
 {%     if interface.inet == 'static' and ifupdown__tpl_ipv4_addresses %}
-    address         {{ ifupdown__tpl_ipv4_addresses[0] | ipaddr('address') }}
-    netmask         {{ ifupdown__tpl_ipv4_addresses[0] | ipaddr('netmask') }}
+    address         {{ ifupdown__tpl_ipv4_addresses[0] | ansible.utils.ipaddr('address') }}
+    netmask         {{ ifupdown__tpl_ipv4_addresses[0] | ansible.utils.ipaddr('netmask') }}
 {%       set _ = ifupdown__tpl_separate_stanza.append(True) %}
 {%       if ifupdown__tpl_ipv4_addresses | length > 1 %}
 {%         for address in ifupdown__tpl_ipv4_addresses[1:] %}

--- a/ansible/roles/ifupdown/templates/lookup/ifupdown__combined_interfaces.j2
+++ b/ansible/roles/ifupdown/templates/lookup/ifupdown__combined_interfaces.j2
@@ -112,7 +112,7 @@
 {%       set _ = params.update({"inet6":"6to4"}) %}
 {%     endif %}
 {%     if params.options is undefined and params.options6 is undefined and 'local' not in params.keys() %}
-{%       if ansible_default_ipv4.address | ipv4('public') %}
+{%       if ansible_default_ipv4.address | ansible.utils.ipv4('public') %}
 {%         set _ = params.update({"local":ansible_default_ipv4.address}) %}
 {%       else %}
 {%         set _ = params.update({"state":"absent"}) %}

--- a/ansible/roles/ifupdown/templates/lookup/ifupdown__ferm__dependent_rules.j2
+++ b/ansible/roles/ifupdown/templates/lookup/ifupdown__ferm__dependent_rules.j2
@@ -25,14 +25,14 @@
 {%         set ifupdown__tpl_ipv4_addresses = [] %}
 {%         if params.address | d() %}
 {%           for element in ([ params.address ] if params.address is string else params.address) %}
-{%             if element | ipv4('host/prefix') %}
+{%             if element | ansible.utils.ipv4('host/prefix') %}
 {%               set _ = ifupdown__tpl_ipv4_addresses.append(element) %}
 {%             endif %}
 {%           endfor %}
 {%         endif %}
 {%         if params.addresses | d() %}
 {%           for element in ([ params.addresses ] if params.addresses is string else params.addresses) %}
-{%             if element | ipv4('host/prefix') %}
+{%             if element | ansible.utils.ipv4('host/prefix') %}
 {%               set _ = ifupdown__tpl_ipv4_addresses.append(element) %}
 {%             endif %}
 {%           endfor %}
@@ -48,10 +48,10 @@
 
 @if $ipv4_enabled {
     domain ip table nat chain POSTROUTING {
-        source ' + (network | ipaddr('network')) + '/' + (network | ipaddr('netmask')) + ' destination 224.0.0.0/255.255.255.0 RETURN;
-        source ' + (network | ipaddr('network')) + '/' + (network | ipaddr('netmask')) + ' destination 255.255.255.255 RETURN;
-        destination ' + (network | ipaddr('network')) + '/' + (network | ipaddr('netmask')) + ' RETURN;
-        source ' + (network | ipaddr('network')) + '/' + (network | ipaddr('netmask')) + (' MASQUERADE' if ((params.nat_masquerade | d(ifupdown__default_nat_masquerade)) | bool) else ' SNAT to ' + (params.nat_snat_address if (params.nat_snat_address | d() and params.nat_snat_address | ipv4('address')) else (hostvars[inventory_hostname]["ansible_" + params.nat_snat_interface]["ipv4"].address if params.nat_snat_interface | d() else ansible_default_ipv4.address))) + ';
+        source ' + (network | ansible.utils.ipaddr('network')) + '/' + (network | ansible.utils.ipaddr('netmask')) + ' destination 224.0.0.0/255.255.255.0 RETURN;
+        source ' + (network | ansible.utils.ipaddr('network')) + '/' + (network | ansible.utils.ipaddr('netmask')) + ' destination 255.255.255.255 RETURN;
+        destination ' + (network | ansible.utils.ipaddr('network')) + '/' + (network | ansible.utils.ipaddr('netmask')) + ' RETURN;
+        source ' + (network | ansible.utils.ipaddr('network')) + '/' + (network | ansible.utils.ipaddr('netmask')) + (' MASQUERADE' if ((params.nat_masquerade | d(ifupdown__default_nat_masquerade)) | bool) else ' SNAT to ' + (params.nat_snat_address if (params.nat_snat_address | d() and params.nat_snat_address | ansible.utils.ipv4('address')) else (hostvars[inventory_hostname]["ansible_" + params.nat_snat_interface]["ipv4"].address if params.nat_snat_interface | d() else ansible_default_ipv4.address))) + ';
     }
 }') %}
 {%         endfor %}

--- a/ansible/roles/ldap/templates/lookup/ldap__device_ip_addresses.j2
+++ b/ansible/roles/ldap/templates/lookup/ldap__device_ip_addresses.j2
@@ -17,7 +17,7 @@
 {%   if hostvars[inventory_hostname][iface].ipv6 | d() %}
 {%     for element in hostvars[inventory_hostname][iface].ipv6 %}
 {%       set address = element.address + '/' + element.prefix %}
-{%       if not address | ipv6('link-local') %}
+{%       if not address | ansible.utils.ipv6('link-local') %}
 {%         set _ = ldap__tpl_device_ip_addresses.append(element.address) %}
 {%       endif %}
 {%     endfor %}
@@ -39,7 +39,7 @@
 {%       if hostvars[inventory_hostname][iface].ipv6 | d() %}
 {%         for element in hostvars[inventory_hostname][iface].ipv6 %}
 {%           set address = element.address + '/' + element.prefix %}
-{%           if not address | ipv6('link-local') %}
+{%           if not address | ansible.utils.ipv6('link-local') %}
 {%             set _ = ldap__tpl_device_ip_addresses.append(element.address) %}
 {%           endif %}
 {%         endfor %}

--- a/ansible/roles/libvirt/templates/lookup/network/dnsmasq.xml.j2
+++ b/ansible/roles/libvirt/templates/lookup/network/dnsmasq.xml.j2
@@ -24,23 +24,23 @@
   <domain name="{{ item.domain }}" localOnly="{{ "yes" if item.domain_local | d() else "no" }}"/>
 {% endif %}
 {% if item.addresses | d() %}
-{% for subnet in item.addresses | ipv4('host/prefix') %}
-  <ip family="ipv4" address="{{ subnet | ipaddr('address') }}" netmask="{{ subnet | ipaddr('netmask') }}">
+{% for subnet in item.addresses | ansible.utils.ipv4('host/prefix') %}
+  <ip family="ipv4" address="{{ subnet | ansible.utils.ipaddr('address') }}" netmask="{{ subnet | ansible.utils.ipaddr('netmask') }}">
 {% if item.dhcp | d() and loop.first %}
     <dhcp>
 {% if item.bootp | d() %}
       <bootp file="{{ item.bootp_file | d('/undionly.kpxe') }}"{% if item.bootp_server | d() %} server="{{ item.bootp_server }}"{% endif %}/>
 {% endif %}
-      <range start="{{ subnet | ipaddr(libvirt__tpl_dhcp_range_start) | ipaddr('address') }}" end="{{ subnet | ipaddr(libvirt__tpl_dhcp_range_end) | ipaddr('address') }}"/>
+      <range start="{{ subnet | ansible.utils.ipaddr(libvirt__tpl_dhcp_range_start) | ansible.utils.ipaddr('address') }}" end="{{ subnet | ansible.utils.ipaddr(libvirt__tpl_dhcp_range_end) | ansible.utils.ipaddr('address') }}"/>
     </dhcp>
 {% endif %}
   </ip>
 {% endfor %}
-{% for subnet in item.addresses | ipv6('host/prefix') %}
-  <ip family="ipv6" address="{{ subnet | ipaddr('address') }}" prefix="{{ subnet | ipaddr('prefix') }}">
+{% for subnet in item.addresses | ansible.utils.ipv6('host/prefix') %}
+  <ip family="ipv6" address="{{ subnet | ansible.utils.ipaddr('address') }}" prefix="{{ subnet | ansible.utils.ipaddr('prefix') }}">
 {% if item.dhcp | d() and loop.first %}
     <dhcp>
-      <range start="{{ subnet | ipaddr(libvirt__tpl_dhcp_range_start) | ipaddr('address') }}" end="{{ subnet | ipaddr(libvirt__tpl_dhcp_range_end) | ipaddr('address') }}"/>
+      <range start="{{ subnet | ansible.utils.ipaddr(libvirt__tpl_dhcp_range_start) | ansible.utils.ipaddr('address') }}" end="{{ subnet | ansible.utils.ipaddr(libvirt__tpl_dhcp_range_end) | ansible.utils.ipaddr('address') }}"/>
     </dhcp>
 {% endif %}
   </ip>

--- a/ansible/roles/lxc/templates/etc/default/lxc-net.j2
+++ b/ansible/roles/lxc/templates/etc/default/lxc-net.j2
@@ -12,11 +12,11 @@
 USE_LXC_BRIDGE="{{ 'true' if (lxc__net_deploy_state == 'present') else 'false' }}"
 {% if (lxc__net_deploy_state == 'present') %}
 LXC_BRIDGE="{{ lxc__net_bridge }}"
-LXC_ADDR="{{ lxc__net_address | ipaddr('address') }}"
-LXC_NETMASK="{{ lxc__net_address | ipaddr('netmask') }}"
-LXC_NETWORK="{{ lxc__net_address | ipaddr('subnet') }}"
-LXC_DHCP_RANGE="{{ lxc__net_address | ipaddr(lxc__net_dhcp_start | int) | ipaddr('address') + ',' + lxc__net_address | ipaddr(lxc__net_dhcp_end | int) | ipaddr('address') }}"
-LXC_DHCP_MAX="{{ (lxc__net_address | ipaddr('size')) | int - ((lxc__net_dhcp_start | int|abs) + (lxc__net_dhcp_end | int|abs)) }}"
+LXC_ADDR="{{ lxc__net_address | ansible.utils.ipaddr('address') }}"
+LXC_NETMASK="{{ lxc__net_address | ansible.utils.ipaddr('netmask') }}"
+LXC_NETWORK="{{ lxc__net_address | ansible.utils.ipaddr('subnet') }}"
+LXC_DHCP_RANGE="{{ lxc__net_address | ansible.utils.ipaddr(lxc__net_dhcp_start | int) | ansible.utils.ipaddr('address') + ',' + lxc__net_address | ansible.utils.ipaddr(lxc__net_dhcp_end | int) | ansible.utils.ipaddr('address') }}"
+LXC_DHCP_MAX="{{ (lxc__net_address | ansible.utils.ipaddr('size')) | int - ((lxc__net_dhcp_start | int|abs) + (lxc__net_dhcp_end | int|abs)) }}"
 LXC_DHCP_CONFILE="{{ lxc__net_dnsmasq_conf }}"
 LXC_DOMAIN="{{ lxc__net_domain }}"
 {% endif %}

--- a/ansible/roles/lxc/templates/etc/lxc/lxc-net-dnsmasq.conf.j2
+++ b/ansible/roles/lxc/templates/etc/lxc/lxc-net-dnsmasq.conf.j2
@@ -12,7 +12,7 @@
 dns-loop-detect
 
 # Mark the LXC domain as local and generate PTR resource records automatically
-domain = {{ lxc__net_domain + ',' + (lxc__net_address | ipaddr('subnet')) + (',local' if (lxc__net_address | ipaddr('prefix') in [ 8, 16, 24 ]) else '') }}
+domain = {{ lxc__net_domain + ',' + (lxc__net_address | ansible.utils.ipaddr('subnet')) + (',local' if (lxc__net_address | ansible.utils.ipaddr('prefix') in [ 8, 16, 24 ]) else '') }}
 
 # Set the FQDN name of the bridge interface in the DNS
 interface-name = {{ lxc__net_fqdn }},{{ lxc__net_bridge }}

--- a/ansible/roles/mailman/defaults/main/web_configuration.yml
+++ b/ansible/roles/mailman/defaults/main/web_configuration.yml
@@ -385,7 +385,8 @@ mailman__web_default_configuration:
                 + ((ansible_all_ipv4_addresses | map("regex_replace", "^", "::ffff:") | list)
                    if ansible_all_ipv4_addresses | d([]) else [])
                 + (ansible_all_ipv6_addresses | d([])
-                   | difference(ansible_all_ipv6_addresses | d([]) | ipaddr("link-local"))))
+                   | difference(ansible_all_ipv6_addresses | d([])
+                   | ansible.utils.ipaddr("link-local"))))
                | sort | unique }}'
 
                                                                    # ]]]

--- a/ansible/roles/netbase/defaults/main.yml
+++ b/ansible/roles/netbase/defaults/main.yml
@@ -108,7 +108,7 @@ netbase__domain: '{{ ""
                                (ansible_local.netbase.self_domain | d()) and
                                (ansible_local.netbase.self_local_hostname | d()) | bool)
                            else ((ansible_host | d(ansible_ssh_host | d("0"))).split(".")[1:] | join(".")
-                                 if (not (ansible_host | d(ansible_ssh_host | d("0"))) | ipaddr)
+                                 if (not (ansible_host | d(ansible_ssh_host | d("0"))) | ansible.utils.ipaddr)
                                  else (inventory_hostname.split(".")[1:] | join(".")
                                        if (inventory_hostname.split(".") | count > 1)
                                        else ""))) }}'

--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -743,8 +743,9 @@ nginx_status: []
 #
 # By default allow access to the status page from webserver itself
 nginx_status_localhost: '{{ ["127.0.0.1/32", "::1/128"] + ansible_all_ipv4_addresses | d([]) +
-                            (ansible_all_ipv6_addresses | d([]) |
-                             difference(ansible_all_ipv6_addresses | d([]) | ipaddr("link-local"))) }}'
+                            (ansible_all_ipv6_addresses | d([])
+                             | difference(ansible_all_ipv6_addresses | d([])
+                             | ansible.utils.ipaddr("link-local"))) }}'
 
                                                                    # ]]]
 # .. envvar:: nginx_status_name [[[

--- a/ansible/roles/nginx/templates/etc/nginx/sites-available/default.conf.j2
+++ b/ansible/roles/nginx/templates/etc/nginx/sites-available/default.conf.j2
@@ -508,7 +508,7 @@
 {%   set nginx__tpl_hostnames = []                       %}
 {%   for element in ([ item.name ] if (item.name is string) else item.name) %}
 {%     set element_hostname = element | regex_replace(('\.' + (nginx__tpl_hostname_domain | replace('.', '\.')) + '$'), '') %}
-{%     if (not element_hostname | ipaddr and
+{%     if (not element_hostname | ansible.utils.ipaddr and
            element_hostname not in ([ item.name ] if (item.name is string) else item.name) and
            not element_hostname.startswith('www') and
            element_hostname is not search('[^a-zA-Z0-9\-\_\.]+')) and
@@ -704,7 +704,7 @@ server {
         ssl_stapling_verify       on;
         ssl_trusted_certificate   {{ nginx_tpl_ssl_trusted_certificate }};
 {%         endif                                                %}
-        resolver                  {{ (item.ocsp_resolvers | d(nginx_ocsp_resolvers)) | ipwrap | join(" ") }} valid=300s;
+        resolver                  {{ (item.ocsp_resolvers | d(nginx_ocsp_resolvers)) | ansible.utils.ipwrap | join(" ") }} valid=300s;
         resolver_timeout          5s;
 {%     endif                                                        %}
 {%     if (item.ssl_verify_client | d(nginx_default_ssl_verify_client)) | bool      %}

--- a/ansible/roles/ntp/templates/etc/ntpd/ntp.conf.j2
+++ b/ansible/roles/ntp/templates/etc/ntpd/ntp.conf.j2
@@ -59,17 +59,17 @@ restrict default ignore
 restrict -6 default ignore
 
 {%   if ntp__allow is string %}
-{%     if ntp__allow|ipv4 %}
-restrict {{ ntp__allow|ipaddr('network') }} mask {{ ntp__allow|ipaddr('netmask') }} notrap nomodify nopeer
+{%     if ntp__allow | ansible.utils.ipv4 %}
+restrict {{ ntp__allow | ansible.utils.ipaddr('network') }} mask {{ ntp__allow | ansible.utils.ipaddr('netmask') }} notrap nomodify nopeer
 {%     else %}
-restrict -6 {{ ntp__allow|ipaddr('network') }} mask {{ ntp__allow|ipaddr('netmask') }} notrap nomodify nopeer
+restrict -6 {{ ntp__allow | ansible.utils.ipaddr('network') }} mask {{ ntp__allow | ansible.utils.ipaddr('netmask') }} notrap nomodify nopeer
 {%     endif %}
 {%   else %}
 {%     for address in ntp__allow %}
-{%       if address|ipv4 %}
-restrict {{ address|ipaddr('network') }} mask {{ address|ipaddr('netmask') }} notrap nomodify nopeer
+{%       if address | ansible.utils.ipv4 %}
+restrict {{ address | ansible.utils.ipaddr('network') }} mask {{ address | ansible.utils.ipaddr('netmask') }} notrap nomodify nopeer
 {%       else %}
-restrict -6 {{ address|ipaddr('network') }} mask {{ address|ipaddr('netmask') }} notrap nomodify nopeer
+restrict -6 {{ address | ansible.utils.ipaddr('network') }} mask {{ address | ansible.utils.ipaddr('netmask') }} notrap nomodify nopeer
 {%       endif %}
 {%     endfor %}
 {%   endif %}

--- a/ansible/roles/pdns/defaults/main.yml
+++ b/ansible/roles/pdns/defaults/main.yml
@@ -299,13 +299,13 @@ pdns__default_configuration:
       Local IP addresses to which we bind. Accepts IPv6 addresses since pdns
       4.3.0.
     value: '{{ (pdns__local_address if ansible_local.pdns.version is version("4.3.0", ">=")
-                else (pdns__local_address | ipv4)) | join(",") }}'
+                else (pdns__local_address | ansible.utils.ipv4)) | join(",") }}'
 
   - name: 'local-ipv6'
     comment: |-
       Local IPv6 addresses to which we bind. Will be deprecated in pdns 4.3.0
       and removed in pdns 4.5.0.
-    value: '{{ pdns__local_address | ipv6 | join(",") }}'
+    value: '{{ pdns__local_address | ansible.utils.ipv6 | join(",") }}'
     state: '{{ "present"
                if ansible_local.pdns.version is version("4.3.0", "<")
                else "absent" }}'

--- a/ansible/roles/pki/defaults/main.yml
+++ b/ansible/roles/pki/defaults/main.yml
@@ -121,9 +121,9 @@ pki_vcs_ignore_patterns_host: []
 # Enable or disable support for ACME certificates.
 pki_acme: '{{ (True
                if (((ansible_all_ipv4_addresses | d([]) +
-                    ansible_all_ipv6_addresses | d([])) | ipaddr("public") and
-                    pki_default_domain)
-                  or pki_acme_type != "acme-tiny")
+                     ansible_all_ipv6_addresses | d([])) | ansible.utils.ipaddr("public")
+                    and pki_default_domain)
+                   or pki_acme_type != "acme-tiny")
                else False) | bool }}'
 
                                                                    # ]]]

--- a/ansible/roles/postconf/templates/lookup/postconf__env_capabilities.j2
+++ b/ansible/roles/postconf/templates/lookup/postconf__env_capabilities.j2
@@ -8,7 +8,7 @@
         (ansible_local.dovecot | d() and (ansible_local.dovecot.installed | d()) | bool))) %}
 {%   set _ = postconf__tpl_env_capabilities.extend([ 'auth', 'unauth-sender' ]) %}
 {% endif %}
-{% if (ansible_all_ipv4_addresses | d([]) + ansible_all_ipv6_addresses | d([])) | ipaddr('public') %}
+{% if (ansible_all_ipv4_addresses | d([]) + ansible_all_ipv6_addresses | d([])) | ansible.utils.ipaddr('public') %}
 {%   set _ = postconf__tpl_env_capabilities.append('public-mx-required') %}
 {% endif %}
 {{ postconf__tpl_env_capabilities | list }}

--- a/ansible/roles/postfix/templates/etc/postfix/main.cf.j2
+++ b/ansible/roles/postfix/templates/etc/postfix/main.cf.j2
@@ -68,12 +68,12 @@
 {%           endif %}
 {%           if element.state | d('present') != 'hidden' %}
 {%             if element_value is not string and element_value is not mapping and element_value is iterable %}
-{%               if element_value | ipwrap | join(', ') | length <= 50 %}
-{{ ('{}{} ={}{}').format(option_commented, element_name, (' ' if (element_value or element_value == 0) else ''), element_value | ipwrap | join(', ')) }}
+{%               if element_value | ansible.utils.ipwrap | join(', ') | length <= 50 %}
+{{ ('{}{} ={}{}').format(option_commented, element_name, (' ' if (element_value or element_value == 0) else ''), element_value | ansible.utils.ipwrap | join(', ')) }}
 {%               else %}
 {{ ('{}{} =').format(option_commented, element_name) }}
 {%                 for thing in element_value %}
-{{ ('{}{:<4}{}').format(option_commented, '', (thing | ipwrap) + ('' if loop.last | bool else ',')) }}
+{{ ('{}{:<4}{}').format(option_commented, '', (thing | ansible.utils.ipwrap) + ('' if loop.last | bool else ',')) }}
 {%                 endfor %}
 
 {%               endif %}
@@ -82,13 +82,13 @@
 {{ ('{}{} =').format(option_commented, element_name) }}
 {%                 set element_value_strip = element_value | regex_replace('\n$','') %}
 {%                 for thing in element_value_strip.split('\n') | list %}
-{{ ('{}{:<4}{}').format(option_commented, '', thing | ipwrap) }}
+{{ ('{}{:<4}{}').format(option_commented, '', thing | ansible.utils.ipwrap) }}
 {%                 endfor %}
 {%                 if not option_commented %}
 
 {%                 endif %}
 {%               else %}
-{{ ('{}{} ={}{}').format(option_commented, element_name, (' ' if (element_value or element_value == 0) else ''), element_value | ipwrap) }}
+{{ ('{}{} ={}{}').format(option_commented, element_name, (' ' if (element_value or element_value == 0) else ''), element_value | ansible.utils.ipwrap) }}
 {%               endif %}
 {%             else %}
 {{ ('{}{} ={}{}').format(option_commented, element_name, (' ' if (element_value or element_value == 0) else ''), element_value) }}

--- a/ansible/roles/postgresql_server/templates/etc/postgresql/pg_hba.conf.j2
+++ b/ansible/roles/postgresql_server/templates/etc/postgresql/pg_hba.conf.j2
@@ -49,14 +49,14 @@
 {%             set element_tpl_address4 = hostvars[host].ansible_all_ipv4_addresses | d([]) %}
 {%             if element_tpl_address4 %}
 {%               for part in element_tpl_address4 %}
-{%                 set _ = element_tpl_address.append(part | ipaddr('cidr')) %}
+{%                 set _ = element_tpl_address.append(part | ansible.utils.ipaddr('cidr')) %}
 {%               endfor %}
 {%             endif %}
 {%             if hostvars[host].ansible_all_ipv6_addresses | d() %}
-{%               set element_tpl_address6 = (hostvars[host].ansible_all_ipv6_addresses | difference(hostvars[host].ansible_all_ipv6_addresses | ipaddr('link-local'))) %}
+{%               set element_tpl_address6 = (hostvars[host].ansible_all_ipv6_addresses | difference(hostvars[host].ansible_all_ipv6_addresses | ansible.utils.ipaddr('link-local'))) %}
 {%               if element_tpl_address6 %}
 {%                 for part in element_tpl_address6 %}
-{%                   set _ = element_tpl_address.append(part | ipaddr('cidr')) %}
+{%                   set _ = element_tpl_address.append(part | ansible.utils.ipaddr('cidr')) %}
 {%                 endfor %}
 {%               endif %}
 {%             endif %}

--- a/ansible/roles/postscreen/defaults/main.yml
+++ b/ansible/roles/postscreen/defaults/main.yml
@@ -73,8 +73,8 @@ postscreen__combined_access: '{{ postscreen__access
 # hosts with public IP addresses.
 postscreen__dnsbl_enabled: '{{ True
                                if ((ansible_all_ipv4_addresses | d([])
-                                   + ansible_all_ipv6_addresses | d([]))
-                                   | ipaddr("public"))
+                                    + ansible_all_ipv6_addresses | d([]))
+                                   | ansible.utils.ipaddr("public"))
                                else False }}'
 
                                                                    # ]]]

--- a/ansible/roles/radvd/defaults/main.yml
+++ b/ansible/roles/radvd/defaults/main.yml
@@ -40,7 +40,7 @@ radvd__packages: []
 # .. envvar:: radvd__rdnss [[[
 #
 # List of DNS nameservers which should be advertised to the IPv6 clients.
-radvd__rdnss: '{{ (ansible_dns.nameservers | d([])) | ipv6 }}'
+radvd__rdnss: '{{ (ansible_dns.nameservers | d([])) | ansible.utils.ipv6 }}'
 
                                                                    # ]]]
 # .. envvar:: radvd__dnssl [[[

--- a/ansible/roles/radvd/templates/etc/radvd.conf.j2
+++ b/ansible/roles/radvd/templates/etc/radvd.conf.j2
@@ -90,14 +90,14 @@ interface {{ interface.name }} {
 {%     if radvd__tpl_prefixes %}
 {%       for prefix in radvd__tpl_prefixes %}
 {%         if prefix is string %}
-{%           if prefix | ipv6('subnet') %}
+{%           if prefix | ansible.utils.ipv6('subnet') %}
 
-{{ "        prefix {} {{\n        }};".format(prefix | ipv6('subnet')) }}
+{{ "        prefix {} {{\n        }};".format(prefix | ansible.utils.ipv6('subnet')) }}
 {%           endif %}
 {%         elif prefix is mapping %}
 {%           if prefix.name | d() and prefix.state | d('present') != 'absent' %}
 
-{{ "        prefix {} {{".format(prefix.name | ipv6('subnet')) }}
+{{ "        prefix {} {{".format(prefix.name | ansible.utils.ipv6('subnet')) }}
 {%             if prefix.options | d() %}
 {%               for option in prefix.options %}
 {%                 if option.name | d() and option.value | d() and option.state | d('present') != 'absent' %}
@@ -131,14 +131,14 @@ interface {{ interface.name }} {
 {%     if radvd__tpl_routes %}
 {%       for route in radvd__tpl_routes %}
 {%         if route is string %}
-{%           if route | ipv6('subnet') %}
+{%           if route | ansible.utils.ipv6('subnet') %}
 
-{{ "        route {} {{\n        }};".format(route | ipv6('subnet')) }}
+{{ "        route {} {{\n        }};".format(route | ansible.utils.ipv6('subnet')) }}
 {%           endif %}
 {%         elif route is mapping %}
 {%           if route.name | d() and route.state | d('present') != 'absent' %}
 
-{{ "        route {} {{".format(route.name | ipv6('subnet')) }}
+{{ "        route {} {{".format(route.name | ansible.utils.ipv6('subnet')) }}
 {%             if route.options | d() %}
 {%               for option in route.options %}
 {%                 if option.name | d() and option.value | d() and option.state | d('present') != 'absent' %}

--- a/ansible/roles/radvd/templates/lookup/radvd__default_interfaces.j2
+++ b/ansible/roles/radvd/templates/lookup/radvd__default_interfaces.j2
@@ -3,8 +3,8 @@
  # SPDX-License-Identifier: GPL-3.0-only
  #}
 {% set radvd__tpl_output = [] %}
-{% if (ansible_all_ipv6_addresses | difference(ansible_all_ipv6_addresses | ipv6('link-local'))) %}
-{%   set _ = radvd__tpl_output.append({'addresses': (ansible_all_ipv6_addresses | difference(ansible_all_ipv6_addresses | ipv6('link-local')))}) %}
+{% if (ansible_all_ipv6_addresses | difference(ansible_all_ipv6_addresses | ansible.utils.ipv6('link-local'))) %}
+{%   set _ = radvd__tpl_output.append({'addresses': (ansible_all_ipv6_addresses | difference(ansible_all_ipv6_addresses | ansible.utils.ipv6('link-local')))}) %}
 {%   for interface in ansible_interfaces %}
 {%     if interface != 'lo' %}
 {%       set radvd__tpl_interface = {

--- a/ansible/roles/snmpd/defaults/main.yml
+++ b/ansible/roles/snmpd/defaults/main.yml
@@ -128,8 +128,9 @@ snmpd_host_allow: []
 # List of IP addresses or CIDR networks which can connect to SNMP service
 # (from localhost). If not specified, remote connections are blocked.
 snmpd_local_allow: '{{ ansible_all_ipv4_addresses | d([]) +
-                       (ansible_all_ipv6_addresses | d([]) |
-                        difference(ansible_all_ipv6_addresses | d([]) | ipaddr("link-local"))) }}'
+                       (ansible_all_ipv6_addresses | d([])
+                        | difference(ansible_all_ipv6_addresses | d([])
+                                     | ansible.utils.ipaddr("link-local"))) }}'
 
                                                                    # ]]]
 # .. envvar:: snmpd_agent_address [[[

--- a/ansible/roles/tcpwrappers/templates/etc/hosts.allow.d/allow.j2
+++ b/ansible/roles/tcpwrappers/templates/etc/hosts.allow.d/allow.j2
@@ -31,19 +31,19 @@
 {%   endif %}
 {%   if item.client | d() %}
 {%     if item.client is string %}
-{%       set _ = tcpwrappers__tpl_client.append(item.client | ipwrap) %}
+{%       set _ = tcpwrappers__tpl_client.append(item.client | ansible.utils.ipwrap) %}
 {%     else %}
 {%       for element in item.client %}
-{%         set _ = tcpwrappers__tpl_client.append(element | ipwrap) %}
+{%         set _ = tcpwrappers__tpl_client.append(element | ansible.utils.ipwrap) %}
 {%       endfor %}
 {%     endif %}
 {%   endif %}
 {%   if item.clients | d() %}
 {%     if item.clients is string %}
-{%       set _ = tcpwrappers__tpl_client.append(item.clients | ipwrap) %}
+{%       set _ = tcpwrappers__tpl_client.append(item.clients | ansible.utils.ipwrap) %}
 {%     else %}
 {%       for element in item.clients %}
-{%         set _ = tcpwrappers__tpl_client.append(element | ipwrap) %}
+{%         set _ = tcpwrappers__tpl_client.append(element | ansible.utils.ipwrap) %}
 {%       endfor %}
 {%     endif %}
 {%   endif %}

--- a/ansible/roles/tcpwrappers/templates/etc/hosts.allow.d/ansible_controller.j2
+++ b/ansible/roles/tcpwrappers/templates/etc/hosts.allow.d/ansible_controller.j2
@@ -6,16 +6,16 @@
 {% set tcpwrappers__tpl_local_ansible_controllers = [] %}
 {% if ansible_local.core.ansible_controllers | d() %}
 {%   for element in ansible_local.core.ansible_controllers %}
-{%     set _ = tcpwrappers__tpl_local_ansible_controllers.append(element | ipwrap) %}
+{%     set _ = tcpwrappers__tpl_local_ansible_controllers.append(element | ansible.utils.ipwrap) %}
 {%   endfor %}
 {% endif %}
 {% if (ansible_local.tcpwrappers.ansible_controllers | d()) %}
 {%   for element in ansible_local.tcpwrappers.ansible_controllers %}
-{%     set _ = tcpwrappers__tpl_local_ansible_controllers.append(element | ipwrap) %}
+{%     set _ = tcpwrappers__tpl_local_ansible_controllers.append(element | ansible.utils.ipwrap) %}
 {%   endfor %}
 {% endif %}
 {% for element in tcpwrappers__ansible_controllers or [] %}
-{%       set _ = tcpwrappers__tpl_local_ansible_controllers.append(element | ipwrap) %}
+{%       set _ = tcpwrappers__tpl_local_ansible_controllers.append(element | ansible.utils.ipwrap) %}
 {% endfor %}
 {% for element in (tcpwrappers__tpl_local_ansible_controllers | unique | sort) %}
 sshd : {{ element }}

--- a/ansible/roles/tinc/defaults/main.yml
+++ b/ansible/roles/tinc/defaults/main.yml
@@ -226,25 +226,32 @@ tinc__host_addresses: '{{ tinc__host_addresses_fqdn +
 #
 # Include the host FQDN if public IP addresses are available.
 tinc__host_addresses_fqdn: '{{ [ansible_fqdn]
-                               if ((ansible_all_ipv4_addresses | d([]) + (ansible_all_ipv6_addresses | d([])
-                                   | difference(ansible_all_ipv6_addresses | d([]) | ipaddr("link-local"))))
-                                  | ipaddr("public")) else [] }}'
+                               if ((ansible_all_ipv4_addresses | d([])
+                                    + (ansible_all_ipv6_addresses | d([])
+                                       | difference(ansible_all_ipv6_addresses | d([])
+                                                    | ansible.utils.ipaddr("link-local"))))
+                                   | ansible.utils.ipaddr("public"))
+                               else [] }}'
 
                                                                    # ]]]
 # .. envvar:: tinc__host_addresses_ip_public [[[
 #
 # Include all public IP addresses, without IPv6 link-local.
-tinc__host_addresses_ip_public: '{{ (ansible_all_ipv4_addresses | d([]) + (ansible_all_ipv6_addresses | d([])
-                                     | difference(ansible_all_ipv6_addresses | d([]) | ipaddr("link-local"))))
-                                    | ipaddr("public") }}'
+tinc__host_addresses_ip_public: '{{ (ansible_all_ipv4_addresses | d([])
+                                     + (ansible_all_ipv6_addresses | d([])
+                                        | difference(ansible_all_ipv6_addresses | d([])
+                                                     | ansible.utils.ipaddr("link-local"))))
+                                    | ansible.utils.ipaddr("public") }}'
 
                                                                    # ]]]
 # .. envvar:: tinc__host_addresses_ip_private [[[
 #
 # Include all private IP addresses, without IPv6 link-local.
-tinc__host_addresses_ip_private: '{{ (ansible_all_ipv4_addresses | d([]) + (ansible_all_ipv6_addresses | d([])
-                                      | difference(ansible_all_ipv6_addresses | d([]) | ipaddr("link-local"))))
-                                     | ipaddr("private") }}'
+tinc__host_addresses_ip_private: '{{ (ansible_all_ipv4_addresses | d([])
+                                      + (ansible_all_ipv6_addresses | d([])
+                                         | difference(ansible_all_ipv6_addresses | d([])
+                                                      | ansible.utils.ipaddr("link-local"))))
+                                     | ansible.utils.ipaddr("private") }}'
 
                                                                    # ]]]
 # .. envvar:: tinc__exclude_addresses [[[

--- a/ansible/roles/tinc/templates/etc/tinc/network/tinc-down.j2
+++ b/ansible/roles/tinc/templates/etc/tinc/network/tinc-down.j2
@@ -21,13 +21,13 @@ readarray -t interface_addresses << EOF
 {%   set _ = tinc__tpl_addresses.extend(([ item.value.address ]
                                          if item.value.address is string
                                          else item.value.address)
-                                        | ipaddr('host/prefix')) %}
+                                        | ansible.utils.ipaddr('host/prefix')) %}
 {% endif %}
 {% if item.value.addresses | d() %}
 {%   set _ = tinc__tpl_addresses.extend(([ item.value.addresses ]
                                          if item.value.addresses is string
                                          else item.value.addresses)
-                                        | ipaddr('host/prefix')) %}
+                                        | ansible.utils.ipaddr('host/prefix')) %}
 {% endif %}
 {% for entry in tinc__tpl_addresses %}
 {{ entry }}

--- a/ansible/roles/tinc/templates/etc/tinc/network/tinc-up.j2
+++ b/ansible/roles/tinc/templates/etc/tinc/network/tinc-up.j2
@@ -34,13 +34,13 @@ readarray -t interface_addresses << EOF
 {%   set _ = tinc__tpl_addresses.extend(([ item.value.address ]
                                          if item.value.address is string
                                          else item.value.address)
-                                        | ipaddr('host')) %}
+                                        | ansible.utils.ipaddr('host')) %}
 {% endif %}
 {% if item.value.addresses | d() %}
 {%   set _ = tinc__tpl_addresses.extend(([ item.value.addresses ]
                                          if item.value.addresses is string
                                          else item.value.addresses)
-                                        | ipaddr('host')) %}
+                                        | ansible.utils.ipaddr('host')) %}
 {% endif %}
 {% for entry in tinc__tpl_addresses %}
 {{ entry }}

--- a/ansible/roles/unbound/templates/etc/unbound/unbound.conf.d/macros.j2
+++ b/ansible/roles/unbound/templates/etc/unbound/unbound.conf.d/macros.j2
@@ -18,9 +18,9 @@
 {%       endif %}
 {%     endif %}
 {%   elif option_values is string %}
-{%     if option_values | ipaddr %}
+{%     if option_values | ansible.utils.ipaddr %}
 {{ ('    {:<' + value_indent + '} {}').format(option_name + ':', option_values) }}
-{%     elif ('@' in option_values and option_values.split('@')[0] | ipaddr and option_values.split('@')[1] | int) %}
+{%     elif ('@' in option_values and option_values.split('@')[0] | ansible.utils.ipaddr and option_values.split('@')[1] | int) %}
 {{ ('    {:<' + value_indent + '} {}').format(option_name + ':', option_values) }}
 {%     elif '"' in option_values %}
 {{ ("    {:<" + value_indent + "} '{}'").format(option_name + ':', option_values) }}
@@ -48,9 +48,9 @@
 {%           endif %}
 {%         endif %}
 {%       elif value.name is string %}
-{%         if value.name | ipaddr %}
+{%         if value.name | ansible.utils.ipaddr %}
 {{ ('    {:<' + value_indent + '} {}{}').format(option_name + ':', value.name, (' ' + option_args) if option_args else '') }}
-{%         elif ('@' in value.name and value.name.split('@')[0] | ipaddr and value.name.split('@')[1] | int) %}
+{%         elif ('@' in value.name and value.name.split('@')[0] | ansible.utils.ipaddr and value.name.split('@')[1] | int) %}
 {{ ('    {:<' + value_indent + '} {}{}').format(option_name + ':', value.name, (' ' + option_args) if option_args else '') }}
 {%         elif '"' in value.name %}
 {{ ("    {:<" + value_indent + "} '{}'{}").format(option_name + ':', value.name, (' ' + option_args) if option_args else '') }}

--- a/ansible/roles/unbound/templates/etc/unbound/unbound.conf.d/zone.conf.j2
+++ b/ansible/roles/unbound/templates/etc/unbound/unbound.conf.d/zone.conf.j2
@@ -8,23 +8,23 @@
 {% set unbound__tpl_local_zones = [] %}
 {% set unbound__tpl_nameservers = [] %}
 {% if item.revdns | d() %}
-{%   for entry in ([ item.revdns ] if item.revdns is string else item.revdns) | ipv4('subnet') %}
+{%   for entry in ([ item.revdns ] if item.revdns is string else item.revdns) | ansible.utils.ipv4('subnet') %}
 {#
  # This currently doesn't work properly for subnet sizes < 16
  # due to netaddr library always returning /24 revdns delegation
 #}
-{%     if (entry | ipaddr('prefix') | int <= 15) %}
+{%     if (entry | ansible.utils.ipaddr('prefix') | int <= 15) %}
 {%       set subnet_prefix = '16' %}
-{%     elif (entry | ipaddr('prefix') | int <= 24) %}
+{%     elif (entry | ansible.utils.ipaddr('prefix') | int <= 24) %}
 {%       set subnet_prefix = '24' %}
 {%     else %}
 {%       set subnet_prefix = '24' %}
 {%     endif %}
 {%     for i in range(0, (entry | ipsubnet(subnet_prefix) | int)) %}
-{%       set _ = unbound__tpl_ipv4_revdns_zones.append((entry | ipsubnet(subnet_prefix, i) | ipaddr('revdns')).split('.')[1:-1] | join('.')) %}
+{%       set _ = unbound__tpl_ipv4_revdns_zones.append((entry | ipsubnet(subnet_prefix, i) | ansible.utils.ipaddr('revdns')).split('.')[1:-1] | join('.')) %}
 {%     endfor %}
 {%   endfor %}
-{%   set unbound__tpl_local_zones = item.revdns | ipaddr("private") %}
+{%   set unbound__tpl_local_zones = item.revdns | ansible.utils.ipaddr("private") %}
 {% endif %}
 {% if item.nameserver | d() %}
 {%   for entry in ([ item.nameserver ] if item.nameserver is string else item.nameserver) %}

--- a/docs/ansible/roles/dnsmasq/defaults-detailed.rst
+++ b/docs/ansible/roles/dnsmasq/defaults-detailed.rst
@@ -339,7 +339,7 @@ Define PTR resource records for hosts:
      - ptr: '40.2.0.192.in-addr.arpa'
        target: 'host1.example.org'
 
-     - ptr: '{{ "192.0.2.50" | ipaddr("revdns") }}'
+     - ptr: '{{ "192.0.2.50" | ansible.utils.ipaddr("revdns") }}'
        target: 'host2.example.org'
 
 Syntax

--- a/docs/ansible/roles/ferm/guides.rst
+++ b/docs/ansible/roles/ferm/guides.rst
@@ -159,7 +159,7 @@ through the firewall based on source IP addresses and network ranges. This is
 typically done by defining a corresponding ``service_allow`` variable. In case
 of debops.nginx_ this configuration would look as following::
 
-    nginx_allow: [ '{{ ansible_eth1.ipv4.network }}/{{ ("0.0.0.0/" + ansible_eth1.ipv4.netmask) | ipaddr("prefix") }}' ]
+    nginx_allow: [ '{{ ansible_eth1.ipv4.network }}/{{ ("0.0.0.0/" + ansible_eth1.ipv4.netmask) | ansible.utils.ipaddr("prefix") }}' ]
 
 This will restrict access to the HTTP service running on the gateway host to
 the internal IPv4 network which is automatically defined using the ``ansible_eth1``


### PR DESCRIPTION
This fixes warnings from ansible such as:
[DEPRECATION WARNING]: Use 'ansible.utils.ipv4' module instead. This feature will be removed from ansible.netcommon in a release after 2024-01-01...

Resolves: https://github.com/debops/debops/issues/2271