### PR TITLE
fix(python): use explicit boolean in when conditional to avoid AnsibleUnicode deprecation

### DIFF
--- a/ansible/roles/apt_preferences/tasks/main.yml
+++ b/ansible/roles/apt_preferences/tasks/main.yml
@@ -82,12 +82,12 @@
                            + apt_preferences__host_list
                            + apt_preferences__dependent_list) }}'
   when: ((((item.state | d('present')) != 'absent' and (not (item.delete | d() | bool))) and
-          (item.package | d() or item.packages | d())) and
-         (item.raw | d() or
+          (item.package | d() or item.packages | d()) | bool) and
+         ((item.raw | d() or
           item.version | d() or
           (item.pin is undefined and
            (item.backports is undefined or
             (item.backports is iterable and item.backports and
              ansible_distribution_release in item.backports)) and
             ansible_distribution_release in apt_preferences__next_release.keys()) or
-           item.pin | d()))
+           item.pin | d()) | bool))

--- a/ansible/roles/apt_preferences/tasks/main.yml
+++ b/ansible/roles/apt_preferences/tasks/main.yml
@@ -82,12 +82,12 @@
                            + apt_preferences__host_list
                            + apt_preferences__dependent_list) }}'
   when: ((((item.state | d('present')) != 'absent' and (not (item.delete | d() | bool))) and
-          (item.package | d() or item.packages | d()) | bool) and
-         ((item.raw | d() or
-          item.version | d() or
+          (item.package | d() | length > 0 or item.packages | d() | length > 0)) and
+         (item.raw | d() | length > 0 or
+          item.version | d() | length > 0 or
           (item.pin is undefined and
            (item.backports is undefined or
             (item.backports is iterable and item.backports and
              ansible_distribution_release in item.backports)) and
             ansible_distribution_release in apt_preferences__next_release.keys()) or
-           item.pin | d()) | bool))
+           item.pin | d() | length > 0))

--- a/ansible/roles/atd/tasks/main.yml
+++ b/ansible/roles/atd/tasks/main.yml
@@ -59,8 +59,8 @@
                            + atd_host_allow) }}'
   when: (atd_enabled | bool and
          (atd_default_allow | d() or atd_allow | d() or
-          atd_group_allow | d() or atd_host_allow | d()) and
-          item | d())
+          atd_group_allow | d() or atd_host_allow | d()) | bool and
+         (item | d()) | bool)
   tags: [ 'role::atd:users' ]
 
 - name: Remove /etc/at.allow if list is empty

--- a/ansible/roles/atd/tasks/main.yml
+++ b/ansible/roles/atd/tasks/main.yml
@@ -59,8 +59,8 @@
                            + atd_host_allow) }}'
   when: (atd_enabled | bool and
          (atd_default_allow | d() or atd_allow | d() or
-          atd_group_allow | d() or atd_host_allow | d()) | bool and
-         (item | d()) | bool)
+          atd_group_allow | d() or atd_host_allow | d()) | length > 0 and
+         item | d() | length > 0)
   tags: [ 'role::atd:users' ]
 
 - name: Remove /etc/at.allow if list is empty

--- a/ansible/roles/dhparam/handlers/main.yml
+++ b/ansible/roles/dhparam/handlers/main.yml
@@ -18,5 +18,5 @@
     units: '{{ dhparam__generate_init_units }}'
     unique: True
   when: (dhparam__generate_init | bool and
-         (ansible_local | d()) | bool and (ansible_local.atd | d()) | bool and
+         ansible_local | d() | length > 0 and ansible_local.atd | d() | length > 0 and
          ansible_local.atd.enabled | bool)

--- a/ansible/roles/dhparam/handlers/main.yml
+++ b/ansible/roles/dhparam/handlers/main.yml
@@ -18,5 +18,5 @@
     units: '{{ dhparam__generate_init_units }}'
     unique: True
   when: (dhparam__generate_init | bool and
-         (ansible_local | d() and ansible_local.atd | d() and
-          ansible_local.atd.enabled | bool))
+         (ansible_local | d()) | bool and (ansible_local.atd | d()) | bool and
+         ansible_local.atd.enabled | bool)

