### PR TITLE
Deb822 repository bookworm

### DIFF
--- a/ansible/roles/apt/defaults/main.yml
+++ b/ansible/roles/apt/defaults/main.yml
@@ -219,6 +219,31 @@ apt__group_repositories: []
 apt__host_repositories: []
                                                                    # ]]]
                                                                    # ]]]
+# APT deb822 repositories [[[
+# --------------------
+
+# These lists define additional APT repositories in deb822 format
+# :file:`/etc/apt/sources.list.d/` directory.
+
+# .. envvar:: apt__deb822_repositories [[[
+#
+# List of additional APT repositories for all hosts in Ansible inventory.
+apt__deb822_repositories: []
+
+                                                                   # ]]]
+# .. envvar:: apt__group_deb822_repositories [[[
+#
+# List of additional APT repositories for all hosts in Ansible inventory.
+apt__group_deb822_repositories: []
+
+                                                                   # ]]]
+# .. envvar:: apt__host_deb822_repositories [[[
+#
+# List of additional APT repositories for all hosts in Ansible inventory.
+apt__host_deb822_repositories: []
+
+                                                                   # ]]]
+                                                                   # ]]]
 # APT authentication files [[[
 # ----------------------------
 

--- a/ansible/roles/apt/tasks/main.yml
+++ b/ansible/roles/apt/tasks/main.yml
@@ -159,11 +159,10 @@
     mode:          '{{ item.mode | d(omit) }}'
     signed_by:     '{{ item.signed_by | d(omit) }}'
     state:         '{{ item.state | d("present") }}'
-    types:         '{{ item.types | d(omit) }}'
-  with_flattened:
-    - '{{ apt__deb822_repositories }}'
-    - '{{ apt__group_deb822_repositories }}'
-    - '{{ apt__host_deb822_repositories }}'
+    types:         '{{ item.types | d("deb") }}'         # noqa args
+  loop: '{{ q("flattened", apt__deb822_repositories
+                           + apt__deb822_group_repositories
+                           + apt__deb822_host_repositories) }}'
   register: apt__register_deb822_repositories
   when: (apt__enabled|bool and item.name|d())
 

--- a/ansible/roles/apt/tasks/main.yml
+++ b/ansible/roles/apt/tasks/main.yml
@@ -149,6 +149,22 @@
   register: apt__register_repositories
   when: (apt__enabled | bool and item.repo | d())
 
+- name: Configure custom APT deb822 repositories
+  ansible.builtin.deb822_repository:
+    name:       '{{ item.name }}'
+    types:      '{{ item.types | d(omit) }}'
+    uris:       '{{ item.uris }}'
+    suites:     '{{ item.suites | d(omit) }}'
+    components: '{{ item.components | d(omit) }} '
+    signed_by:  '{{ item.signed_by | d(omit) }}'
+    state:      '{{ item.state | d("present") }}'
+  with_flattened:
+    - '{{ apt__deb822_repositories }}'
+    - '{{ apt__group_deb822_repositories }}'
+    - '{{ apt__host_deb822_repositories }}'
+  register: apt__register_deb822_repositories
+  when: (apt__enabled|bool and item.name|d())
+
 - name: Remove APT auth configuration if requested
   ansible.builtin.file:
     path: '{{ "/etc/apt/auth.conf.d/" + (item.name | regex_replace(".conf$", "")) + ".conf" }}'

--- a/ansible/roles/apt/tasks/main.yml
+++ b/ansible/roles/apt/tasks/main.yml
@@ -151,13 +151,15 @@
 
 - name: Configure custom APT deb822 repositories
   ansible.builtin.deb822_repository:
-    name:       '{{ item.name }}'
-    uris:       '{{ item.uris }}'
-    components: '{{ item.components | d("main") }} '
-    suites:     '{{ item.suites | d(ansible_distribution_release) }}'
-    types:      '{{ item.types | d(omit) }}'
-    signed_by:  '{{ item.signed_by | d(omit) }}'
-    state:      '{{ item.state | d("present") }}'
+    name:          '{{ item.name }}'
+    uris:          '{{ item.uris }}'
+    components:    '{{ item.components | d("main") }} '
+    suites:        '{{ item.suites | d(ansible_distribution_release) }}'
+    architectures: '{{ item.architectures | d(omit) }}'
+    mode:          '{{ item.mode | d(omit) }}'
+    signed_by:     '{{ item.signed_by | d(omit) }}'
+    state:         '{{ item.state | d("present") }}'
+    types:         '{{ item.types | d(omit) }}'
   with_flattened:
     - '{{ apt__deb822_repositories }}'
     - '{{ apt__group_deb822_repositories }}'

--- a/ansible/roles/apt/tasks/main.yml
+++ b/ansible/roles/apt/tasks/main.yml
@@ -152,10 +152,10 @@
 - name: Configure custom APT deb822 repositories
   ansible.builtin.deb822_repository:
     name:       '{{ item.name }}'
-    types:      '{{ item.types | d(omit) }}'
     uris:       '{{ item.uris }}'
