### PR TITLE
[icinga_db] Don't install dbconfig-no-thanks

### DIFF
--- a/ansible/roles/icinga_db/defaults/main.yml
+++ b/ansible/roles/icinga_db/defaults/main.yml
@@ -231,9 +231,6 @@ icinga_db__ssl_ca_certificate: '{{ icinga_db__pki_path + "/"
 #
 # The list of APT packages to install for Icinga 2 database support.
 icinga_db__base_packages:
-
-  # Disable dbconfig support, DebOps roles will handle the Icinga database
-  - 'dbconfig-no-thanks'
   - '{{ "icinga2-ido-" + icinga_db__ido }}'
 
                                                                    # ]]]

--- a/ansible/roles/icinga_db/tasks/main.yml
+++ b/ansible/roles/icinga_db/tasks/main.yml
@@ -21,6 +21,24 @@
   run_once: True
   delegate_to: 'localhost'
 
+- name: Make sure that the dbconfig directory exists
+  ansible.builtin.file:
+    path: '/etc/dbconfig-common'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+  when: icinga_db__icinga_installed | bool
+
+- name: Disable dbconfig for package icinga2-ido-{{ icinga_db__ido }}
+  ansible.builtin.template:
+    src: 'etc/dbconfig-common/icinga2-ido.conf.j2'
+    dest: '/etc/dbconfig-common/icinga2-ido-{{ icinga_db__ido }}.conf'
+    owner: 'root'
+    group: 'root'
+    mode: '0600'
+  when: icinga_db__icinga_installed | bool
+
 - name: Install required packages
   ansible.builtin.package:
     name: '{{ q("flattened", icinga_db__base_packages + icinga_db__packages) }}'

--- a/ansible/roles/icinga_db/templates/etc/dbconfig-common/icinga2-ido.conf.j2
+++ b/ansible/roles/icinga_db/templates/etc/dbconfig-common/icinga2-ido.conf.j2
@@ -1,0 +1,25 @@
+{# Copyright (C) 2023 David Härdeman <david@hardeman.nu>
+ # Copyright (C) 2023 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-only
+ #}
+
+#
+# dbconfig interferes with the database management carried out by the DebOps
+# icinga_db Ansible role, so we need to disable dbconfig.
+#
+# See https://github.com/debops/debops/pull/2295 for details.
+#
+# {{ ansible_managed }}
+#
+
+# dbc_install: configure database with dbconfig-common?
+#              set to anything but "true" to opt out of assistance
+dbc_install='false'
+
+# dbc_upgrade: upgrade database with dbconfig-common?
+#              set to anything but "true" to opt out of assistance
+dbc_upgrade='false'
+
+# dbc_remove: deconfigure database with dbconfig-common?
+#             set to anything but "true" to opt out of assistance
+dbc_remove='false'


### PR DESCRIPTION
As discussed in https://github.com/debops/debops/pull/2295, dbconfig-no-thanks will disable dbconfig on a system-wide basis. This patch implements a more fine-grained approach by disabling dbconfig only for select packages.