### PR TITLE
fix(web/apps/languages roles): ensure when conditionals return bool (Ansible 2.19)

### DIFF
--- a/ansible/roles/foodsoft/tasks/main.yml
+++ b/ansible/roles/foodsoft/tasks/main.yml
@@ -74,7 +74,7 @@
   tags: [ 'role::foodsoft:gems' ]
   # become: True
   # become_user: '{{ foodsoft__user }}'
-  when: foodsoft__bundler_exclude_groups | d()
+  when: foodsoft__bundler_exclude_groups | d() | length > 0
 
 ## https://github.com/foodcoops/foodsoft/blob/master/doc/SETUP_DEVELOPMENT.md#manual-configuration
 - name: Configure Foodsoft
@@ -128,8 +128,8 @@
   register: foodsoft__register_db_setup
   changed_when: foodsoft__register_db_setup.changed | bool
   when: (not (ansible_local.foodsoft[foodsoft__database + "_initialized"] | bool
-              if (ansible_local | d() and ansible_local.foodsoft | d() and
-                  ansible_local.foodsoft[foodsoft__database + "_initialized"] | d())
+              if (ansible_local | d() | length > 0 and ansible_local.foodsoft | d() | length > 0 and
+                  ansible_local.foodsoft[foodsoft__database + "_initialized"] | d() | length > 0)
               else False))
 
 ## Maybe only needed for https://github.com/foodcoop-adam/foodsoft

--- a/ansible/roles/golang/tasks/golang_build_install.yml
+++ b/ansible/roles/golang/tasks/golang_build_install.yml
@@ -12,7 +12,7 @@
   args:
     executable: '/bin/bash'
   register: golang__register_build_apt_packages
-  when: build.apt_packages | d()
+  when: build.apt_packages | d() | length > 0
   changed_when: False
   check_mode: False
 
@@ -28,7 +28,7 @@
            | intersect(golang__register_build_apt_packages.stdout_lines))))
 
 - name: Prepare Go UNIX environment
