### PR TITLE
enable override template in sshd role

### DIFF
--- a/ansible/roles/sshd/tasks/main.yml
+++ b/ansible/roles/sshd/tasks/main.yml
@@ -236,7 +236,7 @@
 
 - name: Generate /etc/pam.d/sshd configuration
   ansible.builtin.template:
-    src: 'etc/pam.d/sshd.j2'
+    src: '{{ lookup("debops.debops.template_src", "etc/pam.d/sshd.j2") }}'
     dest: '/etc/pam.d/sshd'
     mode: '0644'
   when: sshd__pam_deploy_state == 'present'


### PR DESCRIPTION
Adjust the src field into the "Generate /etc/pam.d/sshd configuration" task of the role sshd in order to allow to be override by the user