### PR TITLE
[nginx] Remove /index.html from default try_files

### DIFF
--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -1023,8 +1023,6 @@ nginx_default_try_files:
   - '$uri/'
   - '$uri.html'
   - '$uri.htm'
-  - '/index.html'
-  - '/index.htm'
 
                                                                    # ]]]
 # .. envvar:: nginx__log_format [[[


### PR DESCRIPTION
I might be missing something as to why /index.html and /index.htm are tried by default, but this seems wrong to me for most cases. It results in no 404s to ever be returned if any of these two files were present in the root. This patch removes them from the default list of files to try.