### PR TITLE
fix(monitoring/containers/misc roles): ensure when conditionals return bool (Ansible 2.19)

### DIFF
--- a/ansible/roles/controller/tasks/main.yml
+++ b/ansible/roles/controller/tasks/main.yml
@@ -43,12 +43,12 @@
     dest: '{{ controller__project_name if controller__project_name else controller__project_git_repo | basename }}'
     version: 'master'
     update: True
-  when: controller__project_git_repo | d()
+  when: controller__project_git_repo | d() | length > 0
 
 - name: Initialize new project
   become: '{{ controller__install_systemwide | bool }}'
   ansible.builtin.command: debops-init '{{ controller__project_name }}'
   args:
     creates: '{{ controller__project_name }}/.debops.cfg'
-  when: controller__project_name | d() and
+  when: controller__project_name | d() | length > 0 and
         not controller__project_git_repo | d()

--- a/ansible/roles/filebeat/tasks/main.yml
+++ b/ansible/roles/filebeat/tasks/main.yml
@@ -64,7 +64,7 @@
   loop: '{{ filebeat__combined_snippets | debops.debops.parse_kv_config }}'
   loop_control:
     label:  '{{ {"name": item.name, "state": item.state} }}'
-  when: item.state | d('present') not in ['absent', 'ignore', 'init'] and item.config | d()
+  when: item.state | d('present') not in ['absent', 'ignore', 'init'] and item.config | d() | length > 0
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Remove snippet configuration if requested
@@ -75,7 +75,7 @@
   loop_control:
     label:  '{{ {"name": item.name, "state": item.state, "config": item.config} }}'
   notify: [ 'Test filebeat configuration and restart' ]
-  when: item.state | d('present') == 'absent' and item.config | d()
+  when: item.state | d('present') == 'absent' and item.config | d() | length > 0
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Generate snippet configuration
@@ -87,7 +87,7 @@
   loop_control:
     label:  '{{ {"name": item.name, "state": item.state, "config": item.config} }}'
   notify: [ 'Test filebeat configuration and restart' ]
-  when: item.state | d('present') not in ['absent', 'ignore', 'init'] and item.config | d()
+  when: item.state | d('present') not in ['absent', 'ignore', 'init'] and item.config | d() | length > 0
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Check if the Filebeat keystore exists

--- a/ansible/roles/gitlab_runner/tasks/main.yml
+++ b/ansible/roles/gitlab_runner/tasks/main.yml
@@ -154,7 +154,7 @@
   delegate_to: '{{ item.host }}'
   become: '{{ item.become | d(True) }}'
   with_items: '{{ gitlab_runner__ssh_install_to }}'
-  when: gitlab_runner__ssh_generate | bool and item.user | d() and item.host | d()
+  when: gitlab_runner__ssh_generate | bool and item.user | d() | length > 0 and item.host | d() | length > 0
 
 - name: Make sure that the ~/.ssh directory exists
   ansible.builtin.file:
@@ -163,7 +163,7 @@
     owner: '{{ gitlab_runner__user }}'
     group: '{{ gitlab_runner__group }}'
     mode: '0700'
-  when: gitlab_runner__ssh_known_hosts | d()
+  when: gitlab_runner__ssh_known_hosts | d() | length > 0
 
 - name: Make sure the ~/.ssh/known_hosts file exists
   ansible.builtin.copy:
@@ -173,7 +173,7 @@
     group: '{{ gitlab_runner__group }}'
     mode: '0644'
     force: False
-  when: gitlab_runner__ssh_known_hosts | d()
+  when: gitlab_runner__ssh_known_hosts | d() | length > 0
 
 - name: Get list of already scanned host fingerprints
   ansible.builtin.shell: set -o nounset -o pipefail -o errexit &&
@@ -181,7 +181,7 @@
   args:
     executable: 'bash'
   with_items: '{{ gitlab_runner__ssh_known_hosts }}'
-  when: gitlab_runner__ssh_known_hosts | d()
+  when: gitlab_runner__ssh_known_hosts | d() | length > 0
   register: gitlab_runner__register_known_hosts
   changed_when: False
   failed_when: False

--- a/ansible/roles/icinga_web/tasks/main.yml
+++ b/ansible/roles/icinga_web/tasks/main.yml
@@ -63,8 +63,8 @@
     dest: '{{ icinga_web__src + "/" + item.git_repo.split("://")[1] }}'
     version: '{{ item.git_version }}'
   with_items: '{{ (icinga_web__default_modules + icinga_web__modules) | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.git_repo | d() and
-        item.git_version | d() and item.state | d('present') != 'absent'
+  when: item.name | d() | length > 0 and item.git_repo | d() | length > 0 and
+        item.git_version | d() | length > 0 and item.state | d('present') != 'absent'
 
 - name: Symlink Icinga upstream modules to Icinga Web application
   ansible.builtin.file:
@@ -74,8 +74,8 @@
     force: '{{ True if ansible_check_mode | bool else omit }}'
     mode: '0755'
   with_items: '{{ (icinga_web__default_modules + icinga_web__modules) | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.git_repo | d() and
