### PR TITLE
[logrotate] Add support for systemd timer

### DIFF
--- a/ansible/playbooks/service/logrotate.yml
+++ b/ansible/playbooks/service/logrotate.yml
@@ -17,6 +17,7 @@
 
     - role: cron
       tags: [ 'role::cron', 'skip::cron' ]
+      when: logrotate__scheduler == 'cron'
 
     - role: logrotate
       tags: [ 'role::logrotate', 'skip::logrotate' ]

--- a/ansible/roles/logrotate/defaults/main.yml
+++ b/ansible/roles/logrotate/defaults/main.yml
@@ -37,19 +37,39 @@ logrotate__base_packages: [ 'logrotate' ]
 logrotate__packages: []
 
                                                                    # ]]]
+# .. envvar:: logrotate__scheduler [[[
+#
+# Scheduler used to periodically apply log rotation.  Supported values are:
+# ``cron``, ``systemd``.
+logrotate__scheduler: '{{
+    "cron" if (ansible_distribution == "Debian"
+               and ansible_distribution_major_version is version("11", "<="))
+           or (ansible_distribution == "Ubuntu"
+               and ansible_distribution_major_version is version("24", "<="))
+           else
+    "systemd"
+  }}'
+
+                                                                   # ]]]
+# .. envvar:: logrotate__scheduler_period [[[
+#
+# Specify how often :ref:`logrotate__config` should execute log rotation. By
+# default the ``logrotate`` command will be executed daily. Available periods
+# are: ``hourly``, ``daily``, ``weekly``, ``monthly``.
+logrotate__scheduler_period: 'daily'
+
+                                                                   # ]]]
 # .. envvar:: logrotate__cron_period [[[
 #
-# Specify how often :program:`cron` should execute log rotation. By default the
-# ``logrotate`` command will be executed daily. Available periods are:
-# ``hourly``, ``daily``, ``weekly``, ``monthly``.
-logrotate__cron_period: 'daily'
+# Deprecated, use :ref:`logrotate__scheduler_period` instead.
+logrotate__cron_period: '{{ logrotate__scheduler_period }}'
 
                                                                    # ]]]
 # .. envvar:: logrotate__default_period [[[
 #
 # Select the default log rotation period. Supported values are: ``daily``,
-# ``weekly``, ``monthly``, ``yearly``. The ``logrotate`` command is currently
-# run daily via a :program:`cron` script.
+# ``weekly``, ``monthly``, ``yearly``.  The ``logrotate`` command is currently
+# run daily via a :program:`cron` script or a :program:`systemd` timer.
 logrotate__default_period: 'weekly'
 
                                                                    # ]]]

--- a/ansible/roles/logrotate/tasks/main.yml
+++ b/ansible/roles/logrotate/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 # Copyright (C) 2016-2017 Maciej Delmanowski <drybjed@gmail.com>
 # Copyright (C) 2016-2017 DebOps <https://debops.org/>
+# Copyright (C) 2025-2026 Seven beep <seven-beep@entreparentheses.xyz>
 # SPDX-License-Identifier: GPL-3.0-only
 
 - name: Install required packages
@@ -19,7 +20,9 @@
     executable: 'bash'
   register: logrotate__register_cron_diversion
   changed_when: False
-  when: logrotate__enabled | bool
+  when:
+    - logrotate__enabled | bool
+    - logrotate__scheduler == "cron"
 
 - name: Remove previous cron log rotation
   debops.debops.dpkg_divert:
@@ -28,6 +31,7 @@
     state: 'absent'
     delete: True
   when: (logrotate__enabled | bool and
+         logrotate__scheduler == "cron" and
          logrotate__register_cron_diversion.stdout | d() and
          logrotate__register_cron_diversion.stdout | d() !=
          ('/etc/cron.' + logrotate__cron_period + '/logrotate'))
@@ -37,7 +41,20 @@
     path: '/etc/cron.daily/logrotate'
     divert: '/etc/cron.{{ logrotate__cron_period }}/logrotate'
   when: (logrotate__enabled | bool and
+         logrotate__scheduler == "cron" and
          logrotate__cron_period in ['hourly', 'weekly', 'monthly'])
+
+- name: Configure systemd logrotate.timer {{ logrotate__scheduler_period }}
+  ansible.builtin.template:
+    src: 'etc/systemd/system/logrotate.timer.j2'
+    dest: '/etc/systemd/system/logrotate.timer'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  when:
+    - logrotate__enabled | bool
+    - logrotate__scheduler == "systemd"
+  notify: [ 'Reload systemd daemon' ]
 
 - name: Add/remove diversion of the logrotate config file
   debops.debops.dpkg_divert:

--- a/ansible/roles/logrotate/templates/etc/systemd/system/logrotate.timer.j2
+++ b/ansible/roles/logrotate/templates/etc/systemd/system/logrotate.timer.j2
@@ -1,0 +1,16 @@
+{# Copyright (C) 2025 Seven beep <seven-beep@entreparentheses.xyz>
+ # SPDX-License-Identifier: GPL-3.0-only
+ #}
+# {{ ansible_managed }}
+
+[Unit]
+Description={{ logrotate__scheduler_period | title }} rotation of log files
+Documentation=man:logrotate(8) man:logrotate.conf(5)
+
+[Timer]
+OnCalendar={{ logrotate__scheduler_period }}
+AccuracySec=1h
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Since Debian Bookworm, logrotate is not implemented via cron but with a systemd
timer.  On previous systems and Ubuntu, the crontab and the systemd timer are
both installed.

While is it not harmful to have multiple schedulers calling logrotate, it is
unnecessary, and it also pull cron as a dependency on systems where it may not
be installed.

This commit shift from cron to a systemd timer starting at Debian>11 and
Ubuntu>24.