### PR TITLE
acme: Make acmetiny world readable to facilitate execution

### DIFF
--- a/ansible/roles/pki/tasks/acme_tiny.yml
+++ b/ansible/roles/pki/tasks/acme_tiny.yml
@@ -39,6 +39,12 @@
         dest: '{{ pki_acme_tiny_src + "/acme-tiny" }}'
         version: '{{ pki_acme_tiny_version }}'
 
+    - name: Make script world readable
+      ansible.builtin.file:
+        path: '{{ pki_acme_tiny_src + "/acme-tiny" }}'
+        state: 'directory'
+        mode: '0755'
+
     - name: Install acme-tiny script
       ansible.builtin.file:
         path: '{{ pki_acme_tiny_bin }}'


### PR DESCRIPTION
I had trouble running the PKI scheduler because the script could not be executed!

The problem manifested itself in this error.log:

    $ cat  myrealm/acme/error.log
    sh: 1: /usr/local/bin/acme-tiny: Permission denied

This is a symlink into another directory which only root can enter.

This change makes the directory readable for other users so that acme-tiny can be executed.