### PR TITLE
slapd: Support for Debian 13 Trixie

### DIFF
--- a/ansible/roles/slapd/defaults/main.yml
+++ b/ansible/roles/slapd/defaults/main.yml
@@ -427,10 +427,13 @@ slapd__tls_private_key: '{{ slapd__pki_path + "/" + slapd__pki_realm + "/" + sla
                                                                    # ]]]
 # .. envvar:: slapd__tls_cipher_suite [[[
 #
-# TLS cipher suite required by the server. On Debian, you need to use the
-# GnuTLS cipher suite names, because :command:`slapd` daemon is compiled
-# against GnuTLS instead of OpenSSL.
-slapd__tls_cipher_suite: 'SECURE256:PFS:-VERS-SSL3.0:-VERS-TLS-ALL:+VERS-TLS1.2:-SHA1:-ARCFOUR-128'
+# TLS cipher suite required by the server. On Debian and up to Bookword
+# included, you need to use the GnuTLS cipher suite names, because
+# :command:`slapd` daemon is compiled against GnuTLS instead of OpenSSL. On
+# Trixie, you need to use OpenSSL.
+slapd__tls_cipher_suite: '{{ ECDHE:DHE:!aNULL:!eNULL:!SHA1:!RC4:@SECLEVEL=2
+                             if ansible_distribution_release in ["trixie"]
+                             else SECURE256:PFS:-VERS-SSL3.0:-VERS-TLS-ALL:+VERS-TLS1.2:-SHA1:-ARCFOUR-128 }}'
                                                                    # ]]]
                                                                    # ]]]
 # OpenLDAP configuration tasks [[[
@@ -728,6 +731,7 @@ slapd__default_tasks:
   - name: 'Configure TLS cipher suites'
     dn: 'cn=config'
     attributes:
+      olcTLSProtocolMin: '3.3'
       olcTLSCipherSuite: '{{ slapd__tls_cipher_suite }}'
     state: '{{ "exact" if slapd__pki | bool else "init" }}'
 

--- a/ansible/roles/slapd/defaults/main.yml
+++ b/ansible/roles/slapd/defaults/main.yml
@@ -1080,7 +1080,6 @@ slapd__structure_tasks:
     objectClass: 'organizationalRole'
     attributes:
       cn: 'Hidden Object Viewer'
-      memberOf: '{{ (["cn=Hidden Objects", "ou=Groups"] + slapd__base_dn) | join(",") }}'
       description: 'LDAP objects which can see hidden objects'
 
   - name: 'Create cn=Hidden Objects group'
@@ -1091,7 +1090,6 @@ slapd__structure_tasks:
       member:
         - '{{ (["cn=Hidden Objects", "ou=Groups"] + slapd__base_dn) | join(",") }}'
         - '{{ (["cn=Hidden Object Viewer", "ou=Roles"] + slapd__base_dn) | join(",") }}'
-      memberOf: '{{ (["cn=Hidden Objects", "ou=Groups"] + slapd__base_dn) | join(",") }}'
       description: 'LDAP objects which are accessible only by privileged accounts'
 
   - name: 'Create cn=UNIX SSH users group'

--- a/ansible/roles/slapd/defaults/main.yml
+++ b/ansible/roles/slapd/defaults/main.yml
@@ -657,7 +657,7 @@ slapd__default_tasks:
     state: 'exact'
 
   - name: 'Configure LastBind overlay in the main database'
-    dn: 'olcOverlay={11}lastbind,olcDatabase={1}mdb,cn=config'
+    dn: [ 'olcDatabase={1}mdb', 'cn=config' ]
     attributes:
       olcLastBindPrecision: '{{ (60 * 60 * 24) }}'
     state: 'exact'

--- a/ansible/roles/slapd/defaults/main.yml
+++ b/ansible/roles/slapd/defaults/main.yml
@@ -62,12 +62,9 @@ slapd__default_schemas:
   # 'organizationalStructure' object, used to define basic directory structure.
   - '{{ slapd__debops_schema_path + "/orgstructure.schema" }}'
 
