### PR TITLE
[global_handlers] Namespace variables in handlers

### DIFF
--- a/ansible/roles/global_handlers/handlers/bind.yml
+++ b/ansible/roles/global_handlers/handlers/bind.yml
@@ -8,8 +8,8 @@
   #       included snippets, keys, etc.
 - name: Test named configuration and restart
   ansible.builtin.command: runuser -u bind -- /usr/bin/named-checkconf
-  register: bind__register_checkconf
-  changed_when: bind__register_checkconf.changed | bool
+  register: global_handlers__bind_register_checkconf
+  changed_when: global_handlers__bind_register_checkconf.changed | bool
   notify: [ 'Restart named' ]
 
 - name: Restart named

--- a/ansible/roles/global_handlers/handlers/dnsmasq.yml
+++ b/ansible/roles/global_handlers/handlers/dnsmasq.yml
@@ -6,8 +6,8 @@
 
 - name: Test and restart dnsmasq
   ansible.builtin.command: dnsmasq --test
-  register: dnsmasq__register_config_test
-  changed_when: dnsmasq__register_config_test.changed | bool
+  register: global_handlers__dnsmasq_register_config_test
+  changed_when: global_handlers__dnsmasq_register_config_test.changed | bool
   notify: [ 'Restart dnsmasq' ]
 
 - name: Restart dnsmasq

--- a/ansible/roles/global_handlers/handlers/etc_aliases.yml
+++ b/ansible/roles/global_handlers/handlers/etc_aliases.yml
@@ -5,8 +5,8 @@
 
 - name: Update /etc/aliases.db database
   ansible.builtin.command: newaliases
-  register: etc_aliases__register_newaliases
-  changed_when: etc_aliases__register_newaliases.changed | bool
+  register: global_handlers__etc_aliases_register_newaliases
+  changed_when: global_handlers__etc_aliases_register_newaliases.changed | bool
   when: ansible_local | d() and ansible_local.etc_aliases | d() and
         ansible_local.etc_aliases.newaliases is defined and
         ansible_local.etc_aliases.newaliases | bool

--- a/ansible/roles/global_handlers/handlers/etckeeper.yml
+++ b/ansible/roles/global_handlers/handlers/etckeeper.yml
@@ -6,6 +6,6 @@
 
 - name: Commit changes in etckeeper
   ansible.builtin.shell: etckeeper unclean && etckeeper commit 'Committed by Ansible "etckeeper" handler' || true
-  register: etckeeper__register_commit
-  changed_when: etckeeper__register_commit.changed | bool
+  register: global_handlers__etckeeper_register_commit
+  changed_when: global_handlers__etckeeper_register_commit.changed | bool
   when: (ansible_local.etckeeper.enabled | d()) | bool

--- a/ansible/roles/global_handlers/handlers/fail2ban.yml
+++ b/ansible/roles/global_handlers/handlers/fail2ban.yml
@@ -20,5 +20,5 @@
 - name: Reload fail2ban jails
   ansible.builtin.shell: type fail2ban-server > /dev/null
          && (fail2ban-client ping > /dev/null && fail2ban-client reload > /dev/null || true) || true
-  register: fail2ban__register_reload
-  changed_when: fail2ban__register_reload.changed | bool
+  register: global_handlers__fail2ban_register_reload
+  changed_when: global_handlers__fail2ban_register_reload.changed | bool

--- a/ansible/roles/global_handlers/handlers/filebeat.yml
+++ b/ansible/roles/global_handlers/handlers/filebeat.yml
@@ -5,8 +5,8 @@
 
 - name: Test filebeat configuration and restart
   ansible.builtin.command: 'filebeat test config'
-  register: filebeat__register_test_config
-  changed_when: filebeat__register_test_config.changed | bool
+  register: global_handlers__filebeat_register_test_config
+  changed_when: global_handlers__filebeat_register_test_config.changed | bool
   notify:
     - 'Restart filebeat'
     - 'Commit changes in etckeeper'
