### PR TITLE
[pki] Remove ACME contacts feature

### DIFF
--- a/ansible/roles/pki/defaults/main.yml
+++ b/ansible/roles/pki/defaults/main.yml
@@ -222,14 +222,6 @@ pki_acme_ca_api_map:
   'le-staging-v2': 'https://acme-staging-v02.api.letsencrypt.org/directory'
 
                                                                    # ]]]
-# .. envvar:: pki_acme_contacts [[[
-#
-# List of (mailto:) URLs that the ACME server can use to contact you for issues
-# related to your account. For example, the server may wish to notify you about
-# server-initiated revocation or certificate expiration.
-pki_acme_contacts: [ 'mailto:{{ ansible_local.core.admin_public_email[0] | d("root@" + ansible_domain) }}' ]
-
-                                                                   # ]]]
 # .. envvar:: pki_acme_challenge_dir [[[
 #
 # Directory where the ACME client should store responses to ACME CA challenges.

--- a/ansible/roles/pki/files/usr/local/lib/pki/pki-realm
+++ b/ansible/roles/pki/files/usr/local/lib/pki/pki-realm
@@ -181,8 +181,6 @@ initialize_environment () {
     )
     config["acme_ca_api"]="${acme_ca_api_map[${config['acme_ca']}]}"
 
-    config["acme_contacts"]=""
-
     config["acme_expiration_days"]="30"
 
     # shellcheck disable=SC2154
