### PR TITLE
[users] Allow user to configure default group append behavior.

### DIFF
--- a/ansible/roles/users/defaults/main.yml
+++ b/ansible/roles/users/defaults/main.yml
@@ -39,6 +39,17 @@ users__acl_enabled: '{{ True if ("acl" in users__base_packages) else False }}'
 # a defined shell either.
 users__default_shell: ''
                                                                    # ]]]
+# .. envvar:: users__groups_append [[[
+#
+# Boolean. Controls the default behavior of 'append' setting in General account parameters.
+# # Can be overridden per user.
+# If `True`, the specified groups will be added to the list of existing groups
+# the account belongs to.
+# If `False`, all other groups than those present on the group list will be removed stripped.
+# Can be overridden by setting `append` in a given user's general account parameters.
+users__groups_append: True
+
+                                                                   # ]]]
                                                                    # ]]]
 # APT packages [[[
 # ----------------

--- a/ansible/roles/users/tasks/main.yml
+++ b/ansible/roles/users/tasks/main.yml
@@ -108,7 +108,7 @@
                        | intersect(getent_group.keys()))
                       if (item.groups is defined or (item.chroot | d()) | bool)
                       else omit }}'
-    append:       '{{ item.append | d(True) }}'
+    append:       '{{ item.append | d(users__groups_append) }}'
     state:        '{{ item.state | d("present") }}'
     create_home:  '{{ item.create_home | d(omit) }}'
   loop: '{{ users__combined_accounts | debops.debops.parse_kv_items }}'

--- a/docs/ansible/roles/users/defaults-detailed.rst
+++ b/docs/ansible/roles/users/defaults-detailed.rst
@@ -123,9 +123,10 @@ General account parameters
   Only existing groups will be added to the account.
 
 ``append``
-  Optional, boolean. If ``True`` (default), the specified groups will be added
+  Optional, boolean. If ``True``, the specified groups will be added
   to the list of existing groups the account belongs to. If ``False``, all
   other groups than those present on the group list will be removed stripped.
+  Defaults to the value of ``users__groups_append`` (``True``).
 
 ``comment``
   Optional. A comment, or GECOS field configured for a specified UNIX account.


### PR DESCRIPTION
Because users configuration can span many group_vars/ and hosts_vars/, current role forces one to set 'append' for each user if one wants to always set 'append' to 'false'.

This is not practical with users configuration spread in many group_vars/ and hosts/vars/.

The solution is to give the user the ability to set a default value through a global default variable.
It is set to 'True' by default, therefore will not alter existing inventories.

See #2641