### PR TITLE
[auth] Fix pwhistory template

### DIFF
--- a/ansible/roles/auth/templates/usr/share/pam-configs/pwhistory.j2
+++ b/ansible/roles/auth/templates/usr/share/pam-configs/pwhistory.j2
@@ -2,14 +2,9 @@
  # Copyright (C) 2014-2017 DebOps <https://debops.org/>
  # SPDX-License-Identifier: GPL-3.0-only
  #}
-# {{ ansible_managed }}
-
-# Remember previous local passwords to enforce rotation
-
 Name: Unix password history
 Default: yes
 Priority: 500
-Auth-Type: Primary
 Password-Type: Primary
 Password:
 	required			pam_pwhistory.so use_authtok enforce_for_root remember={{ auth_pwhistory_remember }}


### PR DESCRIPTION
The pam-auth-update doesn't support comments and gets confused by the stray "Auth-Type: Primary" line, which causes some scary looking console spam whenever pam-auth-update is executed.