### PR TITLE
[nginx] Add support http2 directive

### DIFF
--- a/ansible/roles/nginx/templates/etc/nginx/sites-available/default.conf.j2
+++ b/ansible/roles/nginx/templates/etc/nginx/sites-available/default.conf.j2
@@ -672,7 +672,7 @@ server {
 {%     endif %}
 {%     for port in nginx_tpl_listen_ssl %}
 {%      set opts = [ 'ssl' ] %}
-{%      if nginx_version is version_compare('1.9.5', '>=') %}
+{%      if nginx_version is version_compare('1.9.5', '>=') and nginx_version is version_compare('1.25.1', '<') %}
 {%        if nginx_enable_http2 | bool %}
 {%          set _ = opts.append('http2') %}
 {%        endif %}
@@ -683,6 +683,9 @@ server {
 {%      endif %}
         listen {{ port }} {{ opts | join(" ") }};
 {%     endfor %}
+{%     if nginx_enable_http2 | bool and nginx_version is version_compare('1.25.1', '>=') %}
+        http2 on;
+{%     endif %}
 
         ssl_certificate           {{ nginx_tpl_ssl_certificate }};
         ssl_certificate_key       {{ nginx_tpl_ssl_certificate_key }};


### PR DESCRIPTION
The patch provides the ability to use the new `http2` directive for nginx version `1.25.1` or higher, instead of the corresponding parameter for `listen` directive. To avoid warnings in logs:

```
nginx: [warn] the "listen ... http2" directive is deprecated, use the "http2" directive instead
```

From nginx [changelog](https://nginx.org/en/CHANGES), for `1.25.1` version:

> Feature: the "http2" directive, which enables HTTP/2 on a per-server basis; the "http2" parameter of the "listen" directive is now deprecated.