### PR TITLE
[onwcloud] Add missing password for postgresql

### DIFF
--- a/ansible/roles/owncloud/defaults/main.yml
+++ b/ansible/roles/owncloud/defaults/main.yml
@@ -568,7 +568,7 @@ owncloud__database_map:
     dbtype: 'pgsql'
     dbname: '{{ owncloud__database_name | d(owncloud__app_user) }}'
     dbuser: '{{ owncloud__database_user | d(owncloud__app_user) }}'
-    dbpass: ''
+    dbpass: '{{ owncloud__database_password }}'
     dbhost: '{{ owncloud__database_server | d("/var/run/postgresql") }}'
     dbtableprefix: ''
 


### PR DESCRIPTION
When using PostgreSQL as a backend for owncloud / nextcloud the password for authentification against the database is missing. Without that password the occ command to install fails. So we simply add that password.