### PR TITLE
fix(networking roles): ensure when conditionals return bool (Ansible 2.19)

### DIFF
--- a/ansible/roles/avahi/tasks/avahi_alias.yml
+++ b/ansible/roles/avahi/tasks/avahi_alias.yml
@@ -43,7 +43,7 @@
     mode: '0644'
   with_dict: '{{ avahi__combined_services }}'
   register: avahi__register_aliases
-  when: item.value.cname | d()
+  when: item.value.cname | d() | length > 0
 
 - name: Manage avahi-alias.service
   ansible.builtin.systemd:

--- a/ansible/roles/avahi/tasks/main.yml
+++ b/ansible/roles/avahi/tasks/main.yml
@@ -109,7 +109,7 @@
     state: 'present'
     mode: '0644'
   with_dict: '{{ avahi__hosts | combine(avahi__group_hosts) | combine(avahi__host_hosts) }}'
-  when: item.key | d() and item.value | d()
+  when: item.key | d() | length > 0 and item.value | d() | length > 0
 
 - name: Configure Avahi CNAME aliases
   ansible.builtin.include_tasks: avahi_alias.yml
@@ -121,7 +121,7 @@
     path: '/etc/avahi/services/{{ item.value.filename | d(item.key) }}.service'
     state: 'absent'
   with_dict: '{{ avahi__combined_services }}'
-  when: item.value.filename | d(item.key) and item.value.state | d('present') == 'absent'
+  when: item.value.filename | d(item.key) | length > 0 and item.value.state | d('present') == 'absent'
   tags: [ 'role::avahi:alias', 'role::avahi:services' ]
 
 - name: Configure Avahi services
@@ -132,8 +132,8 @@
     group: 'root'
     mode: '0644'
   with_dict: '{{ avahi__combined_services }}'
-  when: (item.value.filename | d(item.key) and item.value.state | d('present') != 'absent' and
-         (item.value.services | d() or item.value.type | d()))
+  when: (item.value.filename | d(item.key) | length > 0 and item.value.state | d('present') != 'absent' and
+         (item.value.services | d() | length > 0 or item.value.type | d() | length > 0))
   tags: [ 'role::avahi:alias', 'role::avahi:services' ]
 
 - name: Ensure that the avahi-daemon service in in the desired state

--- a/ansible/roles/dnsmasq/tasks/main.yml
+++ b/ansible/roles/dnsmasq/tasks/main.yml
@@ -58,7 +58,7 @@
     state: 'absent'
   with_items: '{{ dnsmasq__combined_configuration | debops.debops.parse_kv_items }}'
   notify: [ 'Test and restart dnsmasq' ]
-  when: (item.name | d() and item.state | d('present') == 'absent')
+  when: (item.name | d() | length > 0 and item.state | d('present') == 'absent')
 
 - name: Generate dnsmasq configuration
   ansible.builtin.template:
@@ -69,7 +69,7 @@
     mode: '0644'
   with_items: '{{ dnsmasq__combined_configuration | debops.debops.parse_kv_items }}'
   notify: [ 'Test and restart dnsmasq' ]
-  when: (item.name | d() and item.state | d('present') not in ['absent', 'ignore', 'init'])
+  when: (item.name | d() | length > 0 and item.state | d('present') not in ['absent', 'ignore', 'init'])
 
 - name: Remove DHCP host configuration and DNS records if requested
   ansible.builtin.file:
@@ -86,7 +86,7 @@
     group: 'root'
     mode: '0644'
   notify: [ 'Test and restart dnsmasq' ]
-  when: dnsmasq__dhcp_hosts | d() or dnsmasq__dns_records | d()
+  when: dnsmasq__dhcp_hosts | d() | length > 0 or dnsmasq__dns_records | d() | length > 0
 
 - name: Divert original dnsmasq environment file
   debops.debops.dpkg_divert:
