### PR TITLE
[opensearch] Minor fixes

### DIFF
--- a/ansible/roles/opensearch/tasks/main.yml
+++ b/ansible/roles/opensearch/tasks/main.yml
@@ -39,10 +39,14 @@
       become_user: '{{ opensearch__user }}'
       changed_when: False
 
+    - name: Populate service facts
+      ansible.builtin.service_facts:
+
     - name: Stop service
       ansible.builtin.service:
         name: 'opensearch'
         state: 'stopped'
+      when: ansible_facts.services['opensearch.service'] is defined
 
     - name: Remove old installation directory
       ansible.builtin.file:

--- a/ansible/roles/opensearch/tasks/main.yml
+++ b/ansible/roles/opensearch/tasks/main.yml
@@ -74,7 +74,7 @@
         remote_src: True
         owner: 'root'
         group: '{{ opensearch__group }}'
-        mode: '0640'
+        mode: '0750'
 
 - name: Configure OpenSearch and the JVM
   ansible.builtin.template:


### PR DESCRIPTION
This fixes two minor issues with `openserach`.

1. The role wants to stop the service `opensearch.service` without before checking if it exists, causing a crash at first install.
**Fixed** by populating service facts beforehand and placing a condition for the stop command.

2. The permissions for directory `/etc/opensearch` are missing the executable bit. Thus, opensearch fails to start with error `/usr/local/share/opensearch/bin/opensearch-env: line 106: cd: /etc/opensearch: Permission denied`.
**Fixed** by changing the permissions from `640` to `750`.