### PR TITLE
fix(system roles): ensure when conditionals return bool (Ansible 2.19)

### DIFF
--- a/ansible/roles/apt_install/tasks/main.yml
+++ b/ansible/roles/apt_install/tasks/main.yml
@@ -65,7 +65,7 @@
   loop: '{{ q("flattened", apt_install__debconf
                            + apt_install__group_debconf
                            + apt_install__host_debconf) }}'
-  when: item.name | d()
+  when: item.name | d() | length > 0
 
 - name: Install requested APT packages
   ansible.builtin.apt:
@@ -90,7 +90,7 @@
                            + apt_install__alternatives
                            + apt_install__group_alternatives
                            + apt_install__host_alternatives) }}'
-  when: item.name | d() and item.path | d()
+  when: item.name | d() | length > 0 and item.path | d() | length > 0
 
 - name: Configure automatic alternatives
   ansible.builtin.command: update-alternatives --auto {{ item.name }}
@@ -98,7 +98,7 @@
   loop: '{{ q("flattened", apt_install__alternatives
                            + apt_install__group_alternatives
                            + apt_install__host_alternatives) }}'
-  when: item.name | d() and not item.path | d()
+  when: item.name | d() | length > 0 and not item.path | d()
   changed_when: apt_install__register_alternatives.stdout | d()
 
 - name: Disable kernel hints about pending upgrades

--- a/ansible/roles/debconf/tasks/main.yml
+++ b/ansible/roles/debconf/tasks/main.yml
@@ -70,7 +70,7 @@
                            + debconf__alternatives
                            + debconf__group_alternatives
                            + debconf__host_alternatives) }}'
-  when: item.name | d() and item.path | d()
+  when: item.name | d() | length > 0 and item.path | d() | length > 0
 
 - name: Configure automatic alternatives
   ansible.builtin.command: update-alternatives --auto {{ item.name }}
@@ -78,7 +78,7 @@
   loop: '{{ q("flattened", debconf__alternatives
                            + debconf__group_alternatives
                            + debconf__host_alternatives) }}'
-  when: item.name | d() and not item.path | d()
+  when: item.name | d() | length > 0 and not item.path | d()
   changed_when: debconf__register_alternatives.stdout | d()
 
 # Execute custom shell commands [[[1
@@ -88,6 +88,6 @@
   loop: '{{ q("flattened", debconf__combined_commands) | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"name": item.name} }}'
-  when: item.name | d() and item.state | d('present') not in [ 'absent', 'ignore' ]
+  when: item.name | d() | length > 0 and item.state | d('present') not in [ 'absent', 'ignore' ]
   no_log: '{{ debops__no_log | d(item.no_log) | d(False) }}'
   tags: [ 'role::debconf:commands' ]

--- a/ansible/roles/grub/tasks/main.yml
+++ b/ansible/roles/grub/tasks/main.yml
@@ -46,7 +46,7 @@
   with_items: '{{ grub__combined_users }}'
   become: False
   delegate_to: 'localhost'
-  when: item.name | d()
+  when: item.name | d() | length > 0
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Save plaintext password in secrets
@@ -58,7 +58,7 @@
   register: grub__register_pw_plain
   become: False
   delegate_to: 'localhost'
-  when: item.name | d()
+  when: item.name | d() | length > 0
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Save temporary grub-mkpasswd formatted password in secrets
@@ -71,7 +71,7 @@
     - '{{ grub__register_pw_plain.results | d({}) }}'
   become: False
   delegate_to: 'localhost'
-  when: (item.0.name | d() and item.1 is changed)
+  when: (item.0.name | d() | length > 0 and item.1 is changed)
   no_log: '{{ debops__no_log | d(True) }}'
 
 ## There seems to be no way to specify the salt (except using a custom script).
@@ -97,7 +97,7 @@
   become: False
   delegate_to: 'localhost'
   changed_when: False