@@ -112,4 +112,4 @@
     mode: '0644'
     unsafe_writes: '{{ True if (core__unsafe_writes | d(ansible_local.core.unsafe_writes | d()) | bool) else omit }}'
   notify: [ 'Test and restart dnsmasq' ]
-  when: dnsmasq__nameservers | d()
+  when: dnsmasq__nameservers | d() | length > 0

--- a/ansible/roles/iscsi/tasks/main.yml
+++ b/ansible/roles/iscsi/tasks/main.yml
@@ -49,7 +49,7 @@
   ansible.builtin.service:  # noqa no-handler
     name:  'open-iscsi'
     state: 'restarted'
-  when: iscsi__enabled | d() and iscsi__register_initiatorname | d() and iscsi__register_initiatorname is changed
+  when: iscsi__enabled | d() | length > 0 and iscsi__register_initiatorname | d() | length > 0 and iscsi__register_initiatorname is changed
 
 - name: Generate iSCSI interface configuration
   ansible.builtin.shell: iscsiadm -m iface -I {{ item }} -o new ;
@@ -78,7 +78,7 @@
     auto_node_startup: '{{ False if (not item.auto | d(True)) else True }}'
   with_items: '{{ iscsi__targets }}'
   register: iscsi__register_targets
-  when: iscsi__targets | d()
+  when: iscsi__targets | d() | length > 0
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Make sure that local facts directory exists

--- a/ansible/roles/iscsi/tasks/manage_lvm.yml
+++ b/ansible/roles/iscsi/tasks/manage_lvm.yml
@@ -11,7 +11,7 @@
     state:  'absent'
   with_items: '{{ iscsi__logical_volumes }}'
   when: iscsi__logical_volumes | d(False) and
-        item.vg | d() and item.lv | d() and item.size | d() and
+        item.vg | d() | length > 0 and item.lv | d() | length > 0 and item.size | d() | length > 0 and
         item.mount | d(False) and
         (item.state is defined and item.state == 'absent')
 
@@ -24,8 +24,8 @@
     state: 'absent'
   with_items: '{{ iscsi__logical_volumes }}'
   when: iscsi__logical_volumes | d(False) and
-        item.vg | d() and item.lv | d() and item.size | d() and
-        item.state | d() and item.state == 'absent'
+        item.vg | d() | length > 0 and item.lv | d() | length > 0 and item.size | d() | length > 0 and
+        item.state | d() | length > 0 and item.state == 'absent'
 
 - name: Manage LVM Volume Groups
   community.general.lvg:
@@ -36,8 +36,8 @@
     force:      '{{ item.item.lvm_force | d(omit) }}'
     vg_options: '{{ item.item.lvm_options | d(omit) }}'
   with_items: '{{ iscsi__register_targets.results }}'
-  when: iscsi__register_targets | d(False) and iscsi__register_targets.results | d() and
-        item.devicenodes | d() and item.item.lvm_vg | d()
+  when: iscsi__register_targets | d(False) and iscsi__register_targets.results | d() | length > 0 and
+        item.devicenodes | d() | length > 0 and item.item.lvm_vg | d() | length > 0
 
 - name: Manage LVM Logical Volumes
   community.general.lvol:
@@ -48,7 +48,7 @@
     state: 'present'
   with_items: '{{ iscsi__logical_volumes }}'
   when: iscsi__logical_volumes | d(False) and
-        item.vg | d() and item.lv | d() and item.size | d() and
+        item.vg | d() | length > 0 and item.lv | d() | length > 0 and item.size | d() | length > 0 and
         (item.state is undefined or item.state != 'absent')
 
 - name: Manage filesystems
@@ -59,10 +59,10 @@
     opts:   '{{ item.fs_opts | d(omit) }}'
   with_items: '{{ iscsi__logical_volumes }}'
   when: iscsi__logical_volumes | d(False) and