-  when: ((build.git | d() or build.url | d()) and ((build.upstream | d()) | bool or
+  when: ((build.git | d() | length > 0 or build.url | d() | length > 0) and ((build.upstream | d()) | bool or
          (build.apt_packages is undefined or
           (not (([build.apt_packages] if (build.apt_packages is string) else build.apt_packages)
                 | intersect(golang__register_build_apt_packages.stdout_lines))))))
@@ -56,13 +56,13 @@
     state: 'present'
   register: golang__register_install_apt_required_packages
   until: golang__register_install_apt_required_packages is succeeded
-  when: (build.url | d() and build.upstream_type | d('git') == 'url' and (((build.upstream | d()) | bool or
+  when: (build.url | d() | length > 0 and build.upstream_type | d('git') == 'url' and (((build.upstream | d()) | bool or
          (build.apt_packages is undefined or
           (not (([build.apt_packages] if (build.apt_packages is string) else build.apt_packages)
                 | intersect(golang__register_build_apt_packages.stdout_lines)))))))
 
 - name: Download Go binaries directly
-  when: (build.url | d() and build.upstream_type | d('git') == 'url' and ((build.upstream | d()) | bool or
+  when: (build.url | d() | length > 0 and build.upstream_type | d('git') == 'url' and ((build.upstream | d()) | bool or
          (build.apt_packages is undefined or
           (not (([build.apt_packages] if (build.apt_packages is string) else build.apt_packages)
                 | intersect(golang__register_build_apt_packages.stdout_lines))))))
@@ -132,7 +132,7 @@
   loop: '{{ build.url_binaries | d([]) }}'
   loop_control:
     loop_var: 'binary_item'
-  when: (build.url_binaries | d() and build.upstream_type | d('git') == 'url' and ((build.upstream | d()) | bool or
+  when: (build.url_binaries | d() | length > 0 and build.upstream_type | d('git') == 'url' and ((build.upstream | d()) | bool or
          (build.apt_packages is undefined or
           (not (([build.apt_packages] if (build.apt_packages is string) else build.apt_packages)
                 | intersect(golang__register_build_apt_packages.stdout_lines))))))
@@ -143,13 +143,13 @@
     state: 'present'
   register: golang__register_install_apt_dev_packages
   until: golang__register_install_apt_dev_packages is succeeded
-  when: (build.git | d() and build.upstream_type | d('git') == 'git' and (((build.upstream | d()) | bool or
+  when: (build.git | d() | length > 0 and build.upstream_type | d('git') == 'git' and (((build.upstream | d()) | bool or
          (build.apt_packages is undefined or
           (not (([build.apt_packages] if (build.apt_packages is string) else build.apt_packages)
                 | intersect(golang__register_build_apt_packages.stdout_lines)))))))
 
 - name: Build Go applications from source
-  when: (build.git | d() and build.upstream_type | d('git') == 'git' and (((build.upstream | d()) | bool or
+  when: (build.git | d() | length > 0 and build.upstream_type | d('git') == 'git' and (((build.upstream | d()) | bool or
          (build.apt_packages is undefined or
           (not (([build.apt_packages] if (build.apt_packages is string) else build.apt_packages)
                 | intersect(golang__register_build_apt_packages.stdout_lines)))))))
@@ -182,7 +182,7 @@
       loop: '{{ build.git }}'
       loop_control:
         loop_var: 'git_item'
-      when: git_item.build_script | d() and
+      when: git_item.build_script | d() | length > 0 and
             golang__register_build_source is changed
       register: golang__register_build
       changed_when: golang__register_build.changed | bool
@@ -204,7 +204,7 @@
   loop: '{{ build.git_binaries | d([]) }}'
   loop_control:
     loop_var: 'binary_item'
-  when: (build.git_binaries | d() and build.upstream_type | d('git') == 'git' and ((build.upstream | d()) | bool or
+  when: (build.git_binaries | d() | length > 0 and build.upstream_type | d('git') == 'git' and ((build.upstream | d()) | bool or
          (build.apt_packages is undefined or
           (not (([build.apt_packages] if (build.apt_packages is string) else build.apt_packages)
                 | intersect(golang__register_build_apt_packages.stdout_lines))))))
@@ -218,7 +218,7 @@
     dest: '{{ golang__bin_database }}'
     mode: '0644'
     force: False
-  when: build.url_binaries | d() or build.git_binaries | d()
+  when: build.url_binaries | d() | length > 0 or build.git_binaries | d() | length > 0
 
 - name: Register binaries for {{ build.name }}
   ansible.builtin.lineinfile:
@@ -233,13 +233,13 @@
   loop_control:
     loop_var: 'binary_item'
   register: golang__register_build_database
-  when: build.url_binaries | d() or build.git_binaries | d()
+  when: build.url_binaries | d() | length > 0 or build.git_binaries | d() | length > 0
 
   # An exception to the rule. Role needs to refresh facts without executing any
   # other pending handlers.
 - name: Update Ansible local facts if they were modified
   ansible.builtin.setup:  # noqa no-handler
-  when: (ansible_local | d() and ansible_local.golang | d() and
+  when: (ansible_local | d() | length > 0 and ansible_local.golang | d() | length > 0 and
          (ansible_local.golang.configured | d()) | bool and
          (golang__register_build_database is changed or
           golang__register_download_install is changed or

--- a/ansible/roles/gunicorn/tasks/newer_releases.yml
+++ b/ansible/roles/gunicorn/tasks/newer_releases.yml
@@ -18,8 +18,8 @@
     state: 'present'
   loop: '{{ q("flattened", gunicorn__applications
                            + gunicorn__dependent_applications) }}'
-  when: item.name | d() and item.state | d('present') != 'absent' and
-        item.group | d()
+  when: item.name | d() | length > 0 and item.state | d('present') != 'absent' and
+        item.group | d() | length > 0
 
 - name: Ensure that required users exist
   ansible.builtin.user:
@@ -30,8 +30,8 @@
     state: 'present'
   loop: '{{ q("flattened", gunicorn__applications
                            + gunicorn__dependent_applications) }}'
-  when: item.name | d() and item.state | d('present') != 'absent' and
-        item.user | d() and item.home | d()
+  when: item.name | d() | length > 0 and item.state | d('present') != 'absent' and
+        item.user | d() | length > 0 and item.home | d() | length > 0
 
 - name: Create log directories
   ansible.builtin.file:
@@ -42,7 +42,7 @@
     mode: '0775'
   loop: '{{ q("flattened", gunicorn__applications
                            + gunicorn__dependent_applications) }}'
-  when: item.name | d() and item.state | d('present') != 'absent'
+  when: item.name | d() | length > 0 and item.state | d('present') != 'absent'
 
 - name: Create logrotate configs
   ansible.builtin.template:
@@ -53,7 +53,7 @@
     mode: '0644'
   loop: '{{ q("flattened", gunicorn__applications
                            + gunicorn__dependent_applications) }}'
-  when: item.name | d() and item.state | d('present') != 'absent'
+  when: item.name | d() | length > 0 and item.state | d('present') != 'absent'
 
 - name: Check if systemd instances for Green Unicorn are configured
   ansible.builtin.stat:
@@ -69,9 +69,9 @@
                            + gunicorn__dependent_applications) }}'
   notify: [ 'Reload systemd daemon (gunicorn)' ]
   when: ansible_service_mgr == 'systemd' and
-        gunicorn__register_systemd_templated.stat | d() and
+        gunicorn__register_systemd_templated.stat | d() | length > 0 and
         gunicorn__register_systemd_templated.stat.exists | bool and
-        item.name | d() and item.state | d('present') == 'absent'
+        item.name | d() | length > 0 and item.state | d('present') == 'absent'
 
 - name: Generate systemd configuration files
   ansible.builtin.template:
@@ -92,7 +92,7 @@
                            + gunicorn__dependent_applications) }}'
   notify: [ 'Reload systemd daemon (gunicorn)' ]
   when: ansible_service_mgr == 'systemd' and
-        item.name | d() and item.state | d('present') == 'absent'
+        item.name | d() | length > 0 and item.state | d('present') == 'absent'
 
 - name: Create per-instance systemd directory
   ansible.builtin.file:
@@ -104,7 +104,7 @@
   loop: '{{ q("flattened", gunicorn__applications
                            + gunicorn__dependent_applications) }}'
   when: ansible_service_mgr == 'systemd' and