-        item.git_version | d() and item.state | d('present') != 'absent'
+  when: item.name | d() | length > 0 and item.git_repo | d() | length > 0 and
+        item.git_version | d() | length > 0 and item.state | d('present') != 'absent'
 
 - name: Manage Icinga Web modules
   ansible.builtin.file:
@@ -86,7 +86,7 @@
     force: '{{ True if ansible_check_mode | bool else omit }}'
     mode: '0755'
   with_items: '{{ (icinga_web__default_modules + icinga_web__modules) | debops.debops.parse_kv_items }}'
-  when: item.name | d()
+  when: item.name | d() | length > 0
 
 - name: Generate Icinga Web configuration
   ansible.builtin.template:

--- a/ansible/roles/ipxe/tasks/debian_netboot.yml
+++ b/ansible/roles/ipxe/tasks/debian_netboot.yml
@@ -10,7 +10,7 @@
     state: 'directory'
     mode: '0755'
   loop: '{{ ipxe__debian_netboot_combined_release_map | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'ignore'] and
+  when: item.name | d() | length > 0 and item.state | d('present') not in ['absent', 'ignore'] and
         item.release in ipxe__debian_netboot_releases and item.architecture in ipxe__debian_netboot_architectures
 
 - name: Create Debian installer directories
@@ -20,7 +20,7 @@
     state: 'directory'
     mode: '0775'  # tarball enforces this mode
   loop: '{{ ipxe__debian_netboot_combined_release_map | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'ignore'] and
+  when: item.name | d() | length > 0 and item.state | d('present') not in ['absent', 'ignore'] and
         item.release in ipxe__debian_netboot_releases and item.architecture in ipxe__debian_netboot_architectures
 
 - name: Download Debian netboot tarballs
@@ -34,7 +34,7 @@
     checksum: '{{ item.netboot_checksum | d(omit) }}'
     mode: '0644'
   loop: '{{ ipxe__debian_netboot_combined_release_map | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'ignore'] and
+  when: item.name | d() | length > 0 and item.state | d('present') not in ['absent', 'ignore'] and
         item.release in ipxe__debian_netboot_releases and item.architecture in ipxe__debian_netboot_architectures
   register: ipxe__register_get_netboot
   until: ipxe__register_get_netboot is succeeded
@@ -51,7 +51,7 @@
                  + item.netboot_version + (item.netboot_subdir | d("")) + "/pxelinux.0" }}'
   loop: '{{ ipxe__debian_netboot_combined_release_map | debops.debops.parse_kv_items }}'
   register: ipxe__register_debian_installer
-  when: item.name | d() and item.state | d('present') not in ['absent', 'ignore'] and
+  when: item.name | d() | length > 0 and item.state | d('present') not in ['absent', 'ignore'] and
         item.release in ipxe__debian_netboot_releases and item.architecture in ipxe__debian_netboot_architectures
 
 - name: Point current Debian netboot symlink to correct version
@@ -61,7 +61,7 @@
     state: 'link'
     mode: '0775'
   loop: '{{ ipxe__debian_netboot_combined_release_map | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'ignore'] and
+  when: item.name | d() | length > 0 and item.state | d('present') not in ['absent', 'ignore'] and
         item.release in ipxe__debian_netboot_releases and item.architecture in ipxe__debian_netboot_architectures and
         (item.netboot_current | d(True)) | bool
 
@@ -71,8 +71,8 @@
     state: 'directory'
     mode: '0755'
   loop: '{{ ipxe__debian_netboot_combined_release_map | debops.debops.parse_kv_items }}'
-  when: ipxe__debian_netboot_firmware | bool and item.name | d() and item.state | d('present') not in ['absent', 'ignore'] and
-        item.release in ipxe__debian_netboot_releases and item.firmware_version | d()
+  when: ipxe__debian_netboot_firmware | bool and item.name | d() | length > 0 and item.state | d('present') not in ['absent', 'ignore'] and
+        item.release in ipxe__debian_netboot_releases and item.firmware_version | d() | length > 0
 
 - name: Download Debian firmware tarballs
   ansible.builtin.get_url:
@@ -83,8 +83,8 @@
     checksum: '{{ item.firmware_checksum | d(omit) }}'
     mode: '0644'
   loop: '{{ ipxe__debian_netboot_combined_release_map | debops.debops.parse_kv_items }}'
-  when: ipxe__debian_netboot_firmware | bool and item.name | d() and item.state | d('present') not in ['absent', 'ignore'] and
-        item.release in ipxe__debian_netboot_releases and item.firmware_version | d()
+  when: ipxe__debian_netboot_firmware | bool and item.name | d() | length > 0 and item.state | d('present') not in ['absent', 'ignore'] and
+        item.release in ipxe__debian_netboot_releases and item.firmware_version | d() | length > 0
   register: ipxe__register_get_firmware
   until: ipxe__register_get_firmware is succeeded
 
@@ -97,4 +97,4 @@
   loop: '{{ ipxe__register_debian_installer.results }}'  # noqa no-handler
   register: ipxe__register_netboot_merge
   changed_when: ipxe__register_netboot_merge.changed | bool
