### PR TITLE
[pki] Make sure changes to realm configuration are applied

### DIFF
--- a/ansible/roles/pki/tasks/main.yml
+++ b/ansible/roles/pki/tasks/main.yml
@@ -185,8 +185,7 @@
     --dhparam "{{ (item.dhparam | d(pki_dhparam)) | bool | lower }}"
     --dhparam-file "{{ item.dhparam_file | d(pki_dhparam_file) }}"
     --selfsigned-sign-days "{{ item.selfsigned_sign_days | d('365') }}"
-  args:
-    creates: '{{ pki_root + "/realms/" + item.name + "/config/realm.conf" }}'
+
   loop: '{{ q("flattened", pki_realms
                            + pki_group_realms
                            + pki_host_realms


### PR DESCRIPTION
command.args.creates causes task "Initialize PKI realms" to be skipped if realm.conf already exists.

This means if user changes a pki_ variable (for instance pki_acme_contacts) for an existing realm, change would not be applied until user removes config/realm.conf to force task re-execution.

Solution: always re-execute "Initialize PKI realms" and rely on pki-realm for idempotency.