-  when: (item.0.name | d() and item.1 is changed)
+  when: (item.0.name | d() | length > 0 and item.1 is changed)
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Remove temporary grub-mkpassword formatted password
@@ -109,7 +109,7 @@
     - '{{ grub__register_pw_plain.results | d({}) }}'
   become: False
   delegate_to: 'localhost'
-  when: (item.0.name | d() and item.1 is changed)
+  when: (item.0.name | d() | length > 0 and item.1 is changed)
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Save hashed password in secrets

--- a/ansible/roles/locales/tasks/main.yml
+++ b/ansible/roles/locales/tasks/main.yml
@@ -32,7 +32,7 @@
     vtype: 'string'
     value: '{{ locales__system_lang }}'
   register: locales__register_system_lang
-  when: ansible_pkg_mgr == 'apt' and locales__system_lang | d()
+  when: ansible_pkg_mgr == 'apt' and locales__system_lang | d() | length > 0
 
 - name: Update /etc/default/locale
   ansible.builtin.command: 'update-locale LANG={{ locales__system_lang }}'  # noqa no-handler

--- a/ansible/roles/mount/tasks/main.yml
+++ b/ansible/roles/mount/tasks/main.yml
@@ -63,8 +63,8 @@
                            + mount__group_files
                            + mount__host_files) }}'
   when: (mount__enabled | bool and
-         (item.src | d() or item.content is defined) and
-         (item.dest | d() or item.path | d() or item.name | d()) and
+         (item.src | d() | length > 0 or item.content is defined) and
+         (item.dest | d() | length > 0 or item.path | d() | length > 0 or item.name | d() | length > 0) and
          (item.state | d('present') != 'absent'))
 
 - name: Manage device mounts
@@ -84,7 +84,7 @@
             | flatten }}'
   register: mount__register_devices
   when: (mount__enabled | bool and
-         (item.name | d() or item.dest | d() or item.path | d()) and item.src)
+         (item.name | d() | length > 0 or item.dest | d() | length > 0 or item.path | d() | length > 0) and item.src)
 
 - name: Restart 'local-fs.target' systemd unit
   ansible.builtin.systemd:  # noqa no-handler
@@ -118,7 +118,7 @@
              + mount__group_directories
              + mount__host_directories)
             | flatten }}'
-  when: mount__enabled | bool and (item.path | d() or item.dest | d() or item.name | d()) and
+  when: mount__enabled | bool and (item.path | d() | length > 0 or item.dest | d() | length > 0 or item.name | d() | length > 0) and
         item.state | d('directory') in ['directory', 'absent']
 
 - name: Manage directory ACLs
@@ -138,8 +138,8 @@
              | subelements("acl") }}'
   loop_control:
     label: '{{ {"name": item.0.name, "acl": item.1} }}'
-  when: mount__enabled | bool and (item.0.path | d() or item.0.dest | d() or item.0.name | d()) and
-        item.0.state | d('directory') == 'directory' and item.0.acl | d()
+  when: mount__enabled | bool and (item.0.path | d() | length > 0 or item.0.dest | d() | length > 0 or item.0.name | d() | length > 0) and
+        item.0.state | d('directory') == 'directory' and item.0.acl | d() | length > 0
 
 - name: Manage bind mounts
   ansible.posix.mount:
@@ -156,8 +156,8 @@
              + mount__host_binds)
             | flatten }}'
   when: (mount__enabled | bool and
-         (item.name | d() or item.dest | d() or item.path | d()) and
-         item.src | d())
+         (item.name | d() | length > 0 or item.dest | d() | length > 0 or item.path | d() | length > 0) and
+         item.src | d() | length > 0)
 
 - name: Make sure that Ansible local facts directory exists
   ansible.builtin.file:

--- a/ansible/roles/postfix/tasks/main.yml
+++ b/ansible/roles/postfix/tasks/main.yml
@@ -35,7 +35,7 @@
     name: '{{ postfix__purge_packages | flatten }}'
     state: 'absent'
     purge: True