-        item.name | d() and item.state | d('present') != 'absent'
+        item.name | d() | length > 0 and item.state | d('present') != 'absent'
 
 - name: Generate per-instance systemd configuration
   ansible.builtin.template:
@@ -117,7 +117,7 @@
                            + gunicorn__dependent_applications) }}'
   notify: [ 'Reload systemd daemon (gunicorn)', 'Start Green Unicorn instances' ]
   when: ansible_service_mgr == 'systemd' and
-        item.name | d() and item.state | d('present') != 'absent'
+        item.name | d() | length > 0 and item.state | d('present') != 'absent'
 
 - name: Remove Unicorn instance configuration
   ansible.builtin.file:
@@ -125,7 +125,7 @@
     state: 'absent'
   loop: '{{ q("flattened", gunicorn__applications
                            + gunicorn__dependent_applications) }}'
-  when: item.name | d() and item.state | d('present') == 'absent'
+  when: item.name | d() | length > 0 and item.state | d('present') == 'absent'
 
 - name: Generate Unicorn instance configuration
   ansible.builtin.template:
@@ -137,7 +137,7 @@
   notify: [ 'Start Green Unicorn instances' ]
   loop: '{{ q("flattened", gunicorn__applications
                            + gunicorn__dependent_applications) }}'
-  when: item.name | d() and item.state | d('present') != 'absent'
+  when: item.name | d() | length > 0 and item.state | d('present') != 'absent'
 
 - name: Reload systemd configuration
   ansible.builtin.meta: 'flush_handlers'
@@ -150,4 +150,4 @@
   loop: '{{ q("flattened", gunicorn__applications
                            + gunicorn__dependent_applications) }}'
   when: ansible_service_mgr == 'systemd' and
-        item.name | d() and item.state | d('present') != 'absent'
+        item.name | d() | length > 0 and item.state | d('present') != 'absent'

--- a/ansible/roles/java/tasks/main.yml
+++ b/ansible/roles/java/tasks/main.yml
@@ -24,7 +24,7 @@
   ansible.builtin.command: 'update-java-alternatives -s {{ java__alternatives }}'
   register: java__register_update_alternatives
   changed_when: java__register_update_alternatives.changed | bool
-  when: java__alternatives | d()
+  when: java__alternatives | d() | length > 0
 
 - name: Make sure that Ansible local facts directory exists
   ansible.builtin.file:

--- a/ansible/roles/kodi/tasks/main.yml
+++ b/ansible/roles/kodi/tasks/main.yml
@@ -40,7 +40,7 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  when: kodi__polkit_action | d()
+  when: kodi__polkit_action | d() | length > 0
 
 - name: Remove polkit configuration
   ansible.builtin.file:

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -143,7 +143,7 @@
   ansible.builtin.service:
     name: 'nginx'
     state: 'restarted'
