### PR TITLE
[gitlab_runner] Fix compatible with GitLab 17.0 or higher

### DIFF
--- a/ansible/roles/gitlab_runner/defaults/main.yml
+++ b/ansible/roles/gitlab_runner/defaults/main.yml
@@ -174,7 +174,7 @@ gitlab_runner__api_url: 'https://{{ gitlab_runner__api_fqdn }}/'
 # The personal GitLab API access token used to register or remove the runners in GitLab.
 # You can generate an access token in GitLab "User Settings", "Access Tokens"
 # configuration page.
-gitlab_runner__api_token: ''
+gitlab_runner__api_token: '{{ lookup("env", "GITLAB_API_TOKEN") }}'
 
                                                                    # ]]]
 # .. envvar:: gitlab_runner__runner_type [[[

--- a/ansible/roles/gitlab_runner/defaults/main.yml
+++ b/ansible/roles/gitlab_runner/defaults/main.yml
@@ -171,24 +171,38 @@ gitlab_runner__api_url: 'https://{{ gitlab_runner__api_fqdn }}/'
                                                                    # ]]]
 # .. envvar:: gitlab_runner__api_token [[[
 #
-# The personal GitLab API access token used for API operations, for example
-# removal of existing Runners. This is not a Runner registration token. You can
-# generate an access token in GitLab "User Settings", "Access Tokens"
+# The personal GitLab API access token used to register or remove the runners in GitLab.
+# You can generate an access token in GitLab "User Settings", "Access Tokens"
 # configuration page.
 gitlab_runner__api_token: ''
+
+                                                                   # ]]]
+# .. envvar:: gitlab_runner__runner_type [[[
+#
+# The scope of the runner.
+# It can be one of the following values: ``instance_type``,
+# ``group_type`` or ``project_type``
+gitlab_runner__runner_type: 'instance_type'
+
+                                                                   # ]]]
+# .. envvar:: gitlab_runner__group_id [[[
+#
+# The ID of the group that the runner is created in.
+# Required if ``gitlab_runner__runner_type`` is ``group_type``.
+gitlab_runner__group_id: ~
+
+                                                                   # ]]]
+# .. envvar:: gitlab_runner__project_id [[[
+#
+# The ID of the project that the runner is created in.
+# Required if ``gitlab_runner__runner_type`` is ``project_type``.
+gitlab_runner__project_id: ~
 
                                                                    # ]]]
 # .. envvar:: gitlab_runner__executor [[[
 #
 # Default "executor" used by the runners.
 gitlab_runner__executor: 'shell'
-
-                                                                   # ]]]
-# .. envvar:: gitlab_runner__token [[[
-#
-# The GitLab CI registration token used to register the runners in GitLab.
-# See :ref:`gitlab_runner__token` for more details.
-gitlab_runner__token: '{{ lookup("env", "GITLAB_RUNNER_TOKEN") }}'
 
                                                                    # ]]]
 # .. envvar:: gitlab_runner__metrics_server [[[

--- a/ansible/roles/gitlab_runner/tasks/main.yml
+++ b/ansible/roles/gitlab_runner/tasks/main.yml
@@ -88,14 +88,27 @@
 
 - name: Register new GitLab Runners
   ansible.builtin.uri:
-    url: '{{ (item.api_url | d(gitlab_runner__api_url)) + "api/v4/runners" }}'
+    url: '{{ (item.api_url | d(gitlab_runner__api_url)) + "api/v4/user/runners" }}'
     method: 'POST'
-    body: 'token={{ item.token | d(gitlab_runner__token) }}&description={{ item.name
-           | urlencode }}&tag_list={{ ((item.tags | d([])
-                                        + (gitlab_runner__shell_tags
-                                           if (item.executor == "shell") else [])
-                                        + gitlab_runner__combined_tags) | unique | join(","))
-           | urlencode }}&run_untagged={{ item.run_untagged | d(gitlab_runner__run_untagged) }}'
+    headers:
+      'PRIVATE-TOKEN': '{{ item.api_token | d(gitlab_runner__api_token) }}'
+    body_format: 'form-urlencoded'
+    body:
+      runner_type: '{{ item.runner_type | d(gitlab_runner__runner_type) }}'
+      group_id: '{{ item.group_id | d(gitlab_runner__group_id) | d(omit) }}'
+      project_id: '{{ item.project_id | d(gitlab_runner__project_id) | d(omit) }}'
+      description: '{{ item.name }}'
+      tag_list: '{{ (item.tags | d([])
+                     + (gitlab_runner__shell_tags
+                        if (item.executor == "shell") else [])
+                     + gitlab_runner__combined_tags)
+                     | unique | join(",") }}'
+      run_untagged: '{{ item.run_untagged | d(gitlab_runner__run_untagged) }}'
+      paused: '{{ item.paused | d(omit) }}'
+      locked: '{{ item.locked | d(omit) }}'
+      access_level: '{{ item.access_level | d(omit) }}'
+      maximum_timeout: '{{ item.maximum_timeout | d(omit) }}'
+      maintenance_note: '{{ item.maintenance_note | d(omit) }}'
     status_code: '200,201'
   register: gitlab_runner__register_new_instances
   loop: '{{ q("flattened", gitlab_runner__default_instances
