### PR TITLE
[nfs] change `| d()` to `is defined`

### DIFF
--- a/ansible/roles/nfs/tasks/main.yml
+++ b/ansible/roles/nfs/tasks/main.yml
@@ -32,7 +32,7 @@
   loop: '{{ q("flattened", nfs__shares
                            + nfs__group_shares
                            + nfs__host_shares) }}'
-  when: item.path | d() and item.src | d() and item.state | d('mounted') == 'present'
+  when: item.path is defined and item.src is defined and item.state | d('mounted') == 'present'
 
 - name: Manage NFS mount points
   ansible.posix.mount:
@@ -48,7 +48,7 @@
                            + nfs__group_shares
                            + nfs__host_shares) }}'
   register: nfs__register_devices
-  when: item.path | d() and item.src | d()
+  when: item.path is defined and item.src is defined
 
 - name: Restart 'remote-fs.target' systemd unit
   ansible.builtin.systemd:  # noqa no-handler

--- a/ansible/roles/nfs_server/tasks/main.yml
+++ b/ansible/roles/nfs_server/tasks/main.yml
@@ -45,7 +45,7 @@
     group: '{{ item.group | d("root") }}'
     mode:  '{{ item.mode | d("0755") }}'
   loop: '{{ q("flattened", nfs_server__combined_exports) }}'
-  when: item.path | d() and item.state | d('present') != 'absent' and item.acl | d()
+  when: item.path is defined and item.state | d('present') != 'absent' and item.acl is defined
 
 - name: Bind mount requested directories
   ansible.posix.mount:
@@ -55,7 +55,7 @@
     fstype: 'none'
     state: 'mounted'
   loop: '{{ q("flattened", nfs_server__combined_exports) }}'
-  when: item.path | d() and item.state | d('present') != 'absent' and item.acl | d() and item.bind | d()
+  when: item.path is defined and item.state | d('present') != 'absent' and item.acl is defined and item.bind is defined
 
 - name: Configure NFS exports
   ansible.builtin.template:


### PR DESCRIPTION
## Problem

With ansible-core 2.19 or later (released last year), "broken conditionals" (i.e. `when:` statements which are truthy/falsy but not a boolean type) are deprecated. This is causing the error

<details>
<summary><code>Conditionals must have a boolean result.</code></summary>

```
Task failed.
Origin: /neuro/labs/grantlab/research/prod/sysadmin/collections/ansible_collections/debops/debops/roles/nfs/tasks/main.yml:37:3

35   when: item.path | d() and item.src | d() and item.state | d('mounted') == 'present'
36
37 - name: Manage NFS mount points
     ^ column 3

<<< caused by >>>

Conditional result (True) was derived from value of type 'str' at '/neuro/users/jennings.zhang/sysadmin/inventory/group_vars/eleonora.yml:31:10'. Conditionals must have a boolean result.
Origin: /neuro/labs/grantlab/research/prod/sysadmin/collections/ansible_collections/debops/debops/roles/nfs/tasks/main.yml:51:9

49                            + nfs__host_shares) }}'
50   register: nfs__register_devices
51   when: item.path | d() and item.src | d()
           ^ column 9

Broken conditionals can be temporarily allowed with the `ALLOW_BROKEN_CONDITIONALS` configuration option.
```

</details>

## Proposed Changes

In this PR i fixed the `tasks/main.yml` file for only the roles `debops.nfs` and `debops.nfs_server`.

## Alternate Solution

Note, it is possible to fix these in bulk albeit but inconsistently using a naive global find-and-replace:

```ShellSession
fd --type f . roles/*/tasks | sad '(when: .+) \| d\(\)' '$1 is defined'
```

(btw those commands are [fd](https://github.com/sharkdp/fd) and [sad](https://github.com/ms-jpq/sad))

> [!TIP]
> Anyone stumbling across this problem before it gets solved can set [`allow_broken_conditionals`](https://docs.ansible.com/projects/ansible/latest/reference_appendices/config.html#allow-broken-conditionals)