@@ -1100,10 +1098,6 @@ request_acme_tiny_certificate () {
                     --directory-url \"${config['acme_ca_api']}\" --csr acme/request.pem \
                     --acme-dir \"${config['acme_challenge_dir']}\""
 
-            if [ -n "${config['acme_contacts']}" ]; then
-                acme_tiny_request_params+=(" --contact \"${config['acme_contacts']//,/\" \"}\"")
-            fi
-
             if [ "$EUID" -eq 0 ] ; then
 
                 set +e
@@ -1198,10 +1192,6 @@ request_acme_dns_certificate() {
     local pkirealm=/etc/pki/realms/${config['name']}
     local email=""
 
-    if [ -n "${config['acme_contacts']}" ]; then
-        email="-m${config['acme_contacts']}"
-    fi
-
     local all_dns
     local req_subjects=${config['subject']:-${config['pki_default_subject']:-}}
     # shellcheck disable=SC2001
@@ -1276,10 +1266,6 @@ request_acme_manual_certificate() {
     # We expect the API secrets to be in ./private/dns-*-credentials.key
     local pkirealm=/etc/pki/realms/${config['name']}
     local email=""
-
-    if [ -n "${config['acme_contacts']}" ]; then
-        email="-m${config['acme_contacts']}"
-    fi
 
     local all_dns
     local req_subjects=${config['subject']:-${config['pki_default_subject']:-}}
@@ -2504,12 +2490,6 @@ sub_init () {
                         ;;
                     acme-ca-api=*)
                         args["acme_ca_api"]=${OPTARG#*=}
-                        ;;
-                    acme-contacts)
-                        args["acme_contacts"]="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
-                        ;;
-                    acme-contacts=*)
-                        args["acme_contacts"]=${OPTARG#*=}
                         ;;
                     acme-default-subdomains)
                         args["acme_default_subdomains"]="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))

--- a/ansible/roles/pki/tasks/main.yml
+++ b/ansible/roles/pki/tasks/main.yml
@@ -176,7 +176,6 @@
     --acme-ca "{{ item.acme_ca | d(pki_acme_ca) }}"
     --acme-ca-api "{{ item.acme_ca_api | d(pki_acme_ca_api_map[item.acme_ca | d(pki_acme_ca)]) }}"
     --acme-type "{{ item.type | d(pki_acme_type) }}"
-    --acme-contacts "{{ item.acme_contacts | d(pki_acme_contacts) | join(',') }}"
     --acme-domains "{{ item.acme_domains | d([]) | join('/') }}"
     --acme-default-subdomains "{{ (item.acme_default_subdomains | d(pki_acme_default_subdomains)) | join('/') }}"
     --acme-challenge-dir "{{ item.acme_challenge_dir | d(pki_acme_challenge_dir) }}"

--- a/docs/ansible/roles/pki/acme-certbot-integration.rst
+++ b/docs/ansible/roles/pki/acme-certbot-integration.rst
@@ -124,10 +124,6 @@ group level, in the
    # implicitly enables 'certbot' support.
    pki_acme_type: 'dns-cloudflare'
 
-   # Certbot requires a working e-mail account (it will be validated), you
-   # might need to specify it if the role uses a non-existent e-mail address.
-   pki_acme_contacts: [ 'admin@example.org' ]
-
    # If you want to try the staging Let's Encrypt CA to test if the
    # certificates are obtained correctly, uncomment this variable.
    #pki_acme_ca: 'le-staging-v2'

--- a/docs/ansible/roles/pki/defaults-detailed.rst
+++ b/docs/ansible/roles/pki/defaults-detailed.rst
@@ -148,12 +148,6 @@ List of parameters related to the entire PKI realm:
   Optional, directory where the ACME client should store responses to ACME CA
   challenges. Defaults to :envvar:`pki_acme_challenge_dir`.
 
-``acme_contacts``
-  Optional, list of (mailto:) URLs that the ACME server can use to contact you
-  for issues related to your account. For example, the server may wish to
-  notify you about server-initiated revocation or certificate expiration. If
-  not specified, the list defined in :envvar:`pki_acme_contacts` will be used.
-
 ``internal``
   Optional, boolean. Enable or disable support for internal CA certificates in
   a given realm. If you disable internal CA support, an alternative,


### PR DESCRIPTION
## Description

As _Let's encrypt_ ended it's _expiration notification_ (see https://letsencrypt.org/2025/01/22/ending-expiration-emails/)   the `contact` settings does not work anymore (see also https://github.com/diafygi/acme-tiny/issues/299 ).

DebOps uses `acme-tiny` to generate new or renewal _Let's encrypt_ certificates. Currently there will be an error thrown and no new certificate is generated.

```
root@host:/etc/pki/realms# cat <DOMAIN>/acme/error.log 
Parsing account key...
Parsing CSR...
Found domains: <DOMAIN>
Getting directory...
Directory found!
Registering account...
Registered!
Traceback (most recent call last):
  File "/usr/bin/acme-tiny", line 33, in <module>
    sys.exit(load_entry_point('acme-tiny==4.1.0', 'console_scripts', 'acme-tiny')())
  File "/usr/lib/python3/dist-packages/acme_tiny.py", line 194, in main
    signed_crt = get_crt(args.account_key, args.csr, args.acme_dir, log=LOGGER, CA=args.ca, disable_check=args.disable_check, directory_url=args.directory_url, contact=args.contact)
  File "/usr/lib/python3/dist-packages/acme_tiny.py", line 116, in get_crt
    log.info("Updated contact details:\n{0}".format("\n".join(account['contact'])))
KeyError: 'contact'
```

## Solution
**1. Remove `acme_contacts`-feature**
   * see this pull request
 
**2. Remove `config['acme_contacts']` from `.../config/realm.conf`**
```
find /etc/pki/realms -type f -path "*/config/realm.conf" -exec sed -i '/acme_contacts/d' {} \;
```
**3. Delete `error.log` containing `KeyError: 'contact'` to allow regeneration of new certificates.**
```
find /etc/pki/realms -type f -path "*/acme/error.log" -exec rm -i {} \;
```
**4. (Optional) Run certificate generation manually**
```sh
cd /etc/pki/realms/;
for realm in *;
do
  echo -n "$realm ... ";
  /usr/local/lib/pki/pki-realm run -n $realm;
  echo "DONE";
done
```