### PR TITLE
Add support for read-only Fridays in DebOps script

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -48,6 +48,11 @@ General
   directories. Playbook sets can be used as aliases to call multiple playbooks
   using a custom name. See :ref:`playbook_sets` documentation for more details.
 
+- Users can now enable "read-only Fridays" functionality on a per project
+  basis, to ensure that on Fridays, Ansible playbooks are run only in check
+  mode, with ``--check`` and ``--diff`` arguments automatically added to the
+  :command:`ansible-playbook` command options.
+
 :ref:`debops.apt_install` role
 ''''''''''''''''''''''''''''''
 

--- a/src/debops/_data/templates/projectdir/modern/project.yml.j2
+++ b/src/debops/_data/templates/projectdir/modern/project.yml.j2
@@ -1,6 +1,6 @@
 ---
-{# Copyright (C) 2023 Maciej Delmanowski <drybjed@gmail.com>
- # Copyright (C) 2023 DebOps <https://debops.org/>
+{# Copyright (C) 2023-2024 Maciej Delmanowski <drybjed@gmail.com>
+ # Copyright (C) 2023-2024 DebOps <https://debops.org/>
  # SPDX-License-Identifier: GPL-3.0-or-later
  #}
 # Configuration for a DebOps project
@@ -14,6 +14,9 @@ project:
     # example unlocking or locking the project directory
     auto_commit: True
     auto_commit_message: 'Changes committed automatically by DebOps'
+
+  # Don't make any changes on a Friday, allow only checks
+  read_only_friday: False
 
 # Define custom paths which can be used to override files and templates in
 # Ansible roles or inject tasks via lookup plugins provided with DebOps.

--- a/src/debops/ansibleplaybookrunner.py
+++ b/src/debops/ansibleplaybookrunner.py
@@ -6,6 +6,7 @@ from .utils import unexpanduser
 from .ansibleconfig import AnsibleConfig
 from .ansible.inventory import AnsibleInventory
 import subprocess
+import datetime
 import configparser
 import textwrap
 import logging
@@ -119,6 +120,16 @@ class AnsiblePlaybookRunner(object):
                     self._found_playbooks.append(self._quote_spaces(
                         self._expand_playbook(project, element)))
                     self._parsed_args.append(index)
+
+        # Implement configurable read-only Fridays on a project level
+        if project.config.raw['project'].get('read_only_friday', False):
+            if datetime.date.today().isoweekday() == 5:
+                if ('--check' not in self._ansible_command and
+                        '-C' not in self._ansible_command):
+                    logger.notice("It's Read-Only Friday, switching to check mode",
+                                  extra={'block': 'stderr'})
+                    print("It's Read-Only Friday, switching to check mode")
+                    self._ansible_command.extend(['--diff', '--check'])
 
     def _quote_spaces(self, string):
         if ' ' in string:


### PR DESCRIPTION
This practice should be standard in large IT organizations. :-)

Ref: https://en.wikipedia.org/wiki/2024_CrowdStrike_incident