-  when: (nginx_register_installed | d() and not nginx_register_installed.stat.exists and
+  when: (nginx_register_installed | d() | length > 0 and not nginx_register_installed.stat.exists and
          nginx__deploy_state in ['present', 'config'])
 
 - name: Get list of nameservers configured in /etc/resolv.conf
@@ -159,7 +159,7 @@
 - name: Convert list of nameservers to Ansible list
   ansible.builtin.set_fact:
     nginx_ocsp_resolvers: "{{ nginx_register_nameservers.stdout_lines }}"
-  when: ((nginx_register_nameservers.stdout is defined and nginx_register_nameservers.stdout) and
+  when: ((nginx_register_nameservers.stdout is defined and nginx_register_nameservers.stdout | d() | length > 0) and
          (nginx_ocsp_resolvers is undefined or
          (nginx_ocsp_resolvers is defined and not nginx_ocsp_resolvers)) and
          (nginx__deploy_state in ['present', 'config']))
@@ -188,7 +188,7 @@
     owner: 'root'
     group: 'root'
     mode: '0440'
-  when: (ansible_local | d() and ansible_local.sudo | d() and
+  when: (ansible_local | d() | length > 0 and ansible_local.sudo | d() | length > 0 and
          (ansible_local.sudo.installed | d()) | bool and
          nginx__deploy_state in ['present', 'config'])
 

--- a/ansible/roles/nginx/tasks/nginx_htpasswd.yml
+++ b/ansible/roles/nginx/tasks/nginx_htpasswd.yml
@@ -20,7 +20,7 @@
                            + nginx__default_htpasswd
                            + nginx__dependent_htpasswd
                            + nginx_htpasswd | d([])) }}'
-  when: (item.name | d() and (item.state | d() and item.state == 'absent'))
+  when: (item.name | d() | length > 0 and (item.state | d() | length > 0 and item.state == 'absent'))
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Manage users in htpasswd files
@@ -40,5 +40,5 @@
   with_subelements:
     - '{{ nginx__htpasswd + nginx__default_htpasswd + nginx__dependent_htpasswd + nginx_htpasswd | d([]) }}'
     - 'users'
-  when: (item.0.name | d() and item.0.state | d('present') != 'absent' and item.1 | d())
+  when: (item.0.name | d() | length > 0 and item.0.state | d('present') != 'absent' and item.1 | d() | length > 0)
   no_log: '{{ debops__no_log | d(True) }}'

--- a/ansible/roles/owncloud/tasks/copy.yml
+++ b/ansible/roles/owncloud/tasks/copy.yml
@@ -16,7 +16,7 @@
     owner:   '{{ item.parent_dirs_owner | d(owncloud__app_user) }}'
     group:   '{{ item.parent_dirs_group | d(owncloud__app_group) }}'
     mode:    '{{ item.parent_dirs_mode | d("0755") }}'
-  when: ((item.parent_dirs_create | d(True) | bool) and item.dest | d() and item.state | d("present") != 'absent')
+  when: ((item.parent_dirs_create | d(True) | bool) and item.dest | d() | length > 0 and item.state | d("present") != 'absent')
   loop: '{{ q("flattened", owncloud__user_files
                            + owncloud__user_files_group
                            + owncloud__user_files_host) }}'
@@ -43,7 +43,7 @@
   loop: '{{ q("flattened", owncloud__user_files
                            + owncloud__user_files_group
                            + owncloud__user_files_host) }}'
-  when: ((item.src | d() or item.content | d()) and item.dest | d() and
+  when: ((item.src | d() | length > 0 or item.content | d() | length > 0) and item.dest | d() | length > 0 and
          (item.state | d('present') != 'absent'))
 
 - name: Delete files on remote hosts
@@ -54,7 +54,7 @@
   loop: '{{ q("flattened", owncloud__user_files
                            + owncloud__user_files_group
                            + owncloud__user_files_host) }}'
-  when: (item.dest | d() and (item.state | d('present') == 'absent'))
+  when: (item.dest | d() | length > 0 and (item.state | d('present') == 'absent'))
 
 - name: Run occ commands as specified in the inventory
   ansible.builtin.include_tasks: 'run_occ.yml'  # noqa no-handler

--- a/ansible/roles/owncloud/tasks/main_env.yml
+++ b/ansible/roles/owncloud/tasks/main_env.yml
@@ -14,7 +14,7 @@
     owner: '{{ ansible_local.nginx.user | d("www-data") }}'
     group: 'root'
     mode: '0700'
