### PR TITLE
fix(auth/ssh/users roles): ensure when conditionals return bool (Ansible 2.19)

### DIFF
--- a/ansible/roles/nslcd/tasks/main.yml
+++ b/ansible/roles/nslcd/tasks/main.yml
@@ -42,7 +42,7 @@
     group: '{{ nslcd__group }}'
     mode: '0640'
   register: nslcd__register_config
-  when: nslcd__ldap_base_dn | d()
+  when: nslcd__ldap_base_dn | d() | length > 0
 
 - name: Restart nslcd if its configuration was modified
   ansible.builtin.service:  # noqa no-handler

--- a/ansible/roles/nslcd/tasks/main.yml
+++ b/ansible/roles/nslcd/tasks/main.yml
@@ -42,7 +42,7 @@
     group: '{{ nslcd__group }}'
     mode: '0640'
   register: nslcd__register_config
-  when: nslcd__ldap_base_dn | d()
+  when: nslcd__ldap_base_dn is truthy
 
 - name: Restart nslcd if its configuration was modified
   ansible.builtin.service:  # noqa no-handler

--- a/ansible/roles/pam_access/tasks/main.yml
+++ b/ansible/roles/pam_access/tasks/main.yml
@@ -22,7 +22,7 @@
   loop: '{{ pam_access__combined_rules | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"access_conf": pam_access__var_access_conf, "state": item.state | d("present")} }}'
-  when: (pam_access__enabled | bool and item.name | d() and
+  when: (pam_access__enabled | bool and item.name | d() | length > 0 and
          item.divert | d(False) | bool and
          item.state | d('present') in ['present', 'absent'])
 
@@ -37,7 +37,7 @@
   loop: '{{ pam_access__combined_rules | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"access_conf": pam_access__var_access_conf, "state": item.state | d("present")} }}'
-  when: pam_access__enabled | bool and item.name | d() and item.options | d() and
+  when: pam_access__enabled | bool and item.name | d() | length > 0 and item.options | d() | length > 0 and
         item.state | d('present') not in ['absent', 'init', 'ignore']
 
 - name: Remove PAM access control files
@@ -50,7 +50,7 @@
   loop: '{{ pam_access__combined_rules | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"access_conf": pam_access__var_access_conf, "state": item.state | d("present")} }}'
-  when: pam_access__enabled | bool and item.name | d() and
+  when: pam_access__enabled | bool and item.name | d() | length > 0 and
         not item.divert | d(False) | bool and
         item.state | d('present') == 'absent'
 

--- a/ansible/roles/pam_access/tasks/main.yml
+++ b/ansible/roles/pam_access/tasks/main.yml
@@ -22,7 +22,7 @@
   loop: '{{ pam_access__combined_rules | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"access_conf": pam_access__var_access_conf, "state": item.state | d("present")} }}'
-  when: (pam_access__enabled | bool and item.name | d() and
+  when: (pam_access__enabled | bool and item.name is defined and item.name is truthy and
          item.divert | d(False) | bool and
          item.state | d('present') in ['present', 'absent'])
 

--- a/ansible/roles/saslauthd/tasks/main.yml
+++ b/ansible/roles/saslauthd/tasks/main.yml
@@ -28,7 +28,7 @@
   with_items: '{{ saslauthd__combined_instances | debops.debops.parse_kv_items }}'
   register: saslauthd__register_stop_instance
   changed_when: saslauthd__register_stop_instance.changed | bool
-  when: item.name | d() and item.socket_path | d() and
+  when: item.name | d() | length > 0 and item.socket_path | d() | length > 0 and
         item.state | d('present') == 'absent'
 
 - name: Remove saslauthd instance if requested
@@ -36,7 +36,7 @@
     path: '/etc/default/saslauthd-{{ item.name }}'
     state: 'absent'
   with_items: '{{ saslauthd__combined_instances | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.socket_path | d() and
+  when: item.name | d() | length > 0 and item.socket_path | d() | length > 0 and
         item.state | d('present') == 'absent'
 
 - name: Generate saslauthd instance configuration
@@ -48,7 +48,7 @@
     mode: '0644'
   with_items: '{{ saslauthd__combined_instances | debops.debops.parse_kv_items }}'
   notify: [ 'Restart saslauthd' ]
-  when: item.name | d() and item.socket_path | d() and
+  when: item.name | d() | length > 0 and item.socket_path | d() | length > 0 and
         item.state | d('present') != 'absent'
 
 - name: Ensure that required UNIX groups exist
@@ -57,7 +57,7 @@
     state: 'present'
     system: '{{ (item.system | d(True)) | bool }}'
   with_items: '{{ saslauthd__combined_instances | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.group | d() and
+  when: item.name | d() | length > 0 and item.group | d() | length > 0 and
         item.state | d('present') != 'absent'
 
 - name: Create SASL config directory
@@ -68,7 +68,7 @@
     group: '{{ item.config_dir_group | d("root") }}'
     mode: '{{ item.config_dir_mode | d("0755") }}'
   with_items: '{{ saslauthd__combined_instances | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.config_path | d() and
+  when: item.name | d() | length > 0 and item.config_path | d() | length > 0 and
         item.state | d('present') != 'absent'
 
 - name: Remove SASL instance configuration if requested
@@ -77,7 +77,7 @@
     state: 'absent'
   with_items: '{{ saslauthd__combined_instances | debops.debops.parse_kv_items }}'
   notify: '{{ item.notify if item.notify | d() else omit }}'
-  when: item.name | d() and item.config_path | d() and
+  when: item.name | d() | length > 0 and item.config_path | d() | length > 0 and
         item.state | d('present') == 'absent'
 
 - name: Generate SASL instance configuration
@@ -89,7 +89,7 @@
     mode: '{{ item.config_mode | d("0640") }}'
   with_items: '{{ saslauthd__combined_instances | debops.debops.parse_kv_items }}'
   notify: '{{ item.notify if item.notify | d() else omit }}'
-  when: item.name | d() and item.config_path | d() and
+  when: item.name | d() | length > 0 and item.config_path | d() | length > 0 and
         item.state | d('present') != 'absent'
 
 - name: Remove SASL LDAP profiles if requested
@@ -99,7 +99,7 @@
               else "/etc/saslauthd-" + item.name + ".conf" }}'
     state: 'absent'
   with_items: '{{ saslauthd__ldap_combined_profiles | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') == 'absent'
