### PR TITLE
[ntp] Fix ntp__daemon_enabled ansible system capabilities check

### DIFF
--- a/ansible/roles/ntp/defaults/main.yml
+++ b/ansible/roles/ntp/defaults/main.yml
@@ -30,7 +30,7 @@ ntp__daemon_enabled: '{{ "True"
                              not (ansible_virtualization_role | d("") == "guest" and
                                   ansible_virtualization_type | d("")
                                     in ["container", "lxc"]) and
-                             not (ansible_system_capabilities_enforced | d(True) and
+                             not (ansible_system_capabilities_enforced | d(True) | bool and
                                   "cap_sys_time" not in ansible_system_capabilities))
                          else "False" }}'
 


### PR DESCRIPTION
Since `ansible_system_capabilities_enforced` tends to be a string ("True" / "False") rather than a boolean, it needs to be cast to `bool` in order to successfully set `ntp__daemon_enabled` in environments where `ansible_system_capabilities_enforced` is "False"