@@ -14,8 +14,8 @@
 
 - name: Test filebeat output and restart
   ansible.builtin.command: 'filebeat test output'
-  register: filebeat__register_test_output
-  changed_when: filebeat__register_test_output.changed | bool
+  register: global_handlers__filebeat_register_test_output
+  changed_when: global_handlers__filebeat_register_test_output.changed | bool
   notify: [ 'Restart filebeat' ]
   when: (ansible_local.filebeat.installed | d()) | bool
 

--- a/ansible/roles/global_handlers/handlers/freeradius.yml
+++ b/ansible/roles/global_handlers/handlers/freeradius.yml
@@ -5,8 +5,8 @@
 
 - name: Check freeradius configuration and restart
   ansible.builtin.command: freeradius -C
-  register: freeradius__register_check_config
-  changed_when: freeradius__register_check_config.changed | bool
+  register: global_handlers__freeradius_register_check_config
+  changed_when: global_handlers__freeradius_register_check_config.changed | bool
   notify: [ 'Restart freeradius' ]
 
 - name: Restart freeradius

--- a/ansible/roles/global_handlers/handlers/gitlab.yml
+++ b/ansible/roles/global_handlers/handlers/gitlab.yml
@@ -5,12 +5,12 @@
 
 - name: Reconfigure GitLab Omnibus
   ansible.builtin.command: 'gitlab-ctl reconfigure'
-  register: gitlab__register_reconfigure
-  changed_when: gitlab__register_reconfigure.changed | bool
+  register: global_handlers__gitlab_register_reconfigure
+  changed_when: global_handlers__gitlab_register_reconfigure.changed | bool
   when: (ansible_local.gitlab.omnibus | d()) | bool
 
 - name: Restart GitLab Omnibus
   ansible.builtin.command: 'gitlab-ctl restart'
-  register: gitlab__register_restart
-  changed_when: gitlab__register_restart.changed | bool
+  register: global_handlers__gitlab_register_restart
+  changed_when: global_handlers__gitlab_register_restart.changed | bool
   when: (ansible_local.gitlab.omnibus | d()) | bool

--- a/ansible/roles/global_handlers/handlers/grub.yml
+++ b/ansible/roles/global_handlers/handlers/grub.yml
@@ -7,6 +7,6 @@
 
 - name: Update GRUB
   ansible.builtin.command: update-grub
-  register: handlers__register_grub_update
-  changed_when: handlers__register_grub_update.changed | bool
-  failed_when: ('error' in handlers__register_grub_update.stderr)
+  register: global_handlers__grub_register_update
+  changed_when: global_handlers__grub_register_update.changed | bool
+  failed_when: ('error' in global_handlers__grub_register_update.stderr)

--- a/ansible/roles/global_handlers/handlers/icinga.yml
+++ b/ansible/roles/global_handlers/handlers/icinga.yml
@@ -5,8 +5,8 @@
 
 - name: Check icinga2 configuration and restart
   ansible.builtin.command: icinga2 daemon -C
-  register: icinga__register_config_test
-  changed_when: icinga__register_config_test.changed | bool
+  register: global_handlers__icinga_register_config_test
+  changed_when: global_handlers__icinga_register_config_test.changed | bool
   notify: [ 'Restart icinga2' ]
 
 - name: Restart icinga2

--- a/ansible/roles/global_handlers/handlers/keepalived.yml
+++ b/ansible/roles/global_handlers/handlers/keepalived.yml
@@ -5,14 +5,14 @@
 
 - name: Check keepalived configuration and restart
   ansible.builtin.command: keepalived --config-test
-  register: keepalived__register_config_restart
-  changed_when: keepalived__register_config_restart.changed | bool
+  register: global_handlers__keepalived_register_config_restart
+  changed_when: global_handlers__keepalived_register_config_restart.changed | bool
   notify: [ 'Restart keepalived' ]
 
 - name: Check keepalived configuration and reload
   ansible.builtin.command: keepalived --config-test
