### PR TITLE
fix(postgresql_server): keyring with no postgresql_server__upstream

### DIFF
--- a/ansible/playbooks/service/postgresql_server.yml
+++ b/ansible/playbooks/service/postgresql_server.yml
@@ -19,6 +19,7 @@
       tags: [ 'role::keyring', 'skip::keyring', 'role::postgresql_server' ]
       keyring__dependent_apt_keys:
         - '{{ postgresql_server__keyring__dependent_apt_keys }}'
+      when: postgresql_server__upstream is truthy
 
     - role: etc_services
       tags: [ 'role::etc_services', 'skip::etc_services' ]


### PR DESCRIPTION
When `postgresql_server__upstream` is false, we should not install the upstream
postgresql apt keys.

Notice that the keyring role seems broken on Trixie as apt-key is deprecated, so this commit actually help to fix the playbook when `postgresql_server__upstream` is false, however without addressing the root cause.