### PR TITLE
Add ignore_interface_addresses flag

### DIFF
--- a/ansible/roles/dnsmasq/templates/lookup/dnsmasq__interface_configuration.j2
+++ b/ansible/roles/dnsmasq/templates/lookup/dnsmasq__interface_configuration.j2
@@ -7,7 +7,7 @@
 {% for interface in (dnsmasq__combined_interfaces | flatten | debops.debops.parse_kv_items) %}
 {%   set dnsmasq__tpl_ipv4 = [] %}
 {%   set dnsmasq__tpl_ipv6 = [] %}
-{%   if hostvars[inventory_hostname]["ansible_" + interface.name] | d() %}
+{%   if not interface.ignore_interface_addresses|d(False) and hostvars[inventory_hostname]["ansible_" + interface.name] | d() %}
 {%     if hostvars[inventory_hostname]["ansible_" + interface.name].ipv4 | d() %}
 {%       set _ = dnsmasq__tpl_ipv4.append(hostvars[inventory_hostname]["ansible_" + interface.name].ipv4.address + '/'
                                           + (hostvars[inventory_hostname]["ansible_" + interface.name].ipv4.address + '/'


### PR DESCRIPTION
If you configure `dnsmasq` to act as a DHCP (v4/v6)-server, `dnsmasq` will announce it own interface subnet within the IPv6 router advertisement. This let a client to select an IP within the IPv6 subnet and add the DHCP-Server to it `default`-routes.

In some situation a client can have multiple interfaces (e.g. `internal`, `public`), where multiple DHCP server will serve IP's. 
If the DHCP server at the `internal`-interface has a public route able IPv6 address, it will announce this subnet besides the `internal` IPv6 subnet to the `internal`-Link. If a public IPv6 is also announced at the `public`-interface the client will have at least two `default`-IPv6 routes.

If you have multiple `default`-routes it is hard to have a deterministic traffic flow, therefore it would be a solution that the DHCP-Server at the `internal`-interface does not announce it's own public IPv6 subnet.

I added the flag `ignore_interface_addresses` to provide this feature. With this option a `dnsmasq` configuration could be like:
```yaml
dnsmasq__interfaces:
  - name: 'br_internal'
    dhcp_ipv6_mode: 'ra-names,ra-stateless'
    ignore_interface_addresses: True
    addresses: 
      - '{{ server_internal_ipv4_network }}'
      - '{{ server_internal_ipv6_network }}'
```