-  when: (owncloud__webserver in ["nginx"] and owncloud__nginx_client_body_temp_path | d())
+  when: (owncloud__webserver in ["nginx"] and owncloud__nginx_client_body_temp_path | d() | length > 0)
 
 - name: Ensure the custom temp directories are setup
   ansible.builtin.file:
@@ -23,7 +23,7 @@
     owner: '{{ owncloud__app_user }}'
     group: '{{ owncloud__app_group }}'
     mode: '{{ item.mode | d("1750") }}'
-  when: item.path | d()
+  when: item.path | d() | length > 0
   with_items:
     - path: '{{ owncloud__temp_path }}'
     - path: '{{ owncloud__php_temp_path }}'

--- a/ansible/roles/owncloud/tasks/run_occ.yml
+++ b/ansible/roles/owncloud/tasks/run_occ.yml
@@ -59,8 +59,8 @@
   become_user: '{{ owncloud__app_user }}'
   ## https://github.com/debops/ansible-owncloud/issues/62
   when: (owncloud__do_autosetup | d() | bool and
-         owncloud__occ_item | d() and
-         owncloud__occ_item.command | d() and
+         owncloud__occ_item | d() | length > 0 and
+         owncloud__occ_item.command | d() | length > 0 and
          (owncloud__occ_item.when | d(True) | bool) and not
           (ansible_local.owncloud.maintenance | d() | bool and
            (owncloud__occ_item.command.startswith("dav") or
@@ -85,5 +85,5 @@
     ## regex_replace: Relies on the fact that `json_pretty` indents the JSON encoded object.
     owncloud__occ_run_output: '{{ owncloud__occ_run.stdout_lines
                                   | map("regex_replace", "^[^{} ].*$", "") | join("") | from_json }}'
-  when: (owncloud__do_autosetup | d() | bool and owncloud__occ_item | d() and (owncloud__occ_item.get_output | d() | bool) and (not ansible_check_mode))
+  when: (owncloud__do_autosetup | d() | bool and owncloud__occ_item | d() | length > 0 and (owncloud__occ_item.get_output | d() | bool) and (not ansible_check_mode))
   tags: [ 'role::owncloud:occ_config', 'role::owncloud:occ' ]

--- a/ansible/roles/owncloud/tasks/theme.yml
+++ b/ansible/roles/owncloud/tasks/theme.yml
@@ -24,7 +24,7 @@
     path: '{{ owncloud__deploy_path + "/themes/" + owncloud__theme_directory_name }}'
     state: 'directory'
     mode: '0755'
-  when: (owncloud__theme_directory_name | d())
+  when: (owncloud__theme_directory_name | d() | length > 0)
   tags:
     - 'role::owncloud:theme:common_settings'
 
@@ -37,7 +37,7 @@
     group: '{{ owncloud__app_group }}'
     mode: '0640'
     validate: 'php -f %s'
-  when: (owncloud__theme_directory_name | d())
+  when: (owncloud__theme_directory_name | d() | length > 0)
   tags: [ 'role::owncloud:theme:common_settings' ]
 
 - name: Ensure that parent directories exist
@@ -48,7 +48,7 @@
     group: '{{ item.value.base_directory_group | d(omit) }}'
     mode:  '{{ item.value.base_directory_mode | d(omit) }}'
   with_dict: '{{ owncloud__theme_copy_files_combined }}'
-  when: (owncloud__theme_directory_name | d() and item.value.state | d("present") == "present")
+  when: (owncloud__theme_directory_name | d() | length > 0 and item.value.state | d("present") == "present")
   tags: [ 'role::owncloud:theme:copy' ]
 
 - name: Copy additional theme files
@@ -70,7 +70,7 @@
     src:            '{{ item.value.src | d(omit) }}'
     validate:       '{{ item.value.validate | d(omit) }}'
   with_dict: '{{ owncloud__theme_copy_files_combined }}'
-  when: (owncloud__theme_directory_name | d() and item.value.state | d("present") == "present")
+  when: (owncloud__theme_directory_name | d() | length > 0 and item.value.state | d("present") == "present")
   tags: [ 'role::owncloud:theme:copy' ]
 
 - name: Activate custom theme
@@ -80,7 +80,7 @@
     owner: 'root'
     group: '{{ owncloud__app_group }}'
     mode: '0640'
-  when: (owncloud__theme_active | d())
+  when: (owncloud__theme_active | d() | length > 0)
   tags: [ 'role::owncloud:theme:activate' ]
 
 # .. ]]]
@@ -98,7 +98,7 @@
   ansible.builtin.file:
     path: '{{ owncloud__deploy_path + "/themes/" + owncloud__theme_directory_name + "/" + item.key }}'
     state: 'absent'
-  when: (owncloud__theme_directory_name | d() and item.value.state | d("present") == "absent")
+  when: (owncloud__theme_directory_name | d() | length > 0 and item.value.state | d("present") == "absent")
   with_dict: '{{ owncloud__theme_copy_files_combined }}'
   tags: [ 'role::owncloud:theme:copy' ]
 

--- a/ansible/roles/php/tasks/main.yml
+++ b/ansible/roles/php/tasks/main.yml
@@ -71,7 +71,7 @@
     owner: 'root'
     group: 'root'
     mode: '0440'
-  when: (ansible_local | d() and ansible_local.sudo | d() and
+  when: (ansible_local | d() | length > 0 and ansible_local.sudo | d() | length > 0 and
          (ansible_local.sudo.installed | d()) | bool)
 
                                                                    # ]]]
@@ -102,7 +102,7 @@
                            + php__group_configuration
                            + php__host_configuration
                            + php__dependent_configuration) }}'
