### PR TITLE
Add separate option enabling to set basedir variable

### DIFF
--- a/ansible/roles/reprepro/templates/home/reprepro/repositories/instance/conf/options.j2
+++ b/ansible/roles/reprepro/templates/home/reprepro/repositories/instance/conf/options.j2
@@ -5,7 +5,7 @@
 # This file is managed by Ansible, all changes will be lost
 
 {% set default_options = [
-  {'basedir': (reprepro__data_root + '/' + repo.name)},
+  {'basedir': (repo.basedir | d(reprepro__data_root + '/' + repo.name))},
   {'outdir': (repo.outdir | d(reprepro__public_root + '/sites/' + repo.name + '/public/' + (repo.os | d('debian'))))},
   {'waitforlock': 3},
   {'verbose': ''}


### PR DESCRIPTION
This is necessary in a case, when someone needs to have a custom value for this variable to be able to define custom reprepro repository structure for a repository.

It follows the same approach that is defined for the "outdir" variable, that can be set separately, if a defuault generated value can't be used.