### PR TITLE
Remove GPG requirement and reconstruct j2 strings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,9 @@ New DebOps roles
 :ref:`debops.miniflux` role
 '''''''''''''''''''''''''''
 
+- Removed the APT repository option and the :ref:`debops.keyring` dependency due
+  to upstream removed GPG support. The :ref:`debops.miniflux` role now uses URLs
+  as the primary installation method.
 - Bump Miniflux version from 2.0.48 to 2.2.1.
 
 :ref:`debops.core` role

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,11 @@ New DebOps roles
 
   .. __: https://www.influxdata.com/products/influxdb/
 
+:ref:`debops.miniflux` role
+'''''''''''''''''''''''''''
+
+- Bump Miniflux version from 2.0.48 to 2.2.1.
+
 :ref:`debops.core` role
 '''''''''''''''''''''''
 

--- a/ansible/playbooks/service/miniflux.yml
+++ b/ansible/playbooks/service/miniflux.yml
@@ -1,6 +1,6 @@
 ---
 # Copyright (C) 2015-2022 Maciej Delmanowski <drybjed@gmail.com>
-# Copyright (C) 2021-2022 Berkhan Berkdemir <berkhan@tekdanisman.com>
+# Copyright (C) 2021-2024 Berkhan Berkdemir <berkhan@tekdanisman.com>
 # Copyright (C) 2015-2022 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-only
 

--- a/ansible/playbooks/service/miniflux.yml
+++ b/ansible/playbooks/service/miniflux.yml
@@ -16,17 +16,6 @@
 
   roles:
 
-    - role: keyring
-      tags: [ 'role::keyring', 'skip::keyring', 'role::golang' ]
-      keyring__dependent_apt_keys:
-        - '{{ miniflux__keyring__dependent_apt_keys }}'
-      keyring__dependent_gpg_user: '{{ golang__keyring__dependent_gpg_user }}'
-      keyring__dependent_gpg_keys:
-        - '{{ nginx__keyring__dependent_apt_keys }}'
-        - '{{ golang__keyring__dependent_gpg_keys }}'
-      golang__dependent_packages:  # noqa var-naming[no-role-prefix]
-        - '{{ miniflux__golang__dependent_packages }}'
-
     - role: postgresql
       tags: [ 'role::postgresql', 'skip::postgresql' ]
       postgresql__dependent_roles:

--- a/ansible/roles/miniflux/defaults/main.yml
+++ b/ansible/roles/miniflux/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
-# Copyright (C) 2021-2022 Berkhan Berkdemir <berkhan@tekdanisman.com>
+# Copyright (C) 2021-2023 Berkhan Berkdemir <berkhan@tekdanisman.com>
 # Copyright (C) 2022      Maciej Delmanowski <drybjed@gmail.com>
-# Copyright (C) 2022      DebOps <https://debops.org/>
+# Copyright (C) 2023      DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-only
 
 # .. _miniflux__ref_defaults:
@@ -132,14 +132,6 @@ miniflux__database_password: '{{ lookup("password", secret + "/postgresql/" +
 # installation definition can be found in the
 # :envvar:`miniflux__golang__dependent_packages` variable.
 
-# .. envvar:: miniflux__upstream_gpg_key [[[
-#
-# The fingerprint of the GPG key which is used to sign the Miniflux
-# releases. It will be used to verify the downloaded signature file as
-# well as the :command:`git` tags in the source repository.
-miniflux__upstream_gpg_key: '5A7A 89AC F055 24CA A0F3  6F9B AEB7 A164 0710 8DB5'
-
-                                                                   # ]]]
 # .. envvar:: miniflux__upstream_type [[[
 #
 # Specify the method which should be used to install Miniflux binary.  The
@@ -155,7 +147,7 @@ miniflux__upstream_type: 'apt'
 # .. envvar:: miniflux__upstream_version [[[
 #
 # Version of the Miniflux upstream.
-miniflux__upstream_version: '2.0.35'
+miniflux__upstream_version: '2.0.48'
 
                                                                    # ]]]
 # .. envvar:: miniflux__upstream_url_mirror [[[
@@ -177,7 +169,7 @@ miniflux__upstream_platform: 'linux-amd64'
 #
 # The URL of the upstream :command:`git` repository which contains
 # Miniflux source code.
-miniflux__upstream_git_repository: 'https://github.com/miniflux/miniflux'
+miniflux__upstream_git_repository: 'https://github.com/miniflux/v2'
 
                                                                    # ]]]
 # .. envvar:: miniflux__binary [[[
@@ -253,9 +245,7 @@ miniflux__combined_configuration: '{{ miniflux__default_configuration
 
 miniflux__keyring__dependent_apt_keys:
 
-  - id: '{{ miniflux__upstream_gpg_key }}'
-    url: 'https://apt.miniflux.app/KEY.gpg'
-    repo: 'deb https://apt.miniflux.app/ /'
+  - repo: 'deb [trusted=yes] https://repo.miniflux.app/apt/ /'
     state: '{{ "present"
                if (miniflux__upstream_type == "apt")
                else "absent" }}'
@@ -321,21 +311,18 @@ miniflux__golang__dependent_packages:
   - name: 'miniflux'
     upstream_type: '{{ miniflux__upstream_type }}'
     apt_packages: [ 'miniflux' ]
-    gpg:
-      - id: '{{ miniflux__upstream_gpg_key }}'
-        url: 'https://apt.miniflux.app/KEY.gpg'
     url:
       - src: '{{ miniflux__upstream_url_mirror + "download/" + miniflux__upstream_version + "/miniflux-" + miniflux__upstream_platform }}'
-        dest: 'releases/{{ miniflux__upstream_platform }}/miniflux/miniflux/" + miniflux__upstream_version + "/miniflux_" + miniflux__upstream_version + "_linux_amd64'
+        dest: '{{ "releases/" + miniflux__upstream_platform + "/miniflux/v2/" + miniflux__upstream_version + "/miniflux_" + miniflux__upstream_version + "_" + miniflux__upstream_platform.replace("-", "_") }}'
     url_binaries:
-      - src: 'releases/{{ miniflux__upstream_platform }}/miniflux/miniflux/" + miniflux__upstream_version + "/miniflux_" + miniflux__upstream_version + "_linux_amd64'
+      - src: '{{ "releases/" + miniflux__upstream_platform + "/miniflux/v2/" + miniflux__upstream_version + "/miniflux_" + miniflux__upstream_version + "_" + miniflux__upstream_platform.replace("-", "_") }}'
         dest: 'miniflux'
         notify: [ 'Restart miniflux' ]
     git:
       - repo: '{{ miniflux__upstream_git_repository }}'
         version: '{{ miniflux__upstream_version }}'
         build_script: |
-          make clean linux-amd64
+          'make clean {{ miniflux__upstream_platform }}'
     git_binaries:
       - src: 'github.com/miniflux/v2/bin/miniflux.app'
         dest: 'miniflux'

--- a/ansible/roles/miniflux/defaults/main.yml
+++ b/ansible/roles/miniflux/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2023 Berkhan Berkdemir <berkhan@tekdanisman.com>
+# Copyright (C) 2021-2024 Berkhan Berkdemir <berkhan@tekdanisman.com>
 # Copyright (C) 2022      Maciej Delmanowski <drybjed@gmail.com>
 # Copyright (C) 2023      DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-only

--- a/ansible/roles/miniflux/defaults/main.yml
+++ b/ansible/roles/miniflux/defaults/main.yml
@@ -147,7 +147,7 @@ miniflux__upstream_type: 'apt'
 # .. envvar:: miniflux__upstream_version [[[
 #
 # Version of the Miniflux upstream.
-miniflux__upstream_version: '2.0.48'
+miniflux__upstream_version: '2.2.1'
 
                                                                    # ]]]
 # .. envvar:: miniflux__upstream_url_mirror [[[

--- a/ansible/roles/miniflux/defaults/main.yml
+++ b/ansible/roles/miniflux/defaults/main.yml
@@ -134,14 +134,13 @@ miniflux__database_password: '{{ lookup("password", secret + "/postgresql/" +
 
 # .. envvar:: miniflux__upstream_type [[[
 #
-# Specify the method which should be used to install Miniflux binary.  The
-# ``apt`` method will install Miniflux via the configured APT repository, if
-# it's available. The ``url`` method will download the :command:`miniflux`
-# compiled binary and install it directly after verification with the official
-# GPG key. The ``git`` method will download Miniflux source code and compile it
-# locally (this method doesn't work on Debian Bullseye due to missing "embed"
-# Go library).
-miniflux__upstream_type: 'apt'
+# Specify the method which should be used to install Miniflux binary. The
+# ``url`` method will download the :command:`miniflux` compiled binary and
+# install it directly after verification with the official GPG key. The
+# ``git`` method will download Miniflux source code and compile it locally
+# (this method doesn't work on Debian Bullseye due to missing "embed" Go
+# library).
+miniflux__upstream_type: 'url'
 
                                                                    # ]]]
 # .. envvar:: miniflux__upstream_version [[[
@@ -243,14 +242,6 @@ miniflux__combined_configuration: '{{ miniflux__default_configuration
 # Configuration variables for other Ansible roles [[[
 # ---------------------------------------------------
 
-miniflux__keyring__dependent_apt_keys:
-
-  - repo: 'deb [trusted=yes] https://repo.miniflux.app/apt/ /'
-    state: '{{ "present"
-               if (miniflux__upstream_type == "apt")
-               else "absent" }}'
-
-                                                                   # ]]]
 # .. envvar:: miniflux__postgresql__dependent_roles [[[
 #
 # Role configuration for the :ref:`debops.postgresql` Ansible role.
@@ -310,7 +301,6 @@ miniflux__golang__dependent_packages:
 
   - name: 'miniflux'
     upstream_type: '{{ miniflux__upstream_type }}'
-    apt_packages: [ 'miniflux' ]
     url:
       - src: '{{ miniflux__upstream_url_mirror + "download/" + miniflux__upstream_version + "/miniflux-" + miniflux__upstream_platform }}'
         dest: '{{ "releases/" + miniflux__upstream_platform + "/miniflux/v2/" + miniflux__upstream_version + "/miniflux_" + miniflux__upstream_version + "_" + miniflux__upstream_platform.replace("-", "_") }}'

--- a/docs/ansible/roles/miniflux/getting-started.rst
+++ b/docs/ansible/roles/miniflux/getting-started.rst
@@ -13,10 +13,9 @@ Getting started
 Installation methods
 --------------------
 
-The default installation method will be using an upstream APT repository,
-configured by the :ref:`debops.keyring` Ansible role. The :ref:`debops.golang`
-manages the actual installation and provides an option to install from
-a precombined binary or from the source code as well. You can use the
+The default installation method will be using an upstream URL download. The
+:ref:`debops.golang` manages the actual installation and provides an option to
+install from the source code as well. You can use the
 :envvar:`miniflux__upstream_type` variable to select the desired installation
 method.
 


### PR DESCRIPTION
Miniflux project does not use GPG anymore.  With this, having GPG key in there results in errors.  Maintainer moved APT repository to another URL.

Other than that, Jinja templating wasn't working as expected in three different strings.  Now, they are working as expected in the dev env.