--- a/ansible/roles/dhparam/tasks/main.yml
+++ b/ansible/roles/dhparam/tasks/main.yml
@@ -33,7 +33,7 @@
 - name: Assert that required software is installed
   ansible.builtin.assert:
     that:
-      - 'dhparam__register_version is defined and (dhparam__register_version.stdout | bool)'
+      - '(dhparam__register_version is defined and dhparam__register_version.stdout) | bool'
   delegate_to: 'localhost'
   become: False
   run_once: True

--- a/ansible/roles/dhparam/tasks/main.yml
+++ b/ansible/roles/dhparam/tasks/main.yml
@@ -33,7 +33,8 @@
 - name: Assert that required software is installed
   ansible.builtin.assert:
     that:
-      - '(dhparam__register_version is defined and dhparam__register_version.stdout) | bool'
+      - dhparam__register_version is defined
+      - dhparam__register_version.stdout | length > 0
   delegate_to: 'localhost'
   become: False
   run_once: True

--- a/ansible/roles/dhparam/tasks/main.yml
+++ b/ansible/roles/dhparam/tasks/main.yml
@@ -33,7 +33,7 @@
 - name: Assert that required software is installed
   ansible.builtin.assert:
     that:
-      - 'dhparam__register_version is defined and dhparam__register_version.stdout'
+      - 'dhparam__register_version is defined and (dhparam__register_version.stdout | bool)'
   delegate_to: 'localhost'
   become: False
   run_once: True

--- a/ansible/roles/etckeeper/tasks/main.yml
+++ b/ansible/roles/etckeeper/tasks/main.yml
@@ -123,7 +123,7 @@
     name: '{{ etckeeper__vcs_user }}'
     email: '{{ etckeeper__vcs_email }}'
   when: etckeeper__enabled | bool and etckeeper__vcs == 'git' and
-        etckeeper__vcs_user | d() and etckeeper__vcs_email | d()
+        (etckeeper__vcs_user | d()) | bool and (etckeeper__vcs_email | d()) | bool
 
 - name: Remove e-mail notification hook script
   ansible.builtin.file:

--- a/ansible/roles/etckeeper/tasks/main.yml
+++ b/ansible/roles/etckeeper/tasks/main.yml
@@ -123,7 +123,7 @@
     name: '{{ etckeeper__vcs_user }}'
     email: '{{ etckeeper__vcs_email }}'
   when: etckeeper__enabled | bool and etckeeper__vcs == 'git' and
-        (etckeeper__vcs_user | d()) | bool and (etckeeper__vcs_email | d()) | bool
+        etckeeper__vcs_user | d() | length > 0 and etckeeper__vcs_email | d() | length > 0
 
 - name: Remove e-mail notification hook script
   ansible.builtin.file:

--- a/ansible/roles/netbase/tasks/main.yml
+++ b/ansible/roles/netbase/tasks/main.yml
@@ -70,7 +70,8 @@
   loop_control:
     label: '{{ {item.name: (item.value | d([])) | selectattr("name", "defined") | map(attribute="name") | list} }}'
   notify: [ 'Refresh host facts' ]
-  when: netbase__enabled | bool and netbase__hosts_config_type == 'lineinfile' and (item.name | d()) | bool
+  when: netbase__enabled | bool and netbase__hosts_config_type == 'lineinfile' and
+        item.name | d() | length > 0
 
 - name: Manage entries in /etc/networks
   ansible.builtin.lineinfile:  # noqa no-tabs

--- a/ansible/roles/netbase/tasks/main.yml
+++ b/ansible/roles/netbase/tasks/main.yml
@@ -70,7 +70,7 @@
   loop_control:
     label: '{{ {item.name: (item.value | d([])) | selectattr("name", "defined") | map(attribute="name") | list} }}'
   notify: [ 'Refresh host facts' ]
-  when: netbase__enabled | bool and netbase__hosts_config_type == 'lineinfile' and item.name | d()
+  when: netbase__enabled | bool and netbase__hosts_config_type == 'lineinfile' and (item.name | d()) | bool
 
 - name: Manage entries in /etc/networks
   ansible.builtin.lineinfile:  # noqa no-tabs

