### PR TITLE
[bind] Correct IPv6 localhost address

### DIFF
--- a/ansible/roles/bind/defaults/main.yml
+++ b/ansible/roles/bind/defaults/main.yml
@@ -502,7 +502,7 @@ bind__default_configuration:
         options:
 
           - name: 'localhost'
-            raw: '127.0.0.1;'
+            raw: '::1;'
 
       - name: 'qname-minimization'
         comment: 'Perform strict QNAME minimization (RFC7816)'


### PR DESCRIPTION
The nginx configuration connects to the IPv4 address, so this is purely cosmetical at the moment (avoids scary error messages in the log files).