### PR TITLE
[pki] pki-realm specify input format to convert DER to PEM

### DIFF
--- a/ansible/roles/pki/files/usr/local/lib/pki/pki-realm
+++ b/ansible/roles/pki/files/usr/local/lib/pki/pki-realm
@@ -1072,7 +1072,7 @@ convert_der_to_pem () {
 
     if [ -n "${input_file}" ] && [ -r "${input_file}" ] ; then
         if ! openssl x509 -inform PEM -in "${input_file}" -noout 2>/dev/null ; then
-            openssl x509 -in "${input_file}" -outform PEM -out "${input_file}.tmp"
+            openssl x509 -inform DER -in "${input_file}" -outform PEM -out "${input_file}.tmp"
             mv "${input_file}.tmp" "${input_file}"
         fi
     fi


### PR DESCRIPTION
When the input format has been determined to be other than PEM, `openssl -in` by itself fails to read the DER format file. Adding `-inform DER` enables openssl to read the DER file and output a PEM format file as `intermediate.pem.tmp`, allowing the script to continue by renaming it to `intermediate.pem`, preparing `root.pem`, and completing successfully.

Resolves the issue where Let's Encrypt ACME certificates were requested, verified, issued and retrieved, but stored in binary DER format as `intermediate.pem.tmp`, and where conversion to PEM failed, leaving the `/etc/pki/realm/example.org/acme` directory containing:

`account_key.pem`
`cert.pem`  ← *good cert*
`error.log`  ← *no errors*
`intermediate.pem.tmp`  ← *DER format file*
`openssl.conf`
`request.pem`

The certificate chain was left half-prepared, so the pki role deployed the domain CA-signed certificate instead.  With this patch, the ACME certificate chain can be converted into PEM format and the pki role can use and deploy the ACME-issued Let's Encrypt certificate.