-  when: item.state | d() and item.state == 'absent'
+  when: item.state | d() | length > 0 and item.state == 'absent'
   notify: [ 'Restart php-fpm' ]
   tags: [ 'role::php:config' ]
 
@@ -165,7 +165,7 @@
                            + php__group_pools
                            + php__host_pools
                            + php__dependent_pools) }}'
-  when: '"fpm" in php__server_api_packages and item.state | d() and item.state == "absent"'
+  when: '"fpm" in php__server_api_packages and item.state | d() | length > 0 and item.state == "absent"'
   notify: [ 'Restart php-fpm' ]
   tags: [ 'role::php:pools', 'role::php:config' ]
 
@@ -182,7 +182,7 @@
                            + php__group_pools
                            + php__host_pools
                            + php__dependent_pools) }}'
-  when: '"fpm" in php__server_api_packages and item.state | d("present") != "absent" and item.owner | d() and item.home | d()'
+  when: '"fpm" in php__server_api_packages and item.state | d("present") != "absent" and item.owner | d() | length > 0 and item.home | d() | length > 0'
 
 - name: Make sure required system accounts exist
   ansible.builtin.user:
@@ -197,7 +197,7 @@
                            + php__group_pools
                            + php__host_pools
                            + php__dependent_pools) }}'
-  when: '"fpm" in php__server_api_packages and item.state | d("present") != "absent" and item.owner | d() and item.home | d()'
+  when: '"fpm" in php__server_api_packages and item.state | d("present") != "absent" and item.owner | d() | length > 0 and item.home | d() | length > 0'
 
                                                                    # ]]]
 # Ansible local facts [[[

--- a/ansible/roles/ruby/tasks/main.yml
+++ b/ansible/roles/ruby/tasks/main.yml
@@ -40,7 +40,7 @@
                            + ruby__group_user_gems
                            + ruby__host_user_gems
                            + ruby__dependent_user_gems) }}'
-  when: (item.group | d() or item.owner | d())
+  when: (item.group | d() | length > 0 or item.owner | d() | length > 0)
 
 - name: Make sure that required users exist
   ansible.builtin.user:
@@ -54,7 +54,7 @@
                            + ruby__group_user_gems
                            + ruby__host_user_gems
                            + ruby__dependent_user_gems) }}'
-  when: item.owner | d()
+  when: item.owner | d() | length > 0
 
 - name: Install Ruby user gems
   community.general.gem:
@@ -73,4 +73,4 @@
                            + ruby__dependent_user_gems) }}'
   become: True
   become_user: '{{ item.user | d(item.owner) }}'
-  when: (item.user | d() or item.owner | d())
+  when: (item.user | d() | length > 0 or item.owner | d() | length > 0)


### PR DESCRIPTION
Replace | d() truthiness checks with | d() | length > 0 to produce proper boolean results in when conditions, avoiding deprecation warnings that will become errors in Ansible 2.19.

Affected roles: nginx, php, gunicorn, owncloud, foodsoft, ruby, golang, java, kodi