+  when: item.name | d() | length > 0 and item.state | d('present') == 'absent'
 
 - name: Generate SASL LDAP profiles
   ansible.builtin.template:
@@ -112,7 +112,7 @@
     mode: '{{ item.mode | d("0640") }}'
   with_items: '{{ saslauthd__ldap_combined_profiles | debops.debops.parse_kv_items }}'
   notify: [ 'Restart saslauthd' ]
-  when: item.name | d() and item.state | d('present') not in ['absent', 'ignore']
+  when: item.name | d() | length > 0 and item.state | d('present') not in ['absent', 'ignore']
 
 - name: Get list of dpkg-stateoverride paths
   ansible.builtin.shell: set -o nounset -o pipefail -o errexit && dpkg-statoverride --list | awk '{print $4}'
@@ -128,7 +128,7 @@
   notify: [ 'Restart saslauthd' ]
   register: saslauthd__register_statoverride_remove
   changed_when: saslauthd__register_statoverride_remove.changed | bool
-  when: item.name | d() and item.socket_path | d() and item.state | d('present') == 'absent' and
+  when: item.name | d() | length > 0 and item.socket_path | d() | length > 0 and item.state | d('present') == 'absent' and
         item.socket_path in saslauthd__register_statoverride.stdout_lines
 
 - name: Create a dpkg-statoverride entry
@@ -141,7 +141,7 @@
   notify: [ 'Restart saslauthd' ]
   register: saslauthd__register_statoverride_add
   changed_when: saslauthd__register_statoverride_add.changed | bool
-  when: item.name | d() and item.socket_path | d() and item.state | d('present') != 'absent' and
+  when: item.name | d() | length > 0 and item.socket_path | d() | length > 0 and item.state | d('present') != 'absent' and
         item.socket_path not in saslauthd__register_statoverride.stdout_lines
 
 - name: Make sure that Ansible local facts directory exists

--- a/ansible/roles/saslauthd/tasks/main.yml
+++ b/ansible/roles/saslauthd/tasks/main.yml
@@ -28,7 +28,7 @@
   with_items: '{{ saslauthd__combined_instances | debops.debops.parse_kv_items }}'
   register: saslauthd__register_stop_instance
   changed_when: saslauthd__register_stop_instance.changed | bool
-  when: item.name | d() and item.socket_path | d() and
+  when: item.name is defined and item.name is truthy and item.socket_path is defined and item.socket_path is truthy and
         item.state | d('present') == 'absent'
 
 - name: Remove saslauthd instance if requested
@@ -36,7 +36,7 @@
     path: '/etc/default/saslauthd-{{ item.name }}'
     state: 'absent'
   with_items: '{{ saslauthd__combined_instances | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.socket_path | d() and
+  when: item.name is defined and item.name is truthy and item.socket_path is defined and item.socket_path is truthy and
         item.state | d('present') == 'absent'
 
 - name: Generate saslauthd instance configuration
@@ -48,7 +48,7 @@
     mode: '0644'
   with_items: '{{ saslauthd__combined_instances | debops.debops.parse_kv_items }}'
   notify: [ 'Restart saslauthd' ]
-  when: item.name | d() and item.socket_path | d() and
+  when: item.name is defined and item.name is truthy and item.socket_path is defined and item.socket_path is truthy and
         item.state | d('present') != 'absent'
 
 - name: Ensure that required UNIX groups exist
@@ -57,7 +57,7 @@
     state: 'present'
     system: '{{ (item.system | d(True)) | bool }}'
   with_items: '{{ saslauthd__combined_instances | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.group | d() and
+  when: item.name is defined and item.name is truthy and item.group is defined and item.group is truthy and
         item.state | d('present') != 'absent'
 
 - name: Create SASL config directory
@@ -68,7 +68,7 @@
     group: '{{ item.config_dir_group | d("root") }}'
     mode: '{{ item.config_dir_mode | d("0755") }}'
   with_items: '{{ saslauthd__combined_instances | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.config_path | d() and
+  when: item.name is defined and item.name is truthy and item.config_path is defined and item.config_path is truthy and
         item.state | d('present') != 'absent'
 
 - name: Remove SASL instance configuration if requested
@@ -77,7 +77,7 @@
     state: 'absent'
   with_items: '{{ saslauthd__combined_instances | debops.debops.parse_kv_items }}'
   notify: '{{ item.notify if item.notify | d() else omit }}'
-  when: item.name | d() and item.config_path | d() and
+  when: item.name is defined and item.name is truthy and item.config_path is defined and item.config_path is truthy and
         item.state | d('present') == 'absent'
 
 - name: Generate SASL instance configuration
@@ -89,7 +89,7 @@
     mode: '{{ item.config_mode | d("0640") }}'
   with_items: '{{ saslauthd__combined_instances | debops.debops.parse_kv_items }}'
   notify: '{{ item.notify if item.notify | d() else omit }}'
-  when: item.name | d() and item.config_path | d() and
+  when: item.name is defined and item.name is truthy and item.config_path is defined and item.config_path is truthy and
         item.state | d('present') != 'absent'
 
 - name: Remove SASL LDAP profiles if requested
@@ -99,7 +99,7 @@
               else "/etc/saslauthd-" + item.name + ".conf" }}'
     state: 'absent'
   with_items: '{{ saslauthd__ldap_combined_profiles | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') == 'absent'
+  when: item.name is defined and item.name is truthy and item.state | d('present') == 'absent'
 
 - name: Generate SASL LDAP profiles
   ansible.builtin.template:
@@ -112,7 +112,7 @@
     mode: '{{ item.mode | d("0640") }}'
   with_items: '{{ saslauthd__ldap_combined_profiles | debops.debops.parse_kv_items }}'
   notify: [ 'Restart saslauthd' ]