-  register: keepalived__register_config_reload
-  changed_when: keepalived__register_config_reload.changed | bool
+  register: global_handlers__keepalived_register_config_reload
+  changed_when: global_handlers__keepalived_register_config_reload.changed | bool
   notify: [ 'Reload keepalived' ]
 
 - name: Restart keepalived

--- a/ansible/roles/global_handlers/handlers/metricbeat.yml
+++ b/ansible/roles/global_handlers/handlers/metricbeat.yml
@@ -5,8 +5,8 @@
 
 - name: Test metricbeat configuration and restart
   ansible.builtin.command: 'metricbeat test config'
-  register: metricbeat__register_test_config
-  changed_when: metricbeat__register_test_config.changed | bool
+  register: global_handlers__metricbeat_register_test_config
+  changed_when: global_handlers__metricbeat_register_test_config.changed | bool
   notify:
     - 'Restart metricbeat'
     - 'Commit changes in etckeeper'
@@ -14,8 +14,8 @@
 
 - name: Test metricbeat output and restart
   ansible.builtin.command: 'metricbeat test output'
-  register: metricbeat__register_test_output
-  changed_when: metricbeat__register_test_output.changed | bool
+  register: global_handlers__metricbeat_register_test_output
+  changed_when: global_handlers__metricbeat_register_test_output.changed | bool
   notify: [ 'Restart metricbeat' ]
   when: (ansible_local.metricbeat.installed | d()) | bool
 

--- a/ansible/roles/global_handlers/handlers/monit.yml
+++ b/ansible/roles/global_handlers/handlers/monit.yml
@@ -6,8 +6,8 @@
 
 - name: Test monit and reload
   ansible.builtin.command: monit -t
-  register: monit__register_check_config
-  changed_when: monit__register_check_config.changed | bool
+  register: global_handlers__monit_register_check_config
+  changed_when: global_handlers__monit_register_check_config.changed | bool
   notify: [ 'Reload monit' ]
 
 - name: Reload monit

--- a/ansible/roles/global_handlers/handlers/nfs_server.yml
+++ b/ansible/roles/global_handlers/handlers/nfs_server.yml
@@ -10,5 +10,5 @@
 
 - name: Reload NFS exports
   ansible.builtin.command: exportfs -ra
-  register: nfs_server__register_exportfs
-  changed_when: nfs_server__register_exportfs.changed | bool
+  register: global_handlers__nfs_server_register_exportfs
+  changed_when: global_handlers__nfs_server_register_exportfs.changed | bool

--- a/ansible/roles/global_handlers/handlers/nginx.yml
+++ b/ansible/roles/global_handlers/handlers/nginx.yml
@@ -6,14 +6,14 @@
 
 - name: Test nginx and restart
   ansible.builtin.command: nginx -t
-  register: nginx__register_check_restart
-  changed_when: nginx__register_check_restart.changed | bool
+  register: global_handlers__nginx_register_check_restart
+  changed_when: global_handlers__nginx_register_check_restart.changed | bool
   notify: [ 'Restart nginx' ]
 
 - name: Test nginx and reload
   ansible.builtin.command: nginx -t
-  register: nginx__register_check_reload
-  changed_when: nginx__register_check_reload.changed | bool
+  register: global_handlers__nginx_register_check_reload
+  changed_when: global_handlers__nginx_register_check_reload.changed | bool
   notify: [ 'Reload nginx' ]
 
 - name: Restart nginx

--- a/ansible/roles/global_handlers/handlers/opendkim.yml
+++ b/ansible/roles/global_handlers/handlers/opendkim.yml
@@ -5,14 +5,14 @@
 
 - name: Check opendkim and restart
   ansible.builtin.command: opendkim -n
