### PR TITLE
fix(apt_preferences): backport pin now requires `n` instead of `a`

### DIFF
--- a/ansible/roles/apt_preferences/templates/etc/apt/preferences.d/pin.pref.j2
+++ b/ansible/roles/apt_preferences/templates/etc/apt/preferences.d/pin.pref.j2
@@ -26,7 +26,7 @@ Package: {{ item.packages | join(" ") }}
 Pin: version {{ item.version + '*' }}
 Pin-Priority: {{ item.priority | d(apt_preferences__priority_version) }}
 {%     else %}
-Pin: {{ item.pin | d('release a=' + ansible_distribution_release + '-backports') }}
+Pin: {{ item.pin | d('release n=' + ansible_distribution_release + '-backports') }}
 Pin-Priority: {{ item.priority | d(apt_preferences__priority_default) }}
 {%     endif %}
 {%   else %}


### PR DESCRIPTION
Can be checked on bookworm with `apt-cache policy`. I have not found a reason for this but this broke starting with Bookworm.