### PR TITLE
[dovecot] fix ssl_dh when dovecot__ssl_dh_file is empty

### DIFF
--- a/ansible/roles/dovecot/defaults/main.yml
+++ b/ansible/roles/dovecot/defaults/main.yml
@@ -632,7 +632,7 @@ dovecot__default_configuration:
         state: '{{ "present" if dovecot__version is version("2.3.0", ">=") else "absent" }}'
 
       - name: 'ssl_dh'
-        value: '{{ "" if dovecot__ssl_dh_file | length else "<" + dovecot__ssl_dh_file }}'
+        value: '{{ "" if dovecot__ssl_dh_file == "" else "<" + dovecot__ssl_dh_file }}'
         state: '{{ "present" if dovecot__version is version("2.3.0", ">=") else "absent" }}'
 
       - name: 'ssl_cipher_list'

--- a/ansible/roles/dovecot/defaults/main.yml
+++ b/ansible/roles/dovecot/defaults/main.yml
@@ -632,7 +632,7 @@ dovecot__default_configuration:
         state: '{{ "present" if dovecot__version is version("2.3.0", ">=") else "absent" }}'
 
       - name: 'ssl_dh'
-        value: '<{{ dovecot__ssl_dh_file }}'
+        value: '{{ "" if dovecot__ssl_dh_file | length else "<" + dovecot__ssl_dh_file }}'
         state: '{{ "present" if dovecot__version is version("2.3.0", ">=") else "absent" }}'
 
       - name: 'ssl_cipher_list'


### PR DESCRIPTION
when `dovecot__ssl_dh_file` is empty, `ssl_dh = <` doens't allow dovecot to start. Error message `doveconf: Fatal: Error in configuration file /etc/dovecot/dovecot.conf line 53: ssl_dh: read(/etc/dovecot/) failed: Is a directory`. This fixes the issue