### PR TITLE
fix enable swap files | swapfile

### DIFF
--- a/ansible/roles/swapfile/tasks/main.yml
+++ b/ansible/roles/swapfile/tasks/main.yml
@@ -48,10 +48,13 @@
   with_items: '{{ swapfile__register_allocation.results | d([]) }}'
   register: swapfile__register_swapon
   changed_when: swapfile__register_swapon.changed | bool
-  when: (item is changed and item.state | d("present") != 'absent' and
-         ((ansible_system_capabilities_enforced | d()) | bool and
-          "cap_sys_admin" in ansible_system_capabilities) or
-         not (ansible_system_capabilities_enforced | d(True)) | bool)
+  when: (
+        (item is changed and item.state | d("present") != 'absent') and 
+        ((
+            (ansible_system_capabilities_enforced | d()) | bool and
+            "cap_sys_admin" in ansible_system_capabilities
+        ) or not (ansible_system_capabilities_enforced | d(True)) | bool )
+        )
 
 - name: Manage swap files in /etc/fstab
   ansible.posix.mount:


### PR DESCRIPTION
fix task execution even when result condition is false

before:
```
swapfile__manage: True
swapfile__files:
  - state: 'absent'
    path: '/swapfile'
```
leaded to

```
TASK [debops.debops.swapfile : Enable swap files] ******************************
failed: [test.local.com] (item={'changed': False, 'skipped': True, 'skip_reason': 'Conditional result was False',
'false_condition': '(item.state | d("present") != \'absent\')', 'item': {'state': 'absent', 'path': '/swapfile'}, 'ansible_loop_var':
'item'}) => {"ansible_loop_var": "item", "changed": true, "cmd": ["swapon", "-p", "-1", "/swapfile"], "delta":
"0:00:00.003398", "end": "2024-07-06 18:11:28.933988", "item": {"ansible_loop_var": "item", "changed": false,
"false_condition": "(item.state | d(\"present\") != 'absent')", "item": {"path": "/swapfile", "state": "absent"}, "skip_reason":
"Conditional result was False", "skipped": true}, "msg": "non-zero return code", "rc": 255, "start": "2024-07-06
18:11:28.930590", "stderr": "swapon: cannot open /swapfile: No such file or directory", "stderr_lines": ["swapon: cannot
open /swapfile: No such file or directory"], "stdout": "", "stdout_lines": []}
```