-  when: ipxe__debian_netboot_firmware | bool and item.item.firmware_version | d() and item is changed
+  when: ipxe__debian_netboot_firmware | bool and item.item.firmware_version | d() | length > 0 and item is changed

--- a/ansible/roles/libvirtd/tasks/main.yml
+++ b/ansible/roles/libvirtd/tasks/main.yml
@@ -91,7 +91,7 @@
     groups: "{{ libvirtd__unix_sock_group }}"
     append: True
   with_items: '{{ libvirtd__admins }}'
-  when: libvirtd__admins | d()
+  when: libvirtd__admins | d() | length > 0
 
 - name: Install ferm post hook
   ansible.builtin.template:

--- a/ansible/roles/lxc/tasks/main.yml
+++ b/ansible/roles/lxc/tasks/main.yml
@@ -150,7 +150,7 @@
     group: 'root'
     mode: '0755'
   when: (lxc__net_deploy_state == 'present' and
-         ansible_local | d() and ansible_local.ferm | d() and
+         ansible_local | d() | length > 0 and ansible_local.ferm | d() | length > 0 and
          (ansible_local.ferm.enabled | d()) | bool)
   tags: [ 'role::lxc:net' ]
 
@@ -214,14 +214,14 @@
     user: 'root'
     state: 'present'
     exclusive: True
-  when: lxc__default_container_ssh_root_sshkeys | d()
+  when: lxc__default_container_ssh_root_sshkeys | d() | length > 0
 
 - name: Remove LXC configuration if requested
   ansible.builtin.file:
     path: '/etc/lxc/{{ item.filename | d(item.name + ".conf") }}'
     state: 'absent'
   with_items: '{{ lxc__combined_configuration | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') == 'absent'
+  when: item.name | d() | length > 0 and item.state | d('present') == 'absent'
 
 - name: Generate LXC configuration
   ansible.builtin.template:
@@ -231,14 +231,14 @@
     group: 'root'
     mode: '0644'
   with_items: '{{ lxc__combined_configuration | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'ignore', 'init']
+  when: item.name | d() | length > 0 and item.state | d('present') not in ['absent', 'ignore', 'init']
 
 - name: Remove common LXC container configuration if requested
   ansible.builtin.file:
     path: '/usr/share/lxc/config/common.conf.d/{{ item.filename | d(item.name + ".conf") }}'
     state: 'absent'
   with_items: '{{ lxc__common_combined_conf | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') == 'absent'
+  when: item.name | d() | length > 0 and item.state | d('present') == 'absent'
 
 - name: Generate common LXC container configuration
   ansible.builtin.template:
@@ -248,7 +248,7 @@
     group: 'root'
     mode: '0644'
   with_items: '{{ lxc__common_combined_conf | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'ignore', 'init']
+  when: item.name | d() | length > 0 and item.state | d('present') not in ['absent', 'ignore', 'init']
 
 - name: Stop LXC containers if requested
   ansible.builtin.systemd:
@@ -256,7 +256,7 @@
     state: 'stopped'
     enabled: '{{ True if item.state | d("started") == "stopped" else False }}'
   loop: '{{ lxc__containers }}'
-  when: ansible_local | d() and ansible_local.lxc | d() and
+  when: ansible_local | d() | length > 0 and ansible_local.lxc | d() | length > 0 and
         (item.name | d(item)) in ansible_local.lxc.containers | d() and
         item.state | d("started") in ["stopped", "absent"]
   tags: [ 'role::lxc:containers' ]
@@ -267,7 +267,7 @@
     state: 'absent'
   loop: '{{ lxc__containers }}'
   tags: [ 'role::lxc:containers' ]
-  when: ansible_local | d() and ansible_local.lxc | d() and
+  when: ansible_local | d() | length > 0 and ansible_local.lxc | d() | length > 0 and
         (item.name | d(item)) in ansible_local.lxc.containers | d() and
         item.state | d("started") == "absent"
 
@@ -277,9 +277,9 @@
     state: 'absent'
   loop: '{{ lxc__containers }}'
   register: lxc__register_systemd_remove_override
-  when: ansible_local | d() and ansible_local.lxc | d() and
+  when: ansible_local | d() | length > 0 and ansible_local.lxc | d() | length > 0 and
         (item.name | d(item)) in ansible_local.lxc.containers | d() and
-        item.state | d("started") == "absent" and item.systemd_override | d()
+        item.state | d("started") == "absent" and item.systemd_override | d() | length > 0
   tags: [ 'role::lxc:containers' ]
 
 - name: Create systemd override directories for LXC instances
@@ -290,7 +290,7 @@
     group: 'root'
     mode: '0755'
   loop: '{{ lxc__containers }}'
-  when: item.state | d("started") != "absent" and item.systemd_override | d()
+  when: item.state | d("started") != "absent" and item.systemd_override | d() | length > 0
   tags: [ 'role::lxc:containers' ]
 
 - name: Generate systemd LXC instance override files
@@ -302,7 +302,7 @@
     mode: '0644'
   loop: '{{ lxc__containers }}'
   register: lxc__register_systemd_create_override
