### PR TITLE
Avoid generating passwords when one is given

### DIFF
--- a/ansible/roles/mariadb/tasks/manage_contents.yml
+++ b/ansible/roles/mariadb/tasks/manage_contents.yml
@@ -88,10 +88,10 @@
     name: '{{ item.user | d(item.name) }}'
     host: '{{ item.host | default(mariadb__client) }}'
     state: 'present'
-    password: '{{ item.password | default(lookup("password",
+    password: '{{ item.password if item.password is defined else lookup("password",
                   secret + "/mariadb/" + mariadb__delegate_to +
                   "/credentials/" + item.user | d(item.name) + "/password " +
-                  "length=" + mariadb__password_length)) }}'
+                  "length=" + mariadb__password_length) }}'
     login_unix_socket: '/run/mysqld/mysqld.sock'
   loop: '{{ q("flattened", mariadb__users + mariadb__dependent_users + mariadb_users | d([])) }}'
   delegate_to: '{{ mariadb__delegate_to }}'

--- a/ansible/roles/mariadb/templates/home/my.cnf.j2
+++ b/ansible/roles/mariadb/templates/home/my.cnf.j2
@@ -15,7 +15,7 @@ port={{ item.server_port | d(mariadb__port) }}
 # port={{ item.server_port | d(mariadb__port) }}
 {% endif %}
 user={{ item.user | d(item.name) }}
-password="{{ item.password | default(lookup('password', secret + '/mariadb/' + mariadb__delegate_to | d('undefined') + '/credentials/' + item.user | d(item.name) + '/password ' + 'length=' + mariadb__password_length)) }}"
+password="{{ item.password if item.password is defined else lookup('password', secret + '/mariadb/' + mariadb__delegate_to | d('undefined') + '/credentials/' + item.user | d(item.name) + '/password ' + 'length=' + mariadb__password_length) }}"
 {% if item.database | d(False) %}
 database={{ item.database }}
 {% endif %}

--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -98,11 +98,11 @@
   community.postgresql.postgresql_user:
     name: '{{ item.name | d(item.role) }}'
     port: '{{ item.port | d(postgresql__port if postgresql__port else omit) }}'
-    password: '{{ item.password | d(lookup("password",
+    password: '{{ item.password if item.password is defined else lookup("password",
                   secret + "/postgresql/" + postgresql__password_hostname +
                   "/" + (item.port | d(postgresql__port)) +
                   "/credentials/" + item.name | d(item.role) + "/password " +
-                  "length=" + postgresql__password_length + " chars=" + postgresql__password_characters)) }}'
+                  "length=" + postgresql__password_length + " chars=" + postgresql__password_characters) }}'
     encrypted: '{{ item.encrypted | d(True) }}'
     expires: '{{ item.expires | d(omit) }}'
     role_attr_flags: '{{ (item.flags | d() | join(",")) | d(omit) }}'
@@ -268,11 +268,11 @@
                (item.port | d(postgresql__port)),
                (item.database | d("*")),
                (item.role | d(item.owner)),
-               (item.password | d(lookup("password",
+               (item.password if item.password is defined else lookup("password",
                                   secret + "/postgresql/" + (item.server | d(postgresql__password_hostname))
                                   + "/" + (item.port | d(postgresql__port)) + "/credentials/"
                                   + item.name | d(item.role | d(item.owner))
-                                  + "/password length=" + postgresql__password_length))
+                                  + "/password length=" + postgresql__password_length)
                                  | regex_replace("\\", "\\\\") | regex_replace(":", "\:"))]
               | join(":") }}'
     state: 'present'

--- a/ansible/roles/rabbitmq_server/tasks/main.yml
+++ b/ansible/roles/rabbitmq_server/tasks/main.yml
@@ -211,11 +211,20 @@
     write_priv:     '{{ item.write_priv | d(omit) }}'
     state:          '{{ item.state | d("present") }}'
     vhost:          '{{ item.vhost | d(omit) }}'
-    password:       '{{ item.password | d(lookup("password",
-                        secret + "/rabbitmq_server/accounts/"
-                        + (item.user | d(item.name | d(item)))
-                        + "/password length="
-                        + rabbitmq_server__account_password_length)) }}'
+
+    # Avoid a password lookup if the password is defined, or if the account
+    # is meant to be absent (in which case the password is ommitted).
+    password:       '{{ item.password | d(omit) if (
+                            (item.password is defined)
+                            or
+                            (item.state | d("present") == "absent")
+                        ) else lookup("password",
+                          secret + "/rabbitmq_server/accounts/"
+                          + (item.user | d(item.name | d(item)))
+                          + "/password length="
+                          + rabbitmq_server__account_password_length
+                        )
+                    }}'
     tags:           '{{ (((item.tags.split(",") | list)
                           if (item.tags | d() and item.tags is string)
                           else item.tags) | join(","))


### PR DESCRIPTION
When a password is supplied, the password lookup fallback should not be executed, as that lookup is not side-effect free: It creates files (even in check mode).

There are most certainly other roles that do this as well, but here are the ones we need that have this issue. The reason being: When `default` is used, the expression inside the parentheses is evaluated in any case.

By rewriting it, we can avoid evaluating the lookup.

We use this in our fork, because we have an external secrets provider that does not use `password` as lookup.