### PR TITLE
Prevent using broken pyyaml versions in docker_server virtualenv

### DIFF
--- a/ansible/roles/docker_server/defaults/main.yml
+++ b/ansible/roles/docker_server/defaults/main.yml
@@ -183,6 +183,9 @@ docker_server__default_pip_packages:
     path: '/usr/local/bin/docker-compose'
     src:  '{{ docker_server__virtualenv + "/bin/docker-compose" }}'
 
+  # docker-compose requires pyyaml. Prevent using broken pyyaml versions https://github.com/yaml/pyyaml/issues/724
+  - name: 'pyyaml!=6.0.0,!=5.4.0,!=5.4.1'
+
                                                                    # ]]]
 # .. envvar:: docker_server__pip_packages [[[
 #

--- a/ansible/roles/docker_server/tasks/main.yml
+++ b/ansible/roles/docker_server/tasks/main.yml
@@ -80,13 +80,36 @@
 
 - name: Install Python packages in virtualenv
   ansible.builtin.pip:
-    name: '{{ item.name | d(item) }}'
-    version: '{{ item.version | d(omit) }}'
+    # Should install all packages in one go as otherwise the current package does not take into account any constraints
+    # of the previous packages
+    name: '{{ docker_server__combined_pip_package_specs }}'
     virtualenv: '{{ docker_server__virtualenv }}'
     state: '{{ item.state | d("present") }}'
-  loop: '{{ q("flattened", docker_server__default_pip_packages
-                           + docker_server__pip_packages) }}'
+  vars:
+    docker_server__combined_pip_packages: >
+      {{ q( "flattened", docker_server__default_pip_packages + docker_server__pip_packages) }}
+    # Create a list like ['foo', 'bar==1', 'baz>2,<3']
+    docker_server__combined_pip_package_specs: |
+      [
+      {% for item in docker_server__combined_pip_packages %}
+      {% if item.state | d("present") == "present" %}
+      '{{ item.name | d(item) }}{% if item.version | d() %}=={{ item.version }}{% endif %}',
+      {% endif %}
+      {% endfor %}
+      ]
   when: docker_server__install_virtualenv
+
+- name: Uninstall Python packages in virtualenv which should be absent
+  tags: debug123
+  ansible.builtin.pip:
+    name: '{{ item.name | d(item) }}'
+    virtualenv: '{{ docker_server__virtualenv }}'
+    state: '{{ item.state }}'
+  loop: '{{ docker_server__combined_pip_packages }}'
+  vars:
+    docker_server__combined_pip_packages: >
+      {{ q( "flattened", docker_server__default_pip_packages + docker_server__pip_packages) }}
+  when: docker_server__install_virtualenv and item.state | d("present") != "present"
 
 - name: Expose Docker virtualenv for Ansible modules
   ansible.builtin.file:

--- a/ansible/roles/docker_server/tasks/main.yml
+++ b/ansible/roles/docker_server/tasks/main.yml
@@ -100,7 +100,6 @@
   when: docker_server__install_virtualenv
 
 - name: Uninstall Python packages in virtualenv which should be absent
-  tags: debug123
   ansible.builtin.pip:
     name: '{{ item.name | d(item) }}'
     virtualenv: '{{ docker_server__virtualenv }}'


### PR DESCRIPTION
- When deploying the docker_server role, I get the same error as https://github.com/yaml/pyyaml/issues/724. The fix is to install a different pyyaml version (that is also still compatible with docker-compose).
- Pip installing one by one won't do as e.g. even if I put pyyaml first in the list, it would probably install pyyaml>6 because it's not taking into account the version constraint of docker-compose (it needs pyyaml<6). I could include that constraint in the pyyaml item but that constraint may change in the future so this is more robust. Instead this installs all packages in one go so pip can take into account all constraints; afterwards it applies any non-present packages which I assume are only absent packages.