-  # Password Policy schema, included in the 'slapd' APT package
-  - '/etc/ldap/schema/ppolicy.schema'
-
   # Support for 'host' and 'authorizedService' attributes, useful for granular
   # access control to services and machines
-  - '/etc/ldap/schema/fusiondirectory/ldapns.schema'
+  - '{{ slapd__debops_schema_path + "/ldapns.schema" }}'
 
   # Custom schema which defines a 'groupOfEntries' LDAP object which can create
   # empty groups
@@ -77,7 +74,7 @@ slapd__default_schemas:
   - '{{ slapd__debops_schema_path + "/openssh-lpk.schema" }}'
 
   # Support for 'sudo' rules in LDAP directory
-  - '/etc/ldap/schema/fusiondirectory/sudo.schema'
+  - '{{ slapd__debops_schema_path + "/sudo.schema" }}'
 
   # Support for 'eduPerson' and 'eduOrg' schema, included in DebOps
   - '{{ slapd__debops_schema_path + "/eduperson.schema" }}'
@@ -158,7 +155,7 @@ slapd__base_packages: [ 'slapd', 'ldap-utils', 'ssl-cert', 'libldap-common' ]
 #
 # List of APT packages to install in preparation to use ``rfc2307bis`` schema
 # instead of the ``nis`` schema.
-slapd__rfc2307bis_packages: [ 'fusiondirectory-schema' ]
+slapd__rfc2307bis_packages: [ 'schema2ldif' ]
 
                                                                    # ]]]
 # .. envvar:: slapd__schema_packages [[[
@@ -169,8 +166,8 @@ slapd__rfc2307bis_packages: [ 'fusiondirectory-schema' ]
 # of packages should be synchronized.
 slapd__schema_packages:
 
-  # Support for 'sudo' rules in LDAP
-  - 'fusiondirectory-plugin-sudo-schema'
+  # Convert schema to ldif ldap-load-schema
+  - 'schema2ldif'
 
                                                                    # ]]]
 # .. envvar:: slapd__packages [[[