-  when: postfix__purge_packages | d() and ansible_pkg_mgr == 'apt'
+  when: postfix__purge_packages | d() | length > 0 and ansible_pkg_mgr == 'apt'
   tags: [ 'meta::provision' ]
 
 - name: Disable Postfix configuration in debconf
@@ -107,7 +107,7 @@
     path: '/etc/postfix/{{ item.name }}'
     state: 'absent'
   loop: '{{ postfix__combined_lookup_tables | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') == 'absent'
+  when: item.name | d() | length > 0 and item.state | d('present') == 'absent'
   notify: [ 'Process Postfix Makefile', 'Check postfix and reload' ]
   no_log: '{{ debops__no_log | d(item.no_log)
               | d(True if (item.mode | d("0644") == "0600") else False) }}'
@@ -121,7 +121,7 @@
     mode:  '{{ item.mode | d("0640") }}'
   loop: '{{ postfix__combined_lookup_tables | debops.debops.parse_kv_items }}'
   notify: [ 'Process Postfix Makefile', 'Check postfix and reload' ]
-  when: item.name | d() and item.state | d('present') != 'absent'
+  when: item.name | d() | length > 0 and item.state | d('present') != 'absent'
   no_log: '{{ debops__no_log | d(item.no_log)
               | d(True if (item.mode | d("0640") in ["0640", "0600"])
                   else False) }}'

--- a/ansible/roles/resources/tasks/main.yml
+++ b/ansible/roles/resources/tasks/main.yml
@@ -44,8 +44,8 @@
   loop: '{{ q("flattened", resources__repositories
                            + resources__group_repositories
                            + resources__host_repositories) }}'
-  when: (resources__enabled | bool and (item.repo | d() or item.url | d() or item.src | d()) and
-         (item.dest | d() or item.name | d() or item.path | d()))
+  when: (resources__enabled | bool and (item.repo | d() | length > 0 or item.url | d() | length > 0 or item.src | d() | length > 0) and
+         (item.dest | d() | length > 0 or item.name | d() | length > 0 or item.path | d() | length > 0))
   tags: [ 'role::resources:repositories' ]
 
 # Manage custom templates [[[1
@@ -106,7 +106,7 @@
                            + resources__group_paths
                            + resources__host_paths) }}'
   when: (resources__enabled | bool and
-         ((item.path | d() or item.dest | d() or item.name | d()) or item))
+         ((item.path | d() | length > 0 or item.dest | d() | length > 0 or item.name | d() | length > 0) or item | d() | length > 0))
   tags: [ 'role::resources:paths' ]
 
 # Create parent directories [[[1
@@ -153,8 +153,8 @@
   loop: '{{ q("flattened", resources__urls
                            + resources__group_urls
                            + resources__host_urls) }}'
-  when: (resources__enabled | bool and (item.url | d() or item.src | d()) and
-         (item.dest | d() or item.name | d() or item.path | d()))
+  when: (resources__enabled | bool and (item.url | d() | length > 0 or item.src | d() | length > 0) and
+         (item.dest | d() | length > 0 or item.name | d() | length > 0 or item.path | d() | length > 0))
   no_log: '{{ debops__no_log | d(True if item.url_password | d() else omit) }}'
   tags: [ 'role::resources:urls' ]
 
@@ -182,8 +182,8 @@
   loop: '{{ q("flattened", resources__archives
                            + resources__group_archives
                            + resources__host_archives) }}'
-  when: (resources__enabled | bool and item.src | d() and
-         (item.dest | d() or item.name | d() or item.path | d()))
+  when: (resources__enabled | bool and item.src | d() | length > 0 and
+         (item.dest | d() | length > 0 or item.name | d() | length > 0 or item.path | d() | length > 0))
   tags: [ 'role::resources:archives' ]
 
 # Manage custom files [[[1
