### PR TITLE
Remove disutils leftovers for python 3.12 support

### DIFF
--- a/ansible/plugins/lookup/file_src.py
+++ b/ansible/plugins/lookup/file_src.py
@@ -58,7 +58,7 @@ try:
 except ImportError:
     LookupBase = object
 
-from distutils.version import LooseVersion
+from looseversion import LooseVersion
 from ansible import __version__ as __ansible_version__
 
 

--- a/ansible/plugins/lookup/task_src.py
+++ b/ansible/plugins/lookup/task_src.py
@@ -58,7 +58,7 @@ try:
 except ImportError:
     LookupBase = object
 
-from distutils.version import LooseVersion
+from looseversion import LooseVersion
 from ansible import __version__ as __ansible_version__
 
 

--- a/ansible/plugins/lookup/template_src.py
+++ b/ansible/plugins/lookup/template_src.py
@@ -59,7 +59,7 @@ try:
 except ImportError:
     LookupBase = object
 
-from distutils.version import LooseVersion
+from looseversion import LooseVersion
 from ansible import __version__ as __ansible_version__
 
 

--- a/ansible/roles/ansible_plugins/lookup_plugins/file_src.py
+++ b/ansible/roles/ansible_plugins/lookup_plugins/file_src.py
@@ -58,7 +58,7 @@ try:
 except ImportError:
     LookupBase = object
 
-from distutils.version import LooseVersion
+from looseversion import LooseVersion
 from ansible import __version__ as __ansible_version__
 
 

--- a/ansible/roles/ansible_plugins/lookup_plugins/task_src.py
+++ b/ansible/roles/ansible_plugins/lookup_plugins/task_src.py
@@ -59,7 +59,7 @@ try:
 except ImportError:
     LookupBase = object
 
-from distutils.version import LooseVersion
+from looseversion import LooseVersion
 from ansible import __version__ as __ansible_version__
 
 

--- a/ansible/roles/ansible_plugins/lookup_plugins/template_src.py
+++ b/ansible/roles/ansible_plugins/lookup_plugins/template_src.py
@@ -58,7 +58,7 @@ try:
 except ImportError:
     LookupBase = object
 
-from distutils.version import LooseVersion
+from looseversion import LooseVersion
 from ansible import __version__ as __ansible_version__
 
 

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,8 @@ else:
 
 setup(
     install_requires=['distro', 'future', 'jinja2', 'pyyaml',
-                      'pyxdg', 'toml', 'python-dotenv', 'gitpython'],
+                      'pyxdg', 'toml', 'python-dotenv', 'gitpython',
+                      'looseversion'],
     extras_require={
         'ansible': ['ansible', 'netaddr', 'passlib',
                     'python-ldap', 'dnspython', 'pyopenssl']

--- a/src/debops/config.py
+++ b/src/debops/config.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from .constants import DEBOPS_PACKAGE_DATA
-from .utils import unexpanduser
+from .utils import unexpanduser, strtobool
 import os
 import sys
 import dotenv
@@ -13,7 +13,6 @@ import collections.abc
 import toml
 import json
 import yaml
-from distutils.util import strtobool
 from xdg.BaseDirectory import xdg_config_home
 try:
     import configparser

--- a/src/debops/utils.py
+++ b/src/debops/utils.py
@@ -4,6 +4,21 @@
 
 from .constants import DEBOPS_USER_HOME_DIR
 
+_MAP = {
+    'y': True,
+    'yes': True,
+    't': True,
+    'true': True,
+    'on': True,
+    '1': True,
+    'n': False,
+    'no': False,
+    'f': False,
+    'false': False,
+    'off': False,
+    '0': False
+}
+
 
 def unexpanduser(path):
     """Replace the absolute path of the home directory with '~'
@@ -17,3 +32,10 @@ def unexpanduser(path):
         return path.replace(DEBOPS_USER_HOME_DIR, '~', 1)
     else:
         return path
+
+
+def strtobool(value):
+    try:
+        return _MAP[str(value).lower()]
+    except KeyError:
+        raise ValueError('"{}" is not a valid bool value'.format(value))


### PR DESCRIPTION
I switch to the looseversion package and import the strtobool code per PEP-632.
The latter as str2bool does not work for our use case. That is, str2bool does not raise an exception when the string to convert is invalid but returns "False" which breaks "debops project refresh" for all .debops.cfg fields that are not valid boolean strings.

I have been able to run debops on a controller with python 3.12.7 (Debian Testing/Unstable)