### PR TITLE
[grub] Grub cleanups

### DIFF
--- a/ansible/roles/grub/COPYRIGHT
+++ b/ansible/roles/grub/COPYRIGHT
@@ -3,7 +3,8 @@ debops.grub - Manage GRUB configuration
 Copyright (C) 2015 Patryk Ściborek <patryk@sciborek.com>
 Copyright (C) 2015-2018 Maciej Delmanowski <drybjed@gmail.com>
 Copyright (C) 2015-2017 Robin Schneider <ypid@riseup.net>
-Copyright (C) 2015-2018 DebOps <https://debops.org/>
+Copyright (C) 2023 David Härdeman <david@hardeman.nu>
+Copyright (C) 2015-2023 DebOps <https://debops.org/>
 SPDX-License-Identifier: GPL-3.0-only
 
 This Ansible role is part of DebOps.

--- a/ansible/roles/grub/defaults/main.yml
+++ b/ansible/roles/grub/defaults/main.yml
@@ -23,16 +23,20 @@
 
 # These variables define the contents of the
 # :file:`/etc/default/grub.d/ansible.cfg` configuration file which is used to
-# generate GRUB configuration in :file:`/boot/grub/grub.cfg`. Option names
-# don't contain the ``GRUB_`` prefix and will be converted to uppercase in the
-# final configuration file.
+# override values from :file:`/etc/default/grub` before the GRUB configuration
+# file :file:`/boot/grub/grub.cfg` is generated.
+#
+# Option names will be converted to uppercase and given a ``GRUB_`` prefix in
+# the final configuration file (for example: ``default`` will turn into
+# ``GRUB_DEFAULT``).
 #
 # See :ref:`grub__ref_configuration` for more details about the syntax.
 
 # .. envvar:: grub__original_configuration [[[
 #
-# This variable contains original configuration present in the GRUB
-# configuration file on Debian/Ubuntu hosts.
+# This variable largely corresponds to the original configuration present in
+# the GRUB configuration file on Debian/Ubuntu hosts (except where values are
+# imported from the original file via the ``original`` parameter).
 grub__original_configuration:
 
   - name: 'default'
@@ -63,6 +67,17 @@ grub__original_configuration:
     value: []
     original: True
 
+  - name: 'os_prober'
+    comment: |
+      If your computer has multiple operating systems installed, then you
+      probably want to run os-prober. However, if your computer is a host
+      for guest OSes installed via LVM or raw disk devices, running
+      os-prober can cause damage to those guest OSes as it mounts
+      filesystems to look for things.
+    value: False
+    state: 'comment'
+    quote: False
+
   - name: 'badram'
     comment: |
       Uncomment to enable BadRAM filtering, modify to suit your needs
@@ -72,7 +87,7 @@ grub__original_configuration:
     state: 'comment'
 
   - name: 'terminal'
-    comment: 'Uncomment to disable graphical terminal (grub-pc only)'
+    comment: 'Uncomment to disable graphical terminal'
     value: 'console'
     state: 'comment'
     quote: False
@@ -96,6 +111,7 @@ grub__original_configuration:
     comment: 'Uncomment to disable generation of recovery mode menu entries'
     value: True
     state: 'comment'
+    quote: False
 
   - name: 'init_tune'
     comment: 'Uncomment to get a beep at grub start'
@@ -133,17 +149,10 @@ grub__default_configuration:
                    ansible_virtualization_role not in ["guest"])
                else grub__timeout_virtual }}'
 
-  # Enable support for cgroup memory management, useful for LXC/Docker
-  # containers
+  # Enable console blanking (screensaver)
   - name: 'cmdline_linux_default'
     value:
-      - 'cgroup_enable=memory'
-      - 'swapaccount=1'
-
-  # Disable I/O scheduler in virtual machines for better performance
-  - name: 'cmdline_linux_default'
-    value: [ 'elevator=noop' ]
-    state: '{{ "present" if (ansible_virtualization_role | d() == "guest") else "ignore" }}'
+      - 'consoleblank=300'
 
   # Activate GRUB serial console support when requested
   - name: 'terminal'

