### PR TITLE
[debops.nginx] Add support for ngx_http_geo_module

### DIFF
--- a/ansible/roles/nginx/tasks/nginx_configs.yml
+++ b/ansible/roles/nginx/tasks/nginx_configs.yml
@@ -14,7 +14,7 @@
 
 - name: Remove nginx maps if requested
   ansible.builtin.file:
-    dest: '/etc/nginx/conf.d/map_{{ item.name }}.conf'
+    dest: '/etc/nginx/conf.d/{{ item.type | d("map") }}_{{ item.name }}.conf'
     state: 'absent'
   loop: '{{ q("flattened", nginx__maps
                            + nginx__default_maps
@@ -30,7 +30,7 @@
 - name: Configure nginx maps
   ansible.builtin.template:
     src: 'etc/nginx/conf.d/map.conf.j2'
-    dest: '/etc/nginx/conf.d/map_{{ item.name }}.conf'
+    dest: '/etc/nginx/conf.d/{{ item.type | d("map") }}_{{ item.name }}.conf'
     owner: 'root'
     group: 'root'
     mode: '0644'

--- a/ansible/roles/nginx/templates/etc/nginx/conf.d/map.conf.j2
+++ b/ansible/roles/nginx/templates/etc/nginx/conf.d/map.conf.j2
@@ -7,15 +7,22 @@
 #    ==== nginx map template for debops.nginx role ====
 #
 # More information about maps: https://nginx.org/en/docs/http/ngx_http_map_module.html
+# More information about geo: https://nginx.org/en/docs/http/ngx_http_geo_module.html
 # List of parameters supported by this template:
 #
 #   - item.name: ''
 #       Name of the map configuration file. Required.
 #
+#   - item.type: ''
+#       Type of the map. Options: map(default) or geo.
+#
 #   - item.map: ''
 #       Lookup string and variable name to set, for example:
 #         '$http_host $name'
 #         '$http_user_agent $mobile'
+#       For type geo, the FIRST variable is $remote_addr by default, examples:
+#         '$health_allowed'
+#         '$realip_remote_addr $proxy_allowed'
 #
 #   - item.default: ''
 #       Default value to set if no mapping can be selected
@@ -41,7 +48,7 @@
 # {{ ansible_managed }}
 
 {% if item.name is defined and item.name                                          %}
-map {{ item.map }} {
+{{ item.type | d("map") }} {{ item.map }} {
 {%     if item.hostnames is defined and item.hostnames                            %}
         hostnames;
 {%     endif                                                                      %}


### PR DESCRIPTION
Implemented as a new type ('geo') of map.
Closes #2403.