-  when: item.state | d("started") != "absent" and item.systemd_override | d()
+  when: item.state | d("started") != "absent" and item.systemd_override | d() | length > 0
   tags: [ 'role::lxc:containers' ]
 
 - name: Reload systemd configuration when needed
@@ -333,7 +333,7 @@
     lv_name:             '{{ item.lv_name | d(omit) }}'
     lxc_path:            '{{ item.lxc_path | d(omit) }}'
     state:               '{{ item.state | d("started"
-                                            if (ansible_local | d() and ansible_local.lxc | d() and
+                                            if (ansible_local | d() | length > 0 and ansible_local.lxc | d() | length > 0 and
                                                 (item.name | d(item))
                                                 in ansible_local.lxc.containers | d())
                                             else "stopped") }}'
@@ -354,7 +354,7 @@
       - '--arch {{ (item.architecture | d(lxc__default_container_architecture)) | lower }}'
   loop: '{{ lxc__containers }}'
   tags: [ 'role::lxc:containers' ]
-  when: ansible_local | d() and ansible_local.lxc | d() and
+  when: ansible_local | d() | length > 0 and ansible_local.lxc | d() | length > 0 and
         (item.name | d(item)) not in ansible_local.lxc.containers | d() and
         item.state | d("started") != "absent"
 
@@ -363,7 +363,7 @@
   loop: '{{ lxc__containers }}'
   register: lxc__register_hwaddr_static
   changed_when: lxc__register_hwaddr_static.changed | bool
-  when: ansible_local | d() and ansible_local.lxc | d() and
+  when: ansible_local | d() | length > 0 and ansible_local.lxc | d() | length > 0 and
         (item.name | d(item)) not in ansible_local.lxc.containers | d() and
         item.state | d("started") == "started"
   tags: [ 'role::lxc:containers' ]
@@ -377,9 +377,9 @@
     state: 'present'
     mode: '0644'
   loop: '{{ lxc__containers }}'
-  when: ansible_local | d() and ansible_local.lxc | d() and
+  when: ansible_local | d() | length > 0 and ansible_local.lxc | d() | length > 0 and
         (item.name | d(item)) not in ansible_local.lxc.containers | d() and
-        item.state | d("started") == "started" and item.fstab | d() and
+        item.state | d("started") == "started" and item.fstab | d() | length > 0 and
         lxc__version is version("4.0", operator="lt", strict=True)
   tags: [ 'role::lxc:containers' ]
 
@@ -392,9 +392,9 @@
     state: 'present'
     mode: '0644'
   loop: '{{ lxc__containers }}'
-  when: ansible_local | d() and ansible_local.lxc | d() and
+  when: ansible_local | d() | length > 0 and ansible_local.lxc | d() | length > 0 and
         (item.name | d(item)) not in ansible_local.lxc.containers | d() and
-        item.state | d("started") == "started" and item.fstab | d() and
+        item.state | d("started") == "started" and item.fstab | d() | length > 0 and
         lxc__version is version("4.0", operator=">=", strict=True)
   tags: [ 'role::lxc:containers' ]
 
@@ -408,9 +408,9 @@
     group: 'root'
     mode: '0644'
   loop: '{{ lxc__containers }}'
-  when: ansible_local | d() and ansible_local.lxc | d() and
+  when: ansible_local | d() | length > 0 and ansible_local.lxc | d() | length > 0 and
         (item.name | d(item)) not in ansible_local.lxc.containers | d() and
-        item.state | d("started") == "started" and item.fstab | d()
+        item.state | d("started") == "started" and item.fstab | d() | length > 0
   tags: [ 'role::lxc:containers' ]
 
 - name: Start LXC containers after creation
@@ -419,7 +419,7 @@
     state: '{{ "restarted" if (item.state is defined) else "started" }}'
     enabled: '{{ True if item.state | d("started") == "started" else False }}'
   loop: '{{ lxc__containers }}'
-  when: ansible_local | d() and ansible_local.lxc | d() and
+  when: ansible_local | d() | length > 0 and ansible_local.lxc | d() | length > 0 and
         (item.name | d(item)) not in ansible_local.lxc.containers | d() and
         item.state | d("started") == "started"
   tags: [ 'role::lxc:containers' ]
@@ -429,7 +429,7 @@
     name: 'lxc@{{ item.0.name | d(item.0) }}.service'
     state: 'restarted'
   loop: '{{ lxc__containers | zip(lxc__register_systemd_create_override.results | d([])) | list }}'
-  when: ansible_local | d() and ansible_local.lxc | d() and
+  when: ansible_local | d() | length > 0 and ansible_local.lxc | d() | length > 0 and
         (item.0.name | d(item.0)) in ansible_local.lxc.containers | d() and
         item.0.state | d('started') == 'started' and item.1 is changed
   tags: [ 'role::lxc:containers' ]
@@ -446,7 +446,7 @@
   loop: '{{ lxc__containers }}'
   register: lxc__register_prepare_ssh
   changed_when: lxc__register_prepare_ssh.changed | bool