-    suites:     '{{ item.suites | d(omit) }}'
-    components: '{{ item.components | d(omit) }} '
+    components: '{{ item.components | d("main") }} '
+    suites:     '{{ item.suites | d(ansible_distribution_release) }}'
+    types:      '{{ item.types | d(omit) }}'
     signed_by:  '{{ item.signed_by | d(omit) }}'
     state:      '{{ item.state | d("present") }}'
   with_flattened:

--- a/docs/ansible/roles/apt/defaults-detailed.rst
+++ b/docs/ansible/roles/apt/defaults-detailed.rst
@@ -261,7 +261,7 @@ Configure an Ubuntu PPA on Ubuntu hosts:
 .. _apt__ref_deb822_repositories:
 
 apt__deb822_repositories
------------------
+------------------------
 
 This list, along with ``apt__group_deb822_repositories`` and
 ``apt__host_deb822_repositories`` can be used to manage APT repositories through

--- a/docs/ansible/roles/apt/defaults-detailed.rst
+++ b/docs/ansible/roles/apt/defaults-detailed.rst
@@ -258,6 +258,81 @@ Configure an Ubuntu PPA on Ubuntu hosts:
        distribution: 'Ubuntu'
 
 
+.. _apt__ref_deb822_repositories:
+
+apt__deb822_repositories
+-----------------
+
+This list, along with ``apt__group_deb822_repositories`` and
+``apt__host_deb822_repositories`` can be used to manage APT repositories through
+Ansible inventory. Each entry is a YAML dictionary with parameters that
+correspond to the `Ansible ansible.builtin.deb822_repository module`_. See its
+documentation for parameter advanced usage and syntax.
+
+``name``
+  Required. Name of the repo. Specifically used for ``X-Repolib-Name`` and in
+  naming the repository and signing key files.
+
+``uris``
+  Required. Must specify the base of the Debian distribution archive, from which
+  APT finds the information it needs. Multiple URIs can be specified in a list.
+
+``state``
+  Optional. Either ``present`` for the repository to be present (default), or
+  ``absent`` for the repository to be removed.
+
+``architectures``
+  Optional. Architectures to search within repository, for example ``amd64``
+  (default) or ``i386``.
+
+``components``
+  Optional. Specify different sections of one distribution version present in
+  Suite, such as ``main`` (default), ``contrib``, ``non-free-firmware``…
+
+``mode``
+  Optional. The octal mode for newly created files in
+  :file:`/etc/apt/sources.list.d/` directory.
+
+``suites``
+  Optional. Can take the form of a distribution release name (default).
+
+``signed_by``
+  Optional. Either a URL to a GPG key, absolute path to a keyring file, one or
+  more fingerprints of keys. Keys will be store in :file:`/etc/apt/keyrings/`
+  directory (automatically created if absent).
+
+``types``
+  Optional. Which types of packages to look for from a given source; either
+  binary ``deb`` (default) or source code ``deb-src``.
+
+Examples
+~~~~~~~~
+
+Add an APT repository with several components on all hosts without any
+conditions:
+
+.. code-block:: yaml
+
+   apt__deb822_repositories:
+   - name: debian
+     types: deb
+     uris: http://deb.debian.org/debian
+     suites: bookworm
+     components:
+     - main
+     - contrib
+     - non-free-firmware
+
+Add third-party APT repository with GPG key URL:
+
+.. code-block:: yaml
+
+   apt__deb822_repositories:
+     - name: 'my-repo'
+       uris: 'http://example.com/debian'
+       signed_by: 'http://example.com/debian/example.com.asc'
+
+
 .. _apt__ref_auth_files:
 
 apt__auth_files
@@ -308,7 +383,7 @@ repository is managed by the :ref:`debops.reprepro` role which uses the
 Syntax
 ~~~~~~
 
-THe variables are defined as a list of YAML dictionaries .Each configuration
+The variables are defined as a list of YAML dictionaries .Each configuration
 entry defines a separate file in the :file:`/etc/apt/auth.conf.d/` directory.
 The state and contents of the file are specified using specific parameters:
 

--- a/docs/includes/global.rst
+++ b/docs/includes/global.rst
@@ -119,6 +119,7 @@
 .. _Ansible ansible.builtin.apt module: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_module.html
 .. _Ansible ansible.builtin.apt_key module: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_key_module.html
 .. _Ansible ansible.builtin.apt_repository module: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_repository_module.html
+.. _Ansible ansible.builtin.deb822_repository module: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/deb822_repository_module.html
 .. _Ansible arista.eos.eos_acl_interfaces module: https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_acl_interfaces_module.html
 .. _Ansible arista.eos.eos_acls module: https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_acls_module.html
 .. _Ansible arista.eos.eos_banner module: https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_banner_module.html


### PR DESCRIPTION
This PR should bring [deb822_repository](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/deb822_repository_module.html) module support.

One thing missing, this module requires **python3-debian** (which is not installed by default by Debian or DebOps) but i don't know the best place/module to install it :)

This should also avoid apt_key deprecation warning (see #2377).