-  when: item.name | d() and item.state | d('present') not in ['absent', 'ignore']
+  when: item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore']
 
 - name: Get list of dpkg-stateoverride paths
   ansible.builtin.shell: set -o nounset -o pipefail -o errexit && dpkg-statoverride --list | awk '{print $4}'
@@ -128,7 +128,7 @@
   notify: [ 'Restart saslauthd' ]
   register: saslauthd__register_statoverride_remove
   changed_when: saslauthd__register_statoverride_remove.changed | bool
-  when: item.name | d() and item.socket_path | d() and item.state | d('present') == 'absent' and
+  when: item.name is defined and item.name is truthy and item.socket_path is defined and item.socket_path is truthy and item.state | d('present') == 'absent' and
         item.socket_path in saslauthd__register_statoverride.stdout_lines
 
 - name: Create a dpkg-statoverride entry
@@ -141,7 +141,7 @@
   notify: [ 'Restart saslauthd' ]
   register: saslauthd__register_statoverride_add
   changed_when: saslauthd__register_statoverride_add.changed | bool
-  when: item.name | d() and item.socket_path | d() and item.state | d('present') != 'absent' and
+  when: item.name is defined and item.name is truthy and item.socket_path is defined and item.socket_path is truthy and item.state | d('present') != 'absent' and
         item.socket_path not in saslauthd__register_statoverride.stdout_lines
 
 - name: Make sure that Ansible local facts directory exists

--- a/ansible/roles/slapd/tasks/main.yml
+++ b/ansible/roles/slapd/tasks/main.yml
@@ -149,7 +149,7 @@
     label: '{{ {"state": item.state,
                 "dn": item.dn,
                 "attributes": item.attributes | d({})} }}'
-  when: item.name | d() and item.dn | d() and
+  when: item.name | d() | length > 0 and item.dn | d() | length > 0 and
         item.state | d('present') not in [ 'init', 'ignore' ]
   tags: [ 'role::slapd:tasks' ]
   no_log: '{{ debops__no_log | d(item.no_log)
@@ -173,7 +173,7 @@
                 "dn": item.dn,
                 "attributes": item.attributes | d({})} }}'
   when: slapd__slapacl_deploy_state == 'present' and
-        item.name | d() and item.dn | d() and
+        item.name | d() | length > 0 and item.dn | d() | length > 0 and
         item.state | d('present') not in [ 'init', 'ignore' ]
   tags: [ 'role::slapd:slapacl', 'role::slapd:tasks' ]
   no_log: '{{ debops__no_log | d(item.no_log)

--- a/ansible/roles/slapd/tasks/main.yml
+++ b/ansible/roles/slapd/tasks/main.yml
@@ -163,7 +163,7 @@
     label: '{{ {"state": item.state,
                 "dn": item.dn,
                 "attributes": item.attributes | d({})} }}'
-  when: item.name | d() and item.dn | d() and
+  when: item.name is defined and item.name is truthy and item.dn is defined and item.dn is truthy and
         item.state | d('present') not in [ 'init', 'ignore' ]
   tags: [ 'role::slapd:tasks' ]
   no_log: '{{ debops__no_log | d(item.no_log)
@@ -187,7 +187,7 @@
                 "dn": item.dn,
                 "attributes": item.attributes | d({})} }}'
   when: slapd__slapacl_deploy_state == 'present' and
-        item.name | d() and item.dn | d() and
+        item.name is defined and item.name is truthy and item.dn is defined and item.dn is truthy and
         item.state | d('present') not in [ 'init', 'ignore' ]
   tags: [ 'role::slapd:slapacl', 'role::slapd:tasks' ]
   no_log: '{{ debops__no_log | d(item.no_log)

--- a/ansible/roles/slapd/tasks/slapd_tasks.yml
+++ b/ansible/roles/slapd/tasks/slapd_tasks.yml
@@ -10,7 +10,7 @@
     attributes:  '{{ item.attributes | d(omit) }}'
     state:       '{{ item.entry_state | d(item.state) }}'
   run_once:      '{{ item.run_once | d(False) }}'
