### PR TITLE
Restart fail2ban after ferm restart

### DIFF
--- a/ansible/roles/ferm/defaults/main.yml
+++ b/ansible/roles/ferm/defaults/main.yml
@@ -645,8 +645,8 @@ ferm__default_rules:
     comment: 'Reload fail2ban rules'
     rule_state: '{{ "present" if (ferm__fail2ban | bool) else "absent" }}'
     rules: |
-      @hook post "type fail2ban-server > /dev/null && (fail2ban-client ping > /dev/null && fail2ban-client reload > /dev/null || true) || true";
-      @hook flush "type fail2ban-server > /dev/null && (fail2ban-client ping > /dev/null && fail2ban-client reload > /dev/null || true) || true";
+      @hook post "type fail2ban-server > /dev/null && (fail2ban-client ping > /dev/null && systemctl restart fail2ban > /dev/null || true) || true";
+      @hook flush "type fail2ban-server > /dev/null && (fail2ban-client ping > /dev/null && systemctl restart fail2ban > /dev/null || true) || true";
     weight_class: 'post-hook'
 
     # Remove obsolete forwarding rules


### PR DESCRIPTION
After a ferm restart, the fail2ban iptables rules are not restored. There is already some code to reload fail2ban after a ferm restart but that doesn't seem to work. fail2ban-client reload/restart and `systemctl reload fail2ban` do not restore its iptables rules after a ferm restart; but `systemctl restart fail2ban` does.

```
$ sudo systemctl restart ferm
$ sudo iptables-save | grep fail2ban
$ sudo fail2ban-client reload
2023-12-28 18:46:07,716 fail2ban.configreader   [16590]: WARNING 'allowipv6' not defined in 'Definition'. Using default one: 'auto'
OK
$ sudo iptables-save | grep fail2ban
$ sudo fail2ban-client restart
Shutdown successful
2023-12-28 18:46:20,581 fail2ban.configreader   [16597]: WARNING 'allowipv6' not defined in 'Definition'. Using default one: 'auto'
Server ready
$ sudo iptables-save | grep fail2ban
$ sudo systemctl reload fail2ban
$ sudo iptables-save | grep fail2ban
$ sudo systemctl restart fail2ban
$ sudo iptables-save | grep fail2ban
-A INPUT -m recent --update --seconds 7200 --name fail2ban-sshd --mask 255.255.255.255 --rsource -j REJECT --reject-with icmp-admin-prohibited
```

I am assuming the host is using systemd, however. Not sure if that's a problem, but this fixes it for me.