### PR TITLE
[ifupdown]: escape and unescape interface names in systemd unit name

### DIFF
--- a/ansible/roles/ifupdown/files/script/ifupdown-reconfigure-interfaces
+++ b/ansible/roles/ifupdown/files/script/ifupdown-reconfigure-interfaces
@@ -159,17 +159,19 @@ interface_down () {
         local -a if_hotplug_interfaces
         local -a if_boot_interfaces
         local -a systemd_ifup_instances
+        local systemd_escaped_interface
         mapfile -t if_hotplug_interfaces < <(ifquery --list --allow=hotplug)
         mapfile -t if_boot_interfaces < <(ifquery --list --allow=boot)
-        mapfile -t systemd_ifup_instances < <(systemctl list-units --no-legend --state=active 'ifup@*.service' | awk '{print $1}' | sed -e 's/^ifup\@//' -e 's/\.service$//')
+        mapfile -t systemd_ifup_instances < <(systemctl list-units --no-legend --state=active 'ifup@*.service' | awk '{print $1}' | sed -e 's/^ifup\@//' -e 's/\.service$//' | xargs -0 systemd-escape -u)
+        systemd_escaped_interface="$(systemd-escape "${1}")"
 
         if [ ${#if_hotplug_interfaces[@]} -gt 0 ] && containsElement "${1}" "${if_hotplug_interfaces[@]}" ; then
-            systemctl stop "ifup@${1}.service"
+		systemctl stop "ifup@${systemd_escaped_interface}.service"
         elif [ ${#if_boot_interfaces[@]} -gt 0 ] && containsElement "${1}" "${if_boot_interfaces[@]}" ; then
             if [ ${#if_hotplug_interfaces[@]} -gt 0 ] && [ ${#systemd_ifup_instances[@]} -gt 0 ] && containsElement "${1}" "${systemd_ifup_instances[@]}" ; then
-                systemctl stop "ifup@${1}.service"
+                systemctl stop "ifup@${systemd_escaped_interface}.service"
             else
-                systemctl stop "iface@${1}.service"
+                systemctl stop "iface@${systemd_escaped_interface}.service"
             fi
         fi
     else
@@ -183,14 +185,16 @@ interface_up () {
 
     local -a if_hotplug_interfaces
     local -a if_boot_interfaces
+    local systemd_escaped_interface
     mapfile -t if_hotplug_interfaces < <(ifquery --list --allow=hotplug)
     mapfile -t if_boot_interfaces < <(ifquery --list --allow=boot)
+    systemd_escaped_interface="$(systemd-escape "${1}")"
 
     if is_systemd ; then
         if [ ${#if_hotplug_interfaces[@]} -gt 0 ] && containsElement "${1}" "${if_hotplug_interfaces[@]}" ; then
-            systemctl start "ifup@${1}.service"
+            systemctl start "ifup@${systemd_escaped_interface}.service"
         elif [ ${#if_boot_interfaces[@]} -gt 0 ] && containsElement "${1}" "${if_boot_interfaces[@]}" ; then
-            systemctl start "iface@${1}.service"
+            systemctl start "iface@${systemd_escaped_interface}.service"
         fi
     else
         ifup "${1}"
@@ -230,14 +234,18 @@ if [ -d "${interface_request_path}" ] ; then
         declare -a systemd_iface_instances
         declare -a systemd_interface_instances
         if is_systemd ; then
-            mapfile -t systemd_ifup_instances < <(systemctl list-units --no-legend --state=active 'ifup@*.service' | awk '{print $1}' | sed -e 's/^ifup\@//' -e 's/\.service$//')
-            mapfile -t systemd_iface_instances < <(systemctl list-units --no-legend --state=active 'iface@*.service' | awk '{print $1}' | sed -e 's/^iface\@//' -e 's/\.service$//')
+            declare -a systemd_escaped_ifup_instances
+            declare -a systemd_escaped_iface_instances
+            mapfile -t systemd_escaped_ifup_instances < <(systemctl list-units --no-legend --state=active 'ifup@*.service' | awk '{print $1}' | sed -e 's/^ifup\@//' -e 's/\.service$//')
+            mapfile -t systemd_escaped_iface_instances < <(systemctl list-units --no-legend --state=active 'iface@*.service' | awk '{print $1}' | sed -e 's/^iface\@//' -e 's/\.service$//')
+            mapfile -t systemd_ifup_instances < <(for i in "${systemd_escaped_ifup_instances[@]}"; do systemd-escape -u "${i}"; done)
+            mapfile -t systemd_iface_instances < <(for i in "${systemd_escaped_iface_instances[@]}"; do systemd-escape -u "${i}"; done)
 
             if [ ${#systemd_ifup_instances[@]} -gt 0 ]; then
-                log_message -m "Found active systemd ifup@ instances: $(join_by ',' "${systemd_ifup_instances[@]}")"
+                log_message -m "Found active systemd ifup@ instances: $(join_by ',' "${systemd_escaped_ifup_instances[@]}")"
             fi
             if [ ${#systemd_iface_instances[@]} -gt 0 ]; then
-                log_message -m "Found active systemd iface@ instances: $(join_by ',' "${systemd_iface_instances[@]}")"
+                log_message -m "Found active systemd iface@ instances: $(join_by ',' "${systemd_escaped_iface_instances[@]}")"
             fi
         else
             # Prevent issues with unbound variable

--- a/ansible/roles/ifupdown/templates/etc/systemd/system/iface@.service.j2
+++ b/ansible/roles/ifupdown/templates/etc/systemd/system/iface@.service.j2
@@ -25,7 +25,7 @@ IgnoreOnIsolate=yes
 # avoid stopping on shutdown via stopping system-iface.slice
 Slice=system.slice
 {% endif %}
-ExecStart=/bin/sh -ec 'ifup --allow=boot %i; ifquery --state %i'
-ExecStop=/sbin/ifdown %i
+ExecStart=/bin/sh -ec 'ifup --allow=boot %I; ifquery --state %I'
+ExecStop=/sbin/ifdown %I
 RemainAfterExit=true
 TimeoutStartSec=5min

--- a/ansible/roles/ifupdown/templates/etc/systemd/system/ifup-allow-boot.service.j2
+++ b/ansible/roles/ifupdown/templates/etc/systemd/system/ifup-allow-boot.service.j2
@@ -24,10 +24,11 @@ ExecStart=/bin/sh -ec '\
   for i in $(ifquery --list --exclude lo --allow boot); do INTERFACES="$INTERFACES$i "; done; \
   [ -n "$INTERFACES" ] || exit 0; \
   for i in $INTERFACES; do \
+  escaped_iface="$(systemd-escape "$i")" \
   logger -t ifup-allow-boot "Checking state of the $i interface" ; \
-  if ! ifquery --state $i > /dev/null && ! systemctl is-active iface@$i > /dev/null 2>&1 ; then \
+  if ! ifquery --state $i > /dev/null && ! systemctl is-active iface@${escaped_iface} > /dev/null 2>&1 ; then \
   logger -t ifup-allow-boot "Interface $i is down, bringing it up" ; \
-  systemctl start iface@$i ; sleep 0.5 ; \
+  systemctl start iface@${escaped_iface} ; sleep 0.5 ; \
   while [ -e /run/network/ifup-$i.pid ] ; do sleep 0.5 ; \
   logger -t ifup-allow-boot "Waiting for $i interface" ; done ; \
   logger -t ifup-allow-boot "Interface $i is up" ; \


### PR DESCRIPTION
This fixes systemd unit names escaping. For one it let us escape the "hyphen" in the network interface name when we add them to systemd unit name in ifupdown iface@ services.
This restores unescaping of the systemd instance name to get the network interface name (the removal of this unescaping was a hack to avoid escaping the systemd unit instance name).

Closes #2371.

Note that the old hackish behavior could be fine too but I believe the ifupdown-reconfigure-interfaces script treats ifup@ and iface@ the same while one unescapes the instance name to get the systemd instance name to get the interface name to pass to ifup/ifquery/ifdown while the other does not. I believe (without a thorough check) that this script is tailored for iface@.service but will not play well for ifup@.service when the interface includes a "hyphen".

The plus of this PR is that with it the ifupdown-reconfigure-interfaces script plays well with "hyphen" in the network interface name for both ifup@.service and iface@.service. The down is that the service name will now C escape any non-alphanumeric characters rendering hand typing these instance service names and reading the output of systemctl difficult to read.
