### PR TITLE
feat(proc_hidepid): ensure hidepid is disabled when libvirtd is used 

### DIFF
--- a/ansible/roles/proc_hidepid/defaults/main.yml
+++ b/ansible/roles/proc_hidepid/defaults/main.yml
@@ -77,7 +77,10 @@ proc_hidepid__remount: '{{ True
 # - ``2``: the ``/proc`` contents are invisible to non-owners, only ``root``
 #          and users in the specific UNIX system group can see everything
 #
-proc_hidepid__level: '{{ proc_hidepid__fact_default_level | d("2") }}'
+proc_hidepid__level: '{{ "0"
+                          if (("debops_service_libvirtd" in group_names) or
+                              (ansible_local.libvirtd.installed | d() | bool))
+                          else (proc_hidepid__fact_default_level | d("2")) }}'
 
                                                                    # ]]]
 # .. envvar:: proc_hidepid__group [[[

--- a/docs/ansible/roles/proc_hidepid/getting-started.rst
+++ b/docs/ansible/roles/proc_hidepid/getting-started.rst
@@ -10,6 +10,38 @@ Getting started
    .. contents::
       :local:
 
+Word of precaution
+------------------
+
+This role was written in 2018 to change ``hidepid`` for the whole system. On
+2020-11-26 systemd 247 was released which introduced the ``ProtectProc``
+setting. Setting ``hidepid`` for the whole system has drawbacks. Read
+`Is mounting /proc with "hidepid=2" recommended with RHEL7 and later?`__ and
+`Why is the mount option "hidepid=2" not used by default, is there a danger in using it?`_.
+
+.. __: https://www.influxdata.com/blog/package-repository-for-linux/
+.. __: https://security.stackexchange.com/questions/259134/why-is-the-mount-option-hidepid-2-not-used-by-default-is-there-a-danger-in-us
+
+The way to move forward is to contribute ``ProtectProc`` to all upstream
+projects, wait until Debian releases them and then potentially deprecate this
+role. Until then, this role provides hardening with the potential of breaking
+things.
+
+Handling of polkit
+------------------
+
+> Confirmed, giving access to /proc to polkitd user (running polkitd) is not
+> enough, the authentication agent seems to requires that as well (and granting
+> my user access to /proc denies the interest of hidepid).
+
+.. __: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=860040
+
+https://github.com/Kicksecure/security-misc/issues/173
+
+https://github.com/systemd/systemd/issues/29893
+
+So if polkit is detected or planned to be installed on a host, this hardening
+on a system level will not be enabled.
 
 Static GID assignment
 ---------------------


### PR DESCRIPTION
The current detection does not work when running the site playbook only once because by the time the `proc_hidepid` role runs, polkit is not yet installed. This is fixed by checking for membership in the `debops_service_libvirtd` Ansible host group. Also check Ansible local facts for good measure.