-  when: ansible_local | d() and ansible_local.lxc | d() and
+  when: ansible_local | d() | length > 0 and ansible_local.lxc | d() | length > 0 and
         (item.name | d(item)) not in ansible_local.lxc.containers | d() and
         (item.ssh | d(lxc__default_container_ssh)) | bool and item.state | d("started") == "started"
   tags: [ 'role::lxc:containers' ]

--- a/ansible/roles/metricbeat/tasks/main.yml
+++ b/ansible/roles/metricbeat/tasks/main.yml
@@ -64,7 +64,7 @@
   loop: '{{ metricbeat__combined_snippets | debops.debops.parse_kv_config }}'
   loop_control:
     label:  '{{ {"name": item.name, "state": item.state} }}'
-  when: item.state | d('present') not in ['absent', 'ignore', 'init'] and item.config | d()
+  when: item.state | d('present') not in ['absent', 'ignore', 'init'] and item.config | d() | length > 0
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Manage snippet diversion and reversion
@@ -76,7 +76,7 @@
   loop_control:
     label:  '{{ {"name": item.name, "state": item.state} }}'
   notify: [ 'Test metricbeat configuration and restart' ]
-  when: ansible_pkg_mgr == 'apt' and item.config | d() and (item.divert | d())
+  when: ansible_pkg_mgr == 'apt' and item.config | d() | length > 0 and (item.divert | d() | length > 0)
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Remove snippet configuration if requested
@@ -87,7 +87,7 @@
   loop_control:
     label:  '{{ {"name": item.name, "state": item.state, "config": item.config} }}'
   notify: [ 'Test metricbeat configuration and restart' ]
-  when: item.state | d('present') == 'absent' and item.config | d()
+  when: item.state | d('present') == 'absent' and item.config | d() | length > 0
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Generate snippet configuration
@@ -99,7 +99,7 @@
   loop_control:
     label:  '{{ {"name": item.name, "state": item.state, "config": item.config} }}'
   notify: [ 'Test metricbeat configuration and restart' ]
-  when: item.state | d('present') not in ['absent', 'ignore', 'init'] and item.config | d()
+  when: item.state | d('present') not in ['absent', 'ignore', 'init'] and item.config | d() | length > 0
   no_log: '{{ debops__no_log | d(True) }}'
 
 # The keystore handling is very similar to ../../kibana/tasks/main.yml
@@ -160,4 +160,4 @@
   ansible.builtin.service:  # noqa no-handler
     name: 'metricbeat'
     enabled: True
-  when: ansible_local.metricbeat.installed | d() and metricbeat__register_config_divert is changed
+  when: ansible_local.metricbeat.installed | d() | length > 0 and metricbeat__register_config_divert is changed

--- a/ansible/roles/minio/tasks/main.yml
+++ b/ansible/roles/minio/tasks/main.yml
@@ -100,7 +100,7 @@
     enabled: False
   loop: '{{ minio__combined_instances | debops.debops.parse_kv_items }}'
   when: ansible_service_mgr == 'systemd' and
-        item.name | d() and item.state | d('present') in ['absent']
+        item.name | d() | length > 0 and item.state | d('present') in ['absent']
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Remove MinIO instance configuration files if requested
@@ -108,7 +108,7 @@
     path: '{{ minio__config_dir + "/" + item.name }}'
     state: 'absent'
   loop: '{{ minio__combined_instances | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') in ['absent']
+  when: item.name | d() | length > 0 and item.state | d('present') in ['absent']
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Generate MinIO instance configuration files
@@ -120,7 +120,7 @@
     mode: '0640'
   loop: '{{ minio__combined_instances | debops.debops.parse_kv_items }}'
   register: minio__register_instance_config
-  when: item.name | d() and item.port | d() and
+  when: item.name | d() | length > 0 and item.port | d() | length > 0 and
         item.state | d('present') not in ['absent', 'ignore', 'init']
   no_log: '{{ debops__no_log | d(True) }}'
 
@@ -131,7 +131,7 @@
     enabled: True
   loop: '{{ minio__combined_instances | debops.debops.parse_kv_items }}'
   when: ansible_service_mgr == 'systemd' and
-        item.name | d() and item.port | d() and
+        item.name | d() | length > 0 and item.port | d() | length > 0 and
         item.state | d('present') not in ['absent', 'ignore', 'init']
   no_log: '{{ debops__no_log | d(True) }}'
 

--- a/ansible/roles/mosquitto/tasks/main.yml
+++ b/ansible/roles/mosquitto/tasks/main.yml
@@ -33,7 +33,7 @@
   with_items: '{{ mosquitto__pip_packages }}'
   register: mosquitto__register_pip_install
   until: mosquitto__register_pip_install is succeeded
-  when: mosquitto__pip_packages | d()
+  when: mosquitto__pip_packages | d() | length > 0
 
 - name: Check the installed Mosquitto version
   ansible.builtin.shell: set -o nounset -o pipefail -o errexit &&

--- a/ansible/roles/nixos/tasks/main.yml
+++ b/ansible/roles/nixos/tasks/main.yml
@@ -21,8 +21,8 @@
   ansible.builtin.include_tasks: '{{ lookup("debops.debops.task_src", "nixos/pre_main.yml") }}'
 
 - name: Convert NixOS directory to a git repository
