### PR TITLE
Upgrade actions checkout plugin

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
 
       - name: Clone the repository
-        uses: 'actions/checkout@v2'
+        uses: 'actions/checkout@v3'
 
       - name: Run ansible-lint from main branch
         uses: 'ansible-community/ansible-lint-action@main'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,7 +15,7 @@ jobs:
         run: 'printf "%s/.local/bin\n" "${HOME}" >> ${GITHUB_PATH}'
 
       - name: Clone the repository
-        uses: 'actions/checkout@v2'
+        uses: 'actions/checkout@v3'
 
       - name: Prepare test environment
         run: |
@@ -36,7 +36,7 @@ jobs:
         run: 'printf "%s/.local/bin\n" "${HOME}" >> ${GITHUB_PATH}'
 
       - name: Clone the repository
-        uses: 'actions/checkout@v2'
+        uses: 'actions/checkout@v3'
 
       - name: Prepare test environment
         run: |
@@ -59,7 +59,7 @@ jobs:
         run: 'printf "%s/.local/bin\n" "${HOME}" >> ${GITHUB_PATH}'
 
       - name: Clone the repository
-        uses: 'actions/checkout@v2'
+        uses: 'actions/checkout@v3'
 
       - name: Prepare test environment
         run: |
@@ -81,7 +81,7 @@ jobs:
         run: 'printf "%s/.local/bin\n" "${HOME}" >> ${GITHUB_PATH}'
 
       - name: Clone the repository
-        uses: 'actions/checkout@v2'
+        uses: 'actions/checkout@v3'
         with:
           fetch-depth: 0
 
@@ -111,7 +111,7 @@ jobs:
         run: 'printf "%s/.local/bin\n" "${HOME}" >> ${GITHUB_PATH}'
 
       - name: Clone the repository
-        uses: 'actions/checkout@v2'
+        uses: 'actions/checkout@v3'
 
       - name: Prepare test environment
         run: |
@@ -132,7 +132,7 @@ jobs:
         run: 'printf "%s/.local/bin\n" "${HOME}" >> ${GITHUB_PATH}'
 
       - name: Clone the repository
-        uses: 'actions/checkout@v2'
+        uses: 'actions/checkout@v3'
 
       - name: Prepare test environment
         run: |
@@ -153,7 +153,7 @@ jobs:
         run: 'printf "%s/.local/bin\n" "${HOME}" >> ${GITHUB_PATH}'
 
       - name: Clone the repository
-        uses: 'actions/checkout@v2'
+        uses: 'actions/checkout@v3'
 
       - name: Prepare test environment
         run: |
@@ -171,7 +171,7 @@ jobs:
     steps:
 
       - name: Clone the repository
-        uses: 'actions/checkout@v2'
+        uses: 'actions/checkout@v3'
 
       - name: Build and verify Docker image
         # https://github.com/actions/runner/issues/241
@@ -186,7 +186,7 @@ jobs:
         run: 'printf "%s/.local/bin\n" "${HOME}" >> ${GITHUB_PATH}'
 
       - name: Clone the repository
-        uses: 'actions/checkout@v2'
+        uses: 'actions/checkout@v3'
         with:
           fetch-depth: 0
 
@@ -212,7 +212,7 @@ jobs:
         run: 'printf "%s/.local/bin\n" "${HOME}" >> ${GITHUB_PATH}'
 
       - name: Clone the repository
-        uses: 'actions/checkout@v2'
+        uses: 'actions/checkout@v3'
         with:
           fetch-depth: 0
 
@@ -239,7 +239,7 @@ jobs:
         run: 'printf "%s/.local/bin\n" "${HOME}" >> ${GITHUB_PATH}'
 
       - name: Clone the repository
-        uses: 'actions/checkout@v2'
+        uses: 'actions/checkout@v3'
         with:
           fetch-depth: 0
 
@@ -266,7 +266,7 @@ jobs:
         run: 'printf "%s/.local/bin\n" "${HOME}" >> ${GITHUB_PATH}'
 
       - name: Clone the repository
-        uses: 'actions/checkout@v2'
+        uses: 'actions/checkout@v3'
 
       - name: Prepare test environment
         run: |

--- a/.github/workflows/debops-ci-pipeline.yml
+++ b/.github/workflows/debops-ci-pipeline.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
 
       - name: Check out the repository
-        uses: 'actions/checkout@v2'
+        uses: 'actions/checkout@v3'
 
       - name: Prepare the CI pipeline environment
         uses: './.github/workflows/prepare-ci-pipeline'
@@ -35,7 +35,7 @@ jobs:
     steps:
 
       - name: Check out the repository
-        uses: 'actions/checkout@v2'
+        uses: 'actions/checkout@v3'
 
       - name: Prepare the CI pipeline environment
         uses: './.github/workflows/prepare-ci-pipeline'
@@ -55,7 +55,7 @@ jobs:
     steps:
 
       - name: Check out the repository
-        uses: 'actions/checkout@v2'
+        uses: 'actions/checkout@v3'
 
       - name: Prepare the CI pipeline environment
         uses: './.github/workflows/prepare-ci-pipeline'
@@ -76,7 +76,7 @@ jobs:
     steps:
 
       - name: Check out the repository
-        uses: 'actions/checkout@v2'
+        uses: 'actions/checkout@v3'
 
       - name: Prepare the CI pipeline environment
         uses: './.github/workflows/prepare-ci-pipeline'

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
       - name: Clone the repository
-        uses: 'actions/checkout@v2'
+        uses: 'actions/checkout@v3'
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
`actions/checkout` plugin from version 2 was using Node.js 12.
According to GitHub, that should have been upgraded.  This patch work
upgrades all `actions/checkout` from 2 to 3.