-        item.vg | d() and item.lv | d() and item.size | d() and
+        item.vg | d() | length > 0 and item.lv | d() | length > 0 and item.size | d() | length > 0 and
         (item.state is undefined or item.state != 'absent') and
-        ((item.mount | d() and (item.fs is undefined or item.fs | d()) or
-         item.fs | d()))
+        ((item.mount | d() | length > 0 and (item.fs is undefined or item.fs | d() | length > 0) or
+         item.fs | d() | length > 0))
 
 - name: Manage mount points
   ansible.posix.mount:
@@ -76,6 +76,6 @@
     fstab:  '{{ item.mount_fstab | d(omit) }}'
   with_items: '{{ iscsi__logical_volumes }}'
   when: iscsi__logical_volumes | d(False) and
-        item.vg | d() and item.lv | d() and item.size | d() and
+        item.vg | d() | length > 0 and item.lv | d() | length > 0 and item.size | d() | length > 0 and
         item.mount | d(False) and
         (item.state is undefined or item.state != 'absent')

--- a/ansible/roles/nfs/tasks/main.yml
+++ b/ansible/roles/nfs/tasks/main.yml
@@ -32,7 +32,7 @@
   loop: '{{ q("flattened", nfs__shares
                            + nfs__group_shares
                            + nfs__host_shares) }}'
-  when: item.path | d() and item.src | d() and item.state | d('mounted') == 'present'
+  when: item.path | d() | length > 0 and item.src | d() | length > 0 and item.state | d('mounted') == 'present'
 
 - name: Manage NFS mount points
   ansible.posix.mount:
@@ -48,7 +48,7 @@
                            + nfs__group_shares
                            + nfs__host_shares) }}'
   register: nfs__register_devices
-  when: item.path | d() and item.src | d()
+  when: item.path | d() | length > 0 and item.src | d() | length > 0
 
 - name: Restart 'remote-fs.target' systemd unit
   ansible.builtin.systemd:  # noqa no-handler

--- a/ansible/roles/nfs_server/tasks/main.yml
+++ b/ansible/roles/nfs_server/tasks/main.yml
@@ -45,7 +45,7 @@
     group: '{{ item.group | d("root") }}'
     mode:  '{{ item.mode | d("0755") }}'
   loop: '{{ q("flattened", nfs_server__combined_exports) }}'
-  when: item.path | d() and item.state | d('present') != 'absent' and item.acl | d()
+  when: item.path | d() | length > 0 and item.state | d('present') != 'absent' and item.acl | d() | length > 0
 
 - name: Bind mount requested directories
   ansible.posix.mount:
@@ -55,7 +55,7 @@
     fstype: 'none'
     state: 'mounted'
   loop: '{{ q("flattened", nfs_server__combined_exports) }}'
-  when: item.path | d() and item.state | d('present') != 'absent' and item.acl | d() and item.bind | d()
+  when: item.path | d() | length > 0 and item.state | d('present') != 'absent' and item.acl | d() | length > 0 and item.bind | d() | length > 0
 
 - name: Configure NFS exports
   ansible.builtin.template:

--- a/ansible/roles/tcpwrappers/tasks/main.yml
+++ b/ansible/roles/tcpwrappers/tasks/main.yml
@@ -62,8 +62,8 @@
                            + tcpwrappers_group_allow | d([])
                            + tcpwrappers_host_allow | d([])
                            + tcpwrappers_dependent_allow | d([])) }}'
-  when: ((item.daemon | d() or item.daemons | d()) and
-         item.state | d() and item.state == 'absent')
+  when: ((item.daemon | d() | length > 0 or item.daemons | d() | length > 0) and
+         item.state | d() | length > 0 and item.state == 'absent')
 
 - name: Generate hosts.allow entries
   ansible.builtin.template:
@@ -82,7 +82,7 @@
                            + tcpwrappers_group_allow | d([])
                            + tcpwrappers_host_allow | d([])
                            + tcpwrappers_dependent_allow | d([])) }}'
