### PR TITLE
Fix libvirtd kvm packages

### DIFF
--- a/ansible/roles/libvirtd/defaults/main.yml
+++ b/ansible/roles/libvirtd/defaults/main.yml
@@ -56,10 +56,10 @@ libvirtd__base_packages_map:
 # List of QEMU KVM packages to install. They will be installed on all hosts
 # apart from KVM guests, to not create redundant support.
 libvirtd__kvm_packages: '{{ ["qemu-system-x86", "qemu-utils"]
-                            + ["qemu-kvm"]
+                            + (["qemu-kvm"]
                               if ansible_distribution_release in ["stretch",
                                    "buster", "bionic", "focal"]
-                              else [] }}'
+                              else []) }}'
 
                                                                    # ]]]
 # .. envvar:: libvirtd__network_packages [[[


### PR DESCRIPTION
In bullseye no packages at all will get installed.
Parentheses are evaluated wrong.
