### PR TITLE
bookworm: Fix lxc-containers not getting IPv4 address

### DIFF
--- a/ansible/roles/lxc/templates/etc/default/lxc-net.j2
+++ b/ansible/roles/lxc/templates/etc/default/lxc-net.j2
@@ -19,4 +19,6 @@ LXC_DHCP_RANGE="{{ lxc__net_address | ansible.utils.ipaddr(lxc__net_dhcp_start |
 LXC_DHCP_MAX="{{ (lxc__net_address | ansible.utils.ipaddr('size')) | int - ((lxc__net_dhcp_start | int|abs) + (lxc__net_dhcp_end | int|abs)) }}"
 LXC_DHCP_CONFILE="{{ lxc__net_dnsmasq_conf }}"
 LXC_DOMAIN="{{ lxc__net_domain }}"
+# make lxc-net use iptables as long as ferm uses iptables
+LXC_USE_NFT="false"
 {% endif %}


### PR DESCRIPTION
In Debian 12 (bookworm) lxc-containers don't get an IPv4 address. This is caused by the host firewall (iptable) missing some rule. These rules are set up by `/usr/libexec/lxc/lxc-net`, which in bookworm defaults to 'nft'. (Formerly this script supported only iptables.) Anyhow, ferm still uses 'iptables', thus `lxc-net` needs to use this, too.