### PR TITLE
[netbox] Add support for standby NetBox on read only database

### DIFF
--- a/ansible/roles/netbox/defaults/main.yml
+++ b/ansible/roles/netbox/defaults/main.yml
@@ -34,6 +34,22 @@ netbox__domain: '{{ ansible_domain }}'
 
                                                                    # ]]]
                                                                    # ]]]
+# Primary/Standby configuration [[[
+# -----------------------------
+
+# .. envvar:: netbox__primary [[[
+#
+# Boolean to define if the instance of NetBox will be primary or not.
+# True: This instance will become primary and needs read and write
+# database access.
+# False: This instance will become standby,
+# "netbox__config_maintenance_mode" will be set to True and
+# "netbox__config_session_file_path" will be populated.
+netbox__primary: True
+
+                                                                   # ]]]
+                                                                   # ]]]
+
 # APT packages [[[
 # ----------------
 
@@ -660,7 +676,7 @@ netbox__config_base_path: ''
 #
 # Enable or disable maintenance mode banner.
 # This overwrites potentially existing `dynamic configuration settings <https://netbox.readthedocs.io/en/stable/configuration/dynamic-settings/>`__.
-netbox__config_maintenance_mode: False
+netbox__config_maintenance_mode: '{{ not netbox__primary | bool }}'
 
                                                                    # ]]]
 # .. envvar:: netbox__config_napalm_username [[[
@@ -833,7 +849,7 @@ netbox__config_metrics_enabled: False
 # can be useful for enabling authentication on a standby instance with
 # read-only database access.) Note that the user as which NetBox runs must have
 # read and write permissions to this path.
-netbox__config_session_file_path: False
+netbox__config_session_file_path: '{{ "" if netbox__primary | bool else netbox__data + "/sessions" }}'
 
                                                                    # ]]]
 # .. envvar:: netbox__config_media_root [[[

--- a/ansible/roles/netbox/tasks/main.yml
+++ b/ansible/roles/netbox/tasks/main.yml
@@ -216,9 +216,61 @@
     PATH: '{{ netbox__virtualenv_env_path }}'
   become: True
   become_user: '{{ netbox__user }}'
-  when: netbox__register_checkout is changed
+  when: (netbox__register_checkout is changed and
+         netbox__primary | bool)
   register: netbox__register_migration
   changed_when: netbox__register_migration.changed | bool
+
+- name: Generate static content
+  ## Since we do not run the manage.py file on secondary sites
+  ## we need to generate those files in an extra task.
+  shell:  # noqa no-handler
+    cmd: |
+      set -o nounset -o pipefail -o errexit
+      ./manage.py collectstatic --no-input
+    chdir: '{{ netbox__git_checkout + "/netbox" }}'
+    executable: 'bash'
+  environment:
+    VIRTUAL_ENV: '{{ netbox__virtualenv }}'
+    PATH: '{{ netbox__virtualenv_env_path }}'
+  become: True
+  become_user: '{{ netbox__user }}'
+  when: (netbox__register_checkout is changed and
+         not netbox__primary | bool)
+  register: netbox__register_collectstatic
+  changed_when: not netbox__register_collectstatic.stdout is search('0 static files copied')
+
+- name: Create local session directory
+  file:
+    path: '{{ netbox__data + "/sessions" }}'
+    owner: '{{ netbox__user }}'
+    group: '{{ netbox__group }}'
+    mode: '0770'
+    access_time: preserve
+    modification_time: preserve
+    state: directory
+  become: True
+  become_user: '{{ netbox__user }}'
+  when: (not netbox__primary | bool)
+
+- name: Cleanup stale contenttypes and sessions
+  ## Since we do not run the manage.py file on secondary sites
+  ## we need to run the cleanup in an extra task.
+  shell:  # noqa no-handler
+    cmd: |
+      set -o nounset -o pipefail -o errexit
+      ./manage.py remove_stale_contenttypes --no-input
+      ./manage.py clearsessions
+    chdir: '{{ netbox__git_checkout + "/netbox" }}'
+    executable: 'bash'
+  environment:
+    VIRTUAL_ENV: '{{ netbox__virtualenv }}'
+    PATH: '{{ netbox__virtualenv_env_path }}'
+  become: True
+  become_user: '{{ netbox__user }}'
+  when: (netbox__register_checkout is changed and
+         not netbox__primary | bool)
+  changed_when: false
 
 - name: Create Django superuser account
   community.general.django_manage:
@@ -229,7 +281,8 @@
     DJANGO_SUPERUSER_PASSWORD: '{{ netbox__superuser_password }}'
   become: True
   become_user: '{{ netbox__user }}'
-  when: (not netbox__register_installed.stat.exists | bool and
+  when: (netbox__primary | bool and
+         not netbox__register_installed.stat.exists | bool and
          not netbox__register_migration.stdout is search('No migrations to apply.'))
   no_log: '{{ debops__no_log | d(True) }}'
 

--- a/ansible/roles/netbox/templates/usr/local/lib/netbox/configuration.py.j2
+++ b/ansible/roles/netbox/templates/usr/local/lib/netbox/configuration.py.j2
@@ -232,7 +232,7 @@ SCRIPTS_ROOT = '{{ netbox__config_scripts_root }}'
 # By default, NetBox will store session data in the database. Alternatively, a file path can be specified here to use
 # local file storage instead. (This can be useful for enabling authentication on a standby instance with read-only
 # database access.) Note that the user as which NetBox runs must have read and write permissions to this path.
-SESSION_FILE_PATH = {{ netbox__config_session_file_path }}
+SESSION_FILE_PATH = '{{ netbox__config_session_file_path }}'
 
 # Time zone (default: UTC)
 TIME_ZONE = '{{ netbox__config_time_zone }}'


### PR DESCRIPTION
These changes add support for running NetBox on a PSQL cluster with a primary and read-only node (AKA secondary/standby).
Certain tasks must only run on the primary node, and must be skipped on the standby (read-only) node, others only on the standby node.

A new variable named `netbox__primary` of type `boolean` can be added to define primary/standby nodes.
Default is set to `True` for non-HA setups with only 1 NetBox instance.