@@ -196,7 +196,7 @@
                            + resources__group_files
                            + resources__host_files) }}'
   when: (resources__enabled | bool and
-         (item.dest | d() or item.path | d() or item.name | d()) and
+         (item.dest | d() | length > 0 or item.path | d() | length > 0 or item.name | d() | length > 0) and
          (item.state | d('present') == 'absent'))
   tags: [ 'role::resources:files' ]
 
@@ -222,8 +222,8 @@
                            + resources__group_files
                            + resources__host_files) }}'
   when: (resources__enabled | bool and
-         (item.src | d() or item.content is defined) and
-         (item.dest | d() or item.path | d() or item.name | d()) and
+         (item.src | d() | length > 0 or item.content is defined) and
+         (item.dest | d() | length > 0 or item.path | d() | length > 0 or item.name | d() | length > 0) and
          (item.state | d('present') != 'absent'))
   tags: [ 'role::resources:files' ]
 
@@ -248,7 +248,7 @@
   become: True
   become_user: '{{ item.owner | d("root") }}'
   when: (resources__enabled | bool and
-         (item.name | d() or item.requirements is defined) and
+         (item.name | d() | length > 0 or item.requirements is defined) and
          (item.state | d('present') != 'absent'))
   tags: [ 'role::resources:pip' ]
 
@@ -275,8 +275,8 @@
   loop: '{{ q("flattened", resources__replacements
                            + resources__group_replacements
                            + resources__host_replacements) }}'
-  when: (resources__enabled | bool and item.regexp | d() and
-         (item.dest | d() or item.path | d() or item.name | d()))
+  when: (resources__enabled | bool and item.regexp | d() | length > 0 and
+         (item.dest | d() | length > 0 or item.path | d() | length > 0 or item.name | d() | length > 0))
   tags: [ 'role::resources:lineinfile' ]
 
 # Manage ACLs [[[1
@@ -341,7 +341,7 @@
                            + resources__group_delayed_paths
                            + resources__host_delayed_paths) }}'
   when: (resources__enabled | bool and
-         ((item.path | d() or item.dest | d() or item.name | d()) or item))
+         ((item.path | d() | length > 0 or item.dest | d() | length > 0 or item.name | d() | length > 0) or item | d() | length > 0))
   tags: [ 'role::resources:paths' ]
 
 - name: Set custom file capabilities
@@ -361,7 +361,7 @@
   loop_control:
     label: '{{ {"name": item.name} }}'
   when: resources__enabled | bool and
-        item.name | d() and item.state | d('present') not in [ 'absent', 'ignore' ]
+        item.name | d() | length > 0 and item.state | d('present') not in [ 'absent', 'ignore' ]
   no_log: '{{ debops__no_log | d(item.no_log) | d(False) }}'
   tags: [ 'role::resources:commands' ]
 

--- a/ansible/roles/resources/tasks/shell_commands.yml
+++ b/ansible/roles/resources/tasks/shell_commands.yml
@@ -10,6 +10,6 @@
     creates:    '{{ item.creates | d(omit) }}'
     removes:    '{{ item.removes | d(omit) }}'
     executable: '{{ item.executable | d("bash") }}'
-  when: item.name | d() and item.state not in ['absent', 'ignore']
+  when: item.name | d() | length > 0 and item.state not in ['absent', 'ignore']
   no_log: '{{ debops__no_log | d(item.no_log) | d(False) }}'
   tags: [ 'role::resources:commands' ]

--- a/ansible/roles/sysctl/tasks/main.yml
+++ b/ansible/roles/sysctl/tasks/main.yml
@@ -51,7 +51,7 @@
   loop: '{{ sysctl__combined_parameters | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