--- a/ansible/roles/pki/tasks/main.yml
+++ b/ansible/roles/pki/tasks/main.yml
@@ -85,7 +85,7 @@
   delegate_to: 'localhost'
   become: False
   run_once: True
-  when: pki_authorities | d() and pki_dependent_authorities | d()
+  when: (pki_authorities | d()) | bool and (pki_dependent_authorities | d()) | bool
 # .. ]]]
 
 # Create scripts and library/secrets directory [[[
@@ -106,7 +106,7 @@
   become: False
   delegate_to: 'localhost'
   run_once: True
-  when: (pki_authorities or pki_dependent_authorities)
+  when: (pki_authorities or pki_dependent_authorities) | bool
 
 - name: Install remote PKI scripts
   ansible.builtin.copy:
@@ -404,7 +404,7 @@
   register: pki_register_sign_by_host
   become: False
   run_once: True
-  when: (pki_authorities or pki_dependent_authorities)
+  when: (pki_authorities or pki_dependent_authorities) | bool
   changed_when: pki_register_sign_by_host.stdout | d()
 # ]]]
 

--- a/ansible/roles/pki/tasks/main.yml
+++ b/ansible/roles/pki/tasks/main.yml
@@ -85,7 +85,7 @@
   delegate_to: 'localhost'
   become: False
   run_once: True
-  when: (pki_authorities | d()) | bool and (pki_dependent_authorities | d()) | bool
+  when: pki_authorities | d() | length > 0 and pki_dependent_authorities | d() | length > 0
 # .. ]]]
 
 # Create scripts and library/secrets directory [[[
@@ -106,7 +106,7 @@
   become: False
   delegate_to: 'localhost'
   run_once: True
-  when: (pki_authorities or pki_dependent_authorities) | bool
+  when: pki_authorities | d() | length > 0 or pki_dependent_authorities | d() | length > 0
 
 - name: Install remote PKI scripts
   ansible.builtin.copy:
@@ -404,7 +404,7 @@
   register: pki_register_sign_by_host
   become: False
   run_once: True
-  when: (pki_authorities or pki_dependent_authorities) | bool
+  when: pki_authorities | d() | length > 0 or pki_dependent_authorities | d() | length > 0
   changed_when: pki_register_sign_by_host.stdout | d()
 # ]]]
 

--- a/ansible/roles/python/tasks/main.yml
+++ b/ansible/roles/python/tasks/main.yml
@@ -44,8 +44,8 @@
     dest: '/etc/ansible/facts.d/python.fact'
     mode: '0755'
   notify: [ 'Refresh host facts' ]
