### PR TITLE
[dhcp_probe] Add a Wants= on network-online.target

### DIFF
--- a/ansible/roles/dhcp_probe/templates/etc/systemd/system/dhcp-probe.service.j2
+++ b/ansible/roles/dhcp_probe/templates/etc/systemd/system/dhcp-probe.service.j2
@@ -6,6 +6,7 @@
 
 [Unit]
 Description=Daemon to survery DHCP/BOOTP servers on LAN
+Wants=network-online.target
 After=network-online.target
 Documentation=man:dhcp_probe(8)
 


### PR DESCRIPTION
According to https://systemd.io/NETWORK_ONLINE/ network-online.target is an "active target". This means that this target will not be started unless explicitely needed by another service

We already have an After=network-online.target but After= does not start the target, it only guarantees ordering

This means that if dhcp_probe is the only network-related service,network- online.target will not be started and dhcp_probe will be started too early and fail


See the first FAQ in the page documented above.

**NOTE** This PR is agains stabe-2.3 since this is what I have for testing, but it is probably needed for master too