### PR TITLE
[docker_gen] Fix loop to create required directories

### DIFF
--- a/ansible/roles/docker_gen/tasks/main.yml
+++ b/ansible/roles/docker_gen/tasks/main.yml
@@ -15,10 +15,13 @@
     group: 'root'
     mode: '0755'
   loop:
-    - [ '{{ docker_gen__src }}', '{{ docker_gen__lib }}', '{{ docker_gen__templates }}' ]
-    - [ '{{ ((docker_gen__nginx_dest | dirname)
-             if (docker_gen__nginx | d() and docker_gen__nginx)
-             else []) }}' ]
+    - '{{ docker_gen__src }}'
+    - '{{ docker_gen__lib }}'
+    - '{{ docker_gen__templates }}'
+    - '{{ ((docker_gen__nginx_dest | dirname)
+           if (docker_gen__nginx | d() and docker_gen__nginx)
+           else "") }}'
+  when: item | length > 0
 
 - name: Download docker-gen sources
   ansible.builtin.get_url:


### PR DESCRIPTION
This PR fixes regression after converting `with_flattened` to `loop` (at #2141)