### PR TITLE
[libvirt] Update package default variables for bookworm

### DIFF
--- a/ansible/roles/libvirt/defaults/main.yml
+++ b/ansible/roles/libvirt/defaults/main.yml
@@ -25,7 +25,7 @@
 # List of base packages to install with Libvirt.
 libvirt__base_packages:
   - [ 'gawk', 'netcat-openbsd', 'virtinst' ]
-  - '{{ [] if (ansible_distribution_release in ["bullseye"])
+  - '{{ [] if (ansible_distribution_release in ["bullseye", "bookworm"])
            else "virt-top" }}'
   - '{{ "virt-goodies"
         if (ansible_local | d() and ansible_local.python | d() and

--- a/ansible/roles/libvirt/defaults/main.yml
+++ b/ansible/roles/libvirt/defaults/main.yml
@@ -29,7 +29,8 @@ libvirt__base_packages:
            else "virt-top" }}'
   - '{{ "virt-goodies"
         if (ansible_local | d() and ansible_local.python | d() and
-            (ansible_local.python.installed2 | d()) | bool)
+            (ansible_local.python.installed2 | d()) | bool and
+            ansible_distribution_releare in ["buster"])
         else [] }}'
 
                                                                    # ]]]

--- a/ansible/roles/libvirtd/defaults/main.yml
+++ b/ansible/roles/libvirtd/defaults/main.yml
@@ -82,7 +82,7 @@ libvirtd__misc_packages:
   - 'ovmf'  # UEFI firmware for amd64 VMs
   - 'pm-utils'
   - 'sysfsutils'
-  - '{{ [] if (ansible_distribution_release in ["bullseye"])
+  - '{{ [] if (ansible_distribution_release in ["bullseye", "bookworm"])
            else "virt-top" }}'
 
                                                                    # ]]]


### PR DESCRIPTION
The default variables of the libvirt roles are preventing its playbook to execute on Bookworm, since there is no "virt-top" package here.  Also "virt-goodies" seems only available in Buster so trying to install it should also result in errors.