### PR TITLE
Only create root password secret when necessary

### DIFF
--- a/ansible/roles/root_account/defaults/main.yml
+++ b/ansible/roles/root_account/defaults/main.yml
@@ -62,7 +62,9 @@ root_account__packages: []
 root_account__password: '{{ lookup("password", secret
                             + "/credentials/" + inventory_hostname
                             + "/root_account/password encrypt=sha512_crypt length="
-                            + root_account__password_length | string) }}'
+                            + root_account__password_length | string)
+                            if root_account__enabled
+                            and root_account__password_update }}'
 
                                                                    # ]]]
 # .. envvar:: root_account__password_length [[[


### PR DESCRIPTION
When root_account__password_update was specifically disabled, a secret password
was still created (but not updated on the remote), leading to confusion.

Moreover, deactivating unnecessary secrets write is an improvement towards
compatibility with systems that does not support easily the secret method (eg:
AWX on containers).