-  when: ((item.daemon | d() or item.daemons | d()) and
+  when: ((item.daemon | d() | length > 0 or item.daemons | d() | length > 0) and
          (item.state is undefined or item.state != 'absent'))
 
 - name: Assemble hosts.allow.d

--- a/ansible/roles/tinc/tasks/main.yml
+++ b/ansible/roles/tinc/tasks/main.yml
@@ -112,7 +112,7 @@
     mode: '0644'
     unsafe_writes: '{{ True if (core__unsafe_writes | d(ansible_local.core.unsafe_writes | d()) | bool) else omit }}'
   with_dict: '{{ tinc__combined_networks }}'
-  when: item.value.state | d('present') != 'absent' and item.value.tinc_options | d()
+  when: item.value.state | d('present') != 'absent' and item.value.tinc_options | d() | length > 0
   notify: [ 'Reload tinc' ]
 
 - name: Remove deprecated dhclient hook script
@@ -254,7 +254,7 @@
   with_nested:
     - '{{ lookup("template", "lookup/tinc__network_list.j2", convert_data=False) | from_yaml }}'
     - '{{ lookup("template", "lookup/tinc__inventory_groups.j2", convert_data=False) | from_yaml }}'
-  when: (item.0.name | d() and item.0.state | d('present') != 'absent' and
+  when: (item.0.name | d() | length > 0 and item.0.state | d('present') != 'absent' and
          item.1 in item.0.inventory_groups | d([]) and item.1 in group_names)
   notify: [ 'Reload tinc' ]
 
@@ -330,7 +330,7 @@
     state: '{{ (item.value.state | d("present") in ["absent"]) | ternary("stopped", "started") }}'
   with_dict: '{{ tinc__combined_networks }}'
   when: tinc__systemd | bool and item.value.state | d('present') != 'absent' and
-        item.value.port | d()
+        item.value.port | d() | length > 0
 
 # Ansible facts [[[1
 

--- a/ansible/roles/unbound/tasks/main.yml
+++ b/ansible/roles/unbound/tasks/main.yml
@@ -45,7 +45,7 @@
     group: 'root'
     mode: '0644'
   notify: [ 'Check unbound configuration and reload' ]
-  when: unbound__combined_server | d()
+  when: unbound__combined_server | d() | length > 0
 
 - name: Generate Unbound remote control configuration
   ansible.builtin.template:
@@ -55,7 +55,7 @@
     group: 'root'
     mode: '0644'
   notify: [ 'Check unbound configuration and reload' ]
-  when: unbound__combined_remote_control | d()
+  when: unbound__combined_remote_control | d() | length > 0
 
 - name: Remove DNS zones if requested
   ansible.builtin.file:
@@ -63,7 +63,7 @@
     state: 'absent'
   loop: '{{ q("flattened", unbound__parsed_zones) }}'
   notify: [ 'Check unbound configuration and reload' ]
-  when: item.name | d() and item.state | d('present') == 'absent'
+  when: item.name | d() | length > 0 and item.state | d('present') == 'absent'
 
 - name: Configure DNS zones
   ansible.builtin.template:
@@ -74,7 +74,7 @@
     mode: '0644'
   loop: '{{ q("flattened", unbound__parsed_zones) }}'
   notify: [ 'Check unbound configuration and reload' ]
-  when: item.name | d() and item.state | d('present') != 'absent'
+  when: item.name | d() | length > 0 and item.state | d('present') != 'absent'
 
 - name: Install unbound APT packages
   ansible.builtin.package:


### PR DESCRIPTION
Replace | d() truthiness checks with | d() | length > 0 to produce proper boolean results in when conditions, avoiding deprecation warnings that will become errors in Ansible 2.19.

Affected roles: avahi, dnsmasq, nfs, nfs_server, unbound, tcpwrappers, iscsi, tinc