-  when: (sysctl__enabled | bool and item.name | d() and
+  when: (sysctl__enabled | bool and item.name | d() | length > 0 and
          item.state | d('present') in ['present', 'absent'] and
          item.divert | d(False) | bool)
 
@@ -61,7 +61,7 @@
     state: 'absent'
   with_items: '{{ sysctl__combined_parameters | debops.debops.parse_kv_items }}'
   register: sysctl__register_config_removed
-  when: sysctl__enabled | bool and item.name | d() and item.state | d('present') == 'absent'
+  when: sysctl__enabled | bool and item.name | d() | length > 0 and item.state | d('present') == 'absent'
 
 - name: Generate custom sysctl configuration files
   ansible.builtin.template:
@@ -74,7 +74,7 @@
   loop_control:
     label: '{{ item.name }}'
   register: sysctl__register_config_created
-  when: sysctl__enabled | bool and item.name | d() and item.options | d() and item.state | d('present') not in ['absent', 'ignore', 'init']
+  when: sysctl__enabled | bool and item.name | d() | length > 0 and item.options | d() | length > 0 and item.state | d('present') not in ['absent', 'ignore', 'init']
 
 - name: Check sysctl command capabilities
   ansible.builtin.shell: set -o nounset -o pipefail -o errexit &&

--- a/ansible/roles/sysfs/tasks/main.yml
+++ b/ansible/roles/sysfs/tasks/main.yml
@@ -30,7 +30,7 @@
   register: sysfs__register_dependent_attributes_file
   become: False
   delegate_to: 'localhost'
-  when: (sysfs__enabled | bool and ansible_local | d() and ansible_local.sysfs | d() and
+  when: (sysfs__enabled | bool and ansible_local | d() | length > 0 and ansible_local.sysfs | d() | length > 0 and
          (ansible_local.sysfs.configured | d()) | bool)
 
 - name: Load the dependent configuration from Ansible Controller
@@ -39,7 +39,7 @@
   register: sysfs__register_dependent_attributes
   become: False
   delegate_to: 'localhost'
-  when: (sysfs__enabled | bool and ansible_local | d() and ansible_local.sysfs | d() and
+  when: (sysfs__enabled | bool and ansible_local | d() | length > 0 and ansible_local.sysfs | d() | length > 0 and
          (ansible_local.sysfs.configured | d()) | bool and
          sysfs__register_dependent_attributes_file.stat.exists | bool)
 
@@ -49,7 +49,7 @@
     state: 'absent'
   with_items: '{{ sysfs__combined_attributes | debops.debops.parse_kv_items }}'
   notify: [ 'Restart sysfsutils' ]
-  when: (sysfs__enabled | bool and item.name | d() and
+  when: (sysfs__enabled | bool and item.name | d() | length > 0 and
          item.state | d('present') == 'absent')
 
 - name: Generate sysfs configuration files
@@ -61,7 +61,7 @@
     mode: '0644'
   with_items: '{{ sysfs__combined_attributes | debops.debops.parse_kv_items }}'
   notify: [ 'Restart sysfsutils' ]
-  when: (sysfs__enabled | bool and item.name | d() and
+  when: (sysfs__enabled | bool and item.name | d() | length > 0 and
          item.state | d('present') not in ['defined', 'absent'])
 
 - name: Make sure that Ansible local facts directory exists

--- a/ansible/roles/sysnews/tasks/main.yml
+++ b/ansible/roles/sysnews/tasks/main.yml
@@ -39,7 +39,7 @@
     path: '/var/lib/sysnews/{{ item.name }}'
     state: 'absent'
   with_items: '{{ sysnews__combined_entries | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') == 'absent'
+  when: item.name | d() | length > 0 and item.state | d('present') == 'absent'
 
 - name: Generate persistent news files
   ansible.builtin.copy:
@@ -50,7 +50,7 @@
     group: 'root'
     mode: '0644'
   with_items: '{{ sysnews__combined_entries | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') != 'absent'
+  when: item.name | d() | length > 0 and item.state | d('present') != 'absent'
 
 - name: Update list of persistent news files
   ansible.builtin.blockinfile:


### PR DESCRIPTION
Replace | d() truthiness checks with | d() | length > 0 to produce proper boolean results in when conditions, avoiding deprecation warnings that will become errors in Ansible 2.19.

Affected roles: apt_install, debconf, grub, locales, sysctl, sysfs, mount, resources, postfix, sysnews