### PR TITLE
fix(database/messaging roles): ensure when conditionals return bool (Ansible 2.19)

### DIFF
--- a/ansible/roles/elasticsearch/tasks/authentication.yml
+++ b/ansible/roles/elasticsearch/tasks/authentication.yml
@@ -37,7 +37,7 @@
   loop: '{{ elasticsearch__register_builtin_users.stdout_lines }}'
   become: False
   delegate_to: 'localhost'
-  when: elasticsearch__register_builtin_users.stdout_lines | d()
+  when: elasticsearch__register_builtin_users.stdout_lines | d() | length > 0
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Save generated user passwords on Ansible Controller
@@ -48,5 +48,5 @@
   loop: '{{ elasticsearch__register_builtin_users.stdout_lines }}'
   become: False
   delegate_to: 'localhost'
-  when: elasticsearch__register_builtin_users.stdout_lines | d()
+  when: elasticsearch__register_builtin_users.stdout_lines | d() | length > 0
   no_log: '{{ debops__no_log | d(True) }}'

--- a/ansible/roles/elasticsearch/tasks/main.yml
+++ b/ansible/roles/elasticsearch/tasks/main.yml
@@ -31,7 +31,7 @@
     name: '{{ elasticsearch__user }}'
     groups: '{{ elasticsearch__additional_groups }}'
     append: True
-  when: elasticsearch__additional_groups | d()
+  when: elasticsearch__additional_groups | d() | length > 0
 
 - name: Make sure that Ansible local facts directory exists
   ansible.builtin.file:
@@ -60,7 +60,7 @@
   register: elasticsearch__register_dependent_config_file
   become: False
   delegate_to: 'localhost'
-  when: (ansible_local.elasticsearch.installed | d())
+  when: (ansible_local.elasticsearch.installed | d() | length > 0)
   tags: [ 'role::elasticsearch:config' ]
 
 - name: Load the dependent configuration from Ansible Controller
@@ -69,7 +69,7 @@
   register: elasticsearch__register_dependent_config
   become: False
   delegate_to: 'localhost'
