### PR TITLE
Fix changed_when syntax return sometimes None which is no a boolean

### DIFF
--- a/ansible/roles/python/tasks/main_raw.yml
+++ b/ansible/roles/python/tasks/main_raw.yml
@@ -30,9 +30,9 @@
     LANG=C apt-get --no-install-recommends -yq install {{ python__core_packages | join(" ") }}
   register: python__register_raw
   when: python__enabled | bool
-  changed_when: (not python__register_raw.stdout
-                     | regex_search('0 upgraded, 0 newly installed, 0 to remove and \d+ not upgraded\.') or
-                 python__register_raw.stdout | regex_search('.+ set to manually installed\.'))
+  changed_when: >
+    (python__register_raw.stdout is not search('0 upgraded, 0 newly installed, 0 to remove and \\d+ not upgraded\\.'))
+    or (python__register_raw.stdout is search(' set to manually installed\\.'))
   tags: [ 'meta::facts' ]
 
 - name: Reset connection to the host


### PR DESCRIPTION
Regex_search return None when not found which trigger warning

```
regex_search('.+ set to manually installed\.')
```


```
[DEPRECATION WARNING]: Conditional result at location
/home/tr4sk/scripts/tiersbox/srv/provisioning/venv/lib/python3.14/site-packages/debops/_data
/ansible/collections/ansible_collections/debops/debops/roles/python/tasks/main_raw.yml 33:17
 was of type 'NoneType'. Conditional results should only be True or False. The result was
interpreted as False. This feature will be removed in version 2.19. Deprecation warnings can
 be disabled by setting deprecation_warnings=False in ansible.cfg.```