-  when: (item.objectClass | d() or item.entry_state | d()) and item.state not in ['init', 'ignore']
+  when: (item.objectClass | d() | length > 0 or item.entry_state | d() | length > 0) and item.state not in ['init', 'ignore']
   tags: [ 'role::slapd:tasks', 'role::slapd:slapacl' ]
   no_log: '{{ debops__no_log | d(item.no_log)
               | d(True

--- a/ansible/roles/slapd/tasks/slapd_tasks.yml
+++ b/ansible/roles/slapd/tasks/slapd_tasks.yml
@@ -10,7 +10,7 @@
     attributes:  '{{ item.attributes | d(omit) }}'
     state:       '{{ item.entry_state | d(item.state) }}'
   run_once:      '{{ item.run_once | d(False) }}'
-  when: (item.objectClass | d() or item.entry_state | d()) and item.state not in ['init', 'ignore']
+  when: (item.objectClass is defined or item.entry_state is defined) and item.state not in ['init', 'ignore']
   tags: [ 'role::slapd:tasks', 'role::slapd:slapacl' ]
   no_log: '{{ debops__no_log | d(item.no_log)
               | d(True
@@ -25,7 +25,7 @@
     ordered:    '{{ item.ordered | d(False) }}'
     state:      '{{ item.state }}'
   run_once:     '{{ item.run_once | d(False) }}'
-  when: not item.objectClass | d() and not item.entry_state | d() and item.state not in ['init', 'ignore']
+  when: item.objectClass is undefined and item.entry_state is undefined and item.state not in ['init', 'ignore']
   tags: [ 'role::slapd:tasks', 'role::slapd:slapacl' ]
   no_log: '{{ debops__no_log | d(item.no_log)
               | d(True

--- a/ansible/roles/smstools/tasks/main.yml
+++ b/ansible/roles/smstools/tasks/main.yml
@@ -26,19 +26,19 @@
   ansible.builtin.service:
     name: 'smstools'
     state: 'stopped'
-  when: smstools_register_home is defined and smstools_register_home.stdout | d()
+  when: smstools_register_home is defined and smstools_register_home.stdout | d() | length > 0
 
 - name: Fix smsd home directory
   ansible.builtin.user:
     name: 'smsd'
     home: '/var/spool/sms'
-  when: smstools_register_home is defined and smstools_register_home.stdout | d()
+  when: smstools_register_home is defined and smstools_register_home.stdout | d() | length > 0
 
 - name: Start smsd with new home directory
   ansible.builtin.service:
     name: 'smstools'
     state: 'started'
-  when: smstools_register_home is defined and smstools_register_home.stdout | d()
+  when: smstools_register_home is defined and smstools_register_home.stdout | d() | length > 0
 
 - name: Configure smsd
   ansible.builtin.template:
@@ -119,7 +119,7 @@
     owner: 'root'
     group: 'root'
     mode: '0440'
-  when: (ansible_local | d() and ansible_local.sudo | d() and
+  when: (ansible_local | d() | length > 0 and ansible_local.sudo | d() | length > 0 and
          (ansible_local.sudo.installed | d()) | bool)
 
 - name: Configure xinetd SMS service
@@ -165,7 +165,7 @@
     job: '/usr/local/lib/smstools/test-sms-on-reboot'
     special_time: 'reboot'
     state: 'present'
-  when: (smstools_test_recipients is defined and smstools_test_recipients)
+  when: (smstools_test_recipients is defined and smstools_test_recipients | d() | length > 0)
 
 - name: Check if rsyslog is installed
   ansible.builtin.stat:
@@ -180,7 +180,7 @@
     group: 'root'
     mode: '0644'
   notify: [ 'Restart rsyslogd' ]
-  when: (smstools_register_rsyslog is defined and smstools_register_rsyslog) and
+  when: (smstools_register_rsyslog is defined and smstools_register_rsyslog | d() | length > 0) and
         smstools_register_rsyslog.stat.exists
 
 - name: Configure logrotate
@@ -190,5 +190,5 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  when: (smstools_register_rsyslog is defined and smstools_register_rsyslog) and
+  when: (smstools_register_rsyslog is defined and smstools_register_rsyslog | d() | length > 0) and
         smstools_register_rsyslog.stat.exists

--- a/ansible/roles/smstools/tasks/main.yml
+++ b/ansible/roles/smstools/tasks/main.yml
@@ -26,19 +26,19 @@
   ansible.builtin.service:
     name: 'smstools'
     state: 'stopped'
-  when: smstools_register_home is defined and smstools_register_home.stdout | d()
+  when: smstools_register_home is defined and smstools_register_home.stdout is truthy
 
 - name: Fix smsd home directory
   ansible.builtin.user:
     name: 'smsd'
     home: '/var/spool/sms'
-  when: smstools_register_home is defined and smstools_register_home.stdout | d()
+  when: smstools_register_home is defined and smstools_register_home.stdout is truthy
 
 - name: Start smsd with new home directory
   ansible.builtin.service:
     name: 'smstools'
     state: 'started'
-  when: smstools_register_home is defined and smstools_register_home.stdout | d()
+  when: smstools_register_home is defined and smstools_register_home.stdout is truthy
 
 - name: Configure smsd
   ansible.builtin.template:
@@ -119,7 +119,7 @@
     owner: 'root'
     group: 'root'
     mode: '0440'
-  when: (ansible_local | d() and ansible_local.sudo | d() and
+  when: (ansible_local is truthy and ansible_local.sudo is truthy and
          (ansible_local.sudo.installed | d()) | bool)
 
 - name: Configure xinetd SMS service
@@ -165,7 +165,7 @@
     job: '/usr/local/lib/smstools/test-sms-on-reboot'
     special_time: 'reboot'
     state: 'present'
-  when: (smstools_test_recipients is defined and smstools_test_recipients)
+  when: (smstools_test_recipients is defined and smstools_test_recipients is truthy)
 
 - name: Check if rsyslog is installed
   ansible.builtin.stat:
@@ -180,7 +180,7 @@
     group: 'root'
     mode: '0644'
   notify: [ 'Restart rsyslogd' ]
-  when: (smstools_register_rsyslog is defined and smstools_register_rsyslog) and
+  when: (smstools_register_rsyslog is defined and smstools_register_rsyslog is truthy) and
         smstools_register_rsyslog.stat.exists
 
 - name: Configure logrotate
@@ -190,5 +190,5 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  when: (smstools_register_rsyslog is defined and smstools_register_rsyslog) and
+  when: (smstools_register_rsyslog is defined and smstools_register_rsyslog is truthy) and
         smstools_register_rsyslog.stat.exists

--- a/ansible/roles/sshd/tasks/authorized_keys_lookup.yml
+++ b/ansible/roles/sshd/tasks/authorized_keys_lookup.yml
@@ -37,7 +37,7 @@
     group: 'root'
     mode: '0755'
   with_items: '{{ sshd__authorized_keys_lookup_type }}'
-  when: sshd__authorized_keys_lookup_type | d()
+  when: sshd__authorized_keys_lookup_type | d() | length > 0
 
 - name: Generate authorized keys lookup hook
   ansible.builtin.template:

--- a/ansible/roles/sshd/tasks/authorized_keys_lookup.yml
+++ b/ansible/roles/sshd/tasks/authorized_keys_lookup.yml
@@ -37,7 +37,7 @@
     group: 'root'
     mode: '0755'
   with_items: '{{ sshd__authorized_keys_lookup_type }}'
-  when: sshd__authorized_keys_lookup_type | d()
+  when: sshd__authorized_keys_lookup_type is truthy
 
 - name: Generate authorized keys lookup hook
   ansible.builtin.template:

--- a/ansible/roles/sshd/tasks/main.yml
+++ b/ansible/roles/sshd/tasks/main.yml
@@ -77,7 +77,7 @@
       This file disables the ssh server.  It was created by debops.sshd.
       This file will be removed when configuration is successfully completed.
     mode: '0644'
-  when: (ansible_local | d() and ansible_local.sshd | d() and
+  when: (ansible_local | d() | length > 0 and ansible_local.sshd | d() | length > 0 and
          not (ansible_local.sshd.installed | d()) | bool)
 
   # In a case where the OpenSSH server is installed by the role but not started
@@ -191,7 +191,7 @@
   loop: '{{ q("flattened", sshd__known_hosts
                            + sshd__group_known_hosts
                            + sshd__host_known_hosts) }}'
-  when: item is defined and item
+  when: item is defined and item | d() | length > 0
   register: sshd__register_known_hosts
   changed_when: False
   failed_when: False
@@ -218,7 +218,7 @@
   notify: [ 'Test sshd configuration and restart' ]
   register: sshd__register_moduli
   changed_when: sshd__register_moduli.changed | bool
-  when: sshd__register_moduli.stdout
+  when: sshd__register_moduli.stdout | d() | length > 0
 
 - name: Remove block on OpenSSH server startup
   ansible.builtin.file:

--- a/ansible/roles/sshd/tasks/main.yml
+++ b/ansible/roles/sshd/tasks/main.yml
@@ -77,7 +77,7 @@
       This file disables the ssh server.  It was created by debops.sshd.
       This file will be removed when configuration is successfully completed.
     mode: '0644'
-  when: (ansible_local | d() and ansible_local.sshd | d() and
+  when: (ansible_local is truthy and ansible_local.sshd is truthy and
          not (ansible_local.sshd.installed | d()) | bool)
 
   # In a case where the OpenSSH server is installed by the role but not started
@@ -145,7 +145,7 @@
     owner:    'root'
     group:    'root'
     mode:     '0644'
-  when: sshd__trusted_user_ca_keys | d() | length > 0 and
+  when: sshd__trusted_user_ca_keys is truthy and
         sshd__trusted_user_ca_keys_file is defined
   tags: [ 'role::sshd:config' ]
 
@@ -191,7 +191,7 @@
   loop: '{{ q("flattened", sshd__known_hosts
                            + sshd__group_known_hosts
                            + sshd__host_known_hosts) }}'
-  when: item is defined and item
+  when: item is truthy
   register: sshd__register_known_hosts
   changed_when: False
   failed_when: False

--- a/ansible/roles/sssd/tasks/main.yml
+++ b/ansible/roles/sssd/tasks/main.yml
@@ -38,7 +38,7 @@
     dest: '/etc/sssd/sssd.conf'
     mode: '0600'
   register: sssd__register_config
-  when: sssd__ldap_base_dn | d()
+  when: sssd__ldap_base_dn | d() | length > 0
 
 - name: Restart sssd if its configuration was modified
   ansible.builtin.service:  # noqa no-handler

--- a/ansible/roles/sssd/tasks/main.yml
+++ b/ansible/roles/sssd/tasks/main.yml
@@ -38,7 +38,7 @@
     dest: '/etc/sssd/sssd.conf'
     mode: '0600'
   register: sssd__register_config
-  when: sssd__ldap_base_dn | d()
+  when: sssd__ldap_base_dn is truthy
 
 - name: Restart sssd if its configuration was modified
   ansible.builtin.service:  # noqa no-handler

--- a/ansible/roles/users/tasks/main.yml
+++ b/ansible/roles/users/tasks/main.yml
@@ -39,7 +39,7 @@
   loop_control:
     label: '{{ {"name": (item.group | d(item.name)),
                 "state": item.state | d("present")} }}'