-  when: (ansible_local.elasticsearch.installed | d() and
+  when: (ansible_local.elasticsearch.installed | d() | length > 0 and
          elasticsearch__register_dependent_config_file.stat.exists | bool)
   tags: [ 'role::elasticsearch:config' ]
 
@@ -158,7 +158,7 @@
   loop: '{{ q("flattened", elasticsearch__combined_plugins) }}'
   register: elasticsearch__register_plugin_install
   changed_when: elasticsearch__register_plugin_install.changed | bool
-  when: (item.name | d() and item.state | d('present') != 'absent' and
+  when: (item.name | d() | length > 0 and item.state | d('present') != 'absent' and
          (item.name if ':' not in item.name else item.name.split(':')[1])
          not in elasticsearch__register_plugins.stdout_lines)
 
@@ -170,7 +170,7 @@
   loop: '{{ q("flattened", elasticsearch__combined_plugins) }}'
   register: elasticsearch__register_plugin_remove
   changed_when: elasticsearch__register_plugin_remove.changed | bool
-  when: (item.name | d() and item.state | d('present') == 'absent' and
+  when: (item.name | d() | length > 0 and item.state | d('present') == 'absent' and
          (item.name if ':' not in item.name else item.name.split(':')[1])
          in elasticsearch__register_plugins.stdout_lines)
 

--- a/ansible/roles/elasticsearch/tasks/reset_password.yml
+++ b/ansible/roles/elasticsearch/tasks/reset_password.yml
@@ -21,7 +21,7 @@
     mode: '0755'
   become: False
   delegate_to: 'localhost'
-  when: elasticsearch__register_builtin_password.stdout_lines | d()
+  when: elasticsearch__register_builtin_password.stdout_lines | d() | length > 0
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Save generated password of account '{{ item }}'
@@ -31,5 +31,5 @@
     mode: '0644'
   become: False
   delegate_to: 'localhost'
-  when: elasticsearch__register_builtin_password.stdout | d()
+  when: elasticsearch__register_builtin_password.stdout | d() | length > 0
   no_log: '{{ debops__no_log | d(True) }}'

--- a/ansible/roles/kibana/tasks/main.yml
+++ b/ansible/roles/kibana/tasks/main.yml
@@ -29,7 +29,7 @@
     name: '{{ kibana__user }}'
     groups: '{{ kibana__additional_groups }}'
     append: True
-  when: kibana__additional_groups | d()
+  when: kibana__additional_groups | d() | length > 0
 
 - name: Make sure that Ansible local facts directory exists
   ansible.builtin.file:
@@ -58,7 +58,7 @@
   register: kibana__register_dependent_config_file
   become: False
   delegate_to: 'localhost'
-  when: (ansible_local.kibana.installed | d())
+  when: (ansible_local.kibana.installed | d() | length > 0)
   tags: [ 'role::kibana:config' ]
 
 - name: Load the dependent configuration from Ansible Controller
@@ -67,7 +67,7 @@
   register: kibana__register_dependent_config
   become: False
   delegate_to: 'localhost'
-  when: (ansible_local.kibana.installed | d() and
+  when: (ansible_local.kibana.installed | d() | length > 0 and
          kibana__register_dependent_config_file.stat.exists | bool)
   tags: [ 'role::kibana:config' ]
 
@@ -109,7 +109,7 @@
   loop: '{{ q("flattened", kibana__combined_plugins) }}'
   register: kibana__register_plugin_install
   changed_when: kibana__register_plugin_install.changed | bool
-  when: (item.name | d() and item.state | d('present') != 'absent' and
+  when: (item.name | d() | length > 0 and item.state | d('present') != 'absent' and
          (item.name if ':' not in item.name else item.name.split(':')[1]) not in kibana__register_plugins.stdout_lines)
 
 - name: Remove Kibana plugins
@@ -122,7 +122,7 @@
   loop: '{{ q("flattened", kibana__combined_plugins) }}'
   register: kibana__register_plugin_remove
   changed_when: kibana__register_plugin_remove.changed | bool
-  when: (item.name | d() and item.state | d('present') == 'absent' and
+  when: (item.name | d() | length > 0 and item.state | d('present') == 'absent' and
          (item.name if ':' not in item.name else item.name.split(':')[1]) in kibana__register_plugins.stdout_lines)
 
 # The keystore handling is very similar to ../../metricbeat/tasks/main.yml

--- a/ansible/roles/mariadb_server/tasks/configure_server.yml
+++ b/ansible/roles/mariadb_server/tasks/configure_server.yml
@@ -18,7 +18,7 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  when: mariadb_server__backup | d()
+  when: mariadb_server__backup | d() | length > 0
 
 - name: Enable events table backup in mysqldump
   community.general.ini_file:

--- a/ansible/roles/postgresql_server/tasks/manage_clusters.yml
+++ b/ansible/roles/postgresql_server/tasks/manage_clusters.yml
@@ -25,7 +25,7 @@
     creates: '/etc/postgresql/{{ item.version | d(postgresql_server__version) }}/{{ item.name }}/postgresql.conf'
   register: postgresql_server__register_createcluster
   loop: '{{ q("flattened", postgresql_server__clusters) }}'
-  when: item.name | d() and item.port | d()
+  when: item.name | d() | length > 0 and item.port | d() | length > 0
 
 - name: Remove data directory for PostgreSQL replication standby clusters
   ansible.builtin.file:
@@ -77,7 +77,7 @@
     state: directory
     recurse: yes
   loop: '{{ q("flattened", postgresql_server__clusters) }}'
-  when: item.log_directory | d() and item.log_directory is abs
+  when: item.log_directory | d() | length > 0 and item.log_directory is abs
   tags: [ 'role::postgresql_server:config' ]
 
 - name: Ensure that conf.d directories exist
@@ -88,7 +88,7 @@
     group: '{{ item.group | d(postgresql_server__group) }}'
     mode: '0755'
   loop: '{{ q("flattened", postgresql_server__clusters) }}'
-  when: item.name | d()
+  when: item.name | d() | length > 0
   tags: [ 'role::postgresql_server:config' ]
 
 - name: Configure PostgreSQL clusters
@@ -99,7 +99,7 @@
     group: '{{ item.group | d(postgresql_server__group) }}'
     mode: '0644'
   loop: '{{ q("flattened", postgresql_server__clusters) }}'
-  when: item.name | d()
+  when: item.name | d() | length > 0
   register: postgresql_server__register_config
   tags: [ 'role::postgresql_server:config' ]
 
@@ -111,7 +111,7 @@
     group: '{{ item.group | d(postgresql_server__group) }}'
     mode: '0644'
   loop: '{{ q("flattened", postgresql_server__clusters) }}'
-  when: item.name | d()
+  when: item.name | d() | length > 0
   register: postgresql_server__register_config_environment
   tags: [ 'role::postgresql_server:config' ]
 
@@ -123,7 +123,7 @@
     group: '{{ item.group | d(postgresql_server__group) }}'
     mode: '0640'
   loop: '{{ q("flattened", postgresql_server__clusters) }}'
-  when: item.name | d()
+  when: item.name | d() | length > 0
   register: postgresql_server__register_config_ident
   tags: [ 'role::postgresql_server:config' ]
 
@@ -135,7 +135,7 @@
     group: '{{ item.group | d(postgresql_server__group) }}'
     mode: '0640'
   loop: '{{ q("flattened", postgresql_server__clusters) }}'
-  when: item.name | d()
+  when: item.name | d() | length > 0
   register: postgresql_server__register_config_hba
   tags: [ 'role::postgresql_server:config' ]
 
@@ -147,7 +147,7 @@
     group: '{{ item.group | d(postgresql_server__group) }}'
     mode: '0640'
   loop: '{{ q("flattened", postgresql_server__clusters) }}'
-  when: item.name | d()
+  when: item.name | d() | length > 0
   register: postgresql_server__register_trusted
   tags: [ 'role::postgresql_server:config' ]
 
@@ -159,7 +159,7 @@
     group: '{{ item.group | d(postgresql_server__group) }}'
     mode: '0644'
   loop: '{{ q("flattened", postgresql_server__clusters) }}'
-  when: item.name | d()
+  when: item.name | d() | length > 0
   register: postgresql_server__register_config_start
   tags: [ 'role::postgresql_server:config' ]
 
@@ -173,10 +173,10 @@
     state: 'link'
     mode: '0644'
   loop: '{{ q("flattened", postgresql_server__clusters) }}'
-  when: ((postgresql_server__pki | d() and postgresql_server__pki | bool) and
-         (item.name | d()) and
-         ((item.version | d() and item.version == '9.1') or
-          (postgresql_server__version | d() and postgresql_server__version == '9.1')))
+  when: ((postgresql_server__pki | d() | length > 0 and postgresql_server__pki | bool) and
+         (item.name | d() | length > 0) and
+         ((item.version | d() | length > 0 and item.version == '9.1') or
+          (postgresql_server__version | d() | length > 0 and postgresql_server__version == '9.1')))
 
 - name: Symlink SSL certificate
   ansible.builtin.file:
@@ -188,10 +188,10 @@
     state: 'link'
     mode: '0644'
   loop: '{{ q("flattened", postgresql_server__clusters) }}'
-  when: ((postgresql_server__pki | d() and postgresql_server__pki | bool) and
-         (item.name | d()) and
-         ((item.version | d() and item.version == '9.1') or
-          (postgresql_server__version | d() and postgresql_server__version == '9.1')))
+  when: ((postgresql_server__pki | d() | length > 0 and postgresql_server__pki | bool) and
+         (item.name | d() | length > 0) and
+         ((item.version | d() | length > 0 and item.version == '9.1') or
+          (postgresql_server__version | d() | length > 0 and postgresql_server__version == '9.1')))
 
 - name: Symlink SSL key
   ansible.builtin.file:
@@ -203,10 +203,10 @@
     state: 'link'
     mode: '0640'
   loop: '{{ q("flattened", postgresql_server__clusters) }}'
-  when: ((postgresql_server__pki | d() and postgresql_server__pki | bool) and
-         (item.name | d()) and
-         ((item.version | d() and item.version == '9.1') or
-          (postgresql_server__version | d() and postgresql_server__version == '9.1')))
+  when: ((postgresql_server__pki | d() | length > 0 and postgresql_server__pki | bool) and
+         (item.name | d() | length > 0) and
+         ((item.version | d() | length > 0 and item.version == '9.1') or
+          (postgresql_server__version | d() | length > 0 and postgresql_server__version == '9.1')))
 
 - name: Start PostgreSQL clusters when not started
   ansible.builtin.command: pg_ctlcluster {{ item.version | d(postgresql_server__version) }} {{ item.name }} start
@@ -215,7 +215,7 @@
                                             + "-" + item.name + ".pid") }}'
   loop: '{{ q("flattened", postgresql_server__clusters) }}'
   when: (ansible_service_mgr != 'systemd' and
-         ((item.name | d()) and
+         ((item.name | d() | length > 0) and
           (item.start_conf is undefined or item.start_conf == 'auto')))
 
 - name: Start PostgreSQL clusters when not started (systemd)
@@ -224,7 +224,7 @@
     state: 'started'
   loop: '{{ q("flattened", postgresql_server__clusters) }}'
   when: (ansible_service_mgr == 'systemd' and
-         ((item.name | d()) and
+         ((item.name | d() | length > 0) and
           (item.start_conf is undefined or item.start_conf == 'auto')))
 
 - name: Reload PostgreSQL clusters when needed

--- a/ansible/roles/rabbitmq_server/tasks/main.yml
+++ b/ansible/roles/rabbitmq_server/tasks/main.yml
@@ -81,7 +81,7 @@
   register: rabbitmq_server__register_dependent_config_file
   become: False
   delegate_to: 'localhost'
-  when: (ansible_local | d() and ansible_local.rabbitmq_server | d() and
+  when: (ansible_local | d() | length > 0 and ansible_local.rabbitmq_server | d() | length > 0 and
          ansible_local.rabbitmq_server.installed is defined and
          ansible_local.rabbitmq_server.installed | bool)
   tags: [ 'role::rabbitmq_server:config' ]
@@ -92,7 +92,7 @@
   register: rabbitmq_server__register_dependent_config
   become: False
   delegate_to: 'localhost'
-  when: (ansible_local | d() and ansible_local.rabbitmq_server | d() and
+  when: (ansible_local | d() | length > 0 and ansible_local.rabbitmq_server | d() | length > 0 and
          ansible_local.rabbitmq_server.installed is defined and
          ansible_local.rabbitmq_server.installed | bool and
          rabbitmq_server__register_dependent_config_file.stat.exists | bool)
@@ -183,7 +183,7 @@
     value:     '{{ item.value | d(omit) }}'
     vhost:     '{{ item.vhost | d(omit) }}'
   loop: '{{ q("flattened", rabbitmq_server__combined_parameters) }}'
-  when: (item.name | d() and item.component | d())
+  when: (item.name | d() | length > 0 and item.component | d() | length > 0)
   tags: [ 'role::rabbitmq_server:parameter' ]
 
 - name: Manage RabbitMQ policies
@@ -197,7 +197,7 @@
     state:    '{{ item.state | d("present") }}'
     vhost:    '{{ item.vhost | d(omit) }}'
   loop: '{{ q("flattened", rabbitmq_server__combined_policies) }}'
-  when: (item.name | d() and item.pattern | d() and item.tags | d())
+  when: (item.name | d() | length > 0 and item.pattern | d() | length > 0 and item.tags | d() | length > 0)
   tags: [ 'role::rabbitmq_server:policy' ]
 
 - name: Manage RabbitMQ user accounts

--- a/ansible/roles/redis_sentinel/tasks/main.yml
+++ b/ansible/roles/redis_sentinel/tasks/main.yml
@@ -67,7 +67,7 @@
     mode: '0755'
   loop: '{{ redis_sentinel__combined_configuration | debops.debops.parse_kv_items
             | product(["", "/reconfig.d", "/notify.d"]) | list }}'
-  when: item.0.name | d() and item.0.state | d('present') not in ['absent', 'init', 'ignore']
+  when: item.0.name | d() | length > 0 and item.0.state | d('present') not in ['absent', 'init', 'ignore']
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Generate initial Redis Sentinel configuration
@@ -79,7 +79,7 @@
     mode: '0640'
     force: False
   with_items: '{{ redis_sentinel__combined_configuration | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'init', 'ignore']
+  when: item.name | d() | length > 0 and item.state | d('present') not in ['absent', 'init', 'ignore']
   notify: [ 'Refresh host facts' ]
   no_log: '{{ debops__no_log | d(True) }}'
 
@@ -92,7 +92,7 @@
     mode: '0755'
   loop: '{{ redis_sentinel__combined_configuration | debops.debops.parse_kv_items
             | product(["notify.sh", "reconfig.sh"]) | list }}'
-  when: item.0.name | d() and item.0.state | d('present') not in ['absent', 'init', 'ignore']
+  when: item.0.name | d() | length > 0 and item.0.state | d('present') not in ['absent', 'init', 'ignore']
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Install custom systemd unit files
@@ -115,8 +115,8 @@
     group: 'root'
     mode: '0755'
   with_items: '{{ redis_sentinel__combined_configuration | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'init', 'ignore'] and
-        item.systemd_override | d()
+  when: item.name | d() | length > 0 and item.state | d('present') not in ['absent', 'init', 'ignore'] and
+        item.systemd_override | d() | length > 0
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Generate systemd instance override files
@@ -127,8 +127,8 @@
     group: 'root'
     mode: '0644'
   with_items: '{{ redis_sentinel__combined_configuration | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'init', 'ignore'] and
-        item.systemd_override | d()
+  when: item.name | d() | length > 0 and item.state | d('present') not in ['absent', 'init', 'ignore'] and
+        item.systemd_override | d() | length > 0
   notify: [ 'Reload service manager' ]
   no_log: '{{ debops__no_log | d(True) }}'
 
@@ -138,7 +138,7 @@
     state: 'stopped'
     enabled: False
   with_items: '{{ redis_sentinel__combined_configuration | debops.debops.parse_kv_items }}'
-  when: ansible_service_mgr == 'systemd' and item.name | d() and
+  when: ansible_service_mgr == 'systemd' and item.name | d() | length > 0 and
         item.state | d('present') == 'absent'
   no_log: '{{ debops__no_log | d(True) }}'
 
@@ -148,7 +148,7 @@
     state: 'absent'
   with_items: '{{ redis_sentinel__combined_configuration | debops.debops.parse_kv_items }}'
   notify: [ 'Reload service manager' ]
-  when: ansible_service_mgr == 'systemd' and item.name | d() and
+  when: ansible_service_mgr == 'systemd' and item.name | d() | length > 0 and
         item.state | d('present') == 'absent'
   no_log: '{{ debops__no_log | d(True) }}'
 
@@ -157,7 +157,7 @@
     path: '/etc/redis/sentinel-{{ item.name }}'
     state: 'absent'
   with_items: '{{ redis_sentinel__combined_configuration | debops.debops.parse_kv_items }}'
-  when: ansible_service_mgr == 'systemd' and item.name | d() and
+  when: ansible_service_mgr == 'systemd' and item.name | d() | length > 0 and
         item.state | d('present') == 'absent'
   no_log: '{{ debops__no_log | d(True) }}'
 
@@ -170,6 +170,6 @@
     state: 'started'
     enabled: True
   with_items: '{{ redis_sentinel__combined_configuration | debops.debops.parse_kv_items }}'
-  when: ansible_service_mgr == 'systemd' and item.name | d() and
+  when: ansible_service_mgr == 'systemd' and item.name | d() | length > 0 and
         item.state | d('present') not in ['absent', 'init', 'ignore']
   no_log: '{{ debops__no_log | d(True) }}'

--- a/ansible/roles/redis_server/tasks/main.yml
+++ b/ansible/roles/redis_server/tasks/main.yml
@@ -74,7 +74,7 @@
     group: 'root'
     mode: '0755'
   with_items: '{{ redis_server__combined_configuration | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'init', 'ignore']
+  when: item.name | d() | length > 0 and item.state | d('present') not in ['absent', 'init', 'ignore']
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Install the original Redis config file to instance
@@ -83,7 +83,7 @@
   args:
     creates: '/etc/redis/{{ item.name }}/redis.conf'
   with_items: '{{ redis_server__combined_configuration | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'init', 'ignore']
+  when: item.name | d() | length > 0 and item.state | d('present') not in ['absent', 'init', 'ignore']
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Generate dynamic Redis configuration scripts
@@ -94,7 +94,7 @@
     group: '{{ redis_server__group }}'
     mode: '0750'
   with_items: '{{ redis_server__combined_configuration | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'init', 'ignore']
+  when: item.name | d() | length > 0 and item.state | d('present') not in ['absent', 'init', 'ignore']
   register: redis_server__register_config_dynamic
   notify: [ 'Refresh host facts' ]
   no_log: '{{ debops__no_log | d(True) }}'
@@ -107,7 +107,7 @@
     group: '{{ redis_server__group }}'
     mode: '0640'
   with_items: '{{ redis_server__combined_configuration | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'init', 'ignore']
+  when: item.name | d() | length > 0 and item.state | d('present') not in ['absent', 'init', 'ignore']
   register: redis_server__register_config_static
   notify: [ 'Refresh host facts' ]
   no_log: '{{ debops__no_log | d(True) }}'
@@ -153,8 +153,8 @@
     group: 'root'
     mode: '0755'
   with_items: '{{ redis_server__combined_configuration | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'init', 'ignore'] and
-        item.systemd_override | d()
+  when: item.name | d() | length > 0 and item.state | d('present') not in ['absent', 'init', 'ignore'] and
+        item.systemd_override | d() | length > 0
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Generate systemd instance override files
@@ -165,8 +165,8 @@
     group: 'root'
     mode: '0644'
   with_items: '{{ redis_server__combined_configuration | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'init', 'ignore'] and
-        item.systemd_override | d()
+  when: item.name | d() | length > 0 and item.state | d('present') not in ['absent', 'init', 'ignore'] and
+        item.systemd_override | d() | length > 0
   notify: [ 'Reload service manager' ]
   no_log: '{{ debops__no_log | d(True) }}'
 
@@ -176,7 +176,7 @@
     state: 'stopped'
     enabled: False
   with_items: '{{ redis_server__combined_configuration | debops.debops.parse_kv_items }}'
-  when: ansible_service_mgr == 'systemd' and item.name | d() and
+  when: ansible_service_mgr == 'systemd' and item.name | d() | length > 0 and
         item.state | d('present') == 'absent'
   no_log: '{{ debops__no_log | d(True) }}'
 
@@ -186,7 +186,7 @@
     state: 'absent'
   with_items: '{{ redis_server__combined_configuration | debops.debops.parse_kv_items }}'
   notify: [ 'Reload service manager' ]
-  when: ansible_service_mgr == 'systemd' and item.name | d() and
+  when: ansible_service_mgr == 'systemd' and item.name | d() | length > 0 and
         item.state | d('present') == 'absent'
   no_log: '{{ debops__no_log | d(True) }}'
 
@@ -195,7 +195,7 @@
     path: '/etc/redis/{{ item.name }}'
     state: 'absent'
   with_items: '{{ redis_server__combined_configuration | debops.debops.parse_kv_items }}'
-  when: ansible_service_mgr == 'systemd' and item.name | d() and
+  when: ansible_service_mgr == 'systemd' and item.name | d() | length > 0 and
         item.state | d('present') == 'absent'
   no_log: '{{ debops__no_log | d(True) }}'
 
@@ -208,7 +208,7 @@
     state: 'started'
     enabled: True
   with_items: '{{ redis_server__combined_configuration | debops.debops.parse_kv_items }}'
-  when: ansible_service_mgr == 'systemd' and item.name | d() and
+  when: ansible_service_mgr == 'systemd' and item.name | d() | length > 0 and
         item.state | d('present') not in ['absent', 'init', 'ignore']
   no_log: '{{ debops__no_log | d(True) }}'
 
@@ -244,5 +244,5 @@
               | selectattr('name', 'defined') | list
               | map(attribute='name') | list))))) and
          item.state | d('present') not in ['absent', 'ignore', 'init'] and
-         item.master_host | d() and item.master_port | d())
+         item.master_host | d() | length > 0 and item.master_port | d() | length > 0)
   no_log: '{{ debops__no_log | d(True) }}'


### PR DESCRIPTION
Replace | d() truthiness checks with | d() | length > 0 to produce proper boolean results in when conditions, avoiding deprecation warnings that will become errors in Ansible 2.19.

Affected roles: postgresql_server, mariadb_server, redis_server, redis_sentinel, rabbitmq_server, elasticsearch, kibana