### PR TITLE
Disable systemd-resolved

### DIFF
--- a/ansible/roles/unbound/tasks/main.yml
+++ b/ansible/roles/unbound/tasks/main.yml
@@ -15,6 +15,12 @@
   ansible.builtin.set_fact:
     unbound__fact_ansible_connection: '{{ ansible_connection }}'
 
+- name: Make sure systemd-resolved is stopped and disabled
+  ansible.builtin.service:
+    name: systemd-resolved.service
+    state: stopped
+    enabled: false
+
 - name: Create Unbound configuration directory
   ansible.builtin.file:
     path: '/etc/unbound/unbound.conf.d'


### PR DESCRIPTION
Trying to run both unbound and systemd-resolved on a system, there will be conflicts regarding port usage. Therefore, before installing and configuring unbound, make sure systemd-resolved is stopped and disabled. 

resolves #1778