### PR TITLE
[debconf] Grant users control over package state

### DIFF
--- a/ansible/roles/debconf/defaults/main.yml
+++ b/ansible/roles/debconf/defaults/main.yml
@@ -64,6 +64,16 @@ debconf__filtered_entries: '{{ lookup("template",
 # APT package installation [[[
 # ----------------------------
 
+# .. envvar:: debconf__apt_state [[[
+#
+# Specify the state of the APT packages installed by the :ref:`debops.debconf`
+# role. Either ``present`` (packages will be installed but not upgraded) or
+# ``latest`` (packages will be installed or upgraded if already present). It's
+# best to use this variable on the command line to avoid issues with
+# idempotency.
+debconf__apt_state: 'present'
+
+                                                                   # ]]]
 # .. envvar:: debconf__packages [[[
 #
 # List of APT packages which should be installed by the :ref:`debops.debconf`

--- a/ansible/roles/debconf/tasks/main.yml
+++ b/ansible/roles/debconf/tasks/main.yml
@@ -42,7 +42,7 @@
     name: '{{ q("flattened", debconf__packages
                              + debconf__group_packages
                              + debconf__host_packages) }}'
-    state: 'present'
+    state: '{{ debconf__apt_state }}'
   register: debconf__register_packages
   until: debconf__register_packages is succeeded
 


### PR DESCRIPTION
This change permits the users to selectively upgrade the APT packages managed by the 'debops.debconf' role to make upgrades on multiple hosts easier.