### PR TITLE
* [etc_aliases] condition for save dependent recipients on controller

### DIFF
--- a/ansible/roles/etc_aliases/tasks/main.yml
+++ b/ansible/roles/etc_aliases/tasks/main.yml
@@ -73,3 +73,4 @@
     mode: '0644'
   become: False
   delegate_to: 'localhost'
+  when: etc_aliases__dependent_recipients | length > 0


### PR DESCRIPTION
When using role with AWX, "Save etc_aliases dependent recipients on Ansible Controller" task create the file in AWX job container while it shouldn't if etc_aliases__dependent_recipients is []