### PR TITLE
Fix handling of NFS export paths with spaces

### DIFF
--- a/ansible/roles/nfs_server/templates/etc/exports.d/ansible.exports.j2
+++ b/ansible/roles/nfs_server/templates/etc/exports.d/ansible.exports.j2
@@ -4,9 +4,13 @@
  #}
 # {{ ansible_managed }}
 
+{% macro quote_path(path) -%}
+{% if ' ' in path %}"{{ path }}"{% else %}{{ path }}{% endif %}
+{% endmacro %}
+
 {% macro print_export(export) %}
 {%   if export is mapping and export.state | d('present') != 'absent' and export.path | d() and export.acl | d() %}
-{%     set nfs_server__tpl_export_path = export.path %}
+{%     set nfs_server__tpl_export_path = quote_path(export.path) | trim %}
 {%     set nfs_server__tpl_export_options = [] %}
 {%     set nfs_server__tpl_export_acl = [] %}
 {%     if export.options | d() %}


### PR DESCRIPTION
This change ensures that NFS export paths with spaces are handled correctly, preventing issues in NFS server configuration.

**Problem**
In the /etc/exports.d/ansible.exports file, paths with spaces need to be enclosed in quotes for proper NFS handling. Without this, mounting and configuration can fail. 
The current NFS server template in DebOps does not seem to handle paths containing spaces correctly.

**Solution**
This update introduces a Jinja2 macro "quote_path" that checks if a path contains spaces and encloses it in quotes. This macro is used in the template to ensure paths with spaces are correctly handled.

**Example**
Input variable:
nfs_server__host_exports:
  - path: '/srv/nfs/media/dir/With spaces'
    options: 'rw,fsid=2,no_subtree_check,no_root_squash'
    acl: "*"
    bind:
      src: '/media/dir/With spaces'

Before:
`/srv/nfs/media/dir/With spaces -rw,fsid=2,no_subtree_check,no_root_squash *`

After:
`"/srv/nfs/media/dir/With spaces" -rw,fsid=2,no_subtree_check,no_root_squash *`