### PR TITLE
Allow resolvconf update during early boot stage

### DIFF
--- a/ansible/roles/resolvconf/templates/usr/local/lib/resolvconf-static.j2
+++ b/ansible/roles/resolvconf/templates/usr/local/lib/resolvconf-static.j2
@@ -12,10 +12,14 @@ static_filename="/run/resolvconf/interface/{{ resolvconf__static_filename }}"
 reload_resolvconf () {
     # Don't try to restart resolvconf under systemd if it's not running
     # This avoids issues with resolvconf starting early during boot
+    # During early boot resolvconf is not active, but activating. It is already
+    # ready to be updated with resolvconf -u. Otherwise static config is
+    # not applied
     if [ -d /run/systemd/system ]; then
-        if [ "$(systemctl is-active resolvconf.service)" = "active" ] ; then
-            resolvconf -u
-        fi
+        state=$(systemctl is-active resolvconf.service)
+        case $state in
+            active|activating) echo "resolvconf is active or activating." && resolvconf -u;;
+        esac
     else
         resolvconf -u
     fi


### PR DESCRIPTION
On Debian 11 (bullseye) we saw that problem, that the static update was not set at boot time. Restarting the service afterwards showed the expected behavior. 

It seems, that the service is in state `activating` as the `ExecStartPost` script did not finish yet. Thus we are checking from within this script if the script itself is already done (check for `active`), creating a dependency on itself.
This PR adds `activating` to the list of states, from which it can trigger the update of the static resolvconf file. 

Hope this helps. 