@@ -103,7 +116,7 @@
                            + gitlab_runner__group_instances
                            + gitlab_runner__host_instances) }}'
   when: (gitlab_runner__register_api.status | d() and gitlab_runner__register_api.status == 200 and
-         (item.token | d() or gitlab_runner__token) and item.name and
+         (item.api_token | d() or gitlab_runner__api_token) and item.name and
          (item.state is undefined or item.state != 'absent') and
          (ansible_local is undefined or
           (ansible_local | d() and (ansible_local.gitlab_runner is undefined or
@@ -124,13 +137,14 @@
     url: '{{ (item.0.api_url | d(gitlab_runner__api_url)) + "api/v4/runners/" + item.1.id | string }}'
     method: 'DELETE'
     headers:
-      'PRIVATE-TOKEN': '{{ gitlab_runner__api_token }}'
+      'PRIVATE-TOKEN': '{{ item.0.api_token | d(gitlab_runner__api_token) }}'
   with_together:
     - '{{ gitlab_runner__default_instances + gitlab_runner__instances
           + gitlab_runner__group_instances + gitlab_runner__host_instances }}'
     - '{{ ansible_local.gitlab_runner.instance_tokens | d([]) }}'
   when: (gitlab_runner__register_api.status | d() and gitlab_runner__register_api.status == 200 and
-         gitlab_runner__api_token and item.0.name | d() and item.1.name | d() and item.0.name == item.1.name and
+         (item.0.api_token | d() or gitlab_runner__api_token)
+         and item.0.name | d() and item.1.name | d() and item.0.name == item.1.name and
          (item.0.state | d() and item.0.state == 'absent'))
   failed_when: False
   no_log: '{{ debops__no_log | d(True) }}'

--- a/ansible/roles/gitlab_runner/tasks/main.yml
+++ b/ansible/roles/gitlab_runner/tasks/main.yml
@@ -78,14 +78,6 @@
   register: gitlab_runner__register_packages
   until: gitlab_runner__register_packages is succeeded
 
-- name: Check if GitLab service is available
-  ansible.builtin.uri:
-    url: '{{ gitlab_runner__api_url }}'
-  register: gitlab_runner__register_api
-  when: gitlab_runner__api_url | d() and gitlab_runner__api_url
-  failed_when: False
-  no_log: '{{ debops__no_log | d(True) }}'
-
 - name: Register new GitLab Runners
   ansible.builtin.uri:
     url: '{{ (item.api_url | d(gitlab_runner__api_url)) + "api/v4/user/runners" }}'
@@ -115,8 +107,7 @@
                            + gitlab_runner__instances
                            + gitlab_runner__group_instances
                            + gitlab_runner__host_instances) }}'
-  when: (gitlab_runner__register_api.status | d() and gitlab_runner__register_api.status == 200 and
-         (item.api_token | d() or gitlab_runner__api_token) and item.name and
+  when: ((item.api_token | d() or gitlab_runner__api_token) and item.name and
          (item.state is undefined or item.state != 'absent') and
          (ansible_local is undefined or
           (ansible_local | d() and (ansible_local.gitlab_runner is undefined or
@@ -142,8 +133,7 @@
     - '{{ gitlab_runner__default_instances + gitlab_runner__instances
           + gitlab_runner__group_instances + gitlab_runner__host_instances }}'
     - '{{ ansible_local.gitlab_runner.instance_tokens | d([]) }}'
-  when: (gitlab_runner__register_api.status | d() and gitlab_runner__register_api.status == 200 and
-         (item.0.api_token | d() or gitlab_runner__api_token)
+  when: ((item.0.api_token | d() or gitlab_runner__api_token)
          and item.0.name | d() and item.1.name | d() and item.0.name == item.1.name and
          (item.0.state | d() and item.0.state == 'absent'))
   failed_when: False


### PR DESCRIPTION
Since GitLab 17.0 API server returns `410 Gone` status for the `/api/v4/runners` endpoint. Because the registration token has been [deprecated](https://docs.gitlab.com/ee/update/deprecations.html#registration-tokens-and-server-side-runner-arguments-in-post-apiv4runners-endpoint) and will be removed on GitLab 18.0.

The PR changes the runner registration using new API - [create a runner linked to a user](https://docs.gitlab.com/ee/api/users.html#create-a-runner-linked-to-a-user).
According to GitLab documentation, this should be compatible with GitLab 15.10 or higher.

The new API requires a personal access token, so the `gitlab_runner__api_token` parameter becomes mandatory.

**Second commit**

Removed the task to check GitLab API availability. This guard is useless in cases when the endpoint is overridden in the instance parameters (`api_url`).