### PR TITLE
Template upstream Ubuntu deb822 sources when present

### DIFF
--- a/ansible/roles/apt/tasks/main.yml
+++ b/ansible/roles/apt/tasks/main.yml
@@ -4,6 +4,7 @@
 # Copyright (C) 2013-2023 Maciej Delmanowski <drybjed@gmail.com>
 # Copyright (C) 2015-2017 Robin Schneider <ypid@riseup.net>
 # Copyright (C) 2014-2023 DebOps <https://debops.org/>
+# Copyright (C) 2025-2026 seven-beep <seven-beep@entreparentheses.xyz>
 # SPDX-License-Identifier: GPL-3.0-only
 
 - name: Import DebOps global handlers
@@ -206,19 +207,43 @@
   register: apt__register_sources_diversion
   when: (apt__enabled | bool and apt__deploy_state in ['absent', 'present'])
 
+- name: Register the presence of upstream Ubuntu deb822 sources
+  ansible.builtin.stat:
+    path: "/etc/apt/sources.list.d/ubuntu.sources"
+  register: ubuntu_deb822_system_sources
+
 - name: Configure operating system sources.list
   ansible.builtin.template:
     src: 'etc/apt/sources.list.j2'
     dest: '/etc/apt/sources.list'
     mode: '0644'
   register: apt__register_sources_template
-  when: (apt__enabled | bool and apt__deploy_state == 'present')
+  when: (apt__enabled | bool and apt__deploy_state == 'present' and
+         not ubuntu_deb822_system_sources.stat.exists )
+
+- name: Add diversion of upstream Ubuntu deb822 sources
+  debops.debops.dpkg_divert:
+    path: '/etc/apt/sources.list.d/ubuntu.sources'
+    state: "present"
+    delete: True
+  when: (apt__enabled | bool and apt__deploy_state == 'present' and
+        ubuntu_deb822_system_sources.stat.exists)
+
+- name: Configure operating system deb822 sources
+  ansible.builtin.template:
+    src: 'etc/apt/sources.list.d/system.sources.j2'
+    dest: '/etc/apt/sources.list.d/ubuntu.sources'
+    mode: '0644'
+  register: apt__register_deb822_sources_template
+  when: (apt__enabled | bool and apt__deploy_state == 'present' and
+         ubuntu_deb822_system_sources.stat.exists )
 
 - name: Update APT cache
   ansible.builtin.apt:
     update_cache: True
     cache_valid_time: '{{ omit
                          if (apt__register_sources_template is changed or
+                             apt__register_deb822_sources_template is changed or
                              apt__register_sources_diversion is changed or
                              apt__register_apt_repositories is changed)
                          else apt__cache_valid_time }}'

--- a/ansible/roles/apt/templates/etc/apt/sources.list.d/system.sources.j2
+++ b/ansible/roles/apt/templates/etc/apt/sources.list.d/system.sources.j2
@@ -1,0 +1,95 @@
+{# Copyright (C) 2013-2023 Maciej Delmanowski <drybjed@gmail.com>
+ # Copyright (C) 2015-2017 Robin Schneider <ypid@riseup.net>
+ # Copyright (C) 2014-2023 DebOps <https://debops.org/>
+ # Copyright (C) 2025-2026 seven-beep <seven-beep@entreparentheses.xyz>
+ # SPDX-License-Identifier: GPL-3.0-only
+ #}
+# {{ ansible_managed }}
+
+{% for element in apt__combined_sources | debops.debops.parse_kv_items(merge_keys=['types', 'uris', 'suites', 'components']) %}
+{%   if element.state not in ['absent', 'ignore', 'init'] %}
+{%     set element_comment = ('#' if (element.state == 'comment') else '') %}
+{%     if element.comment | d() %}
+{{       element.comment | regex_replace('\n$', '') | comment(prefix='', postfix='') -}}
+{%     endif %}
+{%     if element.raw | d() %}
+{%       if element_comment %}
+{{         element.raw | regex_replace('\n$', '') | comment(decoration='#', prefix='', postfix='') -}}
+{%       else %}
+{{         element.raw | regex_replace('\n$', '') }}
+{%       endif %}
+{%     else %}
+{%       set types = [] %}
+{%       set uris = [] %}
+{%       set suites = [] %}
+{%       set components = [] %}
+{%       if element.type | d() %}
+{%         set _ = types.append(element.type) %}
+{%       endif %}
+{%       if element.types | d() %}
+{%         set _ = types.extend(element.types | selectattr('state', 'equalto', 'present') | map(attribute='name') | list) %}
+{%       endif %}
+{%       if not types %}
+{%         set _ = types.extend(apt__archive_types) %}
+{%       endif %}
+{%       if element.uri | d() %}
+{%         set _ = uris.append(element.uri) %}
+{%       endif %}
+{%       if element.uris | d() %}
+{%         set _ = uris.extend(element.uris | selectattr('state', 'equalto', 'present') | map(attribute='name') | list) %}
+{%       endif %}
+{%       if element.suite | d() %}
+{%         set _ = suites.append(element.suite) %}
+{%       endif %}
+{%       if element.suites | d() %}
+{%         set suites = element.suites | selectattr('state', 'equalto', 'present') | map(attribute='name') | list %}
+{%       endif %}
+{%       if element.component | d() %}
+{%         set _ = components.append(element.component) %}
+{%       endif %}
+{%       if element.components | d() %}
+{%         set components = element.components | selectattr('state', 'equalto', 'present') | map(attribute='name') | list %}
+{%       endif %}
+{%       set source_options = '' %}
+{%       set parsed_options = [] %}
+{%       if element.options | d() %}
+{%         for option in element.options %}
+{%           if option.value is string %}
+{%             set option_string = option.name + '=' + option.value %}
+{%           else %}
+{%             set option_string = option.name + '=' + option.value | selectattr('state', 'equalto', 'present') | map(attribute='name') | list | join(',') %}
+{%           endif %}
+{%           set _ = parsed_options.append(option_string) %}
+{%         endfor %}
+{%       endif %}
+{%       if parsed_options %}
+{%         set source_options = parsed_options | join(' ') %}
+{%       endif %}
+{%       for uri in uris %}
+{%         if element.state == 'comment' %}
+{%            set element_comment = '#' %}
+{%         else %}
+{%            set element_comment = '' %}
+{%         endif %}
+{%         if apt__archive_sources_disabled | bool and "deb-src" in types %}
+{%               set _ = types.remove("deb-src") %}
+{%         endif %}
+{{         '{}Types: {}'.format(element_comment, types | join(' ')) }}
+{% if source_options %}
+{{         '{}Options: {}'.format(element_comment, source_options) }}
+{% endif %}
+{{         '{}URIs: {}
+{}Suites: {}
+{}Components: {}
+{}Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg'.format(
+             element_comment, uri,
+             element_comment, suites | join(' '),
+             element_comment, components | join(' '),
+             element_comment) }}
+{%       endfor %}
+{%     endif %}
+{%     if element.separate | d(True) and not loop.last %}
+{{       '' }}
+{%     endif %}
+{%   endif %}
+{% endfor %}


### PR DESCRIPTION
As stated on issue #2595, Ubuntu may ship deb822 sources, this commit detects
it, divert the file and template it accordingly to usual debops variables.