--- a/ansible/roles/slapd/files/etc/ldap/schema/debops/ldapns.schema
+++ b/ansible/roles/slapd/files/etc/ldap/schema/debops/ldapns.schema
@@ -1,0 +1,29 @@
+# ldapns.schema - LDAP Name Service Additional Schema
+#
+# Copyright (C) 2003      lukeh Exp
+# Copyright (C) 2012      The FusionDirectory project Oganization <https://www.fusiondirectory.org/>
+# SPDX-License-Identifier: GPL-2.0-only
+
+# From: https://gitlab.fusiondirectory.org/fusiondirectory/fd/-/raw/dev/contrib/openldap/ldapns.schema
+
+# $Id: ldapns.schema,v 1.3 2003/05/29 12:57:29 lukeh Exp $
+# LDAP Name Service Additional Schema
+# http://www.iana.org/assignments/gssapi-service-names
+
+attributetype ( 1.3.6.1.4.1.5322.17.2.1 NAME 'authorizedService'
+	DESC 'IANA GSS-API authorized service name'
+	EQUALITY caseIgnoreMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+
+objectclass ( 1.3.6.1.4.1.5322.17.1.1 NAME 'authorizedServiceObject'
+	DESC 'Auxiliary object class for adding authorizedService attribute'
+	SUP top
+	AUXILIARY
+	MAY authorizedService )
+
+objectclass ( 1.3.6.1.4.1.5322.17.1.2 NAME 'hostObject'
+	DESC 'Auxiliary object class for adding host attribute'
+	SUP top
+	AUXILIARY
+	MAY host )
+

--- a/ansible/roles/slapd/files/etc/ldap/schema/debops/rfc2307bis.schema
+++ b/ansible/roles/slapd/files/etc/ldap/schema/debops/rfc2307bis.schema
@@ -1,0 +1,295 @@
+# rfc2307bis.schema - LDAP as a Network Information Service
+#
+# Copyright (C) 2020      The FusionDirectory project Oganization <https://www.fusiondirectory.org/>
+# SPDX-License-Identifier: GPL-2.0-only
+
+# From: https://gitlab.fusiondirectory.org/fusiondirectory/fd-plugins/-/raw/fusiondirectory-1.4/mixedgroups/contrib/openldap/rfc2307bis.schema
+
+# builtin
+#
+#attributetype ( 1.3.6.1.1.1.1.0 NAME 'uidNumber'
+#  DESC 'An integer uniquely identifying a user in an administrative domain'
+#  EQUALITY integerMatch
+#  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+#  SINGLE-VALUE )
+
+# builtin
+#
+#attributetype ( 1.3.6.1.1.1.1.1 NAME 'gidNumber'
+#  DESC 'An integer uniquely identifying a group in an
+#        administrative domain'
+#  EQUALITY integerMatch
+#  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+#  SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.2 NAME 'gecos'
+  DESC 'The GECOS field; the common name'
+  EQUALITY caseIgnoreIA5Match
+  SUBSTR caseIgnoreIA5SubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.3 NAME 'homeDirectory'
+  DESC 'The absolute path to the home directory'
+  EQUALITY caseExactIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.4 NAME 'loginShell'
+  DESC 'The path to the login shell'
+  EQUALITY caseExactIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.5 NAME 'shadowLastChange'
+  EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+  SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.6 NAME 'shadowMin'
+  EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+  SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.7 NAME 'shadowMax'
+  EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+  SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.8 NAME 'shadowWarning'
+  EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+  SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.9 NAME 'shadowInactive'
+  EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+  SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.10 NAME 'shadowExpire'
+  EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+  SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.11 NAME 'shadowFlag'
+  EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+  SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.12 NAME 'memberUid'
+  EQUALITY caseExactIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.1.1.1.13 NAME 'memberNisNetgroup'
+  EQUALITY caseExactIA5Match
+  SUBSTR caseExactIA5SubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.1.1.1.14 NAME 'nisNetgroupTriple'
+  DESC 'Netgroup triple'
+  EQUALITY caseIgnoreIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.1.1.1.15 NAME 'ipServicePort'
+  DESC 'Service port number'
+  EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+  SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.16 NAME 'ipServiceProtocol'
+  DESC 'Service protocol name'
+  SUP name )
+
+attributetype ( 1.3.6.1.1.1.1.17 NAME 'ipProtocolNumber'
+  DESC 'IP protocol number'
+  EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+  SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.18 NAME 'oncRpcNumber'
+  DESC 'ONC RPC number'
+  EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+  SINGLE-VALUE )
+attributetype ( 1.3.6.1.1.1.1.19 NAME 'ipHostNumber'
+  DESC 'IPv4 addresses as a dotted decimal omitting leading
+        zeros or IPv6 addresses as defined in RFC2373'
+  SUP name )
+
+attributetype ( 1.3.6.1.1.1.1.20 NAME 'ipNetworkNumber'
+  DESC 'IP network as a dotted decimal, eg. 192.168,
+        omitting leading zeros'
+  SUP name
+  SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.21 NAME 'ipNetmaskNumber'
+  DESC 'IP netmask as a dotted decimal, eg. 255.255.255.0,
+        omitting leading zeros'
+  EQUALITY caseIgnoreIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.22 NAME 'macAddress'
+  DESC 'MAC address in maximal, colon separated hex
+        notation, eg. 00:00:92:90:ee:e2'
+  EQUALITY caseIgnoreIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.1.1.1.23 NAME 'bootParameter'
+  DESC 'rpc.bootparamd parameter'
+  EQUALITY caseExactIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.1.1.1.24 NAME 'bootFile'
+  DESC 'Boot image name'
+  EQUALITY caseExactIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.1.1.1.26 NAME 'nisMapName'
+  DESC 'Name of a A generic NIS map'
+  SUP name )
+
+attributetype ( 1.3.6.1.1.1.1.27 NAME 'nisMapEntry'
+  DESC 'A generic NIS entry'
+  EQUALITY caseExactIA5Match
+  SUBSTR caseExactIA5SubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.28 NAME 'nisPublicKey'
+  DESC 'NIS public key'
+  EQUALITY octetStringMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.29 NAME 'nisSecretKey'
+  DESC 'NIS secret key'
+  EQUALITY octetStringMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.30 NAME 'nisDomain'
+  DESC 'NIS domain'
+  EQUALITY caseIgnoreIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26)
+
+attributetype ( 1.3.6.1.1.1.1.31 NAME 'automountMapName'
+  DESC 'automount Map Name'
+  EQUALITY caseExactIA5Match
+  SUBSTR caseExactIA5SubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.32 NAME 'automountKey'
+  DESC 'Automount Key value'
+  EQUALITY caseExactIA5Match
+  SUBSTR caseExactIA5SubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.33 NAME 'automountInformation'
+  DESC 'Automount information'
+  EQUALITY caseExactIA5Match
+  SUBSTR caseExactIA5SubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE )
+
+objectclass ( 1.3.6.1.1.1.2.0 NAME 'posixAccount' SUP top AUXILIARY
+  DESC 'Abstraction of an account with POSIX attributes'
+  MUST ( cn $ uid $ uidNumber $ gidNumber $ homeDirectory )
+  MAY ( userPassword $ loginShell $ gecos $
+        description ) )
+
+objectclass ( 1.3.6.1.1.1.2.1 NAME 'shadowAccount' SUP top AUXILIARY
+  DESC 'Additional attributes for shadow passwords'
+  MUST uid
+  MAY ( userPassword $ description $
+        shadowLastChange $ shadowMin $ shadowMax $
+        shadowWarning $ shadowInactive $
+        shadowExpire $ shadowFlag ) )
+
+objectclass ( 1.3.6.1.1.1.2.2 NAME 'posixGroup' SUP top AUXILIARY
+  DESC 'Abstraction of a group of accounts'
+  MUST gidNumber
+  MAY ( userPassword $ memberUid $
+        description ) )
+
+objectclass ( 1.3.6.1.1.1.2.3 NAME 'ipService' SUP top STRUCTURAL
+  DESC 'Abstraction an Internet Protocol service.
+        Maps an IP port and protocol (such as tcp or udp)
+        to one or more names; the distinguished value of
+        the cn attribute denotes the services canonical
+        name'
+  MUST ( cn $ ipServicePort $ ipServiceProtocol )
+  MAY description )
+
+objectclass ( 1.3.6.1.1.1.2.4 NAME 'ipProtocol' SUP top STRUCTURAL
+  DESC 'Abstraction of an IP protocol. Maps a protocol number
+        to one or more names. The distinguished value of the cn
+        attribute denotes the protocols canonical name'
+  MUST ( cn $ ipProtocolNumber )
+  MAY description )
+
+objectclass ( 1.3.6.1.1.1.2.5 NAME 'oncRpc' SUP top STRUCTURAL
+  DESC 'Abstraction of an Open Network Computing (ONC)
+       [RFC1057] Remote Procedure Call (RPC) binding.
+       This class maps an ONC RPC number to a name.
+       The distinguished value of the cn attribute denotes
+       the RPC services canonical name'
+  MUST ( cn $ oncRpcNumber )
+  MAY description )
+
+objectclass ( 1.3.6.1.1.1.2.6 NAME 'ipHost' SUP top AUXILIARY
+  DESC 'Abstraction of a host, an IP device. The distinguished
+        value of the cn attribute denotes the hosts canonical
+        name. Device SHOULD be used as a structural class'
+  MUST ( cn $ ipHostNumber )
+  MAY ( userPassword $ l $ description $ manager ) )
+
+objectclass ( 1.3.6.1.1.1.2.7 NAME 'ipNetwork' SUP top STRUCTURAL
+  DESC 'Abstraction of a network. The distinguished value of
+        the cn attribute denotes the networks canonical name'
+  MUST ipNetworkNumber
+  MAY ( cn $ ipNetmaskNumber $ l $ description $ manager ) )
+
+objectclass ( 1.3.6.1.1.1.2.8 NAME 'nisNetgroup' SUP top STRUCTURAL
+  DESC 'Abstraction of a netgroup. May refer to other netgroups'
+  MUST cn
+  MAY ( nisNetgroupTriple $ memberNisNetgroup $ description ) )
+
+objectclass ( 1.3.6.1.1.1.2.9 NAME 'nisMap' SUP top STRUCTURAL
+  DESC 'A generic abstraction of a NIS map'
+  MUST nisMapName
+  MAY description )
+
+objectclass ( 1.3.6.1.1.1.2.10 NAME 'nisObject' SUP top STRUCTURAL
+  DESC 'An entry in a NIS map'
+  MUST ( cn $ nisMapEntry $ nisMapName )
+  MAY description )
+
+objectclass ( 1.3.6.1.1.1.2.11 NAME 'ieee802Device' SUP top AUXILIARY
+  DESC 'A device with a MAC address; device SHOULD be
+        used as a structural class'
+  MAY macAddress )
+
+objectclass ( 1.3.6.1.1.1.2.12 NAME 'bootableDevice' SUP top AUXILIARY
+  DESC 'A device with boot parameters; device SHOULD be
+        used as a structural class'
+  MAY ( bootFile $ bootParameter ) )
+
+objectclass ( 1.3.6.1.1.1.2.14 NAME 'nisKeyObject' SUP top AUXILIARY
+  DESC 'An object with a public and secret key'
+  MUST ( cn $ nisPublicKey $ nisSecretKey )
+  MAY ( uidNumber $ description ) )
+
+objectclass ( 1.3.6.1.1.1.2.15 NAME 'nisDomainObject' SUP top AUXILIARY
+  DESC 'Associates a NIS domain with a naming context'
+  MUST nisDomain )
+
+objectclass ( 1.3.6.1.1.1.2.16 NAME 'automountMap' SUP top STRUCTURAL
+  MUST ( automountMapName )
+  MAY description )
+
+objectclass ( 1.3.6.1.1.1.2.17 NAME 'automount' SUP top STRUCTURAL
+  DESC 'Automount information'
+  MUST ( automountKey $ automountInformation )
+  MAY description )
+## namedObject is needed for groups without members
+objectclass ( 1.3.6.1.4.1.5322.13.1.1 NAME 'namedObject' SUP top
+       STRUCTURAL MAY cn )
+

