### PR TITLE
Fix logic in `owncloud__do_autosetup`

### DIFF
--- a/ansible/roles/owncloud/tasks/setup_owncloud.yml
+++ b/ansible/roles/owncloud/tasks/setup_owncloud.yml
@@ -90,8 +90,8 @@
     owncloud__do_autosetup: '{{ (owncloud__autosetup and
                                  owncloud__admin_username | d() and
                                  (owncloud__register_occ_check is not skipped) and
-                                 ("is not installed" in owncloud__register_occ_check.stdout) or
-                                 ("is not installed" in owncloud__register_occ_check.stderr)) }}'
+                                 (("is not installed" in owncloud__register_occ_check.stdout) or
+                                  ("is not installed" in owncloud__register_occ_check.stderr))) }}'
 
 - name: Automatically finish setup via the occ tool
   ansible.builtin.command: |


### PR DESCRIPTION
I am pretty sure this is a logic bug (missing brackets)