### PR TITLE
New sysctl filename - 99-protect-links.conf

### DIFF
--- a/ansible/roles/sysctl/defaults/main.yml
+++ b/ansible/roles/sysctl/defaults/main.yml
@@ -267,7 +267,9 @@ sysctl__default_parameters:
   # original file and regenerate it; the read-only parameters will be
   # automatically commented out in unprivileged LXC containers.
   - name: 'protect-links'
-    filename: 'protect-links.conf'
+    filename: '{{ "protect-links.conf"
+        if (ansible_distribution_release in ["stretch", "buster", "bullseye"])
+        else "99-protect-links.conf" }}'
     divert: True
     comment: |
       Protected links


### PR DESCRIPTION
Bullseye and before: /usr/lib/sysctl.d/protect-links.conf
Since Bookworm: /usr/lib/sysctl.d/99-protect-links.conf