### PR TITLE
Add default value for ferm_parsed_rules

### DIFF
--- a/ansible/roles/ferm/tasks/main.yml
+++ b/ansible/roles/ferm/tasks/main.yml
@@ -122,7 +122,7 @@
     owner: 'root'
     group: 'adm'
     mode: '0644'
-  loop: '{{ ferm__parsed_rules | dict2items }}'
+  loop: '{{ ferm__parsed_rules | d({}) | dict2items }}'
   loop_control:
     label: '{{ item.key }}'
   register: ferm__register_rules_created


### PR DESCRIPTION
Without this, the play can error out with a "Unable to look up a name or access an attribute in template string"