-  when: (users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (users__enabled | bool and item.name | d() | length > 0 and item.name != 'root' and
          item.state | d('present') != 'absent' and (item.private_group | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
 
@@ -84,7 +84,7 @@
   loop_control:
     label: '{{ {"name": item.name,
                 "state": item.state | d("present"), "gecos": item.comment | d()} }}'
-  when: (users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (users__enabled | bool and item.name | d() | length > 0 and item.name != 'root' and
          item.state | d('present') not in ['ignore'] and (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
 
@@ -116,9 +116,9 @@
     label: '{{ {"name": item.name,
                 "state": item.state | d("present"), "gecos": item.comment | d(),
                 "groups": item.groups | d()} }}'
-  when: (users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (users__enabled | bool and item.name | d() | length > 0 and item.name != 'root' and
          item.state | d('present') not in ['ignore'] and
-         (item.groups | d() or (item.chroot | d()) | bool) and
+         (item.groups | d() | length > 0 or (item.chroot | d()) | bool) and
          (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
 
@@ -143,9 +143,9 @@
                                         else ("~" + item.name))
                                        if ((item.create_home | d(True)) | bool)
                                        else ""))} }}'
-  when: (users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (users__enabled | bool and item.name | d() | length > 0 and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and item.create_home | d(True) and
-         (item.home_owner | d() or item.home_group | d() or item.home_mode | d() or (item.local | d(True)) | bool) and
+         (item.home_owner | d() | length > 0 or item.home_group | d() | length > 0 or item.home_mode | d() | length > 0 or (item.local | d(True)) | bool) and
          (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
 
@@ -172,9 +172,9 @@
     label: '{{ {"name": item.0.name,
                 "state": item.0.state | d("present"), "home_acl": item.1} }}'
   when: (users__enabled | bool and users__acl_enabled | bool and
-         item.0.name | d() and item.0.name != 'root' and
+         item.0.name | d() | length > 0 and item.0.name != 'root' and
          item.0.state | d('present') not in ['absent', 'ignore'] and
-         item.0.create_home | d(True) and item.0.home_acl | d() and (item.0.user | d(True)) | bool)
+         item.0.create_home | d(True) and item.0.home_acl | d() | length > 0 and (item.0.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
   tags: [ 'role::users:home_acl', 'skip::users:home_acl', 'skip::check' ]
 
@@ -187,7 +187,7 @@
     label: '{{ {"name": item.name,
                 "state": item.state | d("present"), "linger": item.linger | d(False)} }}'
   when: (users__enabled | bool and ansible_service_mgr == 'systemd' and
-         item.name | d() and item.name != 'root' and
+         item.name | d() | length > 0 and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and
          item.linger is defined and item.linger | bool and (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
@@ -201,7 +201,7 @@
     label: '{{ {"name": item.name,
                 "state": item.state | d("present"), "linger": item.linger | d(False)} }}'
   when: (users__enabled | bool and ansible_service_mgr == 'systemd' and
-         item.name | d() and item.name != 'root' and
+         item.name | d() | length > 0 and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and
          item.linger is defined and not item.linger | bool and (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
@@ -217,9 +217,9 @@
   loop_control:
     label: '{{ {"name": item.name,
                 "state": item.state | d("present"), "sshkeys": item.sshkeys | d()} }}'
