### PR TITLE
Make GUC db_user_namespace conditional on Postgres

### DIFF
--- a/ansible/roles/postgresql_server/templates/etc/postgresql/postgresql.conf.j2
+++ b/ansible/roles/postgresql_server/templates/etc/postgresql/postgresql.conf.j2
@@ -76,7 +76,9 @@ password_encryption = {{ item.password_encryption | d('scram-sha-256') }}
 {% else %}
 password_encryption = {{ item.password_encryption | d('on') }}
 {% endif %}
+{% if (item.version | d(postgresql_server__version)) is version_compare('17','<') %}
 db_user_namespace = {{ item.db_user_namespace | d('off') }}
+{% endif %}
 
 
 # - Kerberos and GSSAPI -


### PR DESCRIPTION
that setting is deprecated since PostgreSQL 16 and was removed on PostgreSQL>=17.