-  register: opendkim__register_check_restart
-  changed_when: opendkim__register_check_restart.changed | bool
+  register: global_handlers__opendkim_register_check_restart
+  changed_when: global_handlers__opendkim_register_check_restart.changed | bool
   notify: [ 'Restart opendkim' ]
 
 - name: Check opendkim and reload
   ansible.builtin.command: opendkim -n
-  register: opendkim__register_check_reload
-  changed_when: opendkim__register_check_reload.changed | bool
+  register: global_handlers__opendkim_register_check_reload
+  changed_when: global_handlers__opendkim_register_check_reload.changed | bool
   notify: [ 'Reload opendkim' ]
   when: ansible_local | d() and ansible_local.opendkim | d() and
         ansible_local.opendkim.installed is defined and

--- a/ansible/roles/global_handlers/handlers/pki.yml
+++ b/ansible/roles/global_handlers/handlers/pki.yml
@@ -6,14 +6,14 @@
 
 - name: Update ca-certificates.crt
   ansible.builtin.command: update-ca-certificates
-  register: pki__register_update_cacerts
-  changed_when: pki__register_update_cacerts.changed | bool
+  register: global_handlers__pki_register_update_cacerts
+  changed_when: global_handlers__pki_register_update_cacerts.changed | bool
   notify: [ 'Install ca-certificates.crt into Postfix chroot' ]
 
 - name: Regenerate ca-certificates.crt
   ansible.builtin.command: update-ca-certificates --fresh
-  register: pki__register_regenerate_cacerts
-  changed_when: pki__register_regenerate_cacerts.changed | bool
+  register: global_handlers__pki_register_regenerate_cacerts
+  changed_when: global_handlers__pki_register_regenerate_cacerts.changed | bool
   notify: [ 'Install ca-certificates.crt into Postfix chroot' ]
 
 - name: Reconfigure ca-certificates
@@ -21,12 +21,12 @@
     DEBIAN_FRONTEND: 'noninteractive'
     DEBCONF_NONINTERACTIVE_SEEN: 'true'
   ansible.builtin.command: dpkg-reconfigure --frontend=noninteractive ca-certificates
-  register: pki__register_reconfigure_cacerts
-  changed_when: pki__register_reconfigure_cacerts.changed | bool
+  register: global_handlers__pki_register_reconfigure_cacerts
+  changed_when: global_handlers__pki_register_reconfigure_cacerts.changed | bool
   notify: [ 'Install ca-certificates.crt into Postfix chroot' ]
 
 - name: Install ca-certificates.crt into Postfix chroot
   ansible.builtin.shell: test -d /var/spool/postfix &&
          cp -f /etc/ssl/certs/ca-certificates.crt /var/spool/postfix/etc/ssl/certs/ca-certificates.crt || true
-  register: pki__register_postfix_chroot
-  changed_when: pki__register_postfix_chroot.changed | bool
+  register: global_handlers__pki_register_postfix_chroot
+  changed_when: global_handlers__pki_register_postfix_chroot.changed | bool

--- a/ansible/roles/global_handlers/handlers/postfix.yml
+++ b/ansible/roles/global_handlers/handlers/postfix.yml
@@ -9,20 +9,20 @@
   ansible.builtin.command: make
   args:
     chdir: '/etc/postfix'
-  register: handlers__register_postfix_make
+  register: global_handlers__postfix_register_make
   notify: [ 'Check postfix and reload' ]
-  changed_when: 'not handlers__register_postfix_make.stdout.startswith("make: Nothing to be done")'
+  changed_when: 'not global_handlers__postfix_register_make.stdout.startswith("make: Nothing to be done")'
 
 - name: Check postfix and restart
   ansible.builtin.command: /usr/sbin/postfix -c /etc/postfix check
