### PR TITLE
[postgresql_server] Correct the template to also use postgresql_server__version

### DIFF
--- a/ansible/roles/postgresql_server/templates/etc/postgresql/postgresql.conf.j2
+++ b/ansible/roles/postgresql_server/templates/etc/postgresql/postgresql.conf.j2
@@ -333,7 +333,7 @@ log_rotation_size = {{ item.log_rotation_size | d('10MB') }}
 
 # These are relevant when logging to syslog:
 syslog_facility = '{{ item.syslog_facility | d("LOCAL0") }}'
-syslog_ident = '{{ item.syslog_ident | d("postgresql-" + item.version + "-" + item.name) }}'
+syslog_ident = '{{ item.syslog_ident | d("postgresql-" + (item.version | d(postgresql_server__version)) + "-" + item.name) }}'
 
 
 # - When to Log -


### PR DESCRIPTION

Introduced by "Change default syslog ident" and should be handled like other version lookups to avoid
'AnsibleUndefinedVariable: ''dict object'' has no attribute ''version'''