### PR TITLE
fix: use default callback with result_format=yaml instead of deprecated community.general.yaml

### DIFF
--- a/src/debops/_data/templates/projectdir/legacy/debops.cfg.j2
+++ b/src/debops/_data/templates/projectdir/legacy/debops.cfg.j2
@@ -31,7 +31,9 @@ display_skipped_hosts = {{ env['ANSIBLE_DISPLAY_SKIPPED_HOSTS'] | d('false') }}
 retry_files_enabled = {{ env['ANSIBLE_RETRY_FILES_ENABLED'] | d('false') }}
 
 # Make the default output of 'ansible-playbook' easier to read by a human.
-stdout_callback = {{ env['ANSIBLE_STDOUT_CALLBACK'] | d('yaml') }}
+# Use default callback with result_format=yaml (community.general.yaml is deprecated).
+stdout_callback = {{ env['ANSIBLE_STDOUT_CALLBACK'] | d('default') }}
+result_format = {{ env['ANSIBLE_RESULT_FORMAT'] | d('yaml') }}
 
 # Define the list of the built-in callback plugins enabled by default.
 callbacks_enabled = {{ env['ANSIBLE_CALLBACKS_ENABLED'] | d('timer') }}

--- a/src/debops/_data/templates/projectdir/modern/view.yml.j2
+++ b/src/debops/_data/templates/projectdir/modern/view.yml.j2
@@ -47,7 +47,9 @@ views:
         retry_files_enabled: {{ env["ANSIBLE_RETRY_FILES_ENABLED"] | d("false") }}
 
         # Make the default output of 'ansible-playbook' easier to read by a human.
-        stdout_callback: '{{ env["ANSIBLE_STDOUT_CALLBACK"] | d("yaml") }}'
+        # Use default callback with result_format=yaml (community.general.yaml is deprecated).
+        stdout_callback: '{{ env["ANSIBLE_STDOUT_CALLBACK"] | d("default") }}'
+        result_format: '{{ env["ANSIBLE_RESULT_FORMAT"] | d("yaml") }}'
 
         # Define the list of the built-in callback plugins enabled by default.
         callbacks_enabled: '{{ env["ANSIBLE_CALLBACKS_ENABLED"] | d("timer") }}'


### PR DESCRIPTION
Replace `stdout_callback=yaml` with `stdout_callback=default` and `result_format=yaml` in both modern view template and legacy `debops.cfg`. Fixes deprecation warning from Ansible 2.13+ (`community.general.yaml` superseded by `ansible.builtin.default` with `result_format=yaml`).
