### PR TITLE
[debops.redis] parent folder needs to be writtable by the redis user

### DIFF
--- a/ansible/roles/redis_server/tasks/main.yml
+++ b/ansible/roles/redis_server/tasks/main.yml
@@ -70,8 +70,8 @@
   ansible.builtin.file:
     path: '/etc/redis/{{ item.name }}'
     state: 'directory'
-    owner: 'root'
-    group: 'root'
+    owner: '{{ redis_server__user }}'
+    group: '{{ redis_server__auth_group }}'
     mode: '0755'
   with_items: '{{ redis_server__combined_configuration | debops.debops.parse_kv_items }}'
   when: item.name | d() and item.state | d('present') not in ['absent', 'init', 'ignore']


### PR DESCRIPTION
`CONFIG REWRITE` falls on newer version of redis if the parent folder is not writable by the redis user.

https://stackoverflow.com/questions/38214269/redis-err-rewriting-config-file-permission-denied-when-using-docker-data-volum