### PR TITLE
Add support for configuring /etc/issue.net

### DIFF
--- a/ansible/roles/machine/defaults/main.yml
+++ b/ansible/roles/machine/defaults/main.yml
@@ -128,6 +128,26 @@ machine__etc_issue_state: 'present'
 machine__etc_issue_template: 'etc/issue.j2'
                                                                    # ]]]
                                                                    # ]]]
+# Configuration of the :file:`/etc/issue.net` file [[[
+# ------------------------------------------------
+
+# .. envvar:: machine__etc_issue_net_state [[[
+#
+# This variable controls if the role should manage the :file:`/etc/issue.net`
+# configuration file. If ``present``, the role will divert the distribution file
+# and generate a custom one; if ``absent``, the role will revert the diverted
+# version and will not modify it.
+machine__etc_issue_net_state: 'present'
+
+                                                                   # ]]]
+# .. envvar:: machine__etc_issue_net_template [[[
+#
+# Path to the Jinja2 template used to generate the :file:`/etc/issue.net`
+# configuration file, relative to the :file:`templates/` directory of this role.
+# Defaults to :file:`machine__etc_issue_template`.
+machine__etc_issue_net_template: "{{ machine__etc_issue_template }}"
+                                                                   # ]]]
+                                                                   # ]]]
 # Dynamic Message Of The Day [[[
 # ------------------------------
 

--- a/ansible/roles/machine/tasks/main.yml
+++ b/ansible/roles/machine/tasks/main.yml
@@ -37,6 +37,15 @@
     delete: True
   when: machine__enabled | bool
 
+- name: Add/remove diversion of /etc/issue.net
+  debops.debops.dpkg_divert:
+    path: '/etc/issue.net'
+    state: '{{ "present"
+               if machine__etc_issue_net_state | d("present") != "absent"
+               else "absent" }}'
+    delete: True
+  when: machine__enabled | bool
+
 - name: Configure /etc/issue file
   ansible.builtin.template:
     src: '{{ machine__etc_issue_template }}'
@@ -45,6 +54,15 @@
     group: 'root'
     mode: '0644'
   when: machine__enabled | bool and machine__etc_issue_state | d('present') != 'absent'
+
+- name: Configure /etc/issue.net file
+  ansible.builtin.template:
+    src: '{{ machine__etc_issue_net_template | default(machine__etc_issue_template) }}'
+    dest: '/etc/issue'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  when: machine__enabled | bool and machine__etc_issue_net_state | d('present') != 'absent'
 
 - name: Remove static /etc/motd file if requested
   ansible.builtin.file:


### PR DESCRIPTION
/etc/issue.net is the network specific twin of /etc/issue so is likely to want modification at the same time.
For ease of administration it defaults to the same template as /etc/issue but can be overridden separately should the requirement call for it.