### PR TITLE
[swapfile] Use intended logic when checking whether to enable swapfiles

### DIFF
--- a/ansible/roles/swapfile/tasks/main.yml
+++ b/ansible/roles/swapfile/tasks/main.yml
@@ -51,10 +51,10 @@
   when: ( item is changed and
           item.state|d("present") != 'absent' and (
             (
-              ansible_system_capabilities_enforced|d() | bool and
+              (ansible_system_capabilities_enforced|d()) | bool and
               "cap_sys_admin" in ansible_system_capabilities
             ) or
-            not ansible_system_capabilities_enforced|d(True) | bool
+            not (ansible_system_capabilities_enforced|d(True)) | bool
           )
         )
 

--- a/ansible/roles/swapfile/tasks/main.yml
+++ b/ansible/roles/swapfile/tasks/main.yml
@@ -48,10 +48,15 @@
   with_items: '{{ swapfile__register_allocation.results | d([]) }}'
   register: swapfile__register_swapon
   changed_when: swapfile__register_swapon.changed | bool
-  when: (item is changed and item.state | d("present") != 'absent' and
-         ((ansible_system_capabilities_enforced | d()) | bool and
-          "cap_sys_admin" in ansible_system_capabilities) or
-         not (ansible_system_capabilities_enforced | d(True)) | bool)
+  when: ( item is changed and
+          item.state|d("present") != 'absent' and (
+            (
+              ansible_system_capabilities_enforced|d() | bool and
+              "cap_sys_admin" in ansible_system_capabilities
+            ) or
+            not ansible_system_capabilities_enforced|d(True) | bool
+          )
+        )
 
 - name: Manage swap files in /etc/fstab
   ansible.posix.mount:


### PR DESCRIPTION
Previously, parentheses resulted in re-enabling swapfile on every run based on value of ansible_system_capabilities_enforced instead of intended logic