--- a/ansible/roles/grub/defaults/main.yml
+++ b/ansible/roles/grub/defaults/main.yml
@@ -4,7 +4,8 @@
 # .. Copyright (C) 2015 Patryk Ściborek <patryk@sciborek.com>
 # .. Copyright (C) 2015-2018 Maciej Delmanowski <drybjed@gmail.com>
 # .. Copyright (C) 2015-2017 Robin Schneider <ypid@riseup.net>
-# .. Copyright (C) 2015-2018 DebOps <https://debops.org/>
+# .. Copyright (C) 2023 David Härdeman <david@hardeman.nu>
+# .. Copyright (C) 2015-2023 DebOps <https://debops.org/>
 # .. SPDX-License-Identifier: GPL-3.0-only
 
 # .. _grub__ref_defaults:
@@ -119,23 +120,6 @@ grub__original_configuration:
     state: 'comment'
 
                                                                    # ]]]
-# .. envvar:: grub__fact_configuration [[[
-#
-# This variable contains configuration based on the Ansible local facts of
-# a given host. This is used to keep the list of kernel parameters idempotent
-# and preserve the original parameters on first run of the role.
-grub__fact_configuration:
-
-  - name: 'default'
-    value: '{{ ansible_local.grub.default | d("0") }}'
-
-  - name: 'cmdline_linux_default'
-    value: '{{ ansible_local.grub.cmdline_default | d([]) }}'
-
-  - name: 'cmdline_linux'
-    value: '{{ ansible_local.grub.cmdline | d([]) }}'
-
-                                                                   # ]]]
 # .. envvar:: grub__default_configuration [[[
 #
 # This variable contains custom GRUB configuration defined by the role.
@@ -222,7 +206,6 @@ grub__dependent_configuration: []
 # This variable combines all of the configuration variables in a specific order
 # which defines the hierarchy. It's used in the final configuration template.
 grub__combined_configuration: '{{ grub__original_configuration