--- a/ansible/roles/slapd/files/etc/ldap/schema/debops/sudo.schema
+++ b/ansible/roles/slapd/files/etc/ldap/schema/debops/sudo.schema
@@ -1,0 +1,76 @@
+# sudo.schema - LDAP sudo schema
+#
+# Copyright (C) 2014      The FusionDirectory project Oganization <https://www.fusiondirectory.org/>
+# SPDX-License-Identifier: GPL-2.0-only
+
+# From: https://gitlab.fusiondirectory.org/fusiondirectory/fd-plugins/-/raw/dev/sudo/contrib/openldap/sudo.schema
+
+attributetype ( 1.3.6.1.4.1.15953.9.1.1
+    NAME 'sudoUser'
+    DESC 'User(s) who may  run sudo'
+    EQUALITY caseExactIA5Match
+    SUBSTR caseExactIA5SubstringsMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.4.1.15953.9.1.2
+    NAME 'sudoHost'
+    DESC 'Host(s) who may run sudo'
+    EQUALITY caseExactIA5Match
+    SUBSTR caseExactIA5SubstringsMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.4.1.15953.9.1.3
+    NAME 'sudoCommand'
+    DESC 'Command(s) to be executed by sudo'
+    EQUALITY caseExactIA5Match
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.4.1.15953.9.1.4
+    NAME 'sudoRunAs'
+    DESC 'User(s) impersonated by sudo (deprecated)'
+    EQUALITY caseExactIA5Match
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.4.1.15953.9.1.5
+    NAME 'sudoOption'
+    DESC 'Options(s) followed by sudo'
+    EQUALITY caseExactIA5Match
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.4.1.15953.9.1.6
+    NAME 'sudoRunAsUser'
+    DESC 'User(s) impersonated by sudo'
+    EQUALITY caseExactIA5Match
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.4.1.15953.9.1.7
+    NAME 'sudoRunAsGroup'
+    DESC 'Group(s) impersonated by sudo'
+    EQUALITY caseExactIA5Match
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.4.1.15953.9.1.8
+    NAME 'sudoNotBefore'
+    DESC 'Start of time interval for which the entry is valid'
+    EQUALITY generalizedTimeMatch
+    ORDERING generalizedTimeOrderingMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.24 )
+
+attributetype ( 1.3.6.1.4.1.15953.9.1.9
+    NAME 'sudoNotAfter'
+    DESC 'End of time interval for which the entry is valid'
+    EQUALITY generalizedTimeMatch
+    ORDERING generalizedTimeOrderingMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.24 )
+
+attributetype ( 1.3.6.1.4.1.15953.9.1.10
+    NAME 'sudoOrder'
+    DESC 'an integer to order the sudoRole entries'
+    EQUALITY integerMatch
+    ORDERING integerOrderingMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 )
+
+objectclass ( 1.3.6.1.4.1.15953.9.2.1 NAME 'sudoRole' SUP top STRUCTURAL
+    DESC 'Sudoer Entries'
+    MUST ( cn )
+    MAY ( sudoUser $ sudoHost $ sudoCommand $ sudoRunAs $ sudoRunAsUser $ sudoRunAsGroup $ sudoOption $ sudoOrder $ sudoNotBefore $ sudoNotAfter $ description ))

