### PR TITLE
[libvirtd] Fix nsswitch

### DIFF
--- a/ansible/roles/nsswitch/defaults/main.yml
+++ b/ansible/roles/nsswitch/defaults/main.yml
@@ -105,6 +105,10 @@ nsswitch__default_database_map:
 
     - 'mymachines'
 
+    - 'libvirt'
+
+    - 'libvirt_guest'
+
     - [ 'mdns_minimal', '[NOTFOUND=return]' ]
 
     - replace: 'mdns4_minimal'
@@ -115,10 +119,6 @@ nsswitch__default_database_map:
     - [ 'resolve', '[!UNAVAIL=return]' ]
 
     - 'dns'
-
-    - 'libvirt'
-
-    - 'libvirt_guest'
 
     - 'wins'
 


### PR DESCRIPTION
Libvirt nss method will not be reached if there is a return action before them (eg: resolve).  This simple re-order ensures that the libvirt nss methods will be used.