### PR TITLE
fix(netbox): match upstream for SESSION_FILE_PATH (`None`, not `False`)

### DIFF
--- a/ansible/roles/netbox/defaults/main.yml
+++ b/ansible/roles/netbox/defaults/main.yml
@@ -828,7 +828,7 @@ netbox__config_metrics_enabled: False
 # can be useful for enabling authentication on a standby instance with
 # read-only database access.) Note that the user as which NetBox runs must have
 # read and write permissions to this path.
-netbox__config_session_file_path: '{{ "" if netbox__primary | bool else netbox__data + "/sessions" }}'
+netbox__config_session_file_path: '{{ "None" if (netbox__primary | bool) else (netbox__data + "/sessions") }}'
 
                                                                    # ]]]
 # .. envvar:: netbox__config_media_root [[[

--- a/ansible/roles/netbox/templates/usr/local/lib/netbox/configuration.py.j2
+++ b/ansible/roles/netbox/templates/usr/local/lib/netbox/configuration.py.j2
@@ -260,7 +260,7 @@ SESSION_COOKIE_NAME = 'sessionid'
 # By default, NetBox will store session data in the database. Alternatively, a file path can be specified here to use
 # local file storage instead. (This can be useful for enabling authentication on a standby instance with read-only
 # database access.) Note that the user as which NetBox runs must have read and write permissions to this path.
-SESSION_FILE_PATH = '{{ netbox__config_session_file_path }}'
+SESSION_FILE_PATH = {{ "None" if (netbox__config_session_file_path == "None") else (netbox__config_session_file_path | to_json) }}
 
 # Time zone (default: UTC)
 TIME_ZONE = '{{ netbox__config_time_zone }}'


### PR DESCRIPTION
Setting `SESSION_FILE_PATH` to `False` has worked for many years but it is not good to derive from upstream config example. We now either set it to `None` or to a string.

Cc: @k-304 as you recently touched those lines #2435 and thus I dug deeper. But the derivation from upstream (`False` and not `None`) was there before you. With your change, it was just changed to "" (empty string). Both `False` and empty string are not ideal I guess (see `settings.py`).

Ref: https://github.com/netbox-community/netbox/blob/27d15615b3590000901984bddfa7a815cd1343d8/netbox/netbox/configuration_example.py#L222
Ref: https://github.com/netbox-community/netbox/blob/27d15615b3590000901984bddfa7a815cd1343d8/netbox/netbox/settings.py#L348-L349