-  when: nixos__repositories | d() or nixos__group_repositories | d() or
-        nixos__host_repositories | d()
+  when: nixos__repositories | d() | length > 0 or nixos__group_repositories | d() | length > 0 or
+        nixos__host_repositories | d() | length > 0
   block:
 
     - name: Check if NixOS configuration directory is a git repository
@@ -110,7 +110,7 @@
   loop: '{{ nixos__combined_configuration | flatten | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"name": item.name | dirname, "state": item.state | d("present")} }}'
-  when: item.raw | d() and item.state | d("present") not in ['absent', 'ignore', 'init'] and
+  when: item.raw | d() | length > 0 and item.state | d("present") not in ['absent', 'ignore', 'init'] and
         item.name is search('/')
 
 - name: Generate NixOS configuration files
@@ -122,7 +122,7 @@
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
   notify: [ 'Rebuild NixOS system' ]
-  when: item.raw | d() and item.state | d("present") not in ['absent', 'ignore', 'init']
+  when: item.raw | d() | length > 0 and item.state | d("present") not in ['absent', 'ignore', 'init']
 
 - name: Ensure that template directories exist
   ansible.builtin.file:

--- a/ansible/roles/reprepro/tasks/configure_reprepro.yml
+++ b/ansible/roles/reprepro/tasks/configure_reprepro.yml
@@ -83,7 +83,7 @@
   become_user: '{{ reprepro__user }}'
   register: reprepro__register_export
   changed_when: reprepro__register_export.changed | bool
-  when: (repo.state | d('present') not in ['absent', 'ignore'] and repo.distributions | d() and
+  when: (repo.state | d('present') not in ['absent', 'ignore'] and repo.distributions | d() | length > 0 and
          (reprepro__register_config is changed or reprepro__register_uploaders is changed))
 
 - name: Generate symlinks
@@ -93,7 +93,7 @@
   become: True
   become_user: '{{ reprepro__user }}'
   changed_when: False
-  when: (repo.state | d('present') not in ['absent', 'ignore'] and repo.distributions | d())
+  when: (repo.state | d('present') not in ['absent', 'ignore'] and repo.distributions | d() | length > 0)
 
 - name: Enable incoming queue monitoring
   ansible.builtin.systemd:
@@ -104,7 +104,7 @@
     enabled: '{{ True
                if (repo.state | d("present") not in ["absent", "ignore"])
                else False }}'
-  when: repo.incoming | d()
+  when: repo.incoming | d() | length > 0
 
 - name: Manage reprepro scripts
   ansible.builtin.template:

--- a/ansible/roles/reprepro/tasks/main.yml
+++ b/ansible/roles/reprepro/tasks/main.yml
@@ -44,7 +44,7 @@
     state: 'present'
     user: '{{ reprepro__user }}'
     exclusive: False
-  when: reprepro__admin_sshkeys | d()
+  when: reprepro__admin_sshkeys | d() | length > 0
 
 - name: Generate queue processing services
   ansible.builtin.template:

--- a/ansible/roles/rsnapshot/tasks/main.yml
+++ b/ansible/roles/rsnapshot/tasks/main.yml
@@ -59,7 +59,7 @@
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
   notify: [ 'Refresh host facts' ]
-  when: item.name | d() and item.state | d('present') not in ['absent', 'ignore']
+  when: item.name | d() | length > 0 and item.state | d('present') not in ['absent', 'ignore']
 
 - name: Make sure /root/.ssh/known_hosts file exists
   ansible.builtin.command: touch /root/.ssh/known_hosts
@@ -96,8 +96,8 @@
   loop: '{{ rsnapshot__combined_hosts | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
-  when: (item.name | d() and item.state | d('present') not in ['absent', 'ignore'] and
-         not item.fqdn | d() and hostvars[item.name] | d() and
+  when: (item.name | d() | length > 0 and item.state | d('present') not in ['absent', 'ignore'] and
+         not item.fqdn | d() and hostvars[item.name] | d() | length > 0 and
          hostvars[item.name]['ansible_fqdn'] is not defined and
          (not rsnapshot__limit | d() or (item.name in rsnapshot__limit)))
 
@@ -112,8 +112,8 @@
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present"),
                 "packages": q("flattened", rsnapshot__host_packages)} }}'
-  when: (item.name | d() and item.state | d('present') not in ['absent', 'ignore'] and
-         (item.rsync | d(True)) | bool and hostvars[item.name] | d() and
+  when: (item.name | d() | length > 0 and item.state | d('present') not in ['absent', 'ignore'] and
+         (item.rsync | d(True)) | bool and hostvars[item.name] | d() | length > 0 and
          (not rsnapshot__limit | d() or (item.name in rsnapshot__limit)))
 
   # Example: https://github.com/anamba/rrsync-custom
@@ -138,8 +138,8 @@
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present"),
                 "packages": q("flattened", rsnapshot__host_packages)} }}'