-                                  + grub__fact_configuration
                                   + grub__default_configuration
                                   + lookup("flattened",
                                            grub__dependent_configuration,

--- a/ansible/roles/grub/templates/etc/ansible/facts.d/grub.fact.j2
+++ b/ansible/roles/grub/templates/etc/ansible/facts.d/grub.fact.j2
@@ -4,7 +4,8 @@
 # Copyright (C) 2015 Patryk Ściborek <patryk@sciborek.com>
 # Copyright (C) 2015-2018 Maciej Delmanowski <drybjed@gmail.com>
 # Copyright (C) 2015-2017 Robin Schneider <ypid@riseup.net>
-# Copyright (C) 2015-2018 DebOps <https://debops.org/>
+# Copyright (C) 2023 David Härdeman <david@hardeman.nu>
+# Copyright (C) 2015-2023 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-only
 
 # {{ ansible_managed }}
@@ -13,12 +14,6 @@ from __future__ import print_function
 from json import loads, dumps
 import subprocess
 import os
-
-
-try:
-    from subprocess import DEVNULL
-except ImportError:
-    DEVNULL = open(os.devnull, 'wb')
 
 
 def cmd_exists(cmd):
@@ -39,21 +34,23 @@ if os.path.exists(grub_conf) and os.path.isfile(grub_conf):
             for line in f:
                 if not line.startswith('#') and '=' in line:
                     line = line.strip().split('=', 1)
+                    option = line[0].upper()
+                    value = line[1].strip('"')
 
-                    if line[0].lower() == 'grub_cmdline_linux_default':
-                        value = line[1].strip('"').split()
-                        if ('$' + line[0].upper()) in value:
-                            value.remove('$' + line[0].upper())
-                        output['cmdline_default'] = value
+                    if option == 'GRUB_CMDLINE_LINUX_DEFAULT':
+                        values = value.split()
+                        if ('$' + option) in values:
+                            values.remove('$' + option)
+                        output['cmdline_default'] = values
 
-                    elif line[0].lower() == 'grub_cmdline_linux':
-                        value = line[1].strip('"').split()
-                        if ('$' + line[0].upper()) in value:
-                            value.remove('$' + line[0].upper())
-                        output['cmdline'] = value
+                    elif option == 'GRUB_CMDLINE_LINUX':
+                        values = value.split()
+                        if ('$' + option) in values:
+                            values.remove('$' + option)
+                        output['cmdline'] = values
 
-                    elif line[0].lower() == 'grub_default':
-                        output['default'] = line[1].strip('"')
+                    elif option == 'GRUB_DEFAULT':
+                        output['default'] = value
 
     except Exception:
         pass

--- a/ansible/roles/grub/templates/etc/default/grub.d/ansible.cfg.j2
+++ b/ansible/roles/grub/templates/etc/default/grub.d/ansible.cfg.j2
@@ -1,7 +1,8 @@
 {# Copyright (C) 2015 Patryk Ściborek <patryk@sciborek.com>
  # Copyright (C) 2015-2018 Maciej Delmanowski <drybjed@gmail.com>
  # Copyright (C) 2015-2017 Robin Schneider <ypid@riseup.net>
- # Copyright (C) 2015-2018 DebOps <https://debops.org/>
+ # Copyright (C) 2023 David Härdeman <david@hardeman.nu>
+ # Copyright (C) 2015-2023 DebOps <https://debops.org/>
  # SPDX-License-Identifier: GPL-3.0-only
  #}
 # {{ ansible_managed }}
@@ -19,33 +20,38 @@
 {%     set element_export = ('export ' if (element.export | d(False)) | bool else '') %}
 {%     set element_quote = ('"' if (element.quote | d(True)) | bool else '') %}
 {%     set element_name = ('grub_' + (element.name | lower | regex_replace('^grub_',''))) | upper %}
-{%     set element_original = ((('$grub_' + (element.name | lower | regex_replace('^grub_','')) + ' ') | upper) if (element.original | d()) | bool else '')  %}
+{%     set element_original = ((('$grub_' + (element.name | lower | regex_replace('^grub_',''))) | upper) if (element.original | d()) | bool else '')  %}
 {%     set element_value = element.value | d('') %}
+{##}
 {%     if element.comment | d() %}
-{{ element.comment | regex_replace('\n$','') | comment(prefix='\n', postfix='') -}}
+{{       element.comment | regex_replace('\n$','') | comment(prefix='\n', postfix='') -}}
 {%     endif %}
+{##}
 {%     if element_value is string %}
-{{ '{}{}{}={}{}{}{}'.format(element_comment, element_export, element_name, element_quote, element_original, element_value, element_quote) }}
-{%     elif element_value | bool and element_value is not iterable %}
-{%       if element_value | string == '1' %}
-{{ '{}{}{}={}{}{}{}'.format(element_comment, element_export, element_name, element_quote, element_original, element_value, element_quote) }}
-{%       else %}
-{{ '{}{}{}={}{}{}'.format(element_comment, element_export, element_name, element_quote, 'true', element_quote) }}
-{%       endif %}
-{%     elif not element_value | bool and element_value is not iterable %}
-{%       if element_value is not none %}
-{%         if element_value | int %}
-{{ '{}{}{}={}{}{}{}'.format(element_comment, element_export, element_name, element_quote, element_original, element_value, element_quote) }}
+{%       set element_str = element_value %}
+{%     elif element_value is not iterable %}
+{%       if element_value | bool %}
+{%         if element_value | string == '1' %}
+{%           set element_str = element_value %}
 {%         else %}
-{%           if element_value | string == '0' %}
-{{ '{}{}{}={}{}{}{}'.format(element_comment, element_export, element_name, element_quote, element_original, element_value, element_quote) }}
-{%           else %}
-{{ '{}{}{}={}{}{}'.format(element_comment, element_export, element_name, element_quote, 'false', element_quote) }}
-{%           endif %}
+{%           set element_str = 'true' %}
+{%         endif %}
+{%       else %}
+{%         if element_value | int %}
+{%           set element_str = element_value %}
+{%         elif element_value | string == '0' %}
+{%           set element_str = element_value %}
+{%         else %}
+{%           set element_str = 'false' %}
 {%         endif %}
 {%       endif %}
-{%     elif element_value is iterable and element_value is not string and element_value is not mapping %}
-{{ '{}{}{}={}{}{}{}'.format(element_comment, element_export, element_name, element_quote, element_original, element_value | selectattr('state', 'equalto', 'present') | map(attribute='name') | list | join(' '), element_quote) }}
+{%     elif element_value is not mapping %}
+{%       set element_str = element_value | selectattr('state', 'equalto', 'present') | map(attribute='name') | list | join(' ') %}
+{%     else %}
+{%       set element_str = '' %}
 {%     endif %}
+{##}
+{%     set element_str = [ element_original, element_str ] | join(' ') | trim %}
+{{     '{}{}{}={}{}{}'.format(element_comment, element_export, element_name, element_quote, element_str, element_quote) }}
 {%   endif %}
 {% endfor %}

--- a/ansible/roles/grub/templates/etc/default/grub.d/ansible.cfg.j2
+++ b/ansible/roles/grub/templates/etc/default/grub.d/ansible.cfg.j2
@@ -6,8 +6,10 @@
  #}
 # {{ ansible_managed }}
 
-# If you change this file, run 'update-grub' afterwards to update
-# /boot/grub/grub.cfg.
+# You should not make changes to this file directly, but instead make changes
+# through the Ansible inventory. The "grub" role will make sure to run
+# 'update-grub' afterwards to update /boot/grub/grub.cfg.
+#
 # For full documentation of the options in this file, see:
 #   info -f grub -n 'Simple configuration'
 

--- a/docs/ansible/roles/grub/defaults-detailed.rst
+++ b/docs/ansible/roles/grub/defaults-detailed.rst
@@ -43,15 +43,20 @@ Configure unattended filesystem check and repair on boot:
        value:
          - 'fsck.mode=force'
 
-Remove the ``quiet`` parameter from the default kernel command line:
+The ``quiet`` parameter for the default kernel command line is usually defined
+in :file:`/etc/default/grub` and imported into
+:file:`/etc/default/grub.d/ansible.cfg` via the ``original`` parameter (see
+below). If you want to remove the ``quiet`` default parameter, you therefore
+need to *not* import the original value(s):
 
 .. code-block:: yaml
 
    grub__configuration:
      - name: 'cmdline_linux_default'
-       value:
-         - name: 'quiet'
-           state: 'absent'
+       original: False
+
+If you do so, make sure that you're not unintentionally excluding any other
+parameters already set in :file:`/etc/default/grub`.
 
 
 Syntax
@@ -108,10 +113,10 @@ a configuration file option using specific parameters:
   ``False``, the value will not be quoted.
 
 ``original``
-  Optional, boolean. If ``True``, the role will add ``$GRUB_<NAME>`` string to
-  the given configuration option, based on the entry name. This allows to
-  preserve existing GRUB options from the :file:`/etc/default/grub`; this is
-  useful only for specific options like kernel parameters.
+  Optional, boolean. If ``True``, the role will add a ``$GRUB_<NAME>`` string
+  to the given configuration option, based on the entry name. This allows
+  existing GRUB options from the :file:`/etc/default/grub` to be preserved
+  and is generally only useful for specific options like kernel parameters.
 
 ``export``
   Optional, boolean. if ``True``, the option will be exported in the GRUB


### PR DESCRIPTION
This patchset brings the Grub configuration up to date with current kernel parameters and Grub default configuration file options.

Also, a bunch of cleanups to the fact script, template and the removal of a variable (grub__fact_configuration) which, unless I'm mistaken, merely counteracts the facts from the Ansible inventory.
