### PR TITLE
[sshd] set ChallengeResponseAuthentication to False by default

### DIFF
--- a/ansible/roles/sshd/defaults/main.yml
+++ b/ansible/roles/sshd/defaults/main.yml
@@ -360,6 +360,13 @@ sshd__original_configuration:
     value: True
     state: 'init'
 
+  - name: 'KbdInteractiveAuthentication'
+    comment: |
+      Change to yes to enable challenge-response passwords (beware issues with
+      some PAM modules and threads)
+    value: False
+    state: 'init'
+
   - name: 'PermitEmptyPasswords'
     value: False
     state: 'init'
@@ -629,6 +636,14 @@ sshd__default_configuration:
                if (ansible_local.root_account.ssh_authorized_keys | d() | bool or
                    ansible_local.system_users.configured | d() | bool)
                else True }}'
+    state: 'present'
+
+  # Disable KbdInteractiveAuthentication (new name of the deprecated
+  # ChallengeResponseAuthentication) by default. Otherwise, setting
+  # PasswordAuthentication to False is not enough to force authentication
+  # by public key.
+  - name: 'KbdInteractiveAuthentication'
+    value: False
     state: 'present'
 
   # Enable support for client hostname lookups by the SSH service. This is


### PR DESCRIPTION
Currently, public key authentication is not enforced if KbdInteractiveAuthentication is set to  *yes*, even if PasswordAuthentication is set to *no*.

Setting KbdInteractiveAuthentication to *no* seems a good idea: this is the default value in /usr/share/openssh-server/sshd_config.