### PR TITLE
RFC: Switch all Debian releases : bookworm is now stable

### DIFF
--- a/ansible/playbooks/tools/dist-upgrade.yml
+++ b/ansible/playbooks/tools/dist-upgrade.yml
@@ -30,10 +30,10 @@
     # * ansible/roles/reprepro/defaults/main.yml
     # * ansible/playbooks/tools/dist-upgrade.yml
     dist_upgrade_version_map:
-      'jessie': 'stretch'
       'stretch': 'buster'
       'buster': 'bullseye'
-      # 'bullseye': 'bookworm'
+      'bullseye': 'bookworm'
+      #'bookworm': 'trixie'
       'trusty': 'utopic'
 
     # Current release

--- a/ansible/roles/apt/defaults/main.yml
+++ b/ansible/roles/apt/defaults/main.yml
@@ -320,7 +320,7 @@ apt__distribution_release: '{{ ansible_lsb.codename
 # map is used to configure security repositories only on the OS releases that
 # have them available.
 apt__distribution_release_map:
-  'Debian': [ 'stretch', 'buster', 'bullseye', 'bookworm' ]
+  'Debian': [ 'stretch', 'buster', 'bullseye', 'bookworm', 'trixie' ]
   'Ubuntu': [ 'trusty', 'xenial', 'bionic' ]
   'Devuan': [ 'ascii', 'beowulf' ]
 
@@ -332,10 +332,11 @@ apt__distribution_release_map:
 # repository suffixes should be configured on the current host in case the role
 # is used on a Debian Testing system.
 apt__distribution_suite_map:
-  'Debian_stretch':     'lts'
-  'Debian_buster':      'oldstable'
-  'Debian_bullseye':    'stable'
-  'Debian_bookworm':    'testing'
+  'Debian_stretch':     'archive'
+  'Debian_buster':      'oldoldstable'
+  'Debian_bullseye':    'oldstable'
+  'Debian_bookworm':    'stable'
+  'Debian_trixie':      'testing'
   'Debian_sid':         'unstable'
   'Raspbian_stretch':   'oldstable'
   'Raspbian_buster':    'stable'
@@ -363,16 +364,17 @@ apt__distribution_suite: '{{ apt__distribution_suite_map[apt__distribution + "_"
 # If the combination of OS distribution and release is not found, the default
 # list of suffixes will be used automatically.
 apt__distribution_suffix_map:
-  'Debian_archive':  [ '', '-backports' ]
-  'Debian_lts':      [ '', '-backports' ]
-  'Debian_stable':   [ '', '-updates', '-backports' ]
-  'Debian_testing':  [ '', '-updates' ]
-  'Debian_unstable': [ '' ]
-  'Raspbian':        [ '' ]
-  'Devuan_stable':   [ '', '-updates', '-backports' ]
-  'Devuan_testing':  [ '', '-updates' ]
-  'Devuan_unstable': [ '' ]
-  'default':         [ '', '-updates', '-backports' ]
+  'Debian_archive':      [ '', '-backports' ]
+  'Debian_oldoldstable': [ '', '-updates', '-backports' ]
+  'Debian_oldstable':    [ '', '-updates', '-backports' ]
+  'Debian_stable':       [ '', '-updates', '-backports' ]
+  'Debian_testing':      [ '', '-updates' ]
+  'Debian_unstable':     [ '' ]
+  'Raspbian':            [ '' ]
+  'Devuan_stable':       [ '', '-updates', '-backports' ]
+  'Devuan_testing':      [ '', '-updates' ]
+  'Devuan_unstable':     [ '' ]
+  'default':             [ '', '-updates', '-backports' ]
 
                                                                    # ]]]
 # .. envvar:: apt__distribution_suffixes [[[

--- a/ansible/roles/apt_preferences/defaults/main.yml
+++ b/ansible/roles/apt_preferences/defaults/main.yml
@@ -197,6 +197,7 @@ apt_preferences__next_release:
   'stretch':  'buster'
   'buster':   'bullseye'
   'bullseye': 'bookworm'
+  'bookworm': 'trixie'
 
   # Ubuntu releases
   'trusty':   'utopic'

--- a/ansible/roles/preseed/defaults/main.yml
+++ b/ansible/roles/preseed/defaults/main.yml
@@ -177,6 +177,12 @@ preseed__default_definitions:
     options: '{{ preseed__options_interactive_partman
                  + preseed__options_enable_nonfree }}'
 
+  - name: 'debian-bookworm'
+    flavor: 'debian'
+    release: 'bookworm'
+    options: '{{ preseed__options_interactive_partman
+                 + preseed__options_enable_nonfree }}'
+
   - name: 'debian-stretch-user'
     flavor: 'debian-user'
     release: 'stretch'
@@ -201,6 +207,14 @@ preseed__default_definitions:
                  + preseed__options_enable_nonfree }}'
     admin_username: '{{ preseed__admin_name }}'
 
+  - name: 'debian-bookworm-user'
+    flavor: 'debian-user'
+    release: 'bookworm'
+    options: '{{ preseed__options_interactive_partman
+                 + preseed__options_ansible_user
+                 + preseed__options_enable_nonfree }}'
+    admin_username: '{{ preseed__admin_name }}'
+
   - name: 'debian-stretch-vm'
     flavor: 'debian-vm'
     release: 'stretch'
@@ -212,6 +226,10 @@ preseed__default_definitions:
   - name: 'debian-bullseye-vm'
     flavor: 'debian-vm'
     release: 'bullseye'
+
+  - name: 'debian-bookworm-vm'
+    flavor: 'debian-vm'
+    release: 'bookworm'
 
   - name: 'debian-stretch-vm-user'
     flavor: 'debian-vm-user'
