### PR TITLE
feat(system_users): default to system users (UID < 1000)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -199,6 +199,11 @@ General
 
 - The playbook can now be configured to skip the saslauthd role execution.
 
+:ref:`debops.system_users` role
+'''''''''''''''''''''''''''''''
+
+- System users now default to system users (UID < 1000).
+
 :ref:`debops.zabbix_agent` role
 '''''''''''''''''''''''''''''''
 

--- a/ansible/roles/system_users/tasks/main.yml
+++ b/ansible/roles/system_users/tasks/main.yml
@@ -76,7 +76,7 @@
     comment:            '{{ item.comment | d(omit) }}'
     password:           '{{ item.password | d("*") }}'
     update_password:    '{{ item.update_password | d("on_create") }}'
-    system:             '{{ item.system | d(omit) }}'
+    system:             '{{ item.system | d(True) }}'
     shell:              '{{ item.shell | d(system_users__default_shell
                                            if system_users__default_shell | d()
                                            else omit) }}'


### PR DESCRIPTION
Main advantage being that if a system with graphical user interface is managed, the ansibleadmin users is now shown by the Window manager as possible user to login.