-  when: (users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (users__enabled | bool and item.name | d() | length > 0 and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and item.create_home | d(True) and
-         item.sshkeys | d() and item.sshkeys_state | d('present') != 'absent' and (item.user | d(True)) | bool)
+         item.sshkeys | d() | length > 0 and item.sshkeys_state | d('present') != 'absent' and (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
   tags: [ 'role::users:authorized_keys', 'skip::users:authorized_keys', 'skip::check' ]
 
@@ -232,7 +232,7 @@
     label: '{{ {"name": item.name,
                 "state": item.state | d("present"),
                 "sshkeys_state": item.sshkeys_state | d("present")} }}'
-  when: (users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (users__enabled | bool and item.name | d() | length > 0 and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and item.create_home | d(True) and
          item.sshkeys_state | d('present') == 'absent' and (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
@@ -254,9 +254,9 @@
     label: '{{ {"name": item.name,
                 "state": item.state | d("present"),
                 "forward": item.forward | d()} }}'
-  when: (users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (users__enabled | bool and item.name | d() | length > 0 and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and
-         item.create_home | d(True) and item.forward | d() and (item.user | d(True)) | bool)
+         item.create_home | d(True) and item.forward | d() | length > 0 and (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
   tags: [ 'role::users:forward', 'skip::users:forward', 'skip::check' ]
 
@@ -282,11 +282,11 @@
   check_mode: False
   register: users__register_dotfiles
   changed_when: ('Already up to date.' not in users__register_dotfiles.stdout_lines | regex_replace('-', ' '))
-  when: (users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (users__enabled | bool and item.name | d() | length > 0 and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and item.create_home | d(True) and
-         (ansible_local | d() and ansible_local.yadm | d() and (ansible_local.yadm.installed | d()) | bool) and
+         (ansible_local | d() | length > 0 and ansible_local.yadm | d() | length > 0 and (ansible_local.yadm.installed | d()) | bool) and
          (item.dotfiles | d(item.dotfiles_enabled | d(users__dotfiles_enabled))) | bool and
-         (item.dotfiles_repo | d(users__dotfiles_repo)) and (item.user | d(True)) | bool and not (item.chroot | d()) | bool)
+         (item.dotfiles_repo | d(users__dotfiles_repo)) | length > 0 and (item.user | d(True)) | bool and not (item.chroot | d()) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
   tags: [ 'role::users:dotfiles', 'skip::users:dotfiles', 'skip::check' ]
 
@@ -307,9 +307,9 @@
     label: '{{ {"name": item.0.name,
                 "state": item.0.state | d("present"), "resources": item.1} }}'
   when: (users__enabled | bool and
-         item.0.name | d() and item.0.name != 'root' and
+         item.0.name | d() | length > 0 and item.0.name != 'root' and
          item.0.state | d('present') not in ['absent', 'ignore'] and
-         item.0.create_home | d(True) and item.0.resources | d() and (item.0.user | d(True)) | bool and
+         item.0.create_home | d(True) and item.0.resources | d() | length > 0 and (item.0.user | d(True)) | bool and
          item.1.state | d('directory') in ['directory', 'link', 'touch'] and
          item.1.content is undefined)
   no_log: '{{ debops__no_log | d(item.0.no_log) | d(True if item.0.password | d() else False) }}'
@@ -330,9 +330,9 @@
     label: '{{ {"name": item.0.name,
                 "state": item.0.state | d("present"), "resources": item.1} }}'
   when: (users__enabled | bool and
-         item.0.name | d() and item.0.name != 'root' and
+         item.0.name | d() | length > 0 and item.0.name != 'root' and
          item.0.state | d('present') not in ['absent', 'ignore'] and
-         item.0.create_home | d(True) and item.0.resources | d() and (item.0.user | d(True)) | bool and
+         item.0.create_home | d(True) and item.0.resources | d() | length > 0 and (item.0.user | d(True)) | bool and
          item.1.state | d('directory') in ['present', 'file'])
   no_log: '{{ debops__no_log | d(item.0.no_log) | d(True if item.0.password | d() else False) }}'
 
@@ -352,11 +352,11 @@
     label: '{{ {"name": item.0.name,
                 "state": item.0.state | d("present"), "resources": item.1} }}'
   when: (users__enabled | bool and
-         item.0.name | d() and item.0.name != 'root' and
+         item.0.name | d() | length > 0 and item.0.name != 'root' and
          item.0.state | d('present') not in ['absent', 'ignore'] and
-         item.0.create_home | d(True) and item.0.resources | d() and (item.0.user | d(True)) | bool and
+         item.0.create_home | d(True) and item.0.resources | d() | length > 0 and (item.0.user | d(True)) | bool and
          item.1.state | d('directory') in ['present', 'file'] and
-         (item.1.dest | d() or item.1.path | d()) and (item.1.src | d() or item.1.content | d()))
+         (item.1.dest | d() | length > 0 or item.1.path | d() | length > 0) and (item.1.src | d() | length > 0 or item.1.content | d() | length > 0))
   no_log: '{{ debops__no_log | d(item.0.no_log) | d(True if item.0.password | d() else False) }}'
 
 - name: Remove user resources if requested
