### PR TITLE
Fixed bug in dist-upgrade.yml

### DIFF
--- a/ansible/playbooks/tools/dist-upgrade.yml
+++ b/ansible/playbooks/tools/dist-upgrade.yml
@@ -209,7 +209,8 @@
         group: 'root'
         mode: '0644'
         backup: False
-      when: dist_upgrade_register_etc_services is defined and
+      when: dist_upgrade_register_etc_services is not skipped and
+            dist_upgrade_register_etc_services is defined and
             dist_upgrade_register_etc_services.stat.exists
 
     - name: Remove the lockfile


### PR DESCRIPTION
In cases where dist_upgrade_register_upgrade is undefined or unchanged, the 'Check if /etc/services' will register a dict without any of the stat return parameters. This leads to 'Assemble /etc/services' to fail with '"dict object" has no attribute "stat"'.

Adding another check in the when statement to see if the previous task was skipped will cause this error to not appear again as it does skip there already.