### PR TITLE
fix(netbox): use FQCN to fix ansible-lint in CI

### DIFF
--- a/ansible/roles/netbox/tasks/main.yml
+++ b/ansible/roles/netbox/tasks/main.yml
@@ -225,7 +225,7 @@
 - name: Generate static content
   ## Since we do not run the manage.py file on secondary sites
   ## we need to generate those files in an extra task.
-  shell:  # noqa no-handler
+  ansible.builtin.shell:  # noqa no-handler
     cmd: |
       set -o nounset -o pipefail -o errexit
       ./manage.py collectstatic --no-input
@@ -242,7 +242,7 @@
   changed_when: not netbox__register_collectstatic.stdout is search('0 static files copied')
 
 - name: Create local session directory
-  file:
+  ansible.builtin.file:
     path: '{{ netbox__data + "/sessions" }}'
     owner: '{{ netbox__user }}'
     group: '{{ netbox__group }}'
@@ -257,7 +257,7 @@
 - name: Cleanup stale contenttypes and sessions
   ## Since we do not run the manage.py file on secondary sites
   ## we need to run the cleanup in an extra task.
-  shell:  # noqa no-handler
+  ansible.builtin.shell:  # noqa no-handler
     cmd: |
       set -o nounset -o pipefail -o errexit
       ./manage.py remove_stale_contenttypes --no-input


### PR DESCRIPTION
ansible.builtin.file and ansible.builtin.shell.

Fixes the errors for ansible-lint in github CI:
```
 WARNING  Listing 3 violation(s) that are fatal
fqcn[action-core]: Use FQCN for builtin module actions (shell).
ansible/roles/netbox/tasks/main.yml:225 Use `ansible.builtin.shell` or `ansible.legacy.shell` instead.

fqcn[action-core]: Use FQCN for builtin module actions (file).
ansible/roles/netbox/tasks/main.yml:244 Use `ansible.builtin.file` or `ansible.legacy.file` instead.

fqcn[action-core]: Use FQCN for builtin module actions (shell).
ansible/roles/netbox/tasks/main.yml:257 Use `ansible.builtin.shell` or `ansible.legacy.shell` instead.
Error: Use FQCN for builtin module actions (shell).

Error: Use FQCN for builtin module actions (file).
Error: Use FQCN for builtin module actions (shell).
Read documentation for instructions on how to ignore specific rule violations.

                 Rule Violation Summary                  
 count tag               profile    rule associated tags 
     3 fqcn[action-core] production formatting           

Failed: 3 failure(s), 0 warning(s) on 3954 files. Last profile that met the validation criteria was 'shared'. Rating: 4/5 star
```

Note I have not run tested the netbox role in a project.