### PR TITLE
[php] Add Trixie/Bookworm support

### DIFF
--- a/ansible/roles/php/COPYRIGHT
+++ b/ansible/roles/php/COPYRIGHT
@@ -1,8 +1,8 @@
-debops.php - Manage PHP5/PHP7 environment using Ansible
+debops.php - Manage PHP environment using Ansible
 
 Copyright (C) 2016      Mariano Barcia <mariano.barcia@gmail.com>
 Copyright (C) 2016-2019 Maciej Delmanowski <drybjed@gmail.com>
-Copyright (C) 2016-2019 DebOps <https://debops.org/>
+Copyright (C) 2016-2025 DebOps <https://debops.org/>
 SPDX-License-Identifier: GPL-3.0-only
 
 This Ansible role is part of DebOps.

--- a/ansible/roles/php/defaults/main.yml
+++ b/ansible/roles/php/defaults/main.yml
@@ -3,7 +3,7 @@
 
 # .. Copyright (C) 2016      Mariano Barcia <mariano.barcia@gmail.com>
 # .. Copyright (C) 2016-2019 Maciej Delmanowski <drybjed@gmail.com>
-# .. Copyright (C) 2016-2019 DebOps <https://debops.org/>
+# .. Copyright (C) 2016-2025 DebOps <https://debops.org/>
 # .. SPDX-License-Identifier: GPL-3.0-only
 
 # .. _php__ref_defaults:
@@ -24,7 +24,7 @@
 #
 # List of APT package names which are scanned to check available PHP versions.
 # The first found package wins. The ``php5`` packages are not supported.
-php__version_preference: [ 'php7.4', 'php7.3', 'php', 'php5.6' ]
+php__version_preference: [ 'php8.4', 'php8.2', 'php7.4', 'php7.3', 'php' ]
 
                                                                    # ]]]
 # .. envvar:: php__sury [[[
@@ -33,7 +33,7 @@ php__version_preference: [ 'php7.4', 'php7.3', 'php', 'php5.6' ]
 # maintainer. You can enable these repositories to install PHP 7.0 on Debian
 # Jessie. See :ref:`php__ref_sury` for more details.
 php__sury: '{{ ansible_local.php.sury
-                | d(ansible_distribution_release in ["stretch", "trusty", "xenial"]) | bool }}'
+                | d(ansible_distribution_release in ["trusty", "xenial"]) | bool }}'
 
                                                                    # ]]]
 # .. envvar:: php__sury_apt_key_id [[[
@@ -177,16 +177,17 @@ php__included_packages: '{{ php__php_included_packages
 # Configuration dictionary mapping distribution releases to different PHP
 # packaging configurations. Also see :envvar:`php__included_packages`.
 php__release_included_map:
-  stretch:  '{{ php__php_included_packages }}'
   buster:   '{{ php__php_included_packages }}'
   bullseye: '{{ php__php_included_packages }}'
+  bookworm: '{{ php__php_included_packages }}'
+  trixie:   '{{ php__php_included_packages }}'
   sid:      '{{ php__php_included_packages }}'
   trusty:   '{{ php__php5_included_packages }}'
   xenial:   '{{ php__php_included_packages }}'
   zesty:    '{{ php__php_included_packages }}'
   bionic:   '{{ php__php_included_packages }}'
   focal:    '{{ php__php_included_packages }}'
-  groovy:    '{{ php__php_included_packages }}'
+  groovy:   '{{ php__php_included_packages }}'
 
                                                                    # ]]]
 # .. envvar:: php__php5_included_packages [[[
@@ -249,7 +250,7 @@ php__common_included_packages:
 # will be installed instead.
 php__composer_upstream_enabled: '{{ True
                                     if (ansible_distribution_release in
-                                        ["stretch", "trusty", "xenial",
+                                        ["trusty", "xenial",
                                          "bionic", "focal"])
                                     else False }}'
 
