### PR TITLE
[dnsmasq] allow empty dhcp_ipv6_mode

### DIFF
--- a/ansible/roles/dnsmasq/templates/lookup/dnsmasq__interface_configuration.j2
+++ b/ansible/roles/dnsmasq/templates/lookup/dnsmasq__interface_configuration.j2
@@ -81,10 +81,15 @@
 }) %}
 {%       endfor %}
 {%       for host_address in dnsmasq__tpl_ipv6 %}
+{%         if (interface.dhcp_ipv6_mode is string and interface.dhcp_ipv6_mode == '') %}
+{%           set ra_separator = '' %}
+{%         else %}
+{%           set ra_separator = ',' %}
+{%         endif %}
 {%         set _ = interface_options.append({
   "name": ("dhcp_range_" + (host_address | replace(':','_') | replace('/','_'))),
   "option": "dhcp-range",
-  "value": ("set:" + interface_tag + "," + host_address | ansible.utils.ipv6(interface.dhcp_range_start | d(10) | int) | ansible.utils.ipv6('address') + ',' + host_address | ansible.utils.ipv6(interface.dhcp_range_end | d(-10) | int) | ansible.utils.ipv6('address') + ',' + interface.dhcp_ipv6_mode | d("ra-names,ra-stateless,slaac") + "," + host_address | ansible.utils.ipv6('prefix') | string + ',' + interface.dhcp_lease | d('24h'))
+  "value": ("set:" + interface_tag + "," + host_address | ansible.utils.ipv6(interface.dhcp_range_start | d(10) | int) | ansible.utils.ipv6('address') + ',' + host_address | ansible.utils.ipv6(interface.dhcp_range_end | d(-10) | int) | ansible.utils.ipv6('address') + ',' + interface.dhcp_ipv6_mode | d("ra-names,ra-stateless,slaac") + ra_separator + host_address | ansible.utils.ipv6('prefix') | string + ',' + interface.dhcp_lease | d('24h'))
 }) %}
 {%       endfor %}
 {%     endif %}


### PR DESCRIPTION
if dhcp_ipv6_mode is empty, starting dnsmasq fails
since there is a double separation comma.