### PR TITLE
[icinga] update upstream gpg key id

### DIFF
--- a/ansible/roles/icinga/defaults/main.yml
+++ b/ansible/roles/icinga/defaults/main.yml
@@ -31,7 +31,7 @@ icinga__upstream: '{{ True
 # .. envvar:: icinga__upstream_apt_key_id [[[
 #
 # The GPG key id of the upstream Icinga 2 APT repository.
-icinga__upstream_apt_key_id: 'F51A 91A5 EE00 1AA5 D77D 53C4 C6E3 19C3 3441 0682'
+icinga__upstream_apt_key_id: 'DD3A F619 8ED0 00B4 C0B7 3956 CC11 6F55 AA7F 2382'
 
                                                                    # ]]]
 # .. envvar:: icinga__upstream_apt_repo [[[


### PR DESCRIPTION
See https://icinga.com/blog/2024/08/26/icinga-package-repository-key-rotation-2024/

The GPG key was changed on September 30, 2024. With the old one, I cannot run `apt update` because of 

> Failed to update apt cache: W:GPG error: https://packages.icinga.com/debian icinga-bookworm InRelease: The following signatures couldn''t be verified because the public key is not available: NO_PUBKEY CC116F55AA7F2382