### PR TITLE
Fixed lxc_ssh.py deprecated selectors dependency

### DIFF
--- a/ansible/plugins/connection/lxc_ssh.py
+++ b/ansible/plugins/connection/lxc_ssh.py
@@ -44,7 +44,7 @@ from ansible.errors import (
     AnsibleFileNotFound,
 )
 from ansible.errors import AnsibleOptionsError
-from ansible.compat import selectors
+from ansible_collections.community.docker.plugins.module_utils.selectors import selectors
 from ansible.module_utils.six import PY3, text_type, binary_type
 from ansible.module_utils.six.moves import shlex_quote
 from ansible.module_utils._text import to_bytes, to_native, to_text


### PR DESCRIPTION
Selectors were deprecated in ansible-core 2.17.0.
See: https://github.com/ansible-collections/community.docker/pull/871