### PR TITLE
[ci] Don't pin versions of specific packages in CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -206,6 +206,7 @@ jobs:
 
   debops-wheel:
     runs-on: 'ubuntu-latest'
+    timeout-minutes: 120
     steps:
 
       - name: Add ~/.local/bin to $PATH
@@ -233,6 +234,7 @@ jobs:
 
   debops-sdist:
     runs-on: 'ubuntu-latest'
+    timeout-minutes: 120
     steps:
 
       - name: Add ~/.local/bin to $PATH
@@ -282,6 +284,7 @@ jobs:
 
   documentation:
     runs-on: 'ubuntu-latest'
+    timeout-minutes: 120
     steps:
 
       - name: Add ~/.local/bin to $PATH

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -222,7 +222,7 @@ jobs:
           sudo apt-get -qq update
           sudo apt-get -yq install pandoc pandoc-data graphviz
           pip3 install --user --upgrade pip wheel "setuptools==65.7.0" pypandoc
-          pip3 install --user --upgrade sphinx sphinx-autobuild sphinx_rtd_theme
+          pip3 install --user --upgrade sphinx==5.3.0 sphinx-autobuild sphinx_rtd_theme
 
       - name: Build DebOps Python wheel package
         run: |
@@ -250,7 +250,7 @@ jobs:
           sudo apt-get -qq update
           sudo apt-get -yq install pandoc pandoc-data graphviz
           pip3 install --user --upgrade pip wheel "setuptools==65.7.0" pypandoc
-          pip3 install --user --upgrade sphinx sphinx-autobuild sphinx_rtd_theme
+          pip3 install --user --upgrade sphinx==5.3.0 sphinx-autobuild sphinx_rtd_theme
 
       - name: Build DebOps Python sdist package
         run: |
@@ -298,7 +298,7 @@ jobs:
           sudo apt-get -qq update
           sudo apt-get install -yq graphviz
           pip3 install --user --upgrade pip wheel "setuptools==65.7.0"
-          pip3 install --user --upgrade sphinx sphinx-autobuild sphinx_rtd-theme
+          pip3 install --user --upgrade sphinx==5.3.0 sphinx-autobuild sphinx_rtd-theme
 
       - name: Build documentation site
         run: |

--- a/.github/workflows/prepare-ci-pipeline/action.yml
+++ b/.github/workflows/prepare-ci-pipeline/action.yml
@@ -1,6 +1,6 @@
 ---
-# Copyright (C) 2021 Maciej Delmanowski <drybjed@gmail.com>
-# Copyright (C) 2023 Berkhan Berkdemir <berkhan@tekdanisman.com>
+# Copyright (C) 2021-2024 Maciej Delmanowski <drybjed@gmail.com>
+# Copyright (C) 2023      Berkhan Berkdemir <berkhan@tekdanisman.com>
 # Copyright (C) 2021-2024 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -39,5 +39,7 @@ runs:
         cat <<EOL >> ansible/inventory/hosts
         [debops_all_hosts]
         localhost ansible_connection=local
+        [all:vars]
+        debops__no_log=false
         EOL
       shell: bash

--- a/.github/workflows/prepare-ci-pipeline/action.yml
+++ b/.github/workflows/prepare-ci-pipeline/action.yml
@@ -38,7 +38,7 @@ runs:
         cd ~/src/controller
         cat <<EOL >> ansible/inventory/hosts
         [debops_all_hosts]
-        localhost ansible_connection=local
+        localhost ansible_connection=local ansible_python_interpreter=/usr/bin/python3
         [all:vars]
         debops__no_log=false
         EOL

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -206,7 +206,6 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
     try:
         import sphinx_rtd_theme
         html_theme = 'sphinx_rtd_theme'
-        html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
         html_theme_options = {
             'collapse_navigation': True,
             'logo_only': False

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -1,28 +1,29 @@
 # Copyright (C) 2023 Berkhan Berkdemir <berkhan@tekdanisman.com>
+# Copyright (C) 2024 Maciej Delmanowski <drybjed@gmail.com>
 # Copyright (C) 2024 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 # List of Python packages used by GitHub CI pipeline for continuous integration
 
-ansible==8.0.0a1
-ansible-core==2.15.0b2
-cffi==1.16.0
-cryptography==41.0.5
-distro==1.8.0
-dnspython==2.4.2
-future==0.18.3
-Jinja2==3.1.2
-MarkupSafe==2.1.3
-netaddr==0.9.0
-packaging==23.2
-passlib==1.7.4
-pyasn1==0.5.0
-pyasn1-modules==0.3.0
-pycparser==2.21
-pyOpenSSL==23.2.0
-python-dotenv==1.0.0
-python-ldap==3.4.3
-pyxdg==0.28
-PyYAML==6.0.1
-resolvelib==0.8.1
-toml==0.10.2
+ansible
+ansible-core
+cffi
+cryptography
+distro
+dnspython
+future
+Jinja2
+MarkupSafe
+netaddr
+packaging
+passlib
+pyasn1
+pyasn1-modules
+pycparser
+pyOpenSSL
+python-dotenv
+python-ldap
+pyxdg
+PyYAML
+resolvelib
+toml

--- a/src/debops/cli.py
+++ b/src/debops/cli.py
@@ -10,6 +10,7 @@ from .ansiblerunner import AnsibleRunner
 from .ansibleplaybookrunner import AnsiblePlaybookRunner
 from .envrunner import EnvRunner
 import logging
+import getpass
 import sys
 import os
 
@@ -23,7 +24,7 @@ class Interpreter(object):
         self.config = Configuration()
         self.parsed_args = Subcommands(self.args)
         logger.debug('Command line interpreter initialized')
-        logger.debug('Control user=' + os.getlogin())
+        logger.debug('Control user=' + getpass.getuser())
 
         if self.parsed_args.section == 'project':
             if self.parsed_args.command == 'init':


### PR DESCRIPTION
Continuous Integration should use newest versions of packages to check if the code is compatible.