### PR TITLE
[proc_hidepid] Avoid issues with polkit(d)

### DIFF
--- a/ansible/roles/proc_hidepid/defaults/main.yml
+++ b/ansible/roles/proc_hidepid/defaults/main.yml
@@ -36,6 +36,15 @@ proc_hidepid__base_packages: [ 'libcap2-bin' ]
 #
 # List of additional APT packages to install with hidepid support.
 proc_hidepid__packages: []
+
+                                                                   # ]]]
+# .. envvar:: proc_hidepid__skip_packages [[[
+#
+# List of APT packages which are known to cause issues when hidepid is
+# enabled. When the role detects that they are installed on the host, it
+# will default to using more permissive settings.
+proc_hidepid__skip_packages: [ 'policykit-1', 'polkitd' ]
+
                                                                    # ]]]
                                                                    # ]]]
 # The ``/proc`` filesystem options [[[
@@ -68,7 +77,7 @@ proc_hidepid__remount: '{{ True
 # - ``2``: the ``/proc`` contents are invisible to non-owners, only ``root``
 #          and users in the specific UNIX system group can see everything
 #
-proc_hidepid__level: '2'
+proc_hidepid__level: '{{ proc_hidepid__fact_default_level | d("2") }}'
 
                                                                    # ]]]
 # .. envvar:: proc_hidepid__group [[[

--- a/ansible/roles/proc_hidepid/tasks/main.yml
+++ b/ansible/roles/proc_hidepid/tasks/main.yml
@@ -7,6 +7,26 @@
   ansible.builtin.import_role:
     name: 'global_handlers'
 
+- name: Check if any incompatible package is installed
+  environment:
+    LC_MESSAGES: 'C'
+  ansible.builtin.shell: |
+    set -o nounset -o pipefail -o errexit &&
+    dpkg --get-selections | grep -w -E '({{ proc_hidepid__skip_packages | join("|") }})'
+                          | awk '{print $1}' || true
+  args:
+    executable: '/bin/bash'
+  register: proc_hidepid__register_incompatible
+  changed_when: False
+  failed_when: False
+  check_mode: False
+
+- name: Set default enforcement level
+  ansible.builtin.set_fact:
+    proc_hidepid__fact_default_level: '{{ "2"
+                                          if (not proc_hidepid__register_incompatible.stdout | d())
+                                          else "0" }}'
+
 - name: Install required packages
   ansible.builtin.package:
     name: '{{ q("flattened", (proc_hidepid__base_packages


### PR DESCRIPTION
polkitd expects to be able to dig around in /proc using an unprivileged UID/GID. In addition, polkitd is started as root/root and later drops privileges to polkit/polkit, meaning that the SupplementaryGroups= trick used for other systemd services will not work for polkitd.

The error messages that polkit emits when /proc/pid hiding is enabled are difficult to diagnose ("/proc/pid/blah" missing, though it's clearly "there") and the things that break are not (from a user PoV) obviously linked to polkit or pid hiding (for example: things which are no longer possible for the local user include reboots, connecting/disconnecting from a wireless network, etc)