-  register: postfix__register_check_restart
-  changed_when: postfix__register_check_restart.changed | bool
+  register: global_handlers__postfix_register_check_restart
+  changed_when: global_handlers__postfix_register_check_restart.changed | bool
   notify: [ 'Restart postfix' ]
 
 - name: Check postfix and reload
   ansible.builtin.command: /usr/sbin/postfix -c /etc/postfix check
-  register: postfix__register_check_reload
-  changed_when: postfix__register_check_reload.changed | bool
+  register: global_handlers__postfix_register_check_reload
+  changed_when: global_handlers__postfix_register_check_reload.changed | bool
   notify: [ 'Reload postfix' ]
 
 - name: Restart postfix

--- a/ansible/roles/global_handlers/handlers/radvd.yml
+++ b/ansible/roles/global_handlers/handlers/radvd.yml
@@ -5,8 +5,8 @@
 
 - name: Test radvd and restart
   ansible.builtin.command: radvd --configtest
-  register: radvd__register_test_config
-  changed_when: radvd__register_test_config.changed | bool
+  register: global_handlers__radvd_register_test_config
+  changed_when: global_handlers__radvd_register_test_config.changed | bool
   notify: [ 'Restart radvd' ]
 
 - name: Restart radvd

--- a/ansible/roles/global_handlers/handlers/resolvconf.yml
+++ b/ansible/roles/global_handlers/handlers/resolvconf.yml
@@ -5,10 +5,10 @@
 
 - name: Apply static resolvconf configuration
   ansible.builtin.command: '/usr/local/lib/resolvconf-static'
-  register: resolvconf__register_static_config
-  changed_when: resolvconf__register_static_config.changed | bool
+  register: global_handlers__resolvconf_register_static_config
+  changed_when: global_handlers__resolvconf_register_static_config.changed | bool
 
 - name: Refresh /etc/resolv.conf
   ansible.builtin.command: 'resolvconf -u'
-  register: resolvconf__register_refresh
-  changed_when: resolvconf__register_refresh.changed | bool
+  register: global_handlers__resolvconf_register_refresh
+  changed_when: global_handlers__resolvconf_register_refresh.changed | bool

--- a/ansible/roles/global_handlers/handlers/rstudio_server.yml
+++ b/ansible/roles/global_handlers/handlers/rstudio_server.yml
@@ -5,8 +5,8 @@
 
 - name: Verify rstudio-server
   ansible.builtin.command: rstudio-server test-config
-  register: rstudio_server__register_test_config
-  changed_when: rstudio_server__register_test_config.changed | bool
+  register: global_handlers__rstudio_server_register_test_config
+  changed_when: global_handlers__rstudio_server_register_test_config.changed | bool
   notify: [ 'Restart rstudio-server' ]
 
 - name: Restart rstudio-server

--- a/ansible/roles/global_handlers/handlers/rsyslog.yml
+++ b/ansible/roles/global_handlers/handlers/rsyslog.yml
@@ -6,8 +6,8 @@
 - name: Check and restart rsyslogd
   ansible.builtin.command: rsyslogd -N 1
   notify: [ 'Restart rsyslogd' ]
-  register: rsyslog__register_test_config
-  changed_when: rsyslog__register_test_config.changed | bool
+  register: global_handlers__rsyslog_register_test_config
+  changed_when: global_handlers__rsyslog_register_test_config.changed | bool
   when: (ansible_local.rsyslog.installed | d()) | bool
 
 - name: Restart rsyslogd

--- a/ansible/roles/global_handlers/handlers/samba.yml
+++ b/ansible/roles/global_handlers/handlers/samba.yml
@@ -5,8 +5,8 @@
 
 - name: Check samba config
   ansible.builtin.command: testparm -s
-  register: samba__register_test_config
-  changed_when: samba__register_test_config.changed | bool
+  register: global_handlers__samba_register_test_config
+  changed_when: global_handlers__samba_register_test_config.changed | bool
   notify: [ 'Reload nmbd', 'Reload smbd' ]
 
 - name: Reload nmbd