-  when: (python__enabled | bool and ansible_local | d() and
-         ansible_local.python | d() and
+  when: (python__enabled | bool and ansible_local | d() | length > 0 and
+         ansible_local.python | d() | length > 0 and
          not ansible_local.python.configured | bool)
 
 - name: Re-read local facts if they have been modified

--- a/ansible/roles/python/tasks/main_raw.yml
+++ b/ansible/roles/python/tasks/main_raw.yml
@@ -10,7 +10,7 @@
     fi
   register: python__register_etc_hosts
   changed_when: python__register_etc_hosts.stdout == ''
-  when: python__enabled | bool and python__raw_etc_hosts | d()
+  when: (python__enabled | bool) and ((python__raw_etc_hosts | default('')) | length > 0)
 
 - name: Detect the OS release manually, no Ansible facts available
   ansible.builtin.raw: grep -E '^VERSION=' /etc/os-release | tr -d '(")' | cut -d" " -f2

--- a/ansible/roles/secret/tasks/main.yml
+++ b/ansible/roles/secret/tasks/main.yml
@@ -17,5 +17,5 @@
   become: False
   delegate_to: 'localhost'
   loop: '{{ [secret__directories, secret_directories | d([])] | flatten }}'
-  when: (secret__directories or secret_directories | d()) | bool and (item | bool)
+  when: (secret__directories or secret_directories | d()) | length > 0 and item | length > 0
   changed_when: False

--- a/ansible/roles/secret/tasks/main.yml
+++ b/ansible/roles/secret/tasks/main.yml
@@ -17,5 +17,5 @@
   become: False
   delegate_to: 'localhost'
   loop: '{{ [secret__directories, secret_directories | d([])] | flatten }}'
-  when: (secret__directories or secret_directories | d()) and item
+  when: (secret__directories or secret_directories | d()) | bool and (item | bool)
   changed_when: False

--- a/ansible/roles/system_groups/tasks/main.yml
+++ b/ansible/roles/system_groups/tasks/main.yml
@@ -60,8 +60,8 @@
     validate: '/usr/sbin/visudo -cf %s'
   with_items: '{{ system_groups__combined_list | debops.debops.parse_kv_items }}'
   when: system_groups__enabled | bool and system_groups__sudo_enabled | bool and
-        item.name | d() and item.state | d('present') not in ['init', 'absent', 'ignore'] and
-        item.sudoers | d()
+        (item.name | d()) | bool and item.state | d('present') not in ['init', 'absent', 'ignore'] and
+        (item.sudoers | d()) | bool
 
 - name: Remove tmpfiles configuration if not specified
   ansible.builtin.file:
@@ -69,8 +69,8 @@
     state: 'absent'
   with_items: '{{ system_groups__combined_list | debops.debops.parse_kv_items }}'
   when: system_groups__enabled | bool and ansible_service_mgr == 'systemd' and
-        item.name | d() and item.state | d('present') not in ['init', 'absent', 'ignore'] and
-        not item.tmpfiles | d()
+        (item.name | d()) | bool and item.state | d('present') not in ['init', 'absent', 'ignore'] and
+        not ((item.tmpfiles | d()) | bool)
 
 - name: Generate tmpfiles configuration for UNIX system groups
   ansible.builtin.template:
@@ -82,8 +82,8 @@
   with_items: '{{ system_groups__combined_list | debops.debops.parse_kv_items }}'
   notify: [ 'Create temporary files' ]
   when: system_groups__enabled | bool and ansible_service_mgr == 'systemd' and
-        item.name | d() and item.state | d('present') not in ['init', 'absent', 'ignore'] and
-        item.tmpfiles | d()
+        (item.name | d()) | bool and item.state | d('present') not in ['init', 'absent', 'ignore'] and
+        (item.tmpfiles | d()) | bool
 
 - name: Make sure that Ansible local facts directory exists
   ansible.builtin.file:

--- a/ansible/roles/system_groups/tasks/main.yml
+++ b/ansible/roles/system_groups/tasks/main.yml
@@ -60,8 +60,8 @@
     validate: '/usr/sbin/visudo -cf %s'
   with_items: '{{ system_groups__combined_list | debops.debops.parse_kv_items }}'
   when: system_groups__enabled | bool and system_groups__sudo_enabled | bool and
-        (item.name | d()) | bool and item.state | d('present') not in ['init', 'absent', 'ignore'] and
-        (item.sudoers | d()) | bool
+        item.name | d() | length > 0 and item.state | d('present') not in ['init', 'absent', 'ignore'] and
+        item.sudoers | d() | length > 0
 
 - name: Remove tmpfiles configuration if not specified
   ansible.builtin.file:
@@ -69,8 +69,8 @@
     state: 'absent'
   with_items: '{{ system_groups__combined_list | debops.debops.parse_kv_items }}'
   when: system_groups__enabled | bool and ansible_service_mgr == 'systemd' and
-        (item.name | d()) | bool and item.state | d('present') not in ['init', 'absent', 'ignore'] and
-        not ((item.tmpfiles | d()) | bool)
+        item.name | d() | length > 0 and item.state | d('present') not in ['init', 'absent', 'ignore'] and
+        not (item.tmpfiles | d() | length > 0)
 
 - name: Generate tmpfiles configuration for UNIX system groups
   ansible.builtin.template:
@@ -82,8 +82,8 @@
   with_items: '{{ system_groups__combined_list | debops.debops.parse_kv_items }}'
   notify: [ 'Create temporary files' ]
   when: system_groups__enabled | bool and ansible_service_mgr == 'systemd' and
-        (item.name | d()) | bool and item.state | d('present') not in ['init', 'absent', 'ignore'] and
-        (item.tmpfiles | d()) | bool
+        item.name | d() | length > 0 and item.state | d('present') not in ['init', 'absent', 'ignore'] and
+        item.tmpfiles | d() | length > 0
 
 - name: Make sure that Ansible local facts directory exists
   ansible.builtin.file:

--- a/ansible/roles/system_users/tasks/main.yml
+++ b/ansible/roles/system_users/tasks/main.yml
@@ -267,9 +267,9 @@
     label: '{{ {"name": (item.prefix | d(system_users__prefix)) + item.name,
                 "state": item.state | d("present"),
                 "forward": item.forward | d()} }}'