@@ -370,9 +370,9 @@
     label: '{{ {"name": item.0.name,
                 "state": item.0.state | d("present"), "resources": item.1} }}'
   when: (users__enabled | bool and
-         item.0.name | d() and item.0.name != 'root' and
+         item.0.name | d() | length > 0 and item.0.name != 'root' and
          item.0.state | d('present') not in ['absent', 'ignore'] and
-         item.0.create_home | d(True) and item.0.resources | d() and (item.0.user | d(True)) | bool and
+         item.0.create_home | d(True) and item.0.resources | d() | length > 0 and (item.0.user | d(True)) | bool and
          item.1.state | d('directory') == 'absent')
   no_log: '{{ debops__no_log | d(item.0.no_log) | d(True if item.0.password | d() else False) }}'
 
@@ -385,7 +385,7 @@
   loop_control:
     label: '{{ {"name": (item.group | d(item.name)),
                 "state": item.state | d("present")} }}'
-  when: (users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (users__enabled | bool and item.name | d() | length > 0 and item.name != 'root' and
          item.state | d('present') == 'absent' and
          (item.private_group | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'

--- a/ansible/roles/users/tasks/main.yml
+++ b/ansible/roles/users/tasks/main.yml
@@ -39,7 +39,7 @@
   loop_control:
     label: '{{ {"name": (item.group | d(item.name)),
                 "state": item.state | d("present")} }}'
-  when: (users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (users__enabled | bool and item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') != 'absent' and (item.private_group | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
 
@@ -84,7 +84,7 @@
   loop_control:
     label: '{{ {"name": item.name,
                 "state": item.state | d("present"), "gecos": item.comment | d()} }}'
-  when: (users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (users__enabled | bool and item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') not in ['ignore'] and (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
 
@@ -116,9 +116,9 @@
     label: '{{ {"name": item.name,
                 "state": item.state | d("present"), "gecos": item.comment | d(),
                 "groups": item.groups | d()} }}'
-  when: (users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (users__enabled | bool and item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') not in ['ignore'] and
-         (item.groups | d() or (item.chroot | d()) | bool) and
+         (item.groups is defined and item.groups is truthy or (item.chroot | d()) | bool) and
          (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
 
@@ -143,9 +143,9 @@
                                         else ("~" + item.name))
                                        if ((item.create_home | d(True)) | bool)
                                        else ""))} }}'
-  when: (users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (users__enabled | bool and item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and item.create_home | d(True) and
-         (item.home_owner | d() or item.home_group | d() or item.home_mode | d() or (item.local | d(True)) | bool) and
+         (item.home_owner is defined or item.home_group is defined or item.home_mode is defined or (item.local | d(True)) | bool) and
          (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
 
@@ -172,9 +172,9 @@
     label: '{{ {"name": item.0.name,
                 "state": item.0.state | d("present"), "home_acl": item.1} }}'
   when: (users__enabled | bool and users__acl_enabled | bool and
-         item.0.name | d() and item.0.name != 'root' and
+         item.0.name is defined and item.0.name is truthy and item.0.name != 'root' and
          item.0.state | d('present') not in ['absent', 'ignore'] and
-         item.0.create_home | d(True) and item.0.home_acl | d() and (item.0.user | d(True)) | bool)
+         item.0.create_home | d(True) and item.0.home_acl is defined and item.0.home_acl is truthy and (item.0.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
   tags: [ 'role::users:home_acl', 'skip::users:home_acl', 'skip::check' ]
 
@@ -187,7 +187,7 @@
     label: '{{ {"name": item.name,
                 "state": item.state | d("present"), "linger": item.linger | d(False)} }}'
   when: (users__enabled | bool and ansible_service_mgr == 'systemd' and
-         item.name | d() and item.name != 'root' and
+         item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and
          item.linger is defined and item.linger | bool and (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
@@ -201,7 +201,7 @@
     label: '{{ {"name": item.name,
                 "state": item.state | d("present"), "linger": item.linger | d(False)} }}'
   when: (users__enabled | bool and ansible_service_mgr == 'systemd' and
-         item.name | d() and item.name != 'root' and
+         item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and
          item.linger is defined and not item.linger | bool and (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
@@ -217,9 +217,9 @@
   loop_control:
     label: '{{ {"name": item.name,
                 "state": item.state | d("present"), "sshkeys": item.sshkeys | d()} }}'
-  when: (users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (users__enabled | bool and item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and item.create_home | d(True) and
-         item.sshkeys | d() and item.sshkeys_state | d('present') != 'absent' and (item.user | d(True)) | bool)
+         item.sshkeys is defined and item.sshkeys is truthy and item.sshkeys_state | d('present') != 'absent' and (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
   tags: [ 'role::users:authorized_keys', 'skip::users:authorized_keys', 'skip::check' ]
 
@@ -232,7 +232,7 @@
     label: '{{ {"name": item.name,
                 "state": item.state | d("present"),
                 "sshkeys_state": item.sshkeys_state | d("present")} }}'
-  when: (users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (users__enabled | bool and item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and item.create_home | d(True) and
          item.sshkeys_state | d('present') == 'absent' and (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
@@ -254,9 +254,9 @@
     label: '{{ {"name": item.name,
                 "state": item.state | d("present"),
                 "forward": item.forward | d()} }}'