@@ -756,7 +757,7 @@ php__apt_preferences__dependent_list:
     suffix: '_packages_sury_org'
     state: '{{ "present" if php__sury | bool else "absent" }}'
 
-  - packages: [ 'php', 'php5', 'php5*', 'php7*', 'dh-php', 'php-*',
+  - packages: [ 'php', 'php5', 'php5*', 'php7*', 'php8*', 'dh-php', 'php-*',
                 'libpcre2-8-0', 'libpcre3', 'libzip4', 'libpcre16-3',
                 'libpcre32-3', 'libpcrecpp0v5', 'libpcre3-dev',
                 'libapache2-mod-php', 'libapache2-mod-php*',

--- a/ansible/roles/php/files/script/php-filter-packages.sh
+++ b/ansible/roles/php/files/script/php-filter-packages.sh
@@ -2,7 +2,7 @@
 
 # Copyright (C) 2016      Mariano Barcia <mariano.barcia@gmail.com>
 # Copyright (C) 2016-2019 Maciej Delmanowski <drybjed@gmail.com>
-# Copyright (C) 2016-2019 DebOps <https://debops.org/>
+# Copyright (C) 2016-2023 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-only
 
 # Filter specified PHP package names to the corresponding APT package names
@@ -10,10 +10,10 @@
 # Homepage: https://github.com/debops/ansible-php/
 
 # Usage:
-# Specify the PHP version in the $PHP_VERSION environment variable, either '5'
-# or '7.0'. Only one PHP version is supported at a time.
+# Specify the PHP version in the $PHP_VERSION environment variable.
+# Only one PHP version is supported at a time.
 
-# Specify the list of package names without the 'php5-' or 'php7.0-' prefix
+# Specify the list of package names without the 'php<version>-' prefix
 # as script arguments.
 
 

--- a/ansible/roles/php/meta/main.yml
+++ b/ansible/roles/php/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 # Copyright (C) 2016      Mariano Barcia <mariano.barcia@gmail.com>
 # Copyright (C) 2016-2019 Maciej Delmanowski <drybjed@gmail.com>
-# Copyright (C) 2016-2022 DebOps <https://debops.org/>
+# Copyright (C) 2016-2023 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-only
 
 # Ensure that custom Ansible plugins and modules included in the main DebOps
@@ -32,3 +32,4 @@ galaxy_info:
     - php
     - php5
     - php7
+    - php8

--- a/docs/ansible/roles/php/defaults-detailed.rst
+++ b/docs/ansible/roles/php/defaults-detailed.rst
@@ -21,19 +21,18 @@ simple strings or lists, here you can find documentation and examples for them.
 php__packages
 -------------
 
-The :envvar:`php__packages`, :envvar:`php__group_packages`, :envvar:`php__host_packages` and
-:envvar:`php__dependent_packages` lists can be used to install APT packages. The role
-automatically prepends the package names with correct prefix (``php5-`` or
-``php7.0-``) to install packages for currently active PHP version. Because of
-that you should only use these lists to install PHP-related packages.
+The :envvar:`php__packages`, :envvar:`php__group_packages`,
+:envvar:`php__host_packages` and :envvar:`php__dependent_packages` lists can be
+used to install APT packages. The role automatically prepends the package names
+with correct prefix (``php<version>-``) to install packages for currently
+active PHP version. Because of that you should only use these lists to install
+PHP-related packages.
 
-The packages with names in the form:
+Packages with names in the form:
 
 - ``php-*``
 
-- ``php5-*``
-
-- ``php7.0-*``
+- ``php<version>-*``
 
 will be detected correctly. Any other package names will have the current PHP
 version prepended to their name, which might result in incorrect installation
@@ -62,16 +61,16 @@ php__configuration
 ------------------
 
 The management of the :file:`php.ini` configuration is done using a set of YAML
-lists, named :envvar:`php__configuration`, :envvar:`php__group_configuration` and
-:envvar:`php__host_configuration`. Each element of a list is a YAML dictionary with
-certain parameters.
+lists, named :envvar:`php__configuration`, :envvar:`php__group_configuration`
+and :envvar:`php__host_configuration`. Each element of a list is a YAML
+dictionary with certain parameters.
 
 The configuration is designed to allow easy creation of multiple configuration
-files located in :file:`/etc/php{5,/7.0}/` directories. By default, all files are
-created in the :file:`/etc/php{5,/7.0}/ansible/` directory with the ``.ini``
-extension, and symlinked to the respective PHP SAPI configuration directories.
-If you need, you can create the configuration files directly in the PHP SAPI
-directories as well.
+files located in :file:`/etc/php<version>/` directories. By default, all files
+are created in the :file:`/etc/php<version>/ansible/` directory with the
+``.ini`` extension, and symlinked to the respective PHP SAPI configuration
+directories.  If you need, you can create the configuration files directly in
+the PHP SAPI directories as well.
 
 The role recognizes the parameters below:
 
@@ -81,9 +80,9 @@ The role recognizes the parameters below:
 
 ``path``
   Optional. Change the default path where a given configuration file should be
-  created, relative to :file:`/etc/php{5,/7.0}/`. By default this value is
-  :command:`ansible/`. You need to add the ``/`` character at the end of the path for
-  the role to work correctly.
+  created, relative to :file:`/etc/php<version>/`. By default this value is
+  :command:`ansible/`. You need to add the ``/`` character at the end of the
+  path for the role to work correctly.
 
 ``sections``
   Optional. List of YAML dictionaries, each one describing a part of the given
@@ -97,8 +96,8 @@ one of the YAML dictionaries on the ``sections`` list:
   ``[PHP]`` in the configuration file.
 
 ``options``
-  A YAML text block with :file:`php.ini` configuration options specified in the INI
-  configuration file format.
+  A YAML text block with :file:`php.ini` configuration options specified in the
+  INI configuration file format.
 
 ``comment``
   Optional. A custom comment added before a specified configuration.
@@ -111,7 +110,7 @@ one of the YAML dictionaries on the ``sections`` list:
 Examples
 ~~~~~~~~
 
-Create custom configuration file symlinked to all PHP SAPI directories:
+Create a custom configuration file symlinked to all PHP SAPI directories:
 
 .. code-block:: yaml
 
@@ -121,7 +120,7 @@ Create custom configuration file symlinked to all PHP SAPI directories:
        options: |
          display_errors = On
 
-Create custom configuration file with multiple sections directly in PHP-FPM
+Create a custom configuration file with multiple sections directly in PHP-FPM
 directory:
 
 .. code-block:: yaml
@@ -146,11 +145,11 @@ directory:
 php__pools
 ----------
 
-The :envvar:`php__pools`, :envvar:`php__group_pools`, :envvar:`php__host_pools` and
-:envvar:`php__dependent_pools` lists can be used to create PHP-FPM pools. Each list
-entry is a YAML dictionary with keys and values that represent options in the
-pool configuration file (with some additional parameters used by the role
-itself).
+The :envvar:`php__pools`, :envvar:`php__group_pools`, :envvar:`php__host_pools`
+and :envvar:`php__dependent_pools` lists can be used to create PHP-FPM pools.
+Each list entry is a YAML dictionary with keys and values that represent
+options in the pool configuration file (with some additional parameters used by
+the role itself).
 
 Most of the pool parameters have their corresponding default variables in the
 ``php__fpm_*`` namespace. To use them in the pool configuration, strip the
@@ -198,7 +197,7 @@ otherwise different:
 ``listen``
   Optional. Path to the PHP-FPM socket or IP:port on which a given pool should
   listen for connections. By default it's autogenerated in the format:
-  :file:`/run/php{5,7.0}-fpm-{{ item.name }}.sock`.
+  :file:`/run/php<version>-fpm-{{ item.name }}.sock`.
 
 ``listen_owner``
   Optional. The system user that will be the owner of the PHP-FPM socket. This
@@ -251,14 +250,14 @@ otherwise different:
   dictionary value is the value contents.
 
 ``php_admin_flags``
-  Optional. A YAML dictionary with custom :file:`php.ini` admin flags that should
-  be defined in the PHP-FPM pool. Each dictionary key is the admin flag name,
-  and each dictionary value is the admin flag value.
+  Optional. A YAML dictionary with custom :file:`php.ini` admin flags that
+  should be defined in the PHP-FPM pool. Each dictionary key is the admin flag
+  name, and each dictionary value is the admin flag value.
 
 ``php_admin_values``
-  Optional. A YAML dictionary with custom :file:`php.ini` admin values that should
-  be defined in the PHP-FPM pool. Each dictionary key is the admin value name,
-  and each dictionary value is the admin value contents.
+  Optional. A YAML dictionary with custom :file:`php.ini` admin values that
+  should be defined in the PHP-FPM pool. Each dictionary key is the admin value
+  name, and each dictionary value is the admin value contents.
 
 ``open_basedir``
   Optional. String or list of paths which can be accessed by the PHP

--- a/docs/ansible/roles/php/getting-started.rst
+++ b/docs/ansible/roles/php/getting-started.rst
@@ -18,13 +18,11 @@ The ``debops.php`` role supports management of multiple PHP versions; only one
 PHP version can be managed at a time. By default the role will install and
 configure the PHP version provided with the current OS release.
 
-The role checks for existence of ``php7.3``, ``php`` and ``php5.6`` APT
-packages (by default in that order) and based on available versions installs
-either ``php7.3-*``, the version preferred by the ``php`` package or
-``php5.6-*`` APT packages. If multiple versions of the PHP packages are
-available, the first found one wins. To force an older version in case the
-newer one is installed, you can change the order of the packages used for the
-version detection using the :envvar:`php__version_preference` list.
+The role checks for existence of various PHP APT packages and chooses a version
+based the order in :envvar:`php__version_preference`.  To force an older
+version in case the newer one is installed, you can change the order of the
+packages used for the version detection using the
+:envvar:`php__version_preference` list.
 
 To learn how to specify different PHP packages for installation, refer to
 :ref:`php__ref_packages` documentation.
@@ -36,15 +34,14 @@ PHP packages provided by Ondřej Surý
 ------------------------------------
 
 `Ondřej Surý <https://qa.debian.org/developer.php?login=ondrej%40debian.org>`_
-is a member of the Debian PHP Maintainers team and maintains Debian
-`PHP5 <https://packages.qa.debian.org/p/php5.html>`_ and
-`PHP7 <https://packages.qa.debian.org/p/php7.0.html>`_ packages. He also provides
-`an external APT package repository <https://deb.sury.org/>`_ of PHP5 and PHP7
-packages (among other things) for Debian and Ubuntu distributions.
+is a member of the Debian PHP Maintainers team and maintains Debian PHP
+packages. He also provides `an external APT package repository
+<https://deb.sury.org/>`_ of various PHP versions for Debian and Ubuntu
+distributions.
 
 The ``debops.php`` role can use the packages from the Ondřej Surý repositories
-to provide PHP7 packages on Debian Jessie. Remember that these packages
-**DO NOT** fall under the Debian Stable security support and may contain bugs.
+to provide alternative PHP versions. Remember that these packages **DO NOT**
+fall under the Debian Stable security support and may contain bugs.
 
 To enable the custom APT repository, add in the Ansible inventory:
 
@@ -52,9 +49,7 @@ To enable the custom APT repository, add in the Ansible inventory:
 
    php__sury: True
 
-This will add the required OpenPGP keys and APT repositories. The order of the
-package versions should ensure that the PHP7 packages will be installed on
-Debian Jessie.
+This will add the required OpenPGP keys and APT repositories.
 
 
 Custom environment role
@@ -65,8 +60,8 @@ should be added to the playbook or role dependencies before the main role and
 other roles that use configuration from ``debops.php``, like
 :ref:`debops.logrotate`. The ``debops.php/env`` role configures custom APT
 repositories if they are enabled and prepares the facts needed by other roles
-to function correctly. See the :ref:`provided playbook <php__ref_example_playbook>`
-to see an example usage.
+to function correctly. See the
+:ref:`provided playbook<php__ref_example_playbook>` for an example usage.
 
 
 PHP Composer installation
@@ -74,8 +69,8 @@ PHP Composer installation
 
 The :ref:`debops.php` role will install the `PHP Composer`__, a dependency
 manager for PHP. The version from the OS repositories will be preferred. On
-older OS releases (including Debian Stretch), a known upstream binary will be
-downloaded and installed instead.
+older OS releases, a known upstream binary will be downloaded and installed
+instead.
 
 .. __: https://getcomposer.org/
 
@@ -83,15 +78,15 @@ downloaded and installed instead.
 Layout of the php.ini configuration
 -----------------------------------
 
-The main :file:`/etc/php{5,/7.0}/*/php.ini` files maintained by the OS distribution
-are not modified by the ``debops.php`` role to allow an easy upgrade process.
-Instead, a custom :file:`php.ini` configuration is stored in
-:file:`/etc/php{5,/7.0}/ansible/*.ini` files generated using a simple template,
-which are then linked to each of the PHP SAPI directories in
-:file:`/etc/php{5,/7.0}/*/conf.d/` which are read by the PHP interpreters. This
-allows for configuration synchronization between different PHP interpreters. To
-learn more about this process refer to :ref:`php__ref_configuration`
-documentation.
+The main :file:`/etc/php<version>/*/php.ini` files maintained by the OS
+distribution are not modified by the ``debops.php`` role to allow an easy
+upgrade process.  Instead, a custom :file:`php.ini` configuration is stored in
+:file:`/etc/php<bersion>/ansible/*.ini` files generated using a simple
+template, which is then linked to each of the PHP SAPI directories in
+:file:`/etc/php<version>/*/conf.d/` which are read by the PHP interpreters.
+This allows for configuration synchronization between different PHP
+interpreters. To learn more about this process refer to
+:ref:`php__ref_configuration` documentation.
 
 
 Information stored in Ansible local facts
@@ -102,7 +97,7 @@ through the Ansible local facts. The specific variables are:
 
 ``ansible_local.php.version``
   Short version of the PHP environment, used in package names.
-  Either ``5`` or ``7.0``.
+  For example, ``5`` or ``7.0``.
 
 ``ansible_local.php.long_version``
   Longer version of the PHP environment, used for version comparison. For

--- a/docs/ansible/roles/php/man_description.rst
+++ b/docs/ansible/roles/php/man_description.rst
@@ -8,6 +8,6 @@ Description
 
 The ``debops.php`` role can be used to manage PHP Hypertext Preprocessor
 environment on a Debian/Ubuntu host. The role supports different PHP versions
-available in OS distributions (PHP5, PHP7) with PHP-FPM service and multiple
+available in OS distributions together with the PHP-FPM service and multiple
 PHP-FPM pools. Other Ansible roles can use it as a role dependency to offload
 PHP management for their own use.

--- a/docs/ansible/roles/php/man_index.rst
+++ b/docs/ansible/roles/php/man_index.rst
@@ -5,7 +5,7 @@
 .. Copyright (C) 2016-2019 DebOps <https://debops.org/>
 .. SPDX-License-Identifier: GPL-3.0-only
 
-ebops.php
+debops.php
 ==========
 
 .. toctree::


### PR DESCRIPTION
By adding support for PHP 8.2/8.4. At the same time, the docs have been updated, but instead of adding references to version 8 everywhere, I took the liberty of removing version references so that the docs don't have to be kept in sync with the role variables.