### PR TITLE
[icinga] fix typo in handler condition

### DIFF
--- a/ansible/roles/icinga/handlers/main.yml
+++ b/ansible/roles/icinga/handlers/main.yml
@@ -6,7 +6,7 @@
 - name: Check icinga2 configuration and restart it on the master node
   ansible.builtin.command: icinga2 daemon -C
   register: icinga__register_check_config
-  changed_when: icinga__regidster_check_config.changed | bool
+  changed_when: icinga__register_check_config.changed | bool
   notify: [ 'Restart icinga2 on the master node' ]
   delegate_to: '{{ icinga__master_delegate_to }}'
 


### PR DESCRIPTION
There's a typo in the `changed_when` condition (see variable defined just a line before).