### PR TITLE
[gitlab] set /etc/gitlab/ssl mode to '0755'

### DIFF
--- a/ansible/roles/gitlab/tasks/main.yml
+++ b/ansible/roles/gitlab/tasks/main.yml
@@ -52,7 +52,7 @@
     state: 'directory'
     mode: '{{ item.mode }}'
   loop:
-    - { path: '/etc/gitlab/ssl',           mode: '0775' }
+    - { path: '/etc/gitlab/ssl',           mode: '0755' }
     - { path: '/etc/gitlab/trusted-certs', mode: '0755' }
 
 - name: Manage CA certificate symlinks in GitLab environment


### PR DESCRIPTION
The current mode is '0775', but when `gitlab-ctl reconfigure` runs, it sets the mode back to `0755`, which makes the role not idempotent.