--- a/ansible/roles/global_handlers/handlers/sshd.yml
+++ b/ansible/roles/global_handlers/handlers/sshd.yml
@@ -6,8 +6,8 @@
 
 - name: Test sshd configuration and restart
   ansible.builtin.command: sshd -t
-  register: sshd__register_test_config
-  changed_when: sshd__register_test_config.changed | bool
+  register: global_handlers__sshd_register_test_config
+  changed_when: global_handlers__sshd_register_test_config.changed | bool
   notify: [ 'Restart sshd' ]
 
 - name: Restart sshd

--- a/ansible/roles/global_handlers/handlers/systemd.yml
+++ b/ansible/roles/global_handlers/handlers/systemd.yml
@@ -14,6 +14,6 @@
   ansible.builtin.command: 'systemd-tmpfiles --create'
   listen:
     - 'Create temporary files'
-  register: systemd__register_tmpfiles
-  changed_when: systemd__register_tmpfiles.stdout != ''
+  register: global_handlers__systemd_register_tmpfiles
+  changed_when: global_handlers__systemd_register_tmpfiles.stdout != ''
   when: ansible_service_mgr == 'systemd'

--- a/ansible/roles/global_handlers/handlers/telegraf.yml
+++ b/ansible/roles/global_handlers/handlers/telegraf.yml
@@ -5,8 +5,8 @@
 
 - name: Check telegraf and restart
   ansible.builtin.command: '/usr/bin/telegraf --test --config /etc/telegraf/telegraf.conf --config-directory /etc/telegraf/telegraf.d'
-  register: telegraf__register_config_test
-  changed_when: telegraf__register_config_test.changed | bool
+  register: global_handlers__telegraf_register_config_test
+  changed_when: global_handlers__telegraf_register_config_test.changed | bool
   notify: [ 'Restart telegraf' ]
 
 - name: Restart telegraf

--- a/ansible/roles/global_handlers/handlers/unbound.yml
+++ b/ansible/roles/global_handlers/handlers/unbound.yml
@@ -5,8 +5,8 @@
 
 - name: Check unbound configuration and reload
   ansible.builtin.command: unbound-checkconf /etc/unbound/unbound.conf
-  register: unbound__register_config_test
-  changed_when: unbound__register_config_test.changed | bool
+  register: global_handlers__unbound_register_config_test
+  changed_when: global_handlers__unbound_register_config_test.changed | bool
   notify: [ 'Reload unbound' ]
 
 - name: Reload unbound

--- a/ansible/roles/global_handlers/handlers/zabbix_agent.yml
+++ b/ansible/roles/global_handlers/handlers/zabbix_agent.yml
@@ -5,15 +5,15 @@
 
 - name: Check zabbix-agent and restart
   ansible.builtin.command: '/usr/sbin/zabbix_agentd --print'
-  register: zabbix_agent__register_config_test_c
-  changed_when: zabbix_agent__register_config_test_c.changed | bool
+  register: global_handlers__zabbix_agent_register_config_test_c
+  changed_when: global_handlers__zabbix_agent_register_config_test_c.changed | bool
   when: zabbix_agent__flavor == 'C'
   notify: [ 'Restart zabbix-agent' ]
 
 - name: Check zabbix-agent2 and restart
   ansible.builtin.command: '/usr/sbin/zabbix_agent2 --print'
-  register: zabbix_agent__register_config_test_go
-  changed_when: zabbix_agent__register_config_test_go.changed | bool
+  register: global_handlers__zabbix_agent_register_config_test_go
+  changed_when: global_handlers__zabbix_agent_register_config_test_go.changed | bool
   when: zabbix_agent__flavor == 'Go'
   notify: [ 'Restart zabbix-agent2' ]
 


### PR DESCRIPTION
This change is required due to ansible-lint now enforcing variable namespacing in handlers. Since DebOps has most of the handlers in a separate 'global_handlers' role, the variables need to be renamed to conform to the naming scheme.