@@ -228,6 +246,12 @@ preseed__default_definitions:
   - name: 'debian-bullseye-vm-user'
     flavor: 'debian-vm-user'
     release: 'bullseye'
+    options: '{{ preseed__options_ansible_user }}'
+    admin_username: '{{ preseed__admin_name }}'
+
+  - name: 'debian-bookworm-vm-user'
+    flavor: 'debian-vm-user'
+    release: 'bookworm'
     options: '{{ preseed__options_ansible_user }}'
     admin_username: '{{ preseed__admin_name }}'
 

--- a/ansible/roles/reprepro/defaults/main.yml
+++ b/ansible/roles/reprepro/defaults/main.yml
@@ -235,14 +235,14 @@ reprepro__default_instances:
 
       - name: 'incoming'
         Allow:
+          - 'trixie'
+          - 'testing>trixie'
           - 'bookworm'
-          - 'testing>bookworm'
+          - 'stable>bookworm'
           - 'bullseye'
-          - 'stable>bullseye'
+          - 'oldstable>bullseye'
           - 'buster'
-          - 'oldstable>buster'
-          - 'stretch'
-          - 'oldoldstable>stretch'
+          - 'oldoldstable>buster'
         Options:
           - 'multiple_distributions'
         Cleanup:
@@ -251,14 +251,31 @@ reprepro__default_instances:
 
     distributions:
 
+      - name: 'trixie'
+        Description: 'Packages for Debian GNU/Linux 13 (Trixie)'
+        Origin: '{{ reprepro__origin }}'
+        Codename: 'trixie'
+        Suite: 'testing'
+        Architectures: [ 'source', 'amd64', 'arm64', 'armel', 'armhf', 'i386',
+                         'mips64el', 'mipsel', 'ppc64el', 's390x' ]
+        Components: [ 'main', 'contrib', 'non-free', 'non-free-firmware' ]
+        Uploaders: 'uploaders/anybody'
+        SignWith: 'default'
+        DebIndices: [ 'Packages', 'Release', '.', '.gz', '.xz' ]
+        DscIndices: [ 'Sources', 'Release', '.gz', '.xz' ]
+        Log: |
+          packages.bookworm.log
+          --type=dsc email-changes.sh
+        state: 'present'
+
       - name: 'bookworm'
         Description: 'Packages for Debian GNU/Linux 12 (Bookworm)'
         Origin: '{{ reprepro__origin }}'
         Codename: 'bookworm'
-        Suite: 'testing'
+        Suite: 'stable'
         Architectures: [ 'source', 'amd64', 'arm64', 'armel', 'armhf', 'i386',
                          'mips64el', 'mipsel', 'ppc64el', 's390x' ]
-        Components: [ 'main', 'contrib', 'non-free' ]
+        Components: [ 'main', 'contrib', 'non-free', 'non-free-firmware' ]
         Uploaders: 'uploaders/anybody'
         SignWith: 'default'
         DebIndices: [ 'Packages', 'Release', '.', '.gz', '.xz' ]
@@ -272,7 +289,7 @@ reprepro__default_instances:
         Description: 'Packages for Debian GNU/Linux 11 (Bullseye)'
         Origin: '{{ reprepro__origin }}'
         Codename: 'bullseye'
-        Suite: 'stable'
+        Suite: 'oldstable'
         Architectures: [ 'source', 'amd64', 'arm64', 'armel', 'armhf', 'i386',
                          'mips64el', 'mipsel', 'ppc64el', 's390x' ]
         Components: [ 'main', 'contrib', 'non-free' ]
@@ -289,23 +306,6 @@ reprepro__default_instances:
         Description: 'Packages for Debian GNU/Linux 10 (Buster)'
         Origin: '{{ reprepro__origin }}'
         Codename: 'buster'
-        Suite: 'oldstable'
-        Architectures: [ 'source', 'amd64', 'arm64', 'armel', 'armhf', 'i386',
-                         'mips', 'mips64el', 'mipsel', 'ppc64el', 's390x' ]
-        Components: [ 'main', 'contrib', 'non-free' ]
-        Uploaders: 'uploaders/anybody'
-        SignWith: 'default'
-        DebIndices: [ 'Packages', 'Release', '.', '.gz', '.xz' ]
-        DscIndices: [ 'Sources', 'Release', '.gz', '.xz' ]
-        Log: |
-          packages.buster.log
-          --type=dsc email-changes.sh
-        state: 'present'
-
-      - name: 'stretch'
-        Description: 'Packages for Debian GNU/Linux 9 (Stretch)'
-        Origin: '{{ reprepro__origin }}'
-        Codename: 'stretch'
         Suite: 'oldoldstable'
         Architectures: [ 'source', 'amd64', 'arm64', 'armel', 'armhf', 'i386',
                          'mips', 'mips64el', 'mipsel', 'ppc64el', 's390x' ]
@@ -315,7 +315,7 @@ reprepro__default_instances:
         DebIndices: [ 'Packages', 'Release', '.', '.gz', '.xz' ]
         DscIndices: [ 'Sources', 'Release', '.gz', '.xz' ]
         Log: |
-          packages.stretch.log
+          packages.buster.log
           --type=dsc email-changes.sh
         state: 'present'
 


### PR DESCRIPTION
Add trixie as the new testing.

---

I did not run any testsuite against this patchset on my side (ansible-lint ok)

I did not migrate ipxe to bookworm (I need to check if adding the new name is ok).

I did not add non-free-firmware in the dist-upgrade playbook and the apt role. Should we add it or leave it to the user? (and I did not check if and how to handle a non-free-firlmware in the pressed role)

I also did not add the vagrant box bookworm64 as the new default for Vagrantfile and lib/tests/jane.

bookworm switch from php7.4 to php8.2 is not taken care of. 

I removed stretch from reprepro.