### PR TITLE
Fixes ansible shell with pipefail

### DIFF
--- a/ansible/roles/controller/handlers/main.yml
+++ b/ansible/roles/controller/handlers/main.yml
@@ -17,6 +17,8 @@
   ansible.builtin.shell: |
     set -o nounset -o pipefail -o errexit &&
     type debops-update > /dev/null 2>&1 && (echo 'debops-update' | batch > /dev/null 2>&1) || true
+  args:
+    executable: 'bash'
   register: controller__register_update_batch
   changed_when: controller__register_update_batch.changed | bool
   when: (not controller__update_method == 'sync' and

--- a/ansible/roles/owncloud/tasks/tarball.yml
+++ b/ansible/roles/owncloud/tasks/tarball.yml
@@ -56,7 +56,7 @@
              | sed --silent 's/.*href="nextcloud-\({{ owncloud__release | regex_escape() }}[^"]\+\).zip.asc".*/\1/p'
              | sort --version-sort --reverse
       args:
-        executable: 'sh'
+        executable: 'bash'
       register: owncloud__register_full_version
       changed_when: False
       check_mode: False
@@ -96,7 +96,7 @@
                     + owncloud__variant + "-" + owncloud__register_full_version.stdout_lines[0]
                     + ".zip.sha512" }} | grep '.zip$'
       args:
-        executable: 'sh'
+        executable: 'bash'
       changed_when: False
       register: owncloud__register_checksum
       when: not ansible_check_mode  # Latest checksum file may not be available

--- a/ansible/roles/postwhite/handlers/main.yml
+++ b/ansible/roles/postwhite/handlers/main.yml
@@ -15,6 +15,8 @@
   ansible.builtin.shell: |
     set -o nounset -o pipefail -o errexit &&
     echo '/usr/local/lib/postwhite' | batch > /dev/null 2>&1
+  args:
+    executable: 'bash'
   register: postwhite__register_batch
   changed_when: postwhite__register_batch.changed | bool
   when: postwhite__initial_update_method == 'batch'


### PR DESCRIPTION
pipefail requires bash.
default dash shell on Debian errors out when this option is set.

Fixes #2354.