--- a/ansible/roles/slapd/files/script/ldap-load-schema
+++ b/ansible/roles/slapd/files/script/ldap-load-schema
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 
 # Copyright (C) 2015-2019 Maciej Delmanowski <drybjed@gmail.com>
-# Copyright (C) 2015-2019 DebOps <https://debops.org/>
+# Copyright (C) 2015-2025 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-only
 
 # Check if specified LDAP schema file is loaded in the local slapd cn=config
 # database. If not, try loading it in the server.
-
 
 set -o nounset -o pipefail -o errexit
 
@@ -51,8 +50,11 @@ if [[ "${schema_file}" == *.ldif ]] ; then
 # The schema is not converted to ldif, defer to a helper script
 elif [[ "${schema_file}" == *.schema ]] ; then
 
-    if type fusiondirectory-insert-schema > /dev/null ; then
-        fusiondirectory-insert-schema -i "${schema_file}"
+    if type schema2ldif > /dev/null ; then
+        # convert schema to ldif
+        schema2ldif "${schema_file}" >"${schema_file/%.schema/.ldif}"
+        relaunch the script with the ldif to load it
+        $0 "${schema_file/%.schema/.ldif}"
     else
         printf "Error: %s needs to be in the .ldif format\\n" "${schema_file}" && exit 1
     fi

