### PR TITLE
fix(postgresql_server): missing default version in postgresql.conf.j2

### DIFF
--- a/ansible/roles/postgresql_server/templates/etc/postgresql/postgresql.conf.j2
+++ b/ansible/roles/postgresql_server/templates/etc/postgresql/postgresql.conf.j2
@@ -333,7 +333,7 @@ log_rotation_size = {{ item.log_rotation_size | d('10MB') }}
 
 # These are relevant when logging to syslog:
 syslog_facility = '{{ item.syslog_facility | d("LOCAL0") }}'
-syslog_ident = '{{ item.syslog_ident | d("postgresql-" + item.version + "-" + item.name) }}'
+syslog_ident = '{{ item.syslog_ident | d("postgresql-" + (item.version | d(postgresql_server__version)) + "-" + item.name) }}'
 
 
 # - When to Log -


### PR DESCRIPTION
Hello,

With not version provided in `postgresql_server__cluster_main` (which is the
default), the template fails to render postgresql.conf.

Kind regards.