### PR TITLE
Update roundcube show folder size plugin repository

### DIFF
--- a/ansible/roles/roundcube/defaults/main.yml
+++ b/ansible/roles/roundcube/defaults/main.yml
@@ -3246,7 +3246,7 @@ roundcube__default_plugins:
     # This plugin provides a toolbar button and folder menu option which
     # calculates and displays the sizes of the message folders.
   - name: 'show_folder_size'
-    package: 'jfcherng/show-folder-size'
+    package: 'jfcherng-roundcube/show-folder-size'
     state: 'enabled'
     options:
 
@@ -3263,6 +3263,12 @@ roundcube__default_plugins:
       - name: 'show_toolbar_button'
         comment: 'Show the toolbar button'
         value: False
+
+    # obsolete version of the jfcherng-roundcube/show-folder-size
+    # Force removal
+  - name: 'show_folder_size_obsolete'
+    package: 'jfcherng/show-folder-size'
+    state: 'absent'
 
     # This plugin adds a button on the main toolbar which opens the
     # Nextcloud/ownCloud instance at specified URL.

--- a/ansible/roles/roundcube/tasks/deploy_roundcube.yml
+++ b/ansible/roles/roundcube/tasks/deploy_roundcube.yml
@@ -77,6 +77,22 @@
 
 # ---- Post deployment ----
 
+- name: Remove Roundcube plugins via Composer
+  community.general.composer:  # noqa jinja[spacing]
+    command: 'remove'
+    arguments: '{{ item }}'
+    working_dir: '{{ roundcube__git_dest }}'
+    no_dev: True
+  loop: '{{ roundcube__combined_plugins | debops.debops.parse_kv_items
+            | selectattr("state", "match", "^absent$")
+            | selectattr("package", "defined")
+            | map(attribute="package") | list }}'
+  become: True
+  become_user: '{{ roundcube__user }}'
+  register: roundcube__register_remove_composer_plugins
+  until: roundcube__register_remove_composer_plugins is succeeded
+  tags: [ 'skip::roundcube:plugins' ]
+
 - name: Install or upgrade PHP packages via Composer
   community.general.composer:  # noqa no-handler
     command: '{{ "upgrade"


### PR DESCRIPTION
This PR is required for roundcube role to keep working after the PHP8 PR is merged
That is the old jfcherng/show-folder-size does not support PHP 8 and above.

I took for granted that jfcherng-roundcube/show-folder-size is the new home for jfcherng/show-folder-size as the previous jfcherng is no more and the jfcherng-roundcube author is jfcherng.