### PR TITLE
feat(sshd): Add post-quantum key exchange algorithms

### DIFF
--- a/ansible/roles/sshd/defaults/main.yml
+++ b/ansible/roles/sshd/defaults/main.yml
@@ -847,6 +847,19 @@ sshd__ciphers_additional: []
 # oldest. Newer version supersedes older version.
 sshd__kex_algorithms_map:
 
+  # https://www.openssh.org/pq.html
+  '9.9': [ 'mlkem768x25519-sha256',
+           'sntrup761x25519-sha512', 'sntrup761x25519-sha512@openssh.com',
+           'curve25519-sha256@libssh.org', 'ecdh-sha2-nistp521',
+           'ecdh-sha2-nistp384', 'ecdh-sha2-nistp256',
+           'diffie-hellman-group-exchange-sha256' ]
+
+  # https://www.openssh.org/pq.html
+  '9.0': [ 'sntrup761x25519-sha512', 'sntrup761x25519-sha512@openssh.com',
+           'curve25519-sha256@libssh.org', 'ecdh-sha2-nistp521',
+           'ecdh-sha2-nistp384', 'ecdh-sha2-nistp256',
+           'diffie-hellman-group-exchange-sha256' ]
+
   # Source: https://wiki.mozilla.org/Security/Guidelines/OpenSSH
   '6.5': [ 'curve25519-sha256@libssh.org', 'ecdh-sha2-nistp521',
            'ecdh-sha2-nistp384', 'ecdh-sha2-nistp256',


### PR DESCRIPTION
I classified adding support for the post-quantum key exchange algorithm as a feature, but this could be seen as a fix (or even as a security fix) as this fixes the ability for anyone to be able to replay a recorded ssh session wiith a pre post-quantum key exchange algorithm once quantum computers are able to do it.

Before with sshd equal or above 10 we get:
```
** WARNING: connection is not using a post-quantum key exchange algorithm.
** This session may be vulnerable to "store now, decrypt later" attacks.
** The server may need to be upgraded. See https://openssh.com/pq.html

```