### PR TITLE
[nginx] Add nginx_events_extra_options for additional directives in events context inside nginx.conf file. Current template nginx.conf.j2 doesn't allow to have additional directlves

### DIFF
--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -340,6 +340,13 @@ nginx_http_options: |
 nginx_http_extra_options: ''
 
                                                                    # ]]]
+# .. envvar:: nginx_events_extra_options [[[
+#
+# A string or YAML text block with additional nginx events options placed in the
+# :file:`/etc/nginx/nginx.conf` inside of the "events" block.
+nginx_events_extra_options: ''
+
+                                                                   # ]]]
 # .. envvar:: nginx_extra_options [[[
 #
 # A string or YAML text block with additional nginx options placed in the

--- a/ansible/roles/nginx/templates/etc/nginx/nginx.conf.j2
+++ b/ansible/roles/nginx/templates/etc/nginx/nginx.conf.j2
@@ -41,6 +41,10 @@ env PATH;
 events {
         worker_connections {{ nginx_worker_connections | default('1024') }};
         multi_accept {{ nginx_multi_accept | default('off') }};
+{% if nginx_events_extra_options | d() and nginx_events_extra_options %}
+{{ nginx_events_extra_options | indent(8, true) | regex_replace("(?m)^\s*$", "") }}
+
+{% endif %}
 }
 
 http {


### PR DESCRIPTION
[nginx] Add `nginx_events_extra_options` for additional directives in `events` context inside `nginx.conf` file. Current template `nginx.conf.j2` doesn't allow to have additional directlves. There are only 2 default `worker_connections` and `multi_accept`