### PR TITLE
[apt_preferences] Fix default pin not having effect

### DIFF
--- a/ansible/roles/apt_preferences/templates/etc/apt/preferences.d/pin.pref.j2
+++ b/ansible/roles/apt_preferences/templates/etc/apt/preferences.d/pin.pref.j2
@@ -26,7 +26,7 @@ Package: {{ item.packages | join(" ") }}
 Pin: version {{ item.version + '*' }}
 Pin-Priority: {{ item.priority | d(apt_preferences__priority_version) }}
 {%     else %}
-Pin: {{ item.pin | d('release a=' + ansible_distribution_release + '-backports') }}
+Pin: {{ item.pin | d('release n=' + ansible_distribution_release + '-backports') }}
 Pin-Priority: {{ item.priority | d(apt_preferences__priority_default) }}
 {%     endif %}
 {%   else %}


### PR DESCRIPTION
The default "Pin:" entry in an APT preferences file should match either against `release a=stable-backports` or `release n=<release>-backports`, but it was set to `release a=<release>-backports` and therefore had no effect.

Fixes #2584