--- a/ansible/roles/slapd/tasks/prepare_rfc2307bis.yml
+++ b/ansible/roles/slapd/tasks/prepare_rfc2307bis.yml
@@ -1,14 +1,26 @@
 ---
 # Copyright (C) 2016-2019 Maciej Delmanowski <drybjed@gmail.com>
-# Copyright (C) 2016-2019 DebOps <https://debops.org/>
+# Copyright (C) 2016-2025 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-only
 
-- name: Install APT packages with rfc2307bis LDAP schema
+- name: Install APT packages requiered for rfc2307bis
   ansible.builtin.package:
-    name: '{{ slapd__rfc2307bis_packages }}'
+    name: '{{ slapd__rfc2307bis_packages  }}'
     state: 'present'
-  register: slapd__register_rfc2307bis_packages
-  until: slapd__register_rfc2307bis_packages is succeeded
+  register: slapd__register_rfc2307bis
+  until: slapd__register_rfc2307bis is succeeded
+
+- name: Ensure that DebOps schema directory exists
+  ansible.builtin.file:
+    path: '{{ slapd__debops_schema_path }}'
+    state: 'directory'
+    mode: '0755'
+
+- name: Copy custom DebOps rf2307bis schemas to the OpenLDAP host
+  ansible.builtin.copy:
+    src: 'etc/ldap/schema/debops/rfc2307bis.schema'
+    dest: '{{ slapd__debops_schema_path + "/" }}'
+    mode: '0644'
 
 - name: Divert the original NIS schema included in Debian
   debops.debops.dpkg_divert:
