### PR TITLE
Support follow parameter for authorized_keys

### DIFF
--- a/ansible/roles/authorized_keys/tasks/main.yml
+++ b/ansible/roles/authorized_keys/tasks/main.yml
@@ -59,6 +59,7 @@
     comment:     '{{ item.comment | d(omit) }}'
     path:        '{{ item.path | d(omit) }}'
     exclusive:   '{{ item.exclusive | d(omit) }}'
+    follow:      '{{ item.follow | d(omit) }}'
   loop: '{{ lookup("template", "lookup/authorized_keys__identities.j2") | from_yaml }}'
   loop_control:
     label: '{{ {"identity": item.identity,

--- a/ansible/roles/root_account/defaults/main.yml
+++ b/ansible/roles/root_account/defaults/main.yml
@@ -202,6 +202,12 @@ root_account__combined_authorized_keys: '{{ root_account__authorized_keys
 root_account__authorized_keys_exclusive: False
 
                                                                    # ]]]
+# .. envvar:: root_account__authorized_keys_follow [[[
+#
+# If ``True``, follow symlinks instead of replacing the file.
+root_account__authorized_keys_follow: False
+
+                                                                   # ]]]
 # .. envvar:: root_account__authorized_keys_state [[[
 #
 # If ``present``, the role will manage the :file:`/root/.ssh/authorized_keys`

--- a/ansible/roles/root_account/tasks/main.yml
+++ b/ansible/roles/root_account/tasks/main.yml
@@ -85,8 +85,7 @@
     exclusive: '{{ root_account__authorized_keys_exclusive | bool }}'
     state: 'present'
     user: 'root'
-  when: root_account__enabled | bool and root_account__combined_authorized_keys | d() and
-        root_account__authorized_keys_state != 'absent'
+  when: root_account__enabled|bool and root_account__authorized_keys_state != 'absent'
 
 - name: Remove /root/.ssh/authorized_keys file if requested
   ansible.builtin.file:

--- a/ansible/roles/root_account/tasks/main.yml
+++ b/ansible/roles/root_account/tasks/main.yml
@@ -85,6 +85,7 @@
     exclusive: '{{ root_account__authorized_keys_exclusive | bool }}'
     state: 'present'
     user: 'root'
+    follow: '{{ root_account__authorized_keys_follow | bool }}'
   when: root_account__enabled|bool and root_account__authorized_keys_state != 'absent'
 
 - name: Remove /root/.ssh/authorized_keys file if requested

--- a/ansible/roles/system_users/tasks/main.yml
+++ b/ansible/roles/system_users/tasks/main.yml
@@ -226,6 +226,7 @@
     state: 'present'
     user: '{{ (item.prefix | d(system_users__prefix)) + item.name }}'
     exclusive: '{{ item.sshkeys_exclusive | d(omit) }}'
+    follow: '{{ item.sshkeys_follow | d(omit) }}'
   loop: '{{ system_users__combined_accounts | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"name": (item.prefix | d(system_users__prefix)) + item.name,

--- a/ansible/roles/users/tasks/main.yml
+++ b/ansible/roles/users/tasks/main.yml
@@ -212,6 +212,7 @@
     state: 'present'
     user: '{{ item.name }}'
     exclusive: '{{ item.sshkeys_exclusive | d(omit) }}'
+    follow: '{{ item.sshkeys_follow | d(omit) }}'
   loop: '{{ users__combined_accounts | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"name": item.name,

--- a/docs/ansible/roles/authorized_keys/defaults-detailed.rst
+++ b/docs/ansible/roles/authorized_keys/defaults-detailed.rst
@@ -317,6 +317,10 @@ Each list entry is a YAML dictionary with specific parameters:
     this option can break idempotency if multiple entries with the same
     ``name`` parameter are used.
 
+  ``follow``
+    Optional, boolean. If defined and ``True``, the role will follow symlinks to
+    the :file:`authorized_keys` file instead of replacing them.
+
   ``home``
     Optional, boolean. If not specified or ``False``, the SSH keys will be
     managed in the :file:`/etc/ssh/authorized_keys/` directory, with custom

--- a/docs/ansible/roles/system_users/defaults-detailed.rst
+++ b/docs/ansible/roles/system_users/defaults-detailed.rst
@@ -284,6 +284,10 @@ Parameters related to public SSH keys
   ``~/.ssh/authorized_keys`` file that are not specified in the ``sshkeys``
   parameter.
 
+``sshkeys_follow``
+  Optional, boolean. If ``True``, the role will follow symlinks to the user's
+  ``~/.ssh/authorized_keys`` file instead of replacing them.
+
 ``sshkeys_state``
   Optional. If not specified or ``present``, the SSH keys will be set on the
   user's account. If ``absent``, the ``~/.ssh/authorized_keys`` file will be

--- a/docs/ansible/roles/users/defaults-detailed.rst
+++ b/docs/ansible/roles/users/defaults-detailed.rst
@@ -298,6 +298,10 @@ Parameters related to public SSH keys
   ``~/.ssh/authorized_keys`` file that are not specified in the ``sshkeys``
   parameter.
 
+``sshkeys_follow``
+  Optional, boolean. If ``True``, the role will follow symlinks to the user's
+  ``~/.ssh/authorized_keys`` file instead of replacing them.
+
 ``sshkeys_state``
   Optional. If not specified or ``present``, the SSH keys will be set on the
   user's account. If ``absent``, the ``~/.ssh/authorized_keys`` file will be


### PR DESCRIPTION
Support the `follow` parameter for the authorized_keys module where it makes sense. This allows having the `authorized_keys` file symlinked. The default behaviour remains unchanged.
