### PR TITLE
[rsyslog] set correct default home directory for syslog user on ubunt…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -205,6 +205,12 @@ General
   PostgreSQL 16.x resulting in failed startup of the service. The option will
   be added only on supported PostgreSQL versions.
 
+:ref:`debops.rsyslog` role
+''''''''''''''''''''''''''
+
+- Fixed default syslog home folder for Ubuntu Noble (24.04) hosts. The role
+  will now use the correct path to the syslog home folder.
+
 :ref:`debops.sysctl` role
 '''''''''''''''''''''''''
 

--- a/ansible/roles/rsyslog/defaults/main.yml
+++ b/ansible/roles/rsyslog/defaults/main.yml
@@ -121,8 +121,10 @@ rsyslog__append_groups: '{{ ["ssl-cert"] if (rsyslog__unprivileged | bool
 # The home directory of the :envvar:`rsyslog__user` user, dependent on the OS
 # defaults. Takes effect only when the unprivileged mode is enabled.
 rsyslog__home: '{{ "/home/syslog"
-                   if (ansible_distribution in ["Ubuntu"])
-                   else "/var/log" }}'
+                   if (ansible_distribution in ["Ubuntu"] and ansible_distribution_release not in ["noble"])
+                   else ("/nonexistent"
+                         if (ansible_distribution in ["Ubuntu"] and ansible_distribution_release in ["noble"])
+                         else "/var/log") }}'
 
                                                                    # ]]]
 # .. envvar:: rsyslog__file_owner [[[


### PR DESCRIPTION
…u 24

On Ubuntu 24, the default home folder for user syslog is `/nonexistent`  The error appears because 
The error `usermod: user syslog is currently used by process xxx` appears because it tries to change the home user folder

Fixes #2498 
