### PR TITLE
[nginx] Fix syntax error

### DIFF
--- a/ansible/roles/nginx/tasks/nginx_configs.yml
+++ b/ansible/roles/nginx/tasks/nginx_configs.yml
@@ -65,7 +65,7 @@
 
 - name: Configure nginx upstreams
   ansible.builtin.template:
-    src: '{{ lookup("debops.debops.template_src", "'etc/nginx/conf.d/upstream_" + (item.type | d("default")) + ".conf.j2") }}'
+    src: '{{ lookup("debops.debops.template_src", "etc/nginx/conf.d/upstream_" + (item.type | d("default")) + ".conf.j2") }}'
     dest: '/etc/nginx/conf.d/upstream_{{ item.name }}.conf'
     owner: 'root'
     group: 'root'


### PR DESCRIPTION
This PR fixes the issue related to #2475:

```
TASK [debops.debops.nginx : Generate nginx conf.d/ files] **********************************************************************************************************************************
ERROR! We were unable to read either as JSON nor YAML, these are the errors we got from each:
JSON: Expecting value: line 1 column 1 (char 0)

Syntax Error while loading YAML.
  did not find expected key. while parsing a block mapping
  in "<unicode string>", line 68, column 5
did not find expected key
  in "<unicode string>", line 68, column 53

The error appears to be in '.venv/lib/python3.11/site-packages/debops/_data/ansible/collections/ansible_collections/debops/debops/roles/nginx/tasks/nginx_configs.yml': line 68, column 53, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  ansible.builtin.template:
    src: '{{ lookup("debops.debops.template_src", "'etc/nginx/conf.d/upstream_" + (item.type | d("default")) + ".conf.j2") }}'
                                                    ^ here
We could be wrong, but this one looks like it might be an issue with
missing quotes. Always quote template expression brackets when they
start a value. For instance:

    with_items:
      - {{ foo }}

Should be written as:

    with_items:
      - "{{ foo }}"
```
