### PR TITLE
[postgresql] Update playbook postgresql.yml

### DIFF
--- a/ansible/playbooks/service/postgresql.yml
+++ b/ansible/playbooks/service/postgresql.yml
@@ -15,6 +15,9 @@
 
   roles:
 
+    - role: secret
+      tags: [ 'role::secret', 'role::postgresql' ]
+
     - role: keyring
       tags: [ 'role::keyring', 'skip::keyring', 'role::postgresql' ]
       keyring__dependent_apt_keys:

--- a/ansible/playbooks/service/postgresql_server.yml
+++ b/ansible/playbooks/service/postgresql_server.yml
@@ -15,6 +15,9 @@
 
   roles:
 
+    - role: secret
+      tags: [ 'role::secret', 'role::postgresql_server' ]
+
     - role: keyring
       tags: [ 'role::keyring', 'skip::keyring', 'role::postgresql_server' ]
       keyring__dependent_apt_keys:


### PR DESCRIPTION
Allows the "secret" variable to be used in the task.

Inventory file:

```YML
postgresql__roles:
  - name: 'role_name'
    password: 'my_pass'
    db: 'my_db'
    priv: [ 'ALL' ]
```

Error:

```
TASK [debops.debops.postgresql : Create PostgreSQL roles] ********************************************************************************************
fatal: [dev -> {{ postgresql__delegate_to }}]: FAILED! =>
  msg: |-
    The task includes an option with an undefined variable. The error was: 'secret' is undefined. 'secret' is undefined

    The error appears to be in '/home/talma/src/venv/debops/lib/python3.10/site-packages/debops/_data/ansible/collections/ansible_collections/debops/debops/roles/postgresql/tasks/main.yml': line 98, column 3, but may
    be elsewhere in the file depending on the exact syntax problem.

    The offending line appears to be:


    - name: Create PostgreSQL roles
      ^ here
```