### PR TITLE
Fix ifup-allow-boot.service failing to start

### DIFF
--- a/ansible/roles/ifupdown/templates/etc/systemd/system/ifup-allow-boot.service.j2
+++ b/ansible/roles/ifupdown/templates/etc/systemd/system/ifup-allow-boot.service.j2
@@ -24,11 +24,11 @@ ExecStart=/bin/sh -ec '\
   for i in $(ifquery --list --exclude lo --allow boot); do INTERFACES="$INTERFACES$i "; done; \
   [ -n "$INTERFACES" ] || exit 0; \
   for i in $INTERFACES; do \
-  escaped_iface="$(systemd-escape "$i")" \
+  escaped_iface="$(systemd-escape "$i")"; \
   logger -t ifup-allow-boot "Checking state of the $i interface" ; \
-  if ! ifquery --state $i > /dev/null && ! systemctl is-active iface@${escaped_iface} > /dev/null 2>&1 ; then \
+  if ! ifquery --state $i > /dev/null && ! systemctl is-active iface@"$escaped_iface" > /dev/null 2>&1 ; then \
   logger -t ifup-allow-boot "Interface $i is down, bringing it up" ; \
-  systemctl start iface@${escaped_iface} ; sleep 0.5 ; \
+  systemctl start iface@"$escaped_iface" ; sleep 0.5 ; \
   while [ -e /run/network/ifup-$i.pid ] ; do sleep 0.5 ; \
   logger -t ifup-allow-boot "Waiting for $i interface" ; done ; \
   logger -t ifup-allow-boot "Interface $i is up" ; \


### PR DESCRIPTION
Without this fix, the interface name seems to be empty:

    ifup-allow-boot[786]: Interface floating is down, bringing it up
    sh[787]: Failed to start iface@.service: Unit name iface@.service is missing the instance name.
    sh[787]: See system logs and 'systemctl status iface@.service' for details.
    systemd[1]: ifup-allow-boot.service: Main process exited, code=exited, status=1/FAILURE
    systemd[1]: ifup-allow-boot.service: Failed with result 'exit-code'.
    systemd[1]: Failed to start Bring up non-hotpluggable interfaces on boot.

At least from my tests I'm not sure if this ever worked. In our case, it fails on Ubuntu 20.04 with an interface named `floating`, and IIUC, at least the semicolon is absolutely vital, or `escaped_iface` won't be correct.