-  when: (system_users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (system_users__enabled | bool and (item.name | d()) | bool and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and
-         item.create_home | d(True) and item.forward | d() and (item.user | d(True)) | bool)
+         item.create_home | d(True) and (item.forward | d()) | bool and (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
   tags: [ 'role::system_users:forward', 'skip::system_users:forward', 'skip::check' ]
 
@@ -295,11 +295,11 @@
   check_mode: False
   register: system_users__register_dotfiles
   changed_when: ('Already up to date.' not in system_users__register_dotfiles.stdout_lines | regex_replace('-', ' '))
-  when: (system_users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (system_users__enabled | bool and (item.name | d()) | bool and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and (item.create_home | d(True)) | bool and
          (ansible_local | d() and ansible_local.yadm | d() and (ansible_local.yadm.installed | d()) | bool) and
          (item.dotfiles | d(item.dotfiles_enabled | d(system_users__dotfiles_enabled))) | bool and
-         (item.dotfiles_repo | d(system_users__dotfiles_repo)) and (item.user | d(True)) | bool)
+         (item.dotfiles_repo | d(system_users__dotfiles_repo)) | bool and (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
   tags: [ 'role::system_users:dotfiles', 'skip::system_users:dotfiles', 'skip::check' ]
 

--- a/ansible/roles/system_users/tasks/main.yml
+++ b/ansible/roles/system_users/tasks/main.yml
@@ -267,9 +267,9 @@
     label: '{{ {"name": (item.prefix | d(system_users__prefix)) + item.name,
                 "state": item.state | d("present"),
                 "forward": item.forward | d()} }}'
-  when: (system_users__enabled | bool and (item.name | d()) | bool and item.name != 'root' and
+  when: (system_users__enabled | bool and item.name | d() | length > 0 and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and
-         item.create_home | d(True) and (item.forward | d()) | bool and (item.user | d(True)) | bool)
+         (item.create_home | d(True)) | bool and item.forward | d() | length > 0 and (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
   tags: [ 'role::system_users:forward', 'skip::system_users:forward', 'skip::check' ]
 
@@ -295,11 +295,11 @@
   check_mode: False
   register: system_users__register_dotfiles
   changed_when: ('Already up to date.' not in system_users__register_dotfiles.stdout_lines | regex_replace('-', ' '))
-  when: (system_users__enabled | bool and (item.name | d()) | bool and item.name != 'root' and
+  when: (system_users__enabled | bool and item.name | d() | length > 0 and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and (item.create_home | d(True)) | bool and
-         (ansible_local | d() and ansible_local.yadm | d() and (ansible_local.yadm.installed | d()) | bool) and
+         (ansible_local | d() | length > 0 and ansible_local.yadm | d() | length > 0 and (ansible_local.yadm.installed | d()) | bool) and
          (item.dotfiles | d(item.dotfiles_enabled | d(system_users__dotfiles_enabled))) | bool and
-         (item.dotfiles_repo | d(system_users__dotfiles_repo)) | bool and (item.user | d(True)) | bool)
+         item.dotfiles_repo | d(system_users__dotfiles_repo) | length > 0 and (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
   tags: [ 'role::system_users:dotfiles', 'skip::system_users:dotfiles', 'skip::check' ]
 


### PR DESCRIPTION
Replace `python__raw_etc_hosts | d()` with a condition that evaluates to True/False: `(python__raw_etc_hosts | default('')) | length > 0`. Fixes deprecation warning about conditional results being `AnsibleUnicode` instead of `bool` (Ansible 2.19+).