### PR TITLE
[rabbitmq_server] Use `to_json` filter for parameter values

### DIFF
--- a/ansible/roles/rabbitmq_server/tasks/main.yml
+++ b/ansible/roles/rabbitmq_server/tasks/main.yml
@@ -180,7 +180,7 @@
     name:      '{{ item.name }}'
     node:      '{{ item.node | d(omit) }}'
     state:     '{{ item.state | d("present") }}'
-    value:     '{{ item.value | d(omit) }}'
+    value:     '{{ item.value | to_json or omit }}'
     vhost:     '{{ item.vhost | d(omit) }}'
   loop: '{{ q("flattened", rabbitmq_server__combined_parameters) }}'
   when: (item.name | d() and item.component | d())


### PR DESCRIPTION
Make sure that `community.rabbitmq.rabbitmq_parameter` gets a proper JSON as the parameter's value