-  when: (users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (users__enabled | bool and item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and
-         item.create_home | d(True) and item.forward | d() and (item.user | d(True)) | bool)
+         item.create_home | d(True) and item.forward is defined and item.forward is truthy and (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
   tags: [ 'role::users:forward', 'skip::users:forward', 'skip::check' ]
 
@@ -282,11 +282,11 @@
   check_mode: False
   register: users__register_dotfiles
   changed_when: ('Already up to date.' not in users__register_dotfiles.stdout_lines | regex_replace('-', ' '))
-  when: (users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (users__enabled | bool and item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and item.create_home | d(True) and
-         (ansible_local | d() and ansible_local.yadm | d() and (ansible_local.yadm.installed | d()) | bool) and
+         (ansible_local is truthy and ansible_local.yadm is truthy and (ansible_local.yadm.installed | d()) | bool) and
          (item.dotfiles | d(item.dotfiles_enabled | d(users__dotfiles_enabled))) | bool and
-         (item.dotfiles_repo | d(users__dotfiles_repo)) and (item.user | d(True)) | bool and not (item.chroot | d()) | bool)
+         (item.dotfiles_repo | d(users__dotfiles_repo)) is truthy and (item.user | d(True)) | bool and not (item.chroot | d()) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
   tags: [ 'role::users:dotfiles', 'skip::users:dotfiles', 'skip::check' ]
 
@@ -307,9 +307,9 @@
     label: '{{ {"name": item.0.name,
                 "state": item.0.state | d("present"), "resources": item.1} }}'
   when: (users__enabled | bool and
-         item.0.name | d() and item.0.name != 'root' and
+         item.0.name is defined and item.0.name is truthy and item.0.name != 'root' and
          item.0.state | d('present') not in ['absent', 'ignore'] and
-         item.0.create_home | d(True) and item.0.resources | d() and (item.0.user | d(True)) | bool and
+         item.0.create_home | d(True) and item.0.resources is defined and item.0.resources is truthy and (item.0.user | d(True)) | bool and
          item.1.state | d('directory') in ['directory', 'link', 'touch'] and
          item.1.content is undefined)
   no_log: '{{ debops__no_log | d(item.0.no_log) | d(True if item.0.password | d() else False) }}'
@@ -330,9 +330,9 @@
     label: '{{ {"name": item.0.name,
                 "state": item.0.state | d("present"), "resources": item.1} }}'
   when: (users__enabled | bool and
-         item.0.name | d() and item.0.name != 'root' and
+         item.0.name is defined and item.0.name is truthy and item.0.name != 'root' and
          item.0.state | d('present') not in ['absent', 'ignore'] and
-         item.0.create_home | d(True) and item.0.resources | d() and (item.0.user | d(True)) | bool and
+         item.0.create_home | d(True) and item.0.resources is defined and item.0.resources is truthy and (item.0.user | d(True)) | bool and
          item.1.state | d('directory') in ['present', 'file'])
   no_log: '{{ debops__no_log | d(item.0.no_log) | d(True if item.0.password | d() else False) }}'
 
@@ -352,11 +352,11 @@
     label: '{{ {"name": item.0.name,
                 "state": item.0.state | d("present"), "resources": item.1} }}'
   when: (users__enabled | bool and
-         item.0.name | d() and item.0.name != 'root' and
+         item.0.name is defined and item.0.name is truthy and item.0.name != 'root' and
          item.0.state | d('present') not in ['absent', 'ignore'] and
-         item.0.create_home | d(True) and item.0.resources | d() and (item.0.user | d(True)) | bool and
+         item.0.create_home | d(True) and item.0.resources is defined and item.0.resources is truthy and (item.0.user | d(True)) | bool and
          item.1.state | d('directory') in ['present', 'file'] and
-         (item.1.dest | d() or item.1.path | d()) and (item.1.src | d() or item.1.content | d()))
+         (item.1.dest is defined or item.1.path is defined) and (item.1.src is defined or item.1.content is defined))
   no_log: '{{ debops__no_log | d(item.0.no_log) | d(True if item.0.password | d() else False) }}'
 
 - name: Remove user resources if requested
@@ -370,9 +370,9 @@
     label: '{{ {"name": item.0.name,
                 "state": item.0.state | d("present"), "resources": item.1} }}'
   when: (users__enabled | bool and
-         item.0.name | d() and item.0.name != 'root' and
+         item.0.name is defined and item.0.name is truthy and item.0.name != 'root' and
          item.0.state | d('present') not in ['absent', 'ignore'] and
-         item.0.create_home | d(True) and item.0.resources | d() and (item.0.user | d(True)) | bool and
+         item.0.create_home | d(True) and item.0.resources is defined and item.0.resources is truthy and (item.0.user | d(True)) | bool and
          item.1.state | d('directory') == 'absent')
   no_log: '{{ debops__no_log | d(item.0.no_log) | d(True if item.0.password | d() else False) }}'
 
@@ -385,7 +385,7 @@
   loop_control:
     label: '{{ {"name": (item.group | d(item.name)),
                 "state": item.state | d("present")} }}'
-  when: (users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (users__enabled | bool and item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') == 'absent' and
          (item.private_group | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'


### PR DESCRIPTION
Replace boolean-truthy checks using \`| d() | length > 0\` or \`| d()\` (as a boolean gate) with \`is truthy\` / \`is defined and X is truthy\` syntax, as required by Ansible v2.19 which no longer silently coerces undefined values to False in \`when\` conditionals.

**Style aligned with commit [7ec2fcb](https://github.com/debops/debops/commit/7ec2fcb) by @drybjed**, which fixed analogous issues in the common playbook roles. This PR handles the remaining auth/SSH/user roles not covered by that commit. Changes deduped against 7ec2fcb (pam_access "Generate/Remove PAM access" tasks and sshd moduli tasks already fixed there).

Affected roles:
- **nslcd**: \`nslcd__ldap_base_dn\`
- **pam_access**: \`item.name\` (Add/remove diversion task only; Generate/Remove tasks already fixed in 7ec2fcb)
- **saslauthd**: \`item.name\`, \`item.socket_path\`, \`item.config_path\`, \`item.group\`
- **slapd**: \`item.name\`, \`item.dn\`, \`item.objectClass\`, \`item.entry_state\`
- **smstools**: \`smstools_register_home.stdout\`, \`ansible_local.sudo\`, \`smstools_test_recipients\`, \`smstools_register_rsyslog\`
- **sshd**: \`ansible_local.sshd\` (disable task), loop items (known_hosts), \`sshd__trusted_user_ca_keys\`, \`sshd__authorized_keys_lookup_type\` (moduli tasks already fixed in 7ec2fcb)
- **sssd**: \`sssd__ldap_base_dn\`
- **users**: \`item.name\`, \`item.sshkeys\`, \`item.forward\`, \`item.home_acl\`, \`item.resources\`, \`item.groups\`, \`ansible_local.yadm\`, \`item.dotfiles_repo\`

Fixes: https://github.com/debops/debops/issues/2601