### PR TITLE
[RFC] silence shellcheck with embedded shell script have jinja templating

### DIFF
--- a/ansible/roles/dropbear_initramfs/templates/etc/initramfs-tools/scripts/local-bottom/debops_dropbear_initramfs.j2
+++ b/ansible/roles/dropbear_initramfs/templates/etc/initramfs-tools/scripts/local-bottom/debops_dropbear_initramfs.j2
@@ -17,6 +17,8 @@ prereqs)
     ;;
 esac
 
+# jinja templating is not supported by shellcheck
+# shellcheck disable=all
 {% for name, interface in dropbear_initramfs__combined_interfaces.items() %}
 {%   set interface_name = (interface.iface | d(name)) %}
 ip link    set   dev {{ interface_name | quote }} down

--- a/ansible/roles/grub/templates/etc/grub.d/01_users.j2
+++ b/ansible/roles/grub/templates/etc/grub.d/01_users.j2
@@ -8,6 +8,8 @@
 
 ## {{ ansible_managed }}
 cat <<EOF
+# jinja templating is not supported by shellcheck
+# shellcheck disable=all
 {% set superusers = grub__combined_users|rejectattr("superuser", "none") | map(attribute = 'name') | join(' ') %}
 {% if superusers | length == 0 %}
 ## No users have been defined.

--- a/ansible/roles/slapd/templates/etc/ldap/slapacl-test-suite.j2
+++ b/ansible/roles/slapd/templates/etc/ldap/slapacl-test-suite.j2
@@ -120,6 +120,8 @@ if [ ! -t 2 ] && [ -t 1 ] ; then
     printf "Testing OpenLDAP ACL policies "
 fi
 
+# jinja templating is not supported by shellcheck
+# shellcheck disable=all
 {% for element in slapd__slapacl_combined_tests | debops.debops.parse_kv_items(merge_keys=['queries']) %}
 {%   if element.name | d() and element.dn | d() and element.state | d('present') not in [ 'absent', 'init', 'ignore' ] %}
 {%     if not loop.first %}

--- a/lib/tests/check-shell
+++ b/lib/tests/check-shell
@@ -29,10 +29,7 @@ while read -r in ; do
             printf "%s" "."
         fi
     fi
-done < <(find . -type f -not -iwholename "./.git/*" \
-    -not -wholename "./ansible/roles/grub/templates/etc/grub.d/01_users.j2" \
-    -not -wholename "./ansible/roles/slapd/templates/etc/ldap/slapacl-test-suite.j2" \
-    -not -wholename "./ansible/roles/dropbear_initramfs/templates/etc/initramfs-tools/scripts/local-bottom/debops_dropbear_initramfs.j2")
+done < <(find . -type f -not -iwholename "./.git/*")
 
 printf " %s\\n" "found ${#file_list[@]} shell scripts"
 


### PR DESCRIPTION
shellcheck does not support jinja templating
https://github.com/koalaman/shellcheck/issues/1306

Note that lib/tests/check-shell already has code to ignore these files, but I believe it is better to silence the error in the shell script templates than to maintain a hardcoded list of template files to ignore.

Note that shellcheck disable=all is for shellcheck >= 0.8, ie starting from bookworm.

---
Is it ok to require bookworm for shellcheck ?
Maybe this can wait for forky...