-  when: (item.name | d() and item.state | d('present') not in ['absent', 'ignore'] and
-         (item.rsync | d(True)) | bool and hostvars[item.name] | d() and
+  when: (item.name | d() | length > 0 and item.state | d('present') not in ['absent', 'ignore'] and
+         (item.rsync | d(True)) | bool and hostvars[item.name] | d() | length > 0 and
          (not rsnapshot__limit | d() or (item.name in rsnapshot__limit)))
 
 - name: Deploy root ssh public key on configured hosts
@@ -156,7 +156,7 @@
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
   register: rsnapshot__register_ssh_keys
-  when: (item.name | d() and item.state | d('present') not in ['ignore'] and
+  when: (item.name | d() | length > 0 and item.state | d('present') not in ['ignore'] and
          not (item.local | d()) | bool and (item.ssh_key | d(True)) | bool and
          (not rsnapshot__limit | d() or (item.name in rsnapshot__limit)))
 
@@ -185,7 +185,7 @@
     label: '{{ {"name": item.item.name, "state": item.item.state | d("present")} }}'
   register: rsnapshot__register_keygen_remove
   changed_when: rsnapshot__register_keygen_remove.changed | bool
-  when: (item.item.name | d() and item.item.state | d('present') not in ['absent', 'ignore'] and
+  when: (item.item.name | d() | length > 0 and item.item.state | d('present') not in ['absent', 'ignore'] and
          not (item.item.local | d()) | bool and (item.item.ssh_scan | d(True)) | bool and item is changed and
          (not rsnapshot__limit | d() or (item.item.name in rsnapshot__limit)))
 
@@ -198,7 +198,7 @@
   loop: '{{ rsnapshot__combined_hosts | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
-  when: (item.name | d() and item.state | d('present') not in ['absent', 'ignore'] and
+  when: (item.name | d() | length > 0 and item.state | d('present') not in ['absent', 'ignore'] and
          not (item.local | d()) | bool and (item.ssh_scan | d(True)) | bool and
          (not rsnapshot__limit | d() or (item.name in rsnapshot__limit)))
   register: rsnapshot__register_known_hosts
@@ -214,7 +214,7 @@
     label: '{{ {"name": item.item.name, "state": item.item.state | d("present")} }}'
   register: rsnapshot__register_ssh_keyscan
   changed_when: rsnapshot__register_ssh_keyscan.changed | bool
-  when: (item.item.name | d() and item.item.state | d('present') not in ['absent', 'ignore'] and
+  when: (item.item.name | d() | length > 0 and item.item.state | d('present') not in ['absent', 'ignore'] and
          not (item.item.local | d()) | bool and (item.item.ssh_scan | d(True)) | bool and item.rc | d() > 0 and
          (not rsnapshot__limit | d() or (item.item.name in rsnapshot__limit)))
 
@@ -225,7 +225,7 @@
   loop: '{{ rsnapshot__combined_hosts | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
-  when: (item.name | d() and item.state | d('present') == 'absent' and
+  when: (item.name | d() | length > 0 and item.state | d('present') == 'absent' and
          (not rsnapshot__limit | d() or (item.name in rsnapshot__limit)))
 
 - name: Create host configuration directories
@@ -236,7 +236,7 @@
   loop: '{{ rsnapshot__combined_hosts | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
-  when: (item.name | d() and item.state | d('present') not in ['absent', 'ignore'] and
+  when: (item.name | d() | length > 0 and item.state | d('present') not in ['absent', 'ignore'] and
          (not rsnapshot__limit | d() or (item.name in rsnapshot__limit)))
 
 - name: Generate host configuration files
@@ -251,5 +251,5 @@
             | product(["include.txt", "exclude.txt", "rsnapshot.conf"]) | list }}'
   loop_control:
     label: '{{ {"name": item.0.name, "state": item.0.state | d("present"), "file": item.1} }}'
-  when: (item.0.name | d() and item.0.state | d('present') not in ['absent', 'ignore'] and
+  when: (item.0.name | d() | length > 0 and item.0.state | d('present') not in ['absent', 'ignore'] and
          (not rsnapshot__limit | d() or (item.0.name in rsnapshot__limit)))

--- a/ansible/roles/snapshot_snapper/tasks/main.yml
+++ b/ansible/roles/snapshot_snapper/tasks/main.yml
@@ -63,7 +63,7 @@
   failed_when: False
   changed_when: False
   check_mode: False
-  when: snapshot_snapper__directory | d() and "mlocate" in snapshot_snapper__combined_packages
+  when: snapshot_snapper__directory | d() | length > 0 and "mlocate" in snapshot_snapper__combined_packages
   register: snapshot_snapper__register_updatedb_configured
 
 - name: Configure updatedb to exclude snapshots
@@ -80,7 +80,7 @@
 - name: Check which snapper /etc/snapper/configs/ exist
   ansible.builtin.stat:
     path: '/etc/snapper/configs/{{ item.name }}'
-  when: (snapshot_snapper__auto_reinit | bool and item.path | d() and item.name | d() and
+  when: (snapshot_snapper__auto_reinit | bool and item.path | d() | length > 0 and item.name | d() | length > 0 and
          (item.state | d("present") == "present"))
   register: snapshot_snapper__register_snapper_configs
   tags: [ 'role::snapshot_snapper:reinit' ]
@@ -89,7 +89,7 @@
 - name: Check which snapper snapshot directories exist
   ansible.builtin.stat:
     path: '{{ item.path + "/" + snapshot_snapper__directory }}'
-  when: (snapshot_snapper__auto_reinit | bool and item.path | d() and item.name | d() and
+  when: (snapshot_snapper__auto_reinit | bool and item.path | d() | length > 0 and item.name | d() | length > 0 and
          (item.state | d("present") == "present"))
   tags: [ 'role::snapshot_snapper:reinit' ]
   register: snapshot_snapper__register_snapshot_directory
@@ -151,7 +151,7 @@
            '{{ item.path }}'
   args:
     creates: '/etc/snapper/configs/{{ item.name }}'
-  when: (item.path | d() and item.name | d() and (item.state | d("present") == "present"))
+  when: (item.path | d() | length > 0 and item.name | d() | length > 0 and (item.state | d("present") == "present"))
   with_items: '{{ snapshot_snapper__volumes_combined }}'
 # .. ]]]
 

--- a/ansible/roles/snmpd/tasks/main.yml
+++ b/ansible/roles/snmpd/tasks/main.yml
@@ -72,7 +72,7 @@
     line: '#mibs :'
     mode: '0644'
   notify: [ 'Restart snmpd' ]
-  when: snmpd_download_mibs | d() and snmpd_download_mibs
+  when: snmpd_download_mibs | d() | length > 0 and snmpd_download_mibs
 
 - name: Divert default configuration file
   debops.debops.dpkg_divert:
@@ -129,7 +129,7 @@
     snmpd_fact_account_agent_username: '{{ snmpd_account_agent_username }}'
     snmpd_fact_account_agent_password: '{{ snmpd_account_agent_password }}'
   no_log: '{{ debops__no_log | d(True) }}'
-  when: snmpd_account | d() and snmpd_account
+  when: snmpd_account | d() | length > 0 and snmpd_account
 
 - name: Configure snmpd service
   ansible.builtin.template:
@@ -142,8 +142,8 @@
 
 - name: Configure SNMPv3 credentials
   ansible.builtin.include_tasks: configure_snmpv3_credentials.yml
-  when: ((snmpd_register_version | d() and not snmpd_register_version.stdout) and
-         (snmpd_account | d() and snmpd_account))
+  when: ((snmpd_register_version | d() | length > 0 and not snmpd_register_version.stdout) and
+         (snmpd_account | d() | length > 0 and snmpd_account))
 
 - name: Save local SNMPv3 password for retrieval via Ansible facts
   ansible.builtin.template:

--- a/ansible/roles/telegraf/tasks/main.yml
+++ b/ansible/roles/telegraf/tasks/main.yml
@@ -39,7 +39,7 @@
   loop: '{{ telegraf__combined_plugins | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
-  when: item.state | d('present') == 'absent' and item.config | d()
+  when: item.state | d('present') == 'absent' and item.config | d() | length > 0
   notify: [ 'Check telegraf and restart' ]
 
 - name: Find plugins which are in filesystem
@@ -69,7 +69,7 @@
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
   when: (item.state | d('present') not in ['absent', 'ignore'] and
-         (item.config | d() or item.raw | d()))
+         (item.config | d() | length > 0 or item.raw | d() | length > 0))
   no_log: '{{ debops__no_log | d(True) }}'
   notify: [ 'Check telegraf and restart' ]
 

--- a/ansible/roles/yadm/tasks/manage_dotfiles.yml
+++ b/ansible/roles/yadm/tasks/manage_dotfiles.yml
@@ -15,7 +15,7 @@
   loop: '{{ q("flattened", dotfile.git) }}'
   loop_control:
     loop_var: 'item_git'
-  when: dotfile.git | d() and dotfile.state | d('present') not in ['absent', 'ignore'] and
+  when: dotfile.git | d() | length > 0 and dotfile.state | d('present') not in ['absent', 'ignore'] and
         not ansible_check_mode
 
 - name: Remove dotfiles repo {{ dotfile.name }}
@@ -27,7 +27,7 @@
   loop: '{{ q("flattened", dotfile.git) }}'
   loop_control:
     loop_var: 'item_git'
-  when: dotfile.git | d() and dotfile.state | d('present') == 'absent'
+  when: dotfile.git | d() | length > 0 and dotfile.state | d('present') == 'absent'
 
 - name: Manage the cloned dotfiles repo in system-wide /etc/gitconfig
   community.general.git_config:


### PR DESCRIPTION
Replace | d() truthiness checks with | d() | length > 0 to produce proper boolean results in when conditions, avoiding deprecation warnings that will become errors in Ansible 2.19.

Affected roles: telegraf, metricbeat, filebeat, mosquitto, snmpd, lxc, gitlab_runner, reprepro, rsnapshot, ipxe, libvirtd, snapshot_snapper, minio, icinga_web, nixos, controller, yadm