@@ -17,19 +29,17 @@
     - 'nis.schema'
     - 'nis.ldif'
 
-- name: Convert FusionDirectory rfc2307bis schema to ldif
+- name: Convert rfc2307bis schema to ldif
   ansible.builtin.shell: schema2ldif rfc2307bis.schema > rfc2307bis.ldif
   args:
-    creates: '/etc/ldap/schema/fusiondirectory/rfc2307bis.ldif'
-    chdir: '/etc/ldap/schema/fusiondirectory'
-  when: '"fusiondirectory-schema" in slapd__rfc2307bis_packages'
+    creates: '{{ slapd__debops_schema_path + "/rfc2307bis.ldif" }}'
+    chdir: '{{ slapd__debops_schema_path }}'
 
 - name: Symlink the new rfc2307bis schema in place of NIS schema
   ansible.builtin.file:
     state: 'link'
     path: '/etc/ldap/schema/{{ item | replace("rfc2307bis", "nis") }}'
-    src: '{{ (("fusiondirectory-schema" in slapd__rfc2307bis_packages)
-              | ternary("fusiondirectory", "gosa")) + "/" + item }}'
+    src: '{{ slapd__debops_schema_path + "/" + item }}'
     mode: '0644'
   loop: [ 'rfc2307bis.schema', 'rfc2307bis.ldif' ]
   when: not ansible_check_mode | bool

--- a/ansible/roles/slapd/tasks/prepare_rfc2307bis.yml
+++ b/ansible/roles/slapd/tasks/prepare_rfc2307bis.yml
@@ -3,7 +3,7 @@
 # Copyright (C) 2016-2025 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-only
 
-- name: Install APT packages requiered for rfc2307bis
+- name: Install APT packages required for rfc2307bis
   ansible.builtin.package:
     name: '{{ slapd__rfc2307bis_packages  }}'
     state: 'present'


### PR DESCRIPTION
Adaptation of the slapd role to take into accounts the changes introduced in Trixie:

- inclusion of the FusionDirectory schema in the role, since the Debian packages are no more available in Trixie
- compilation of slapd against OpenSSL instead of GnuTLS
- memberOf should not be set since it is a dynamic value
- Since OpenLDAP 2.6 `olcLastBindPrecision` is required to be configured on its backend entry instead and the overlay


Thanks to @mathieumd for the initial trouble shouting of the role for Trixie. Some test and adaptation might be necessary for Ubuntu 24.04 (https://github.com/debops/debops/issues/2625)