### PR TITLE
[postgresql_server] Set option only in certain versions

### DIFF
--- a/ansible/roles/postgresql_server/templates/etc/postgresql/postgresql.conf.j2
+++ b/ansible/roles/postgresql_server/templates/etc/postgresql/postgresql.conf.j2
@@ -243,7 +243,9 @@ max_replication_slots = {{ item.max_replication_slots | d('0') }}
 
 # These settings are ignored on a standby server
 synchronous_standby_names = '{{ item.synchronous_standby_names | d("") }}'
+{% if (item.version | d(postgresql_server__version)) is version_compare('16','<') %}
 vacuum_defer_cleanup_age = {{ item.vacuum_defer_cleanup_age | d('0') }}
+{% endif %}
 
 
 # - Standby Servers -


### PR DESCRIPTION
Since Postgresql 16 [the `vacuum_defer_cleanup_age` config option is deprecated](https://www.postgresql.org/docs/release/16.0/), this patch updates the template to take care of that.

Partially fixes one of the things mentioned in #2425 