### PR TITLE
Add docker_service role for managing Docker container services

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -573,6 +573,7 @@ stages:
     - 'apt_preferences role'
     - 'ferm role'
     - 'python role'
+    - 'postgresql role'
     - 'nginx role'
     - 'docker_server role'
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -565,6 +565,24 @@ stages:
     JANE_LOG_PATTERN: '\[docker_server\]'
   tags: [ 'shell', 'vagrant-vm' ]
 
+'docker_service role':
+  <<: *test_role_2nd_deps
+  needs:
+    - 'resolvconf role'
+    - 'keyring role'
+    - 'apt_preferences role'
+    - 'ferm role'
+    - 'python role'
+    - 'nginx role'
+    - 'docker_server role'
+  variables:
+    JANE_TEST_FACT: 'docker_service.fact'
+    JANE_TEST_PLAY: '${DEBOPS_PLAYBOOKS}/service/docker_service.yml'
+    JANE_INVENTORY_GROUPS: 'debops_service_docker_service'
+    JANE_DIFF_PATTERN: '.*/roles/docker_service/.*'
+    JANE_LOG_PATTERN: '\[docker_service\]'
+  tags: [ 'shell', 'vagrant-vm' ]
+
 'dokuwiki role':
   <<: *test_role_2nd_deps
   needs:

--- a/ansible/playbooks/service/docker_service.yml
+++ b/ansible/playbooks/service/docker_service.yml
@@ -1,0 +1,49 @@
+---
+# Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
+# Copyright (C) 2024-2026 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+- name: Manage Docker container services
+  collections: [ 'debops.debops', 'debops.roles01',
+                 'debops.roles02', 'debops.roles03' ]
+  hosts: [ 'debops_service_docker_service' ]
+  become: True
+
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
+
+  roles:
+
+    - role: keyring
+      tags: [ 'role::keyring', 'skip::keyring' ]
+      keyring__dependent_gpg_keys:
+        - '{{ nginx__keyring__dependent_apt_keys }}'
+
+    - role: apt_preferences
+      tags: [ 'role::apt_preferences', 'skip::apt_preferences' ]
+      apt_preferences__dependent_list:
+        - '{{ nginx__apt_preferences__dependent_list }}'
+
+    - role: ferm
+      tags: [ 'role::ferm', 'skip::ferm' ]
+      ferm__dependent_rules:
+        - '{{ nginx__ferm__dependent_rules }}'
+
+    - role: python
+      tags: [ 'role::python', 'skip::python' ]
+      python__dependent_packages3:
+        - '{{ docker_service__python__dependent_packages3 }}'
+        - '{{ nginx__python__dependent_packages3 }}'
+      python__dependent_packages2:
+        - '{{ nginx__python__dependent_packages2 }}'
+
+    - role: nginx
+      tags: [ 'role::nginx', 'skip::nginx' ]
+      nginx__dependent_servers:
+        - '{{ docker_service__nginx__dependent_servers }}'
+      nginx__dependent_upstreams:
+        - '{{ docker_service__nginx__dependent_upstreams }}'
+
+    - role: docker_service
+      tags: [ 'role::docker_service', 'skip::docker_service' ]

--- a/ansible/playbooks/service/docker_service.yml
+++ b/ansible/playbooks/service/docker_service.yml
@@ -13,6 +13,15 @@
                    | combine(inventory__group_environment | d({}))
                    | combine(inventory__host_environment  | d({})) }}'
 
+  pre_tasks:
+
+    - name: Build docker_service nginx configuration
+      ansible.builtin.import_role:
+        name: 'docker_service'
+        tasks_from: 'build_nginx_vars'
+      tags: [ 'role::docker_service', 'skip::docker_service',
+              'role::nginx', 'skip::nginx' ]
+
   roles:
 
     - role: keyring

--- a/ansible/playbooks/service/docker_service.yml
+++ b/ansible/playbooks/service/docker_service.yml
@@ -22,30 +22,54 @@
       tags: [ 'role::docker_service', 'skip::docker_service',
               'role::nginx', 'skip::nginx' ]
 
+    - name: Build docker_service postgresql configuration
+      ansible.builtin.import_role:
+        name: 'docker_service'
+        tasks_from: 'build_postgresql_vars'
+      tags: [ 'role::docker_service', 'skip::docker_service',
+              'role::postgresql', 'skip::postgresql' ]
+
   roles:
 
     - role: keyring
       tags: [ 'role::keyring', 'skip::keyring' ]
       keyring__dependent_gpg_keys:
         - '{{ nginx__keyring__dependent_apt_keys }}'
+      when: docker_service__nginx__dependent_servers | d([]) | length > 0
 
     - role: apt_preferences
       tags: [ 'role::apt_preferences', 'skip::apt_preferences' ]
       apt_preferences__dependent_list:
         - '{{ nginx__apt_preferences__dependent_list }}'
+      when: docker_service__nginx__dependent_servers | d([]) | length > 0
 
     - role: ferm
       tags: [ 'role::ferm', 'skip::ferm' ]
       ferm__dependent_rules:
         - '{{ nginx__ferm__dependent_rules }}'
+      when: docker_service__nginx__dependent_servers | d([]) | length > 0
 
     - role: python
       tags: [ 'role::python', 'skip::python' ]
       python__dependent_packages3:
         - '{{ docker_service__python__dependent_packages3 }}'
-        - '{{ nginx__python__dependent_packages3 }}'
+        - '{{ nginx__python__dependent_packages3
+              if (docker_service__nginx__dependent_servers | d([]) | length > 0)
+              else [] }}'
       python__dependent_packages2:
-        - '{{ nginx__python__dependent_packages2 }}'
+        - '{{ nginx__python__dependent_packages2
+              if (docker_service__nginx__dependent_servers | d([]) | length > 0)
+              else [] }}'
+
+    - role: postgresql
+      tags: [ 'role::postgresql', 'skip::postgresql' ]
+      postgresql__dependent_roles:
+        - '{{ docker_service__postgresql__dependent_roles }}'
+      postgresql__dependent_databases:
+        - '{{ docker_service__postgresql__dependent_databases }}'
+      postgresql__dependent_pgpass:
+        - '{{ docker_service__postgresql__dependent_pgpass }}'
+      when: docker_service__postgresql__dependent_roles | d([]) | length > 0
 
     - role: nginx
       tags: [ 'role::nginx', 'skip::nginx' ]
@@ -53,6 +77,7 @@
         - '{{ docker_service__nginx__dependent_servers }}'
       nginx__dependent_upstreams:
         - '{{ docker_service__nginx__dependent_upstreams }}'
+      when: docker_service__nginx__dependent_servers | d([]) | length > 0
 
     - role: docker_service
       tags: [ 'role::docker_service', 'skip::docker_service' ]

--- a/ansible/playbooks/service/docker_service.yml
+++ b/ansible/playbooks/service/docker_service.yml
@@ -15,6 +15,11 @@
 
   pre_tasks:
 
+    - name: Define variables used by Ansible roles
+      ansible.builtin.import_role:
+        name: 'secret'
+      tags: [ 'role::secret', 'role::docker_service' ]
+
     - name: Build docker_service nginx configuration
       ansible.builtin.import_role:
         name: 'docker_service'

--- a/ansible/playbooks/service/docker_service.yml
+++ b/ansible/playbooks/service/docker_service.yml
@@ -1,6 +1,6 @@
 ---
-# Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
-# Copyright (C) 2024-2026 DebOps <https://debops.org/>
+# Copyright (C) 2026 Patryk Ściborek <patryk@sciborek.com>
+# Copyright (C) 2026 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-only
 
 - name: Manage Docker container services

--- a/ansible/roles/docker_service/COPYRIGHT
+++ b/ansible/roles/docker_service/COPYRIGHT
@@ -1,0 +1,19 @@
+debops.docker_service - Manage Docker container services using Ansible
+
+Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
+Copyright (C) 2024-2026 DebOps <https://debops.org/>
+SPDX-License-Identifier: GPL-3.0-only
+
+This Ansible role is part of DebOps.
+
+DebOps is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 3, as
+published by the Free Software Foundation.
+
+DebOps is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with DebOps. If not, see https://www.gnu.org/licenses/.

--- a/ansible/roles/docker_service/COPYRIGHT
+++ b/ansible/roles/docker_service/COPYRIGHT
@@ -1,7 +1,7 @@
 debops.docker_service - Manage Docker container services using Ansible
 
-Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
-Copyright (C) 2024-2026 DebOps <https://debops.org/>
+Copyright (C) 2026 Patryk Ściborek <patryk@sciborek.com>
+Copyright (C) 2026 DebOps <https://debops.org/>
 SPDX-License-Identifier: GPL-3.0-only
 
 This Ansible role is part of DebOps.

--- a/ansible/roles/docker_service/defaults/main.yml
+++ b/ansible/roles/docker_service/defaults/main.yml
@@ -105,20 +105,18 @@ docker_service__python__dependent_packages3:
 # .. envvar:: docker_service__nginx__dependent_upstreams [[[
 #
 # Upstream configuration for the :ref:`debops.nginx` Ansible role.
-# Generated dynamically from the service definitions that have
-# :command:`nginx` reverse proxy enabled.
-docker_service__nginx__dependent_upstreams: '{{ lookup("template",
-                                                "lookup/docker_service__nginx_upstreams.j2")
-                                                | from_yaml }}'
+# Populated dynamically by the ``build_nginx_vars`` task file which is
+# included as a ``pre_task`` in the playbook. The template lookup must
+# run in the ``docker_service`` role context to find the templates.
+docker_service__nginx__dependent_upstreams: []
 
                                                                    # ]]]
 # .. envvar:: docker_service__nginx__dependent_servers [[[
 #
 # Server configuration for the :ref:`debops.nginx` Ansible role.
-# Generated dynamically from the service definitions that have
-# :command:`nginx` reverse proxy enabled.
-docker_service__nginx__dependent_servers: '{{ lookup("template",
-                                              "lookup/docker_service__nginx_servers.j2")
-                                              | from_yaml }}'
+# Populated dynamically by the ``build_nginx_vars`` task file which is
+# included as a ``pre_task`` in the playbook. The template lookup must
+# run in the ``docker_service`` role context to find the templates.
+docker_service__nginx__dependent_servers: []
                                                                    # ]]]
                                                                    # ]]]

--- a/ansible/roles/docker_service/defaults/main.yml
+++ b/ansible/roles/docker_service/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 # .. vim: foldmarker=[[[,]]]:foldmethod=marker
 
-# .. Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
-# .. Copyright (C) 2024-2026 DebOps <https://debops.org/>
+# .. Copyright (C) 2026 Patryk Ściborek <patryk@sciborek.com>
+# .. Copyright (C) 2026 DebOps <https://debops.org/>
 # .. SPDX-License-Identifier: GPL-3.0-only
 
 # .. _docker_service__ref_defaults:

--- a/ansible/roles/docker_service/defaults/main.yml
+++ b/ansible/roles/docker_service/defaults/main.yml
@@ -45,6 +45,15 @@ docker_service__restart_policy: 'unless-stopped'
 # If ``True``, the role will pull Docker images before creating or updating
 # containers. Can be overridden per service.
 docker_service__pull: True
+
+                                                                   # ]]]
+# .. envvar:: docker_service__templates_path [[[
+#
+# Absolute path to the ``resources/templates`` directory on the Ansible
+# Controller. Used by the ``config_dir`` feature to locate template
+# directories. By default the path is derived from the inventory location,
+# following the same convention as :ref:`debops.resources`.
+docker_service__templates_path: '{{ inventory_dir | realpath + "/../resources/templates" }}'
                                                                    # ]]]
                                                                    # ]]]
 # Service definitions [[[
@@ -100,6 +109,30 @@ docker_service__combined_services: '{{ docker_service__default_services
 # Ansible collection used to manage containers.
 docker_service__python__dependent_packages3:
   - 'python3-docker'
+
+                                                                   # ]]]
+# .. envvar:: docker_service__postgresql__dependent_roles [[[
+#
+# Role configuration for the :ref:`debops.postgresql` Ansible role.
+# Populated dynamically by the ``build_postgresql_vars`` task file which is
+# included as a ``pre_task`` in the playbook.
+docker_service__postgresql__dependent_roles: []
+
+                                                                   # ]]]
+# .. envvar:: docker_service__postgresql__dependent_databases [[[
+#
+# Database configuration for the :ref:`debops.postgresql` Ansible role.
+# Populated dynamically by the ``build_postgresql_vars`` task file which is
+# included as a ``pre_task`` in the playbook.
+docker_service__postgresql__dependent_databases: []
+
+                                                                   # ]]]
+# .. envvar:: docker_service__postgresql__dependent_pgpass [[[
+#
+# The ``~/.pgpass`` configuration for the :ref:`debops.postgresql` Ansible
+# role. Populated dynamically by the ``build_postgresql_vars`` task file
+# which is included as a ``pre_task`` in the playbook.
+docker_service__postgresql__dependent_pgpass: []
 
                                                                    # ]]]
 # .. envvar:: docker_service__nginx__dependent_upstreams [[[

--- a/ansible/roles/docker_service/defaults/main.yml
+++ b/ansible/roles/docker_service/defaults/main.yml
@@ -44,7 +44,7 @@ docker_service__restart_policy: 'unless-stopped'
 #
 # If ``True``, the role will pull Docker images before creating or updating
 # containers. Can be overridden per service.
-docker_service__pull: True
+docker_service__pull: true
 
                                                                    # ]]]
 # .. envvar:: docker_service__templates_path [[[

--- a/ansible/roles/docker_service/defaults/main.yml
+++ b/ansible/roles/docker_service/defaults/main.yml
@@ -1,0 +1,124 @@
+---
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+
+# .. Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
+# .. Copyright (C) 2024-2026 DebOps <https://debops.org/>
+# .. SPDX-License-Identifier: GPL-3.0-only
+
+# .. _docker_service__ref_defaults:
+
+# debops.docker_service default variables
+# =======================================
+
+# .. contents:: Sections
+#    :local:
+#
+# .. include:: ../../../../includes/global.rst
+
+# General configuration [[[
+# -------------------------
+
+# .. envvar:: docker_service__domain [[[
+#
+# The DNS domain used for generating default FQDNs for container services
+# when a custom :command:`nginx` FQDN is not specified.
+docker_service__domain: '{{ ansible_domain }}'
+
+                                                                   # ]]]
+# .. envvar:: docker_service__data_path [[[
+#
+# Base directory path on the host for persistent container data. Each service
+# should create its own subdirectory under this path.
+docker_service__data_path: '/srv/docker'
+
+                                                                   # ]]]
+# .. envvar:: docker_service__restart_policy [[[
+#
+# Default restart policy applied to all containers managed by this role.
+# Can be overridden per service. Supported values: ``no``, ``always``,
+# ``on-failure``, ``unless-stopped``.
+docker_service__restart_policy: 'unless-stopped'
+
+                                                                   # ]]]
+# .. envvar:: docker_service__pull [[[
+#
+# If ``True``, the role will pull Docker images before creating or updating
+# containers. Can be overridden per service.
+docker_service__pull: True
+                                                                   # ]]]
+                                                                   # ]]]
+# Service definitions [[[
+# -----------------------
+
+# These variables define Docker container services managed by this role.
+# See :ref:`docker_service__ref_services` for more details.
+
+# .. envvar:: docker_service__default_services [[[
+#
+# List of Docker container services defined by default in the role.
+docker_service__default_services: []
+
+                                                                   # ]]]
+# .. envvar:: docker_service__services [[[
+#
+# List of Docker container services defined on all hosts in the Ansible
+# inventory.
+docker_service__services: []
+
+                                                                   # ]]]
+# .. envvar:: docker_service__group_services [[[
+#
+# List of Docker container services defined on hosts in a specific Ansible
+# inventory group.
+docker_service__group_services: []
+
+                                                                   # ]]]
+# .. envvar:: docker_service__host_services [[[
+#
+# List of Docker container services defined on specific hosts in the Ansible
+# inventory.
+docker_service__host_services: []
+
+                                                                   # ]]]
+# .. envvar:: docker_service__combined_services [[[
+#
+# Variable which combines all Docker container service lists and is used in
+# role tasks and templates.
+docker_service__combined_services: '{{ docker_service__default_services
+                                       + docker_service__services
+                                       + docker_service__group_services
+                                       + docker_service__host_services }}'
+                                                                   # ]]]
+                                                                   # ]]]
+# Configuration for other Ansible roles [[[
+# -----------------------------------------
+
+# .. envvar:: docker_service__python__dependent_packages3 [[[
+#
+# Configuration for the :ref:`debops.python` Ansible role.
+# The ``python3-docker`` package is required by the ``community.docker``
+# Ansible collection used to manage containers.
+docker_service__python__dependent_packages3:
+  - 'python3-docker'
+
+                                                                   # ]]]
+# .. envvar:: docker_service__nginx__dependent_upstreams [[[
+#
+# Upstream configuration for the :ref:`debops.nginx` Ansible role.
+# Generated dynamically from the service definitions that have
+# :command:`nginx` reverse proxy enabled.
+docker_service__nginx__dependent_upstreams: '{{ lookup("template",
+                                                "lookup/docker_service__nginx_upstreams.j2")
+                                                | from_yaml }}'
+
+                                                                   # ]]]
+# .. envvar:: docker_service__nginx__dependent_servers [[[
+#
+# Server configuration for the :ref:`debops.nginx` Ansible role.
+# Generated dynamically from the service definitions that have
+# :command:`nginx` reverse proxy enabled.
+docker_service__nginx__dependent_servers: '{{ lookup("template",
+                                              "lookup/docker_service__nginx_servers.j2")
+                                              | from_yaml }}'
+                                                                   # ]]]
+                                                                   # ]]]

--- a/ansible/roles/docker_service/meta/main.yml
+++ b/ansible/roles/docker_service/meta/main.yml
@@ -3,7 +3,7 @@
 # Copyright (C) 2026 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-only
 
-collections: [ 'debops.debops' ]
+collections: ['debops.debops']
 
 dependencies: []
 
@@ -18,10 +18,10 @@ galaxy_info:
   platforms:
 
     - name: 'Ubuntu'
-      versions: [ 'all' ]
+      versions: ['all']
 
     - name: 'Debian'
-      versions: [ 'all' ]
+      versions: ['all']
 
   galaxy_tags:
     - docker

--- a/ansible/roles/docker_service/meta/main.yml
+++ b/ansible/roles/docker_service/meta/main.yml
@@ -1,6 +1,6 @@
 ---
-# Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
-# Copyright (C) 2024-2026 DebOps <https://debops.org/>
+# Copyright (C) 2026 Patryk Ściborek <patryk@sciborek.com>
+# Copyright (C) 2026 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-only
 
 collections: [ 'debops.debops' ]

--- a/ansible/roles/docker_service/meta/main.yml
+++ b/ansible/roles/docker_service/meta/main.yml
@@ -1,0 +1,30 @@
+---
+# Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
+# Copyright (C) 2024-2026 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+collections: [ 'debops.debops' ]
+
+dependencies: []
+
+galaxy_info:
+
+  author: 'Patryk Ściborek'
+  description: 'Manage Docker container services with nginx reverse proxy'
+  company: 'DebOps'
+  license: 'GPL-3.0-only'
+  min_ansible_version: '2.11.0'
+
+  platforms:
+
+    - name: 'Ubuntu'
+      versions: [ 'all' ]
+
+    - name: 'Debian'
+      versions: [ 'all' ]
+
+  galaxy_tags:
+    - docker
+    - containers
+    - nginx
+    - proxy

--- a/ansible/roles/docker_service/tasks/build_nginx_vars.yml
+++ b/ansible/roles/docker_service/tasks/build_nginx_vars.yml
@@ -1,0 +1,18 @@
+---
+# Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
+# Copyright (C) 2024-2026 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+# This task file is included via pre_tasks in the playbook to build
+# nginx dependent variables before the nginx role runs. The template
+# lookup must execute in the docker_service role context to find
+# the templates in this role's templates/ directory.
+
+- name: Build nginx dependent variables from service definitions
+  ansible.builtin.set_fact:
+    docker_service__nginx__dependent_upstreams: '{{ lookup("template",
+                                                    "lookup/docker_service__nginx_upstreams.j2")
+                                                    | from_yaml }}'
+    docker_service__nginx__dependent_servers: '{{ lookup("template",
+                                                  "lookup/docker_service__nginx_servers.j2")
+                                                  | from_yaml }}'

--- a/ansible/roles/docker_service/tasks/build_nginx_vars.yml
+++ b/ansible/roles/docker_service/tasks/build_nginx_vars.yml
@@ -1,6 +1,6 @@
 ---
-# Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
-# Copyright (C) 2024-2026 DebOps <https://debops.org/>
+# Copyright (C) 2026 Patryk Ściborek <patryk@sciborek.com>
+# Copyright (C) 2026 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-only
 
 # This task file is included via pre_tasks in the playbook to build

--- a/ansible/roles/docker_service/tasks/build_postgresql_vars.yml
+++ b/ansible/roles/docker_service/tasks/build_postgresql_vars.yml
@@ -1,0 +1,21 @@
+---
+# Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
+# Copyright (C) 2024-2026 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+# This task file is included via pre_tasks in the playbook to build
+# postgresql dependent variables before the postgresql role runs. The
+# template lookup must execute in the docker_service role context to
+# find the templates in this role's templates/ directory.
+
+- name: Build postgresql dependent variables from service definitions
+  ansible.builtin.set_fact:
+    docker_service__postgresql__dependent_roles: '{{ lookup("template",
+                                                     "lookup/docker_service__postgresql_roles.j2")
+                                                     | from_yaml }}'
+    docker_service__postgresql__dependent_databases: '{{ lookup("template",
+                                                         "lookup/docker_service__postgresql_databases.j2")
+                                                         | from_yaml }}'
+    docker_service__postgresql__dependent_pgpass: '{{ lookup("template",
+                                                      "lookup/docker_service__postgresql_pgpass.j2")
+                                                      | from_yaml }}'

--- a/ansible/roles/docker_service/tasks/build_postgresql_vars.yml
+++ b/ansible/roles/docker_service/tasks/build_postgresql_vars.yml
@@ -1,6 +1,6 @@
 ---
-# Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
-# Copyright (C) 2024-2026 DebOps <https://debops.org/>
+# Copyright (C) 2026 Patryk Ściborek <patryk@sciborek.com>
+# Copyright (C) 2026 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-only
 
 # This task file is included via pre_tasks in the playbook to build

--- a/ansible/roles/docker_service/tasks/main.yml
+++ b/ansible/roles/docker_service/tasks/main.yml
@@ -1,0 +1,91 @@
+---
+# Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
+# Copyright (C) 2024-2026 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+- name: Import DebOps global handlers
+  ansible.builtin.import_role:
+    name: 'global_handlers'
+
+- name: Install required packages
+  ansible.builtin.apt:
+    name: '{{ docker_service__python__dependent_packages3 | flatten }}'
+    state: 'present'
+    install_recommends: False
+  register: docker_service__register_packages
+  until: docker_service__register_packages is succeeded
+
+- name: Create persistent data directories for bind mounts
+  ansible.builtin.file:
+    path: '{{ item.1.split(":") | first }}'
+    state: 'directory'
+    mode: '0755'
+  loop: '{{ docker_service__combined_services | d([])
+            | subelements("volumes", skip_missing=True) }}'
+  loop_control:
+    label: '{{ item.0.name }}: {{ item.1.split(":") | first }}'
+  when:
+    - item.0.state | d('present') not in ['absent', 'ignore']
+    - item.1.split(":") | first is match("/")
+  tags: [ 'role::docker_service:config' ]
+
+- name: Pull Docker images
+  community.docker.docker_image:
+    name: '{{ item.image }}'
+    source: 'pull'
+    force_source: '{{ item.pull | d(docker_service__pull) | bool }}'
+  loop: '{{ docker_service__combined_services | d([]) }}'
+  loop_control:
+    label: '{{ item.name }}: {{ item.image }}'
+  when:
+    - item.state | d('present') not in ['absent', 'ignore']
+    - item.pull | d(docker_service__pull) | bool
+  tags: [ 'role::docker_service:containers' ]
+
+- name: Manage Docker containers
+  community.docker.docker_container:
+    name: '{{ item.name }}'
+    image: '{{ item.image | d(omit) }}'
+    state: '{{ {"present": "started",
+                "stopped": "stopped",
+                "absent": "absent"}[item.state | d("present")] }}'
+    restart_policy: '{{ item.restart_policy
+                        | d(docker_service__restart_policy) }}'
+    command: '{{ item.command | d(omit) }}'
+    entrypoint: '{{ item.entrypoint | d(omit) }}'
+    user: '{{ item.user | d(omit) }}'
+    ports: '{{ item.ports | d(omit) }}'
+    networks: '{{ item.networks | d(omit) }}'
+    dns_servers: '{{ item.dns | d(omit) }}'
+    hostname: '{{ item.hostname | d(omit) }}'
+    volumes: '{{ item.volumes | d(omit) }}'
+    tmpfs: '{{ item.tmpfs | d(omit) }}'
+    env: '{{ item.env | d(omit) }}'
+    memory: '{{ item.memory | d(omit) }}'
+    memory_reservation: '{{ item.memory_reservation | d(omit) }}'
+    cpus: '{{ item.cpus | d(omit) }}'
+    capabilities: '{{ item.capabilities | d(omit) }}'
+    sysctls: '{{ item.sysctls | d(omit) }}'
+    read_only: '{{ item.read_only | d(omit) }}'
+    labels: '{{ item.labels | d(omit) }}'
+    healthcheck: '{{ item.healthcheck | d(omit) }}'
+    pull: false
+  loop: '{{ docker_service__combined_services | d([]) }}'
+  loop_control:
+    label: '{{ item.name }}'
+  when: item.state | d('present') != 'ignore'
+  tags: [ 'role::docker_service:containers' ]
+
+- name: Make sure that Ansible local facts directory exists
+  ansible.builtin.file:
+    path: '/etc/ansible/facts.d'
+    state: 'directory'
+    mode: '0755'
+
+- name: Save docker_service local facts
+  ansible.builtin.template:
+    src: 'etc/ansible/facts.d/docker_service.fact.j2'
+    dest: '/etc/ansible/facts.d/docker_service.fact'
+    mode: '0755'
+  notify: [ 'Refresh host facts' ]
+  tags: [ 'meta::facts' ]

--- a/ansible/roles/docker_service/tasks/main.yml
+++ b/ansible/roles/docker_service/tasks/main.yml
@@ -144,6 +144,7 @@
     read_only: '{{ item.read_only | d(omit) }}'
     labels: '{{ item.labels | d(omit) }}'
     healthcheck: '{{ item.healthcheck | d(omit) }}'
+    init: '{{ item.init | d(omit) }}'
     pull: false
   loop: '{{ docker_service__combined_services | d([]) }}'
   loop_control:

--- a/ansible/roles/docker_service/tasks/main.yml
+++ b/ansible/roles/docker_service/tasks/main.yml
@@ -15,7 +15,7 @@
   ansible.builtin.apt:
     name: '{{ docker_service__python__dependent_packages3 | flatten }}'
     state: 'present'
-    install_recommends: False
+    install_recommends: false
   register: docker_service__register_packages
   until: docker_service__register_packages is succeeded
 
@@ -33,7 +33,7 @@
     - item.1.split(":") | first is match("/")
     - item.1.split(":") | first not in
       (item.0.config_files | d([]) | map(attribute="dest") | list)
-  tags: [ 'role::docker_service:config' ]
+  tags: ['role::docker_service:config']
 
 - name: Create directories for config files
   ansible.builtin.file:
@@ -45,7 +45,7 @@
   loop_control:
     label: '{{ item.0.name }}: {{ item.1.dest }}'
   when: item.0.state | d('present') not in ['absent', 'ignore']
-  tags: [ 'role::docker_service:config' ]
+  tags: ['role::docker_service:config']
 
 - name: Generate config files with inline content
   ansible.builtin.copy:
@@ -62,7 +62,7 @@
     - item.0.state | d('present') not in ['absent', 'ignore']
     - item.1.content is defined
   register: docker_service__register_config_content
-  tags: [ 'role::docker_service:config' ]
+  tags: ['role::docker_service:config']
 
 - name: Generate config files from templates
   ansible.builtin.template:
@@ -79,7 +79,7 @@
     - item.0.state | d('present') not in ['absent', 'ignore']
     - item.1.src is defined
   register: docker_service__register_config_template
-  tags: [ 'role::docker_service:config' ]
+  tags: ['role::docker_service:config']
 
 - name: Manage config directory trees
   ansible.builtin.include_tasks:
@@ -92,7 +92,7 @@
   when:
     - docker_service__config_dir_service.state | d('present') not in ['absent', 'ignore']
     - docker_service__config_dir_service.config_dir.src | d()
-  tags: [ 'role::docker_service:config' ]
+  tags: ['role::docker_service:config']
 
 - name: Create Docker networks referenced by services
   community.docker.docker_network:
@@ -102,7 +102,7 @@
             | selectattr("networks", "defined")
             | map(attribute="networks") | flatten
             | map(attribute="name") | unique | list }}'
-  tags: [ 'role::docker_service:containers' ]
+  tags: ['role::docker_service:containers']
 
 - name: Pull Docker images
   community.docker.docker_image:
@@ -115,7 +115,7 @@
   when:
     - item.state | d('present') not in ['absent', 'ignore']
     - item.pull | d(docker_service__pull) | bool
-  tags: [ 'role::docker_service:containers' ]
+  tags: ['role::docker_service:containers']
 
 - name: Manage Docker containers
   community.docker.docker_container:
@@ -149,9 +149,9 @@
   loop_control:
     label: '{{ item.name }}'
   when: item.state | d('present') != 'ignore'
-  tags: [ 'role::docker_service:containers' ]
+  tags: ['role::docker_service:containers']
 
-- name: Restart containers with changed config files (content/template)
+- name: Restart containers with changed config files (content/template)  # noqa: no-handler
   community.docker.docker_container:
     name: '{{ item.item.0.name }}'
     state: 'started'
@@ -161,7 +161,7 @@
   loop_control:
     label: '{{ item.item.0.name | d("unknown") }}'
   when: item is changed
-  tags: [ 'role::docker_service:config' ]
+  tags: ['role::docker_service:config']
 
 - name: Restart containers with changed config directory files
   community.docker.docker_container:
@@ -169,7 +169,7 @@
     state: 'started'
     restart: true
   loop: '{{ docker_service__restart_containers | d([]) | unique }}'
-  tags: [ 'role::docker_service:config' ]
+  tags: ['role::docker_service:config']
 
 - name: Make sure that Ansible local facts directory exists
   ansible.builtin.file:
@@ -182,5 +182,5 @@
     src: 'etc/ansible/facts.d/docker_service.fact.j2'
     dest: '/etc/ansible/facts.d/docker_service.fact'
     mode: '0755'
-  notify: [ 'Refresh host facts' ]
-  tags: [ 'meta::facts' ]
+  notify: ['Refresh host facts']
+  tags: ['meta::facts']

--- a/ansible/roles/docker_service/tasks/main.yml
+++ b/ansible/roles/docker_service/tasks/main.yml
@@ -94,6 +94,16 @@
     - docker_service__config_dir_service.config_dir.src | d()
   tags: [ 'role::docker_service:config' ]
 
+- name: Create Docker networks referenced by services
+  community.docker.docker_network:
+    name: '{{ item }}'
+    state: 'present'
+  loop: '{{ docker_service__combined_services | d([])
+            | selectattr("networks", "defined")
+            | map(attribute="networks") | flatten
+            | map(attribute="name") | unique | list }}'
+  tags: [ 'role::docker_service:containers' ]
+
 - name: Pull Docker images
   community.docker.docker_image:
     name: '{{ item.image }}'

--- a/ansible/roles/docker_service/tasks/main.yml
+++ b/ansible/roles/docker_service/tasks/main.yml
@@ -31,6 +31,8 @@
   when:
     - item.0.state | d('present') not in ['absent', 'ignore']
     - item.1.split(":") | first is match("/")
+    - item.1.split(":") | first not in
+      (item.0.config_files | d([]) | map(attribute="dest") | list)
   tags: [ 'role::docker_service:config' ]
 
 - name: Create directories for config files

--- a/ansible/roles/docker_service/tasks/main.yml
+++ b/ansible/roles/docker_service/tasks/main.yml
@@ -7,6 +7,10 @@
   ansible.builtin.import_role:
     name: 'global_handlers'
 
+- name: Import DebOps secret role
+  ansible.builtin.import_role:
+    name: 'secret'
+
 - name: Install required packages
   ansible.builtin.apt:
     name: '{{ docker_service__python__dependent_packages3 | flatten }}'

--- a/ansible/roles/docker_service/tasks/main.yml
+++ b/ansible/roles/docker_service/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
-# Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
-# Copyright (C) 2024-2026 DebOps <https://debops.org/>
+# Copyright (C) 2026 Patryk Ściborek <patryk@sciborek.com>
+# Copyright (C) 2026 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-only
 
 - name: Import DebOps global handlers

--- a/ansible/roles/docker_service/tasks/main.yml
+++ b/ansible/roles/docker_service/tasks/main.yml
@@ -33,6 +33,65 @@
     - item.1.split(":") | first is match("/")
   tags: [ 'role::docker_service:config' ]
 
+- name: Create directories for config files
+  ansible.builtin.file:
+    path: '{{ item.1.dest | dirname }}'
+    state: 'directory'
+    mode: '0755'
+  loop: '{{ docker_service__combined_services | d([])
+            | subelements("config_files", skip_missing=True) }}'
+  loop_control:
+    label: '{{ item.0.name }}: {{ item.1.dest }}'
+  when: item.0.state | d('present') not in ['absent', 'ignore']
+  tags: [ 'role::docker_service:config' ]
+
+- name: Generate config files with inline content
+  ansible.builtin.copy:
+    content: '{{ item.1.content }}'
+    dest: '{{ item.1.dest }}'
+    owner: '{{ item.1.owner | d("root") }}'
+    group: '{{ item.1.group | d("root") }}'
+    mode: '{{ item.1.mode | d("0644") }}'
+  loop: '{{ docker_service__combined_services | d([])
+            | subelements("config_files", skip_missing=True) }}'
+  loop_control:
+    label: '{{ item.0.name }}: {{ item.1.dest }}'
+  when:
+    - item.0.state | d('present') not in ['absent', 'ignore']
+    - item.1.content is defined
+  register: docker_service__register_config_content
+  tags: [ 'role::docker_service:config' ]
+
+- name: Generate config files from templates
+  ansible.builtin.template:
+    src: '{{ item.1.src }}'
+    dest: '{{ item.1.dest }}'
+    owner: '{{ item.1.owner | d("root") }}'
+    group: '{{ item.1.group | d("root") }}'
+    mode: '{{ item.1.mode | d("0644") }}'
+  loop: '{{ docker_service__combined_services | d([])
+            | subelements("config_files", skip_missing=True) }}'
+  loop_control:
+    label: '{{ item.0.name }}: {{ item.1.dest }}'
+  when:
+    - item.0.state | d('present') not in ['absent', 'ignore']
+    - item.1.src is defined
+  register: docker_service__register_config_template
+  tags: [ 'role::docker_service:config' ]
+
+- name: Manage config directory trees
+  ansible.builtin.include_tasks:
+    file: 'manage_config_dir.yml'
+  loop: '{{ docker_service__combined_services | d([])
+            | selectattr("config_dir", "defined") | list }}'
+  loop_control:
+    loop_var: 'docker_service__config_dir_service'
+    label: '{{ docker_service__config_dir_service.name }}'
+  when:
+    - docker_service__config_dir_service.state | d('present') not in ['absent', 'ignore']
+    - docker_service__config_dir_service.config_dir.src | d()
+  tags: [ 'role::docker_service:config' ]
+
 - name: Pull Docker images
   community.docker.docker_image:
     name: '{{ item.image }}'
@@ -79,6 +138,26 @@
     label: '{{ item.name }}'
   when: item.state | d('present') != 'ignore'
   tags: [ 'role::docker_service:containers' ]
+
+- name: Restart containers with changed config files (content/template)
+  community.docker.docker_container:
+    name: '{{ item.item.0.name }}'
+    state: 'started'
+    restart: true
+  loop: '{{ (docker_service__register_config_content.results | d([])
+             + docker_service__register_config_template.results | d([])) }}'
+  loop_control:
+    label: '{{ item.item.0.name | d("unknown") }}'
+  when: item is changed
+  tags: [ 'role::docker_service:config' ]
+
+- name: Restart containers with changed config directory files
+  community.docker.docker_container:
+    name: '{{ item }}'
+    state: 'started'
+    restart: true
+  loop: '{{ docker_service__restart_containers | d([]) | unique }}'
+  tags: [ 'role::docker_service:config' ]
 
 - name: Make sure that Ansible local facts directory exists
   ansible.builtin.file:

--- a/ansible/roles/docker_service/tasks/manage_config_dir.yml
+++ b/ansible/roles/docker_service/tasks/manage_config_dir.yml
@@ -1,6 +1,6 @@
 ---
-# Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
-# Copyright (C) 2024-2026 DebOps <https://debops.org/>
+# Copyright (C) 2026 Patryk Ściborek <patryk@sciborek.com>
+# Copyright (C) 2026 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-only
 
 # Included by main.yml for each service with a 'config_dir' block.

--- a/ansible/roles/docker_service/tasks/manage_config_dir.yml
+++ b/ansible/roles/docker_service/tasks/manage_config_dir.yml
@@ -1,0 +1,54 @@
+---
+# Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
+# Copyright (C) 2024-2026 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+# Included by main.yml for each service with a 'config_dir' block.
+# The outer loop variable is 'docker_service__config_dir_service'.
+#
+# The config_dir.src path is resolved against the DebOps project
+# resources/templates directory (by-host, then by-group/all).
+# Absolute paths in config_dir.src are used as-is.
+
+- name: Resolve config_dir source path
+  ansible.builtin.set_fact:
+    _docker_service__resolved_config_dir_src: >-
+      {{ docker_service__config_dir_service.config_dir.src
+         if (docker_service__config_dir_service.config_dir.src | regex_search("^/"))
+         else (docker_service__templates_path + "/by-host/"
+               + inventory_hostname + "/"
+               + docker_service__config_dir_service.config_dir.src) }}
+
+- name: Create base config directory
+  ansible.builtin.file:
+    path: '{{ docker_service__config_dir_service.config_dir.dest }}'
+    state: 'directory'
+    mode: '0755'
+
+- name: Create subdirectories from config_dir tree
+  ansible.builtin.file:
+    path: '{{ docker_service__config_dir_service.config_dir.dest + "/" + item.path }}'
+    state: 'directory'
+    mode: '{{ item.mode | d("0755") }}'
+  with_community.general.filetree:
+    - '{{ _docker_service__resolved_config_dir_src }}'
+  when: item.state == 'directory'
+
+- name: Generate files from config_dir tree
+  ansible.builtin.template:
+    src: '{{ item.src }}'
+    dest: '{{ docker_service__config_dir_service.config_dir.dest + "/" + item.path }}'
+    owner: '{{ docker_service__config_dir_service.config_dir.owner | d("root") }}'
+    group: '{{ docker_service__config_dir_service.config_dir.group | d("root") }}'
+    mode: '{{ docker_service__config_dir_service.config_dir.mode | d(item.mode | d("0644")) }}'
+  with_community.general.filetree:
+    - '{{ _docker_service__resolved_config_dir_src }}'
+  when: item.state == 'file'
+  register: docker_service__register_config_dir
+
+- name: Track containers needing restart due to config_dir changes
+  ansible.builtin.set_fact:
+    docker_service__restart_containers: >-
+      {{ docker_service__restart_containers | d([])
+         + [docker_service__config_dir_service.name] }}
+  when: docker_service__register_config_dir is changed

--- a/ansible/roles/docker_service/tasks/manage_config_dir.yml
+++ b/ansible/roles/docker_service/tasks/manage_config_dir.yml
@@ -46,7 +46,7 @@
   when: item.state == 'file'
   register: docker_service__register_config_dir
 
-- name: Track containers needing restart due to config_dir changes
+- name: Track containers needing restart due to config_dir changes  # noqa: no-handler
   ansible.builtin.set_fact:
     docker_service__restart_containers: >-
       {{ docker_service__restart_containers | d([])

--- a/ansible/roles/docker_service/templates/etc/ansible/facts.d/docker_service.fact.j2
+++ b/ansible/roles/docker_service/templates/etc/ansible/facts.d/docker_service.fact.j2
@@ -1,0 +1,48 @@
+#!{{ ansible_python['executable'] }}
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
+# Copyright (C) 2024-2026 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+# {{ ansible_managed }}
+
+from __future__ import print_function
+from json import dumps
+import subprocess
+import os
+
+
+def cmd_exists(cmd):
+    return any(
+        os.access(os.path.join(path, cmd), os.X_OK)
+        for path in os.environ["PATH"].split(os.pathsep)
+    )
+
+
+output = {
+    'installed': cmd_exists('docker'),
+    'containers': {},
+}
+
+if output['installed']:
+    try:
+        ps_output = subprocess.check_output(
+            ['docker', 'ps', '-a',
+             '--format', '{% raw %}{{.Names}}\t{{.Image}}\t{{.Status}}{% endraw %}'],
+            stderr=subprocess.DEVNULL
+        ).decode('utf-8').strip()
+
+        for line in ps_output.split('\n'):
+            if line:
+                parts = line.split('\t')
+                if len(parts) >= 3:
+                    name = parts[0]
+                    output['containers'][name] = {
+                        'image': parts[1],
+                        'status': parts[2],
+                    }
+    except Exception:
+        pass
+
+print(dumps(output, sort_keys=True, indent=4))

--- a/ansible/roles/docker_service/templates/etc/ansible/facts.d/docker_service.fact.j2
+++ b/ansible/roles/docker_service/templates/etc/ansible/facts.d/docker_service.fact.j2
@@ -1,8 +1,8 @@
 #!{{ ansible_python['executable'] }}
 # -*- coding: utf-8 -*-
 
-# Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
-# Copyright (C) 2024-2026 DebOps <https://debops.org/>
+# Copyright (C) 2026 Patryk Ściborek <patryk@sciborek.com>
+# Copyright (C) 2026 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-only
 
 # {{ ansible_managed }}

--- a/ansible/roles/docker_service/templates/lookup/docker_service__nginx_servers.j2
+++ b/ansible/roles/docker_service/templates/lookup/docker_service__nginx_servers.j2
@@ -1,0 +1,39 @@
+{# Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
+ # Copyright (C) 2024-2026 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-only
+ #}
+---
+{% for svc in docker_service__combined_services | d([]) %}
+{%   if svc.state | d('present') not in ['absent', 'ignore'] %}
+{%     if svc.nginx is defined and (svc.nginx.enabled | d(False) | bool) %}
+{%       set nginx = svc.nginx %}
+- name: '{{ nginx.fqdn | d(svc.name + "." + docker_service__domain) }}'
+  by_role: 'debops.docker_service'
+  filename: 'debops.docker_service_{{ svc.name }}'
+  type: '{{ nginx.type | d("proxy") }}'
+  proxy_pass: 'http://{{ svc.name }}-upstream'
+  proxy_location: '/'
+  proxy_headers: {{ nginx.proxy_headers | d(True) | bool }}
+{%       if nginx.proxy_options | d() %}
+  proxy_options: |
+{{ nginx.proxy_options | indent(4, true) }}
+{%       endif %}
+{%       if nginx.options | d() %}
+  options: |
+{{ nginx.options | indent(4, true) }}
+{%       endif %}
+{%       if nginx.allow | d([]) %}
+  allow: {{ nginx.allow | to_json }}
+{%       endif %}
+{%       if nginx.deny_all | d(False) | bool %}
+  location_allow: {{ nginx.allow | d([]) | to_json }}
+{%       endif %}
+{%       if nginx.auth_basic | d(False) | bool %}
+  auth_basic: True
+{%         if nginx.auth_basic_realm | d() %}
+  auth_basic_realm: '{{ nginx.auth_basic_realm }}'
+{%         endif %}
+{%       endif %}
+{%     endif %}
+{%   endif %}
+{% endfor %}

--- a/ansible/roles/docker_service/templates/lookup/docker_service__nginx_servers.j2
+++ b/ansible/roles/docker_service/templates/lookup/docker_service__nginx_servers.j2
@@ -1,5 +1,5 @@
-{# Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
- # Copyright (C) 2024-2026 DebOps <https://debops.org/>
+{# Copyright (C) 2026 Patryk Ściborek <patryk@sciborek.com>
+ # Copyright (C) 2026 DebOps <https://debops.org/>
  # SPDX-License-Identifier: GPL-3.0-only
  #}
 ---

--- a/ansible/roles/docker_service/templates/lookup/docker_service__nginx_upstreams.j2
+++ b/ansible/roles/docker_service/templates/lookup/docker_service__nginx_upstreams.j2
@@ -1,5 +1,5 @@
-{# Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
- # Copyright (C) 2024-2026 DebOps <https://debops.org/>
+{# Copyright (C) 2026 Patryk Ściborek <patryk@sciborek.com>
+ # Copyright (C) 2026 DebOps <https://debops.org/>
  # SPDX-License-Identifier: GPL-3.0-only
  #}
 ---

--- a/ansible/roles/docker_service/templates/lookup/docker_service__nginx_upstreams.j2
+++ b/ansible/roles/docker_service/templates/lookup/docker_service__nginx_upstreams.j2
@@ -1,0 +1,13 @@
+{# Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
+ # Copyright (C) 2024-2026 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-only
+ #}
+---
+{% for svc in docker_service__combined_services | d([]) %}
+{%   if svc.state | d('present') not in ['absent', 'ignore'] %}
+{%     if svc.nginx is defined and (svc.nginx.enabled | d(False) | bool) %}
+- name: '{{ svc.name }}-upstream'
+  server: '127.0.0.1:{{ svc.nginx.port }}'
+{% endif %}
+{%   endif %}
+{% endfor %}

--- a/ansible/roles/docker_service/templates/lookup/docker_service__postgresql_databases.j2
+++ b/ansible/roles/docker_service/templates/lookup/docker_service__postgresql_databases.j2
@@ -1,0 +1,14 @@
+{# Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
+ # Copyright (C) 2024-2026 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-only
+ #}
+---
+{% for svc in docker_service__combined_services | d([]) %}
+{%   if svc.state | d('present') not in ['absent', 'ignore'] %}
+{%     if svc.postgresql is defined %}
+{%       set pg = svc.postgresql %}
+- name: '{{ pg.database }}'
+  owner: '{{ pg.database }}'
+{%     endif %}
+{%   endif %}
+{% endfor %}

--- a/ansible/roles/docker_service/templates/lookup/docker_service__postgresql_databases.j2
+++ b/ansible/roles/docker_service/templates/lookup/docker_service__postgresql_databases.j2
@@ -1,5 +1,5 @@
-{# Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
- # Copyright (C) 2024-2026 DebOps <https://debops.org/>
+{# Copyright (C) 2026 Patryk Ściborek <patryk@sciborek.com>
+ # Copyright (C) 2026 DebOps <https://debops.org/>
  # SPDX-License-Identifier: GPL-3.0-only
  #}
 ---

--- a/ansible/roles/docker_service/templates/lookup/docker_service__postgresql_pgpass.j2
+++ b/ansible/roles/docker_service/templates/lookup/docker_service__postgresql_pgpass.j2
@@ -1,5 +1,5 @@
-{# Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
- # Copyright (C) 2024-2026 DebOps <https://debops.org/>
+{# Copyright (C) 2026 Patryk Ściborek <patryk@sciborek.com>
+ # Copyright (C) 2026 DebOps <https://debops.org/>
  # SPDX-License-Identifier: GPL-3.0-only
  #}
 ---

--- a/ansible/roles/docker_service/templates/lookup/docker_service__postgresql_pgpass.j2
+++ b/ansible/roles/docker_service/templates/lookup/docker_service__postgresql_pgpass.j2
@@ -1,0 +1,17 @@
+{# Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
+ # Copyright (C) 2024-2026 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-only
+ #}
+---
+{% for svc in docker_service__combined_services | d([]) %}
+{%   if svc.state | d('present') not in ['absent', 'ignore'] %}
+{%     if svc.postgresql is defined %}
+{%       set pg = svc.postgresql %}
+- owner: '{{ pg.user }}'
+  database: '{{ pg.database }}'
+  role: '{{ pg.user }}'
+  port: '{{ pg.port | d("5432") }}'
+  server: 'localhost'
+{%     endif %}
+{%   endif %}
+{% endfor %}

--- a/ansible/roles/docker_service/templates/lookup/docker_service__postgresql_roles.j2
+++ b/ansible/roles/docker_service/templates/lookup/docker_service__postgresql_roles.j2
@@ -1,0 +1,15 @@
+{# Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
+ # Copyright (C) 2024-2026 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-only
+ #}
+---
+{% for svc in docker_service__combined_services | d([]) %}
+{%   if svc.state | d('present') not in ['absent', 'ignore'] %}
+{%     if svc.postgresql is defined %}
+{%       set pg = svc.postgresql %}
+- name: '{{ pg.user }}'
+- name: '{{ pg.database }}'
+  flags: [ 'NOLOGIN' ]
+{%     endif %}
+{%   endif %}
+{% endfor %}

--- a/ansible/roles/docker_service/templates/lookup/docker_service__postgresql_roles.j2
+++ b/ansible/roles/docker_service/templates/lookup/docker_service__postgresql_roles.j2
@@ -1,5 +1,5 @@
-{# Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
- # Copyright (C) 2024-2026 DebOps <https://debops.org/>
+{# Copyright (C) 2026 Patryk Ściborek <patryk@sciborek.com>
+ # Copyright (C) 2026 DebOps <https://debops.org/>
  # SPDX-License-Identifier: GPL-3.0-only
  #}
 ---

--- a/ansible/roles/docker_service/templates/lookup/docker_service__postgresql_roles.j2
+++ b/ansible/roles/docker_service/templates/lookup/docker_service__postgresql_roles.j2
@@ -8,8 +8,10 @@
 {%     if svc.postgresql is defined %}
 {%       set pg = svc.postgresql %}
 - name: '{{ pg.user }}'
+{% if pg.user != pg.database %}
 - name: '{{ pg.database }}'
   flags: [ 'NOLOGIN' ]
+{% endif %}
 {%     endif %}
 {%   endif %}
 {% endfor %}

--- a/docs/ansible/role-index.rst
+++ b/docs/ansible/role-index.rst
@@ -390,6 +390,7 @@ Virtualization
 - :ref:`debops.docker_gen`
 - :ref:`debops.docker_registry`
 - :ref:`debops.docker_server`
+- :ref:`debops.docker_service`
 - :ref:`debops.libvirt`
 - :ref:`debops.libvirtd`
 - :ref:`debops.libvirtd_qemu`

--- a/docs/ansible/roles/docker_service/defaults-detailed.rst
+++ b/docs/ansible/roles/docker_service/defaults-detailed.rst
@@ -1,0 +1,292 @@
+.. Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
+.. Copyright (C) 2024-2026 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+Default variable details
+========================
+
+Some of ``debops.docker_service`` default variables have more extensive
+configuration than simple strings or lists, here you can find documentation and
+examples for them.
+
+.. only:: html
+
+   .. contents::
+      :local:
+      :depth: 1
+
+
+.. _docker_service__ref_services:
+
+docker_service__services
+------------------------
+
+The ``docker_service__*_services`` variables define Docker container services
+managed by this role. The variables are lists of YAML dictionaries, each
+dictionary defines a container service. Entries from multiple lists are merged
+together in order: ``default``, all hosts, group, host.
+
+Examples
+~~~~~~~~
+
+Minimal service definition (only ``name`` and ``image`` are required):
+
+.. code-block:: yaml
+
+   docker_service__host_services:
+
+     - name: 'redis'
+       image: 'redis:7-alpine'
+
+Service with port mapping and persistent storage:
+
+.. code-block:: yaml
+
+   docker_service__host_services:
+
+     - name: 'victoriametrics'
+       image: 'victoriametrics/victoria-metrics:v1.93.0'
+       ports:
+         - '127.0.0.1:8428:8428'
+       volumes:
+         - '/srv/docker/victoriametrics/data:/victoria-metrics-data'
+       command: '-retentionPeriod=12 -selfScrapeInterval=10s'
+       nginx:
+         enabled: true
+         fqdn: 'vmetrics.example.com'
+         port: '8428'
+
+Service with environment variables and resource limits:
+
+.. code-block:: yaml
+
+   docker_service__host_services:
+
+     - name: 'grafana'
+       image: 'grafana/grafana:11.0.0'
+       ports:
+         - '127.0.0.1:3000:3000'
+       volumes:
+         - '/srv/docker/grafana/data:/var/lib/grafana'
+       env:
+         GF_SERVER_ROOT_URL: 'https://grafana.example.com'
+       memory: '512m'
+       cpus: 1.0
+       nginx:
+         enabled: true
+         fqdn: 'grafana.example.com'
+         port: '3000'
+         proxy_options: |
+           proxy_buffering off;
+
+Removing a previously deployed service:
+
+.. code-block:: yaml
+
+   docker_service__host_services:
+
+     - name: 'old-service'
+       state: 'absent'
+
+Syntax
+~~~~~~
+
+Each entry in the services list is a YAML dictionary with the following
+parameters:
+
+``name``
+  Required. Name of the Docker container. Also used as an identifier when
+  generating :command:`nginx` configuration filenames. Must be unique across
+  all service lists.
+
+``image``
+  Required (unless ``state`` is ``absent``). Docker image to use for the
+  container, including the tag (e.g. ``grafana/grafana:11.0.0``).
+
+``state``
+  Optional. Defines the desired state of the container service. Supported
+  values:
+
+  - ``present`` (default): container is created and started
+  - ``stopped``: container exists but is not running
+  - ``absent``: container is removed
+  - ``ignore``: entry is skipped entirely (DebOps convention)
+
+``restart_policy``
+  Optional, string. Docker restart policy for the container. Defaults to
+  the value of :envvar:`docker_service__restart_policy` (``unless-stopped``).
+  Supported values: ``no``, ``always``, ``on-failure``, ``unless-stopped``.
+
+``pull``
+  Optional, boolean. Whether to pull the Docker image before managing the
+  container. Defaults to :envvar:`docker_service__pull` (``True``).
+
+``command``
+  Optional, string or list. Override the default command (``CMD``) of the
+  Docker image.
+
+``entrypoint``
+  Optional, list. Override the default entrypoint (``ENTRYPOINT``) of the
+  Docker image.
+
+``user``
+  Optional, string. Username or UID to run the container process as.
+
+``ports``
+  Optional, list of strings. Port mappings in standard Docker format:
+  ``[host_ip:]host_port:container_port[/protocol]``. For services behind an
+  :command:`nginx` reverse proxy, bind to localhost only:
+  ``127.0.0.1:8080:8080``.
+
+``networks``
+  Optional, list of dictionaries. Docker networks to connect the container to.
+  Each entry must have a ``name`` key with the network name.
+
+``dns``
+  Optional, list of strings. Custom DNS servers for the container.
+
+``hostname``
+  Optional, string. Hostname to set inside the container.
+
+``volumes``
+  Optional, list of strings. Volume mounts in standard Docker format:
+  ``host_path:container_path[:options]``. The role automatically creates host
+  directories for bind mounts (paths starting with ``/``).
+
+``tmpfs``
+  Optional, list of strings. Tmpfs mounts inside the container.
+
+``env``
+  Optional, dictionary. Environment variables passed to the container.
+  Keys are variable names, values are strings.
+
+``memory``
+  Optional, string. Memory limit for the container (e.g. ``512m``, ``1g``).
+
+``memory_reservation``
+  Optional, string. Soft memory limit for the container.
+
+``cpus``
+  Optional, number. CPU limit for the container (e.g. ``1.5`` for one and
+  a half CPUs).
+
+``capabilities``
+  Optional, list of strings. Linux capabilities to add to the container
+  (e.g. ``NET_ADMIN``).
+
+``sysctls``
+  Optional, dictionary. Sysctl settings for the container.
+
+``read_only``
+  Optional, boolean. If ``True``, the container filesystem is mounted
+  read-only.
+
+``labels``
+  Optional, dictionary. Labels to apply to the container.
+
+``healthcheck``
+  Optional, dictionary. Container healthcheck configuration with the
+  following keys: ``test`` (list), ``interval`` (string), ``timeout``
+  (string), ``retries`` (integer), ``start_period`` (string).
+
+``nginx``
+  Optional, dictionary. When present and ``enabled: true``, configures an
+  :command:`nginx` reverse proxy virtual host for this service. See
+  :ref:`docker_service__ref_nginx` for details.
+
+
+.. _docker_service__ref_nginx:
+
+docker_service__services nginx parameters
+-----------------------------------------
+
+The ``nginx`` dictionary within a service entry controls the :command:`nginx`
+reverse proxy configuration. The role generates :command:`nginx` upstream and
+server block definitions that are passed to the :ref:`debops.nginx` role.
+
+Examples
+~~~~~~~~
+
+Minimal :command:`nginx` configuration:
+
+.. code-block:: yaml
+
+   nginx:
+     enabled: true
+     fqdn: 'app.example.com'
+     port: '8080'
+
+Full :command:`nginx` configuration with all options:
+
+.. code-block:: yaml
+
+   nginx:
+     enabled: true
+     fqdn: 'app.example.com'
+     port: '8080'
+     type: 'proxy'
+     proxy_headers: true
+     proxy_options: |
+       proxy_buffering off;
+       proxy_read_timeout 300s;
+     options: |
+       client_max_body_size 50m;
+     allow:
+       - '192.168.1.0/24'
+       - '10.0.0.0/8'
+     deny_all: true
+     auth_basic: true
+     auth_basic_realm: 'Restricted'
+
+Syntax
+~~~~~~
+
+``enabled``
+  Required, boolean. If ``True``, an :command:`nginx` reverse proxy is
+  configured for this service. If ``False`` or the ``nginx`` dictionary is
+  absent, no proxy is created.
+
+``fqdn``
+  Optional, string. Fully Qualified Domain Name for the :command:`nginx`
+  server block. Defaults to ``<name>.<docker_service__domain>``.
+
+``port``
+  Required (when ``enabled: true``), string. The host-side port that
+  :command:`nginx` should proxy to. This must match the host port in the
+  service ``ports`` mapping.
+
+``type``
+  Optional, string. The :command:`nginx` server template type. Defaults to
+  ``proxy``. See :ref:`debops.nginx` documentation for other available types.
+
+``proxy_headers``
+  Optional, boolean. If ``True`` (default), standard proxy headers are
+  included (``X-Real-IP``, ``X-Forwarded-For``, ``X-Forwarded-Proto``,
+  ``Host``).
+
+``proxy_options``
+  Optional, YAML text block. Additional :command:`nginx` directives placed
+  inside the ``location`` block, after the proxy headers.
+
+``options``
+  Optional, YAML text block. Additional :command:`nginx` directives placed
+  inside the ``server`` block.
+
+``allow``
+  Optional, list of strings. IP addresses or CIDR networks allowed to access
+  the service. When empty (default), no access restrictions are applied.
+
+``deny_all``
+  Optional, boolean. If ``True`` and ``allow`` is specified, a ``deny all``
+  directive is added after the allow rules. Defaults to ``False``.
+
+``ssl``
+  Optional, boolean. Enable HTTPS through DebOps PKI. Defaults to ``True``
+  (handled by the :ref:`debops.nginx` role defaults).
+
+``auth_basic``
+  Optional, boolean. Enable HTTP Basic Authentication. Defaults to ``False``.
+
+``auth_basic_realm``
+  Optional, string. The authentication realm displayed to users when
+  ``auth_basic`` is enabled.

--- a/docs/ansible/roles/docker_service/defaults-detailed.rst
+++ b/docs/ansible/roles/docker_service/defaults-detailed.rst
@@ -1,5 +1,5 @@
-.. Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
-.. Copyright (C) 2024-2026 DebOps <https://debops.org/>
+.. Copyright (C) 2026 Patryk Ściborek <patryk@sciborek.com>
+.. Copyright (C) 2026 DebOps <https://debops.org/>
 .. SPDX-License-Identifier: GPL-3.0-only
 
 Default variable details

--- a/docs/ansible/roles/docker_service/defaults-detailed.rst
+++ b/docs/ansible/roles/docker_service/defaults-detailed.rst
@@ -81,6 +81,45 @@ Service with environment variables, secrets and resource limits:
          proxy_options: |
            proxy_buffering off;
 
+Service with inline config file (``content`` mode):
+
+.. code-block:: yaml
+
+   docker_service__host_services:
+
+     - name: 'vmauth'
+       image: 'victoriametrics/vmauth:latest'
+       config_files:
+         - dest: '/srv/docker/vmauth/auth.yml'
+           content: |
+             users:
+               - username: admin
+                 password: "{{ lookup('password', secret
+                               + '/docker_service/vmauth/admin_password') }}"
+                 url_prefix: "http://127.0.0.1:8428/"
+           mode: '0640'
+       volumes:
+         - '/srv/docker/vmauth/auth.yml:/etc/vmauth/auth.yml:ro'
+       ports:
+         - '127.0.0.1:8427:8427'
+       command: '-auth.config=/etc/vmauth/auth.yml'
+
+Service with a config directory (``config_dir`` mode):
+
+.. code-block:: yaml
+
+   docker_service__host_services:
+
+     - name: 'homepage'
+       image: 'ghcr.io/gethomepage/homepage:latest'
+       config_dir:
+         src: 'docker_service/homepage/config'
+         dest: '/srv/docker/homepage/config'
+       volumes:
+         - '/srv/docker/homepage/config:/app/config:ro'
+       ports:
+         - '127.0.0.1:3000:3000'
+
 Removing a previously deployed service:
 
 .. code-block:: yaml
@@ -194,6 +233,68 @@ parameters:
   following keys: ``test`` (list), ``interval`` (string), ``timeout``
   (string), ``retries`` (integer), ``start_period`` (string).
 
+``config_files``
+  Optional, list of dictionaries. Configuration files to create on the host
+  before starting the container. Each entry creates a file that can then be
+  bind-mounted into the container via the ``volumes`` parameter. The container
+  is automatically restarted when a config file changes. Two modes are
+  supported:
+
+  ``dest``
+    Required, string. Absolute path on the host where the file will be
+    created. Parent directories are created automatically.
+
+  ``content``
+    Optional, string. Inline file content. Mutually exclusive with ``src``.
+    Jinja2 expressions are evaluated at variable expansion time.
+
+  ``src``
+    Optional, string. Path to a Jinja2 template file, relative to the
+    Ansible ``templates/`` search path. Mutually exclusive with ``content``.
+
+  ``mode``
+    Optional, string. File permissions. Defaults to ``0644``.
+
+  ``owner``
+    Optional, string. File owner. Defaults to ``root``.
+
+  ``group``
+    Optional, string. File group. Defaults to ``root``.
+
+``config_dir``
+  Optional, dictionary. A directory of template files to render on the host,
+  useful for applications that need many configuration files (e.g. Homepage).
+  The directory tree is scanned using ``community.general.filetree`` and all
+  files are rendered as Jinja2 templates. The container is automatically
+  restarted when any file changes.
+
+  ``src``
+    Required, string. Path to a directory of template files on the Ansible
+    Controller. Relative paths are resolved against the ``templates/``
+    search path. The directory structure is replicated under ``dest``.
+
+  ``dest``
+    Required, string. Absolute path on the host where the rendered files
+    will be placed. This directory can then be bind-mounted into the
+    container via ``volumes``.
+
+  ``mode``
+    Optional, string. Default file permissions for rendered files. Individual
+    file permissions from the source tree take precedence. Defaults to
+    ``0644``.
+
+  ``owner``
+    Optional, string. File owner. Defaults to ``root``.
+
+  ``group``
+    Optional, string. File group. Defaults to ``root``.
+
+``postgresql``
+  Optional, dictionary. When present, the role automatically provisions a
+  PostgreSQL database and user via the :ref:`debops.postgresql` role. The
+  database password is auto-generated and stored in the DebOps secret
+  directory. See :ref:`docker_service__ref_postgresql` for details.
+
 ``nginx``
   Optional, dictionary. When present and ``enabled: true``, configures an
   :command:`nginx` reverse proxy virtual host for this service. See
@@ -295,3 +396,48 @@ Syntax
 ``auth_basic_realm``
   Optional, string. The authentication realm displayed to users when
   ``auth_basic`` is enabled.
+
+
+.. _docker_service__ref_postgresql:
+
+docker_service__services postgresql parameters
+-----------------------------------------------
+
+The ``postgresql`` dictionary within a service entry enables automatic
+PostgreSQL database provisioning via the :ref:`debops.postgresql` role. When
+a service defines a ``postgresql`` block, the role generates
+``postgresql__dependent_*`` variables that create the required database, user
+and pgpass entry.
+
+Examples
+~~~~~~~~
+
+Service with automatic PostgreSQL provisioning:
+
+.. code-block:: yaml
+
+   docker_service__host_services:
+
+     - name: 'bugsink'
+       image: 'bugsink/bugsink:latest'
+       postgresql:
+         database: 'bugsink'
+         user: 'bugsink'
+       env:
+         DATABASE_URL: 'postgresql:///bugsink?host=/var/run/postgresql'
+         SECRET_KEY: '{{ lookup("password", secret
+                         + "/docker_service/bugsink/secret_key
+                            chars=ascii_letters,digits length=50") }}'
+
+Syntax
+~~~~~~
+
+``database``
+  Required, string. Name of the PostgreSQL database to create.
+
+``user``
+  Required, string. Name of the PostgreSQL user (role) to create. This user
+  will be granted access to the database.
+
+``port``
+  Optional, string. PostgreSQL server port. Defaults to ``5432``.

--- a/docs/ansible/roles/docker_service/defaults-detailed.rst
+++ b/docs/ansible/roles/docker_service/defaults-detailed.rst
@@ -81,14 +81,26 @@ Service with environment variables, secrets and resource limits:
          proxy_options: |
            proxy_buffering off;
 
-Service with inline config file (``content`` mode):
+Service with inline config file (``content`` mode) and inter-container
+networking. Both ``vmauth`` and ``victoriametrics`` share a user-defined
+Docker network so that ``vmauth`` can reach the backend by container name:
 
 .. code-block:: yaml
 
    docker_service__host_services:
 
+     - name: 'victoriametrics'
+       image: 'victoriametrics/victoria-metrics:v1.93.0'
+       networks:
+         - name: 'victoriametrics'
+       volumes:
+         - '/srv/docker/victoriametrics/data:/victoria-metrics-data'
+       command: '-retentionPeriod=12 -selfScrapeInterval=10s'
+
      - name: 'vmauth'
        image: 'victoriametrics/vmauth:latest'
+       networks:
+         - name: 'victoriametrics'
        config_files:
          - dest: '/srv/docker/vmauth/auth.yml'
            content: |
@@ -96,7 +108,7 @@ Service with inline config file (``content`` mode):
                - username: admin
                  password: "{{ lookup('password', secret
                                + '/docker_service/vmauth/admin_password') }}"
-                 url_prefix: "http://127.0.0.1:8428/"
+                 url_prefix: "http://victoriametrics:8428/"
            mode: '0640'
        volumes:
          - '/srv/docker/vmauth/auth.yml:/etc/vmauth/auth.yml:ro'
@@ -181,7 +193,10 @@ parameters:
 
 ``networks``
   Optional, list of dictionaries. Docker networks to connect the container to.
-  Each entry must have a ``name`` key with the network name.
+  Each entry must have a ``name`` key with the network name. Referenced
+  networks are automatically created by the role if they do not exist.
+  Containers on the same user-defined network can communicate using container
+  names as hostnames (DNS-based service discovery).
 
 ``dns``
   Optional, list of strings. Custom DNS servers for the container.

--- a/docs/ansible/roles/docker_service/defaults-detailed.rst
+++ b/docs/ansible/roles/docker_service/defaults-detailed.rst
@@ -192,7 +192,10 @@ parameters:
 ``volumes``
   Optional, list of strings. Volume mounts in standard Docker format:
   ``host_path:container_path[:options]``. The role automatically creates host
-  directories for bind mounts (paths starting with ``/``).
+  directories for bind mounts (paths starting with ``/``). When a volume
+  source path matches a ``config_files`` destination, the directory creation
+  is skipped -- the ``config_files`` tasks create the parent directory and
+  the file itself.
 
 ``tmpfs``
   Optional, list of strings. Tmpfs mounts inside the container.

--- a/docs/ansible/roles/docker_service/defaults-detailed.rst
+++ b/docs/ansible/roles/docker_service/defaults-detailed.rst
@@ -251,6 +251,13 @@ parameters:
   following keys: ``test`` (list), ``interval`` (string), ``timeout``
   (string), ``retries`` (integer), ``start_period`` (string).
 
+``init``
+  Optional, boolean. If ``True``, run an init process (``tini``) inside the
+  container that forwards signals and reaps zombie processes. This is useful
+  for containers whose main process does not handle ``SIGCHLD``, which can
+  lead to zombie process accumulation (e.g. from healthcheck commands).
+  Corresponds to Docker's ``--init`` flag.
+
 ``config_files``
   Optional, list of dictionaries. Configuration files to create on the host
   before starting the container. Each entry creates a file that can then be

--- a/docs/ansible/roles/docker_service/defaults-detailed.rst
+++ b/docs/ansible/roles/docker_service/defaults-detailed.rst
@@ -56,7 +56,7 @@ Service with port mapping and persistent storage:
          fqdn: 'vmetrics.example.com'
          port: '8428'
 
-Service with environment variables and resource limits:
+Service with environment variables, secrets and resource limits:
 
 .. code-block:: yaml
 
@@ -70,6 +70,8 @@ Service with environment variables and resource limits:
          - '/srv/docker/grafana/data:/var/lib/grafana'
        env:
          GF_SERVER_ROOT_URL: 'https://grafana.example.com'
+         GF_SECURITY_ADMIN_PASSWORD: '{{ lookup("password", secret
+                                         + "/docker_service/grafana/admin_password") }}'
        memory: '512m'
        cpus: 1.0
        nginx:
@@ -158,7 +160,10 @@ parameters:
 
 ``env``
   Optional, dictionary. Environment variables passed to the container.
-  Keys are variable names, values are strings.
+  Keys are variable names, values are strings. Sensitive values such as
+  passwords can be auto-generated using the ``lookup("password", secret +
+  "/docker_service/<name>/...")`` pattern -- the :ref:`debops.secret` role
+  is imported automatically to provide the ``secret`` variable.
 
 ``memory``
   Optional, string. Memory limit for the container (e.g. ``512m``, ``1g``).

--- a/docs/ansible/roles/docker_service/getting-started.rst
+++ b/docs/ansible/roles/docker_service/getting-started.rst
@@ -42,6 +42,10 @@ automatically configures an :command:`nginx` reverse proxy virtual host that
 forwards traffic to the container. SSL/TLS is handled by the DebOps PKI
 infrastructure.
 
+For complete deployment examples of popular applications (Grafana,
+VictoriaMetrics, Vaultwarden, Bugsink, Homepage and more), see the
+:ref:`docker_service__ref_guides` page.
+
 
 Nginx reverse proxy
 -------------------
@@ -165,7 +169,9 @@ Available role tags:
   tasks as well as role dependencies.
 
 ``role::docker_service:config``
-  Tasks related to creating persistent data directories.
+  Tasks related to creating persistent data directories, generating
+  configuration files (``config_files`` and ``config_dir``), and restarting
+  containers when configuration changes.
 
 ``role::docker_service:containers``
   Tasks related to pulling Docker images and managing containers.

--- a/docs/ansible/roles/docker_service/getting-started.rst
+++ b/docs/ansible/roles/docker_service/getting-started.rst
@@ -1,0 +1,165 @@
+.. Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
+.. Copyright (C) 2024-2026 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+Getting started
+===============
+
+.. only:: html
+
+   .. contents:: Sections
+      :local:
+
+
+Prerequisites
+-------------
+
+The ``debops.docker_service`` role requires Docker Engine to be already
+installed on the host. Use the :ref:`debops.docker_server` role to set up
+Docker before using this role. The host must be included in both the
+``[debops_service_docker_server]`` and ``[debops_service_docker_service]``
+Ansible inventory groups.
+
+The role uses the ``community.docker`` Ansible collection to manage containers.
+The ``python3-docker`` package is installed automatically to provide the
+required Python bindings.
+
+
+Default setup
+-------------
+
+If you don't specify any configuration, the role will not create any containers.
+You need to define at least one service entry with ``name`` and ``image``
+parameters.
+
+When a service has an ``nginx`` block with ``enabled: true``, the role
+automatically configures an :command:`nginx` reverse proxy virtual host that
+forwards traffic to the container. SSL/TLS is handled by the DebOps PKI
+infrastructure.
+
+
+Nginx reverse proxy
+-------------------
+
+The role integrates with :ref:`debops.nginx` to automatically set up reverse
+proxy virtual hosts for container services. For each service with ``nginx``
+configuration, the role generates:
+
+- An :command:`nginx` upstream pointing to ``127.0.0.1:<port>``
+- A server block with the specified FQDN, proxying to the upstream
+
+The container must expose the relevant port on ``127.0.0.1`` for this to work.
+A typical port mapping looks like ``127.0.0.1:8428:8428``, which binds the
+container port to localhost only -- :command:`nginx` then handles external
+access with SSL termination.
+
+
+Example inventory
+-----------------
+
+To deploy Docker container services on a host, it needs to be included in the
+appropriate Ansible inventory groups:
+
+.. code-block:: none
+
+   [debops_all_hosts]
+   hostname
+
+   [debops_service_docker_server]
+   hostname
+
+   [debops_service_docker_service]
+   hostname
+
+
+Minimal service example
+-----------------------
+
+Deploy a VictoriaMetrics time series database with :command:`nginx` reverse
+proxy:
+
+.. code-block:: yaml
+
+   # ansible/inventory/host_vars/hostname/docker_service.yml
+   docker_service__host_services:
+
+     - name: 'victoriametrics'
+       image: 'victoriametrics/victoria-metrics:v1.93.0'
+       ports:
+         - '127.0.0.1:8428:8428'
+       volumes:
+         - '/srv/docker/victoriametrics/data:/victoria-metrics-data'
+       command: '-retentionPeriod=12 -selfScrapeInterval=10s'
+       nginx:
+         enabled: true
+         fqdn: 'vmetrics.example.com'
+         port: '8428'
+
+
+Multiple services example
+-------------------------
+
+Deploy VictoriaMetrics and Grafana side by side:
+
+.. code-block:: yaml
+
+   docker_service__host_services:
+
+     - name: 'victoriametrics'
+       image: 'victoriametrics/victoria-metrics:v1.93.0'
+       ports:
+         - '127.0.0.1:8428:8428'
+       volumes:
+         - '/srv/docker/victoriametrics/data:/victoria-metrics-data'
+       command: '-retentionPeriod=12 -selfScrapeInterval=10s'
+       memory: '512m'
+       nginx:
+         enabled: true
+         fqdn: 'vmetrics.example.com'
+         port: '8428'
+
+     - name: 'grafana'
+       image: 'grafana/grafana:11.0.0'
+       ports:
+         - '127.0.0.1:3000:3000'
+       volumes:
+         - '/srv/docker/grafana/data:/var/lib/grafana'
+       env:
+         GF_SERVER_ROOT_URL: 'https://grafana.example.com'
+         GF_SECURITY_ADMIN_PASSWORD: 'changeme'
+       nginx:
+         enabled: true
+         fqdn: 'grafana.example.com'
+         port: '3000'
+
+
+Example playbook
+----------------
+
+If you are using this role without DebOps, here's an example Ansible playbook
+that uses the ``debops.docker_service`` role:
+
+.. literalinclude:: ../../../../ansible/playbooks/service/docker_service.yml
+   :language: yaml
+   :lines: 1,5-
+
+
+Ansible tags
+------------
+
+You can use Ansible ``--tags`` or ``--skip-tags`` parameters to limit what
+tasks are performed during Ansible run. This can be used after a host was first
+configured to speed up playbook execution, when you are sure that most of the
+configuration is already in the desired state.
+
+Available role tags:
+
+``role::docker_service``
+  Main role tag, should be used in the playbook to execute all of the role
+  tasks as well as role dependencies.
+
+``role::docker_service:config``
+  Tasks related to creating persistent data directories.
+
+``role::docker_service:containers``
+  Tasks related to pulling Docker images and managing containers.

--- a/docs/ansible/roles/docker_service/getting-started.rst
+++ b/docs/ansible/roles/docker_service/getting-started.rst
@@ -24,6 +24,11 @@ The role uses the ``community.docker`` Ansible collection to manage containers.
 The ``python3-docker`` package is installed automatically to provide the
 required Python bindings.
 
+The role imports the :ref:`debops.secret` role to provide access to the
+``secret`` variable. This allows service definitions to use the
+``lookup("password", ...)`` plugin to auto-generate and store secrets in
+the DebOps secret directory on the Ansible Controller.
+
 
 Default setup
 -------------
@@ -126,7 +131,8 @@ Deploy VictoriaMetrics and Grafana side by side:
          - '/srv/docker/grafana/data:/var/lib/grafana'
        env:
          GF_SERVER_ROOT_URL: 'https://grafana.example.com'
-         GF_SECURITY_ADMIN_PASSWORD: 'changeme'
+         GF_SECURITY_ADMIN_PASSWORD: '{{ lookup("password", secret
+                                         + "/docker_service/grafana/admin_password") }}'
        nginx:
          enabled: true
          fqdn: 'grafana.example.com'

--- a/docs/ansible/roles/docker_service/getting-started.rst
+++ b/docs/ansible/roles/docker_service/getting-started.rst
@@ -1,5 +1,5 @@
-.. Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
-.. Copyright (C) 2024-2026 DebOps <https://debops.org/>
+.. Copyright (C) 2026 Patryk Ściborek <patryk@sciborek.com>
+.. Copyright (C) 2026 DebOps <https://debops.org/>
 .. SPDX-License-Identifier: GPL-3.0-only
 
 Getting started

--- a/docs/ansible/roles/docker_service/guides.rst
+++ b/docs/ansible/roles/docker_service/guides.rst
@@ -1,5 +1,5 @@
-.. Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
-.. Copyright (C) 2024-2026 DebOps <https://debops.org/>
+.. Copyright (C) 2026 Patryk Ściborek <patryk@sciborek.com>
+.. Copyright (C) 2026 DebOps <https://debops.org/>
 .. SPDX-License-Identifier: GPL-3.0-only
 
 .. _docker_service__ref_guides:

--- a/docs/ansible/roles/docker_service/guides.rst
+++ b/docs/ansible/roles/docker_service/guides.rst
@@ -30,15 +30,29 @@ Bugsink
 
 `Bugsink <https://www.bugsink.com/>`_ is a Sentry-compatible error tracking
 server. This example deploys Bugsink with a PostgreSQL database managed by the
-:ref:`debops.postgresql_server` role on the same host.
+:ref:`debops.postgresql_server` role on the same host, connecting through a
+UNIX socket.
 
 Prerequisites
 ~~~~~~~~~~~~~
 
-The host must be a member of the ``[debops_service_postgresql_server]``
-inventory group so that PostgreSQL is installed and configured before the
-``docker_service`` playbook runs. The ``postgresql`` block in the service
-definition will automatically create the database and user.
+The host must be a member of the following inventory groups:
+
+.. code-block:: none
+
+   [debops_service_postgresql_server]
+   bugsink.example.com
+
+   [debops_service_docker_server]
+   bugsink.example.com
+
+   [debops_service_docker_service]
+   bugsink.example.com
+
+The ``[debops_service_postgresql_server]`` group ensures that PostgreSQL is
+installed before the ``docker_service`` playbook runs. The ``postgresql`` block
+in the service definition will automatically create the database and user
+through the :ref:`debops.postgresql` role.
 
 Service definition
 ~~~~~~~~~~~~~~~~~~
@@ -46,44 +60,69 @@ Service definition
 .. code-block:: yaml
 
    # ansible/inventory/host_vars/bugsink.example.com/docker_service.yml
+   ---
+
+   bugsink_secret_key: "{{ lookup('password', secret
+                            + '/bugsink/secret_key
+                               length=50 chars=ascii_letters,digits') }}"
+
+   bugsink__postgresql_password: "{{ lookup('password', secret
+                                     + '/postgresql/'
+                                     + postgresql__password_hostname + '/'
+                                     + postgresql__port
+                                     + '/credentials/bugsink/password
+                                        length=' + postgresql__password_length
+                                     + ' chars=' + postgresql__password_characters) }}"
+
    docker_service__host_services:
 
      - name: 'bugsink'
        image: 'bugsink/bugsink:latest'
+       restart_policy: 'unless-stopped'
        ports:
          - '127.0.0.1:8000:8000'
        volumes:
          - '/srv/docker/bugsink/data:/data'
-       env:
-         SECRET_KEY: '{{ lookup("password", secret
-                         + "/docker_service/bugsink/secret_key
-                            chars=ascii_letters,digits length=50") }}'
-         DATABASE_URL: 'postgresql:///bugsink?host=/var/run/postgresql'
-         PORT: '8000'
-         CREATE_SUPERUSER: 'admin:{{ lookup("password", secret
-                                     + "/docker_service/bugsink/admin_password") }}'
+         - '/var/run/postgresql:/var/run/postgresql:ro'
        postgresql:
          database: 'bugsink'
          user: 'bugsink'
+       env:
+         SECRET_KEY: '{{ bugsink_secret_key }}'
+         DATABASE_URL: 'postgresql://bugsink:{{ bugsink__postgresql_password }}@/bugsink?host=/var/run/postgresql'
+         PORT: '8000'
+         BEHIND_HTTPS_PROXY: 'True'
        nginx:
          enabled: true
          fqdn: 'bugsink.example.com'
          port: '8000'
+
+The ``SECRET_KEY`` and PostgreSQL password are auto-generated and stored in the
+DebOps :file:`secret/` directory. The ``bugsink__postgresql_password`` lookup
+uses the same path as the :ref:`debops.postgresql` role, ensuring the password
+in ``DATABASE_URL`` matches the one set in the database.
+
+The PostgreSQL UNIX socket directory is mounted read-only into the container.
+The ``DATABASE_URL`` uses the ``host=/var/run/postgresql`` query parameter to
+connect through the socket instead of TCP.
+
+Creating the initial superuser
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+After the first deployment, create an admin account by running:
+
+.. code-block:: console
+
+   $ docker exec -it bugsink bugsink-manage createsuperuser
+
+The ``DATABASE_URL`` environment variable is already set in the container, so
+the management command will connect to the correct database automatically.
 
 .. note::
 
    Bugsink does not currently provide an official health check endpoint
    (`issue #98 <https://github.com/bugsink/bugsink/issues/98>`_). A basic
    HTTP check can be used as a workaround once the endpoint is available.
-
-If the container connects to PostgreSQL over a UNIX socket, mount the socket
-directory as a volume:
-
-.. code-block:: yaml
-
-       volumes:
-         - '/srv/docker/bugsink/data:/data'
-         - '/var/run/postgresql:/var/run/postgresql:ro'
 
 
 .. _docker_service__guide_grafana:

--- a/docs/ansible/roles/docker_service/guides.rst
+++ b/docs/ansible/roles/docker_service/guides.rst
@@ -537,6 +537,7 @@ the DebOps PKI certificates into the container:
 
      - name: 'vmauth'
        image: 'victoriametrics/vmauth:latest'
+       init: true
        ports:
          - '0.0.0.0:443:443'
        config_files:
@@ -555,11 +556,26 @@ the DebOps PKI certificates into the container:
        command: >-
          -auth.config=/etc/vmauth/auth.yml
          -tls -tlsCertFile=/etc/vmauth/cert.pem -tlsKeyFile=/etc/vmauth/key.pem
-         -httpListenAddr=:443
+         -httpListenAddr=:443 -httpInternalListenAddr=:8427
+       healthcheck:
+         test: [ 'CMD-SHELL',
+                 'wget --no-check-certificate --no-verbose --tries=1 --spider https://127.0.0.1:8427/health || exit 1' ]
+         interval: '15s'
+         timeout: '5s'
+         retries: 3
+         start_period: '10s'
 
 The certificate paths (``/etc/pki/realms/domain/``) are managed by the
 :ref:`debops.pki` role. vmauth automatically reloads certificates when they
 change on disk, so no container restart is needed for certificate renewal.
+
+.. important::
+
+   The ``init: true`` parameter is required when running vmauth with TLS
+   healthchecks. BusyBox ``wget`` (used in Alpine-based VictoriaMetrics
+   images) spawns a helper ``ssl_client`` process for each HTTPS request.
+   Without an init process to reap these children, they accumulate as zombie
+   processes because vmauth (PID 1) does not handle ``SIGCHLD``.
 
 ..
  Local Variables:

--- a/docs/ansible/roles/docker_service/guides.rst
+++ b/docs/ansible/roles/docker_service/guides.rst
@@ -1,0 +1,529 @@
+.. Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
+.. Copyright (C) 2024-2026 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+.. _docker_service__ref_guides:
+
+Deployment guides
+=================
+
+.. only:: html
+
+   .. contents:: Sections
+      :local:
+
+This page contains ready-to-use examples for deploying popular applications
+with the ``debops.docker_service`` role. Each example includes the complete
+service definition, :command:`nginx` reverse proxy configuration, and a
+container healthcheck where the application supports it.
+
+The examples assume that the target host already has Docker Engine installed
+via the :ref:`debops.docker_server` role and that the host is a member of both
+the ``[debops_service_docker_server]`` and ``[debops_service_docker_service]``
+Ansible inventory groups.
+
+
+.. _docker_service__guide_bugsink:
+
+Bugsink
+-------
+
+`Bugsink <https://www.bugsink.com/>`_ is a Sentry-compatible error tracking
+server. This example deploys Bugsink with a PostgreSQL database managed by the
+:ref:`debops.postgresql_server` role on the same host.
+
+Prerequisites
+~~~~~~~~~~~~~
+
+The host must be a member of the ``[debops_service_postgresql_server]``
+inventory group so that PostgreSQL is installed and configured before the
+``docker_service`` playbook runs. The ``postgresql`` block in the service
+definition will automatically create the database and user.
+
+Service definition
+~~~~~~~~~~~~~~~~~~
+
+.. code-block:: yaml
+
+   # ansible/inventory/host_vars/bugsink.example.com/docker_service.yml
+   docker_service__host_services:
+
+     - name: 'bugsink'
+       image: 'bugsink/bugsink:latest'
+       ports:
+         - '127.0.0.1:8000:8000'
+       volumes:
+         - '/srv/docker/bugsink/data:/data'
+       env:
+         SECRET_KEY: '{{ lookup("password", secret
+                         + "/docker_service/bugsink/secret_key
+                            chars=ascii_letters,digits length=50") }}'
+         DATABASE_URL: 'postgresql:///bugsink?host=/var/run/postgresql'
+         PORT: '8000'
+         CREATE_SUPERUSER: 'admin:{{ lookup("password", secret
+                                     + "/docker_service/bugsink/admin_password") }}'
+       postgresql:
+         database: 'bugsink'
+         user: 'bugsink'
+       nginx:
+         enabled: true
+         fqdn: 'bugsink.example.com'
+         port: '8000'
+
+.. note::
+
+   Bugsink does not currently provide an official health check endpoint
+   (`issue #98 <https://github.com/bugsink/bugsink/issues/98>`_). A basic
+   HTTP check can be used as a workaround once the endpoint is available.
+
+If the container connects to PostgreSQL over a UNIX socket, mount the socket
+directory as a volume:
+
+.. code-block:: yaml
+
+       volumes:
+         - '/srv/docker/bugsink/data:/data'
+         - '/var/run/postgresql:/var/run/postgresql:ro'
+
+
+.. _docker_service__guide_grafana:
+
+Grafana
+-------
+
+`Grafana <https://grafana.com/>`_ is a popular observability dashboard. This
+example deploys Grafana with persistent storage, auto-generated admin password,
+and an :command:`nginx` reverse proxy.
+
+Service definition
+~~~~~~~~~~~~~~~~~~
+
+.. code-block:: yaml
+
+   # ansible/inventory/host_vars/grafana.example.com/docker_service.yml
+   docker_service__host_services:
+
+     - name: 'grafana'
+       image: 'grafana/grafana:11.0.0'
+       ports:
+         - '127.0.0.1:3000:3000'
+       volumes:
+         - '/srv/docker/grafana/data:/var/lib/grafana'
+       env:
+         GF_SERVER_ROOT_URL: 'https://grafana.example.com'
+         GF_SECURITY_ADMIN_PASSWORD: '{{ lookup("password", secret
+                                         + "/docker_service/grafana/admin_password") }}'
+       memory: '512m'
+       healthcheck:
+         test: [ 'CMD-SHELL',
+                 'wget --no-verbose --tries=1 --spider http://127.0.0.1:3000/api/health || exit 1' ]
+         interval: '15s'
+         timeout: '5s'
+         retries: 3
+         start_period: '30s'
+       nginx:
+         enabled: true
+         fqdn: 'grafana.example.com'
+         port: '3000'
+         proxy_options: |
+           proxy_buffering off;
+
+Datasource provisioning
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Grafana supports automatic datasource configuration through provisioning
+files. Use ``config_files`` with the ``src`` parameter to render a Jinja2
+template:
+
+.. code-block:: yaml
+
+     - name: 'grafana'
+       image: 'grafana/grafana:11.0.0'
+       config_files:
+         - dest: '/srv/docker/grafana/provisioning/datasources/victoria.yml'
+           src: 'docker_service/grafana/datasources.yml.j2'
+       volumes:
+         - '/srv/docker/grafana/data:/var/lib/grafana'
+         - '/srv/docker/grafana/provisioning:/etc/grafana/provisioning:ro'
+       # ... remaining parameters ...
+
+The template file (e.g.
+``ansible/resources/templates/by-host/hostname/docker_service/grafana/datasources.yml.j2``)
+might look like:
+
+.. code-block:: yaml
+
+   apiVersion: 1
+   datasources:
+     - name: VictoriaMetrics
+       type: prometheus
+       access: proxy
+       url: http://127.0.0.1:8428
+       isDefault: true
+
+
+.. _docker_service__guide_homepage:
+
+Homepage
+--------
+
+`Homepage <https://gethomepage.dev/>`_ is a modern application dashboard with
+integrations for over 100 services. This example uses ``config_dir`` to manage
+multiple configuration files from a template directory.
+
+Service definition
+~~~~~~~~~~~~~~~~~~
+
+.. code-block:: yaml
+
+   # ansible/inventory/host_vars/dashboard.example.com/docker_service.yml
+   docker_service__host_services:
+
+     - name: 'homepage'
+       image: 'ghcr.io/gethomepage/homepage:latest'
+       ports:
+         - '127.0.0.1:3000:3000'
+       config_dir:
+         src: 'docker_service/homepage/config'
+         dest: '/srv/docker/homepage/config'
+       volumes:
+         - '/srv/docker/homepage/config:/app/config:ro'
+       env:
+         HOMEPAGE_ALLOWED_HOSTS: 'dashboard.example.com'
+       healthcheck:
+         test: [ 'CMD-SHELL',
+                 'wget --no-verbose --tries=1 --spider http://127.0.0.1:3000/api/healthcheck || exit 1' ]
+         interval: '15s'
+         timeout: '5s'
+         retries: 3
+         start_period: '20s'
+       nginx:
+         enabled: true
+         fqdn: 'dashboard.example.com'
+         port: '3000'
+
+Template directory
+~~~~~~~~~~~~~~~~~~
+
+Create the configuration templates in your Ansible resources directory. The
+``config_dir`` parameter scans the source directory using
+``community.general.filetree`` and renders each file as a Jinja2 template:
+
+.. code-block:: none
+
+   ansible/resources/templates/by-host/dashboard.example.com/
+     docker_service/homepage/config/
+       settings.yaml
+       services.yaml
+       bookmarks.yaml
+       widgets.yaml
+
+Example ``settings.yaml``:
+
+.. code-block:: yaml
+
+   ---
+   title: My Dashboard
+   theme: dark
+   color: slate
+   headerStyle: clean
+
+Example ``services.yaml``:
+
+.. code-block:: yaml
+
+   ---
+   - Infrastructure:
+     - Proxmox:
+         href: https://proxmox.example.com
+         icon: proxmox.svg
+         description: Hypervisor
+     - Grafana:
+         href: https://grafana.example.com
+         icon: grafana.svg
+         description: Monitoring dashboard
+
+Example ``bookmarks.yaml``:
+
+.. code-block:: yaml
+
+   ---
+   - Development:
+     - GitLab:
+         - abbr: GL
+           href: https://gitlab.example.com
+
+Example ``widgets.yaml``:
+
+.. code-block:: yaml
+
+   ---
+   - resources:
+       cpu: true
+       memory: true
+       disk: /
+   - search:
+       provider: duckduckgo
+       target: _blank
+
+.. important::
+
+   All Homepage configuration files **must** be provided through ``config_dir``.
+   Because the volume is mounted read-only (``:ro``), the container cannot
+   create missing files at startup. If any expected file (e.g.
+   ``settings.yaml``, ``services.yaml``, ``bookmarks.yaml``, ``widgets.yaml``,
+   ``docker.yaml``, ``custom.css``, ``custom.js``) is absent from the template
+   directory, Homepage will fail to start. Make sure every file that Homepage
+   expects is present in the source directory, even if it only contains an
+   empty YAML document (``---``).
+
+.. note::
+
+   Homepage requires the ``HOMEPAGE_ALLOWED_HOSTS`` environment variable to
+   be set when accessed through a reverse proxy. Set it to the FQDN used in
+   the :command:`nginx` configuration.
+
+
+.. _docker_service__guide_vaultwarden:
+
+Vaultwarden
+-----------
+
+`Vaultwarden <https://github.com/dani-garcia/vaultwarden>`_ is a lightweight,
+Bitwarden-compatible password manager server. It uses SQLite by default, so no
+external database is required.
+
+Service definition
+~~~~~~~~~~~~~~~~~~
+
+.. code-block:: yaml
+
+   # ansible/inventory/host_vars/vault.example.com/docker_service.yml
+   docker_service__host_services:
+
+     - name: 'vaultwarden'
+       image: 'vaultwarden/server:latest'
+       ports:
+         - '127.0.0.1:8080:80'
+       volumes:
+         - '/srv/docker/vaultwarden/data:/data'
+       env:
+         DOMAIN: 'https://vault.example.com'
+         SIGNUPS_ALLOWED: 'false'
+         ADMIN_TOKEN: '{{ lookup("password", secret
+                          + "/docker_service/vaultwarden/admin_token
+                             chars=ascii_letters,digits length=48") }}'
+       healthcheck:
+         test: [ 'CMD-SHELL',
+                 'wget --no-verbose --tries=1 --spider http://127.0.0.1:80/alive || exit 1' ]
+         interval: '30s'
+         timeout: '5s'
+         retries: 3
+         start_period: '15s'
+       nginx:
+         enabled: true
+         fqdn: 'vault.example.com'
+         port: '8080'
+         options: |
+           client_max_body_size 128m;
+
+SMTP configuration
+~~~~~~~~~~~~~~~~~~
+
+To enable email notifications (password reset, 2FA, invitations), add SMTP
+environment variables:
+
+.. code-block:: yaml
+
+       env:
+         DOMAIN: 'https://vault.example.com'
+         SIGNUPS_ALLOWED: 'false'
+         ADMIN_TOKEN: '{{ lookup("password", secret
+                          + "/docker_service/vaultwarden/admin_token
+                             chars=ascii_letters,digits length=48") }}'
+         SMTP_HOST: 'smtp.example.com'
+         SMTP_FROM: 'vaultwarden@example.com'
+         SMTP_PORT: '587'
+         SMTP_SECURITY: 'starttls'
+         SMTP_USERNAME: 'vaultwarden@example.com'
+         SMTP_PASSWORD: '{{ lookup("password", secret
+                            + "/docker_service/vaultwarden/smtp_password") }}'
+
+
+.. _docker_service__guide_victoriametrics:
+
+VictoriaMetrics
+---------------
+
+`VictoriaMetrics <https://victoriametrics.com/>`_ is a fast, cost-effective
+time series database. This is a simple single-node deployment with an
+:command:`nginx` reverse proxy providing TLS termination.
+
+Inventory
+~~~~~~~~~
+
+.. code-block:: none
+
+   [debops_all_hosts]
+   vmetrics.example.com
+
+   [debops_service_docker_server]
+   vmetrics.example.com
+
+   [debops_service_docker_service]
+   vmetrics.example.com
+
+Service definition
+~~~~~~~~~~~~~~~~~~
+
+.. code-block:: yaml
+
+   # ansible/inventory/host_vars/vmetrics.example.com/docker_service.yml
+   docker_service__host_services:
+
+     - name: 'victoriametrics'
+       image: 'victoriametrics/victoria-metrics:v1.93.0'
+       ports:
+         - '127.0.0.1:8428:8428'
+       volumes:
+         - '/srv/docker/victoriametrics/data:/victoria-metrics-data'
+       command: '-retentionPeriod=12 -selfScrapeInterval=10s'
+       memory: '512m'
+       healthcheck:
+         test: [ 'CMD-SHELL',
+                 'wget --no-verbose --tries=1 --spider http://127.0.0.1:8428/health || exit 1' ]
+         interval: '15s'
+         timeout: '5s'
+         retries: 3
+         start_period: '10s'
+       nginx:
+         enabled: true
+         fqdn: 'vmetrics.example.com'
+         port: '8428'
+
+The ``-retentionPeriod=12`` flag configures a 12-month data retention period.
+The ``-selfScrapeInterval=10s`` flag enables internal metrics collection.
+
+The container binds to ``127.0.0.1`` only -- external access is provided by
+:command:`nginx` with TLS termination handled by the DebOps PKI
+infrastructure.
+
+
+.. _docker_service__guide_victoriametrics_vmauth:
+
+VictoriaMetrics with vmauth
+---------------------------
+
+`vmauth <https://docs.victoriametrics.com/vmauth/>`_ is an HTTP
+proxy/authenticator for VictoriaMetrics. It provides authentication (Basic
+Auth, Bearer tokens) and request routing. This example deploys VictoriaMetrics
+together with vmauth as an authentication layer.
+
+Two architectures are possible:
+
+1. **vmauth behind nginx** (recommended) -- :command:`nginx` handles TLS
+   termination; vmauth handles authentication and routes to VictoriaMetrics.
+2. **vmauth with own TLS** -- vmauth terminates TLS directly using DebOps PKI
+   certificates mounted from the host.
+
+This guide demonstrates the recommended approach (vmauth behind :command:`nginx`).
+
+Service definition
+~~~~~~~~~~~~~~~~~~
+
+.. code-block:: yaml
+
+   # ansible/inventory/host_vars/vmetrics.example.com/docker_service.yml
+   docker_service__host_services:
+
+     - name: 'victoriametrics'
+       image: 'victoriametrics/victoria-metrics:v1.93.0'
+       ports:
+         - '127.0.0.1:8428:8428'
+       volumes:
+         - '/srv/docker/victoriametrics/data:/victoria-metrics-data'
+       command: '-retentionPeriod=12 -selfScrapeInterval=10s'
+       healthcheck:
+         test: [ 'CMD-SHELL',
+                 'wget --no-verbose --tries=1 --spider http://127.0.0.1:8428/health || exit 1' ]
+         interval: '15s'
+         timeout: '5s'
+         retries: 3
+         start_period: '10s'
+
+     - name: 'vmauth'
+       image: 'victoriametrics/vmauth:latest'
+       ports:
+         - '127.0.0.1:8427:8427'
+       config_files:
+         - dest: '/srv/docker/vmauth/auth.yml'
+           content: |
+             users:
+               - username: 'metrics'
+                 password: '{{ lookup("password", secret
+                               + "/docker_service/vmauth/metrics_password") }}'
+                 url_prefix: 'http://{{ ansible_default_ipv4.address | d("127.0.0.1") }}:8428/'
+           mode: '0640'
+       volumes:
+         - '/srv/docker/vmauth/auth.yml:/etc/vmauth/auth.yml:ro'
+       command: '-auth.config=/etc/vmauth/auth.yml'
+       healthcheck:
+         test: [ 'CMD-SHELL',
+                 'wget --no-verbose --tries=1 --spider http://127.0.0.1:8427/health || exit 1' ]
+         interval: '15s'
+         timeout: '5s'
+         retries: 3
+         start_period: '10s'
+       nginx:
+         enabled: true
+         fqdn: 'vmetrics.example.com'
+         port: '8427'
+
+In this setup, VictoriaMetrics does not have an ``nginx`` block -- it is only
+accessible through vmauth. The :command:`nginx` reverse proxy terminates TLS
+and forwards traffic to vmauth, which authenticates requests before proxying
+them to VictoriaMetrics.
+
+The ``config_files`` parameter generates the vmauth configuration file with
+an auto-generated password stored in the DebOps secret directory. The file is
+mounted read-only into the container.
+
+Alternative: vmauth with own TLS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you prefer vmauth to handle TLS directly (without :command:`nginx`), mount
+the DebOps PKI certificates into the container:
+
+.. code-block:: yaml
+
+     - name: 'vmauth'
+       image: 'victoriametrics/vmauth:latest'
+       ports:
+         - '0.0.0.0:443:443'
+       config_files:
+         - dest: '/srv/docker/vmauth/auth.yml'
+           content: |
+             users:
+               - username: 'metrics'
+                 password: '{{ lookup("password", secret
+                               + "/docker_service/vmauth/metrics_password") }}'
+                 url_prefix: 'http://{{ ansible_default_ipv4.address | d("127.0.0.1") }}:8428/'
+           mode: '0640'
+       volumes:
+         - '/srv/docker/vmauth/auth.yml:/etc/vmauth/auth.yml:ro'
+         - '/etc/pki/realms/domain/default.crt:/etc/vmauth/cert.pem:ro'
+         - '/etc/pki/realms/domain/default.key:/etc/vmauth/key.pem:ro'
+       command: >-
+         -auth.config=/etc/vmauth/auth.yml
+         -tls -tlsCertFile=/etc/vmauth/cert.pem -tlsKeyFile=/etc/vmauth/key.pem
+         -httpListenAddr=:443
+
+The certificate paths (``/etc/pki/realms/domain/``) are managed by the
+:ref:`debops.pki` role. vmauth automatically reloads certificates when they
+change on disk, so no container restart is needed for certificate renewal.
+
+..
+ Local Variables:
+ mode: rst
+ ispell-local-dictionary: "american"
+ End:

--- a/docs/ansible/roles/docker_service/index.rst
+++ b/docs/ansible/roles/docker_service/index.rst
@@ -1,5 +1,5 @@
-.. Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
-.. Copyright (C) 2024-2026 DebOps <https://debops.org/>
+.. Copyright (C) 2026 Patryk Ściborek <patryk@sciborek.com>
+.. Copyright (C) 2026 DebOps <https://debops.org/>
 .. SPDX-License-Identifier: GPL-3.0-only
 
 .. _debops.docker_service:

--- a/docs/ansible/roles/docker_service/index.rst
+++ b/docs/ansible/roles/docker_service/index.rst
@@ -14,6 +14,7 @@ debops.docker_service
    :maxdepth: 2
 
    getting-started
+   guides
    defaults/main
    defaults-detailed
 

--- a/docs/ansible/roles/docker_service/index.rst
+++ b/docs/ansible/roles/docker_service/index.rst
@@ -1,0 +1,29 @@
+.. Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
+.. Copyright (C) 2024-2026 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+.. _debops.docker_service:
+
+debops.docker_service
+=====================
+
+.. include:: man_description.rst
+   :start-line: 7
+
+.. toctree::
+   :maxdepth: 2
+
+   getting-started
+   defaults/main
+   defaults-detailed
+
+Copyright
+---------
+
+.. literalinclude:: ../../../../ansible/roles/docker_service/COPYRIGHT
+
+..
+ Local Variables:
+ mode: rst
+ ispell-local-dictionary: "american"
+ End:

--- a/docs/ansible/roles/docker_service/man_description.rst
+++ b/docs/ansible/roles/docker_service/man_description.rst
@@ -1,5 +1,5 @@
-.. Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
-.. Copyright (C) 2024-2026 DebOps <https://debops.org/>
+.. Copyright (C) 2026 Patryk Ściborek <patryk@sciborek.com>
+.. Copyright (C) 2026 DebOps <https://debops.org/>
 .. SPDX-License-Identifier: GPL-3.0-only
 
 Description

--- a/docs/ansible/roles/docker_service/man_description.rst
+++ b/docs/ansible/roles/docker_service/man_description.rst
@@ -1,0 +1,16 @@
+.. Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
+.. Copyright (C) 2024-2026 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+Description
+===========
+
+`Docker`__ is a platform for running applications in lightweight, isolated
+containers. The ``debops.docker_service`` Ansible role can be used to manage
+simple Docker container services on hosts where Docker Engine is already
+installed by the :ref:`debops.docker_server` role. The role supports port
+mapping, volume mounts, environment variables, resource limits and automatic
+:command:`nginx` reverse proxy configuration through integration with the
+:ref:`debops.nginx` role.
+
+.. __: https://www.docker.com/

--- a/docs/ansible/roles/docker_service/man_index.rst
+++ b/docs/ansible/roles/docker_service/man_index.rst
@@ -1,0 +1,22 @@
+:orphan:
+
+.. Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
+.. Copyright (C) 2024-2026 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+debops.docker_service
+=====================
+
+.. toctree::
+   :maxdepth: 2
+
+   man_synopsis
+   man_description
+   getting-started
+   defaults-detailed
+
+..
+ Local Variables:
+ mode: rst
+ ispell-local-dictionary: "american"
+ End:

--- a/docs/ansible/roles/docker_service/man_index.rst
+++ b/docs/ansible/roles/docker_service/man_index.rst
@@ -1,7 +1,7 @@
 :orphan:
 
-.. Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
-.. Copyright (C) 2024-2026 DebOps <https://debops.org/>
+.. Copyright (C) 2026 Patryk Ściborek <patryk@sciborek.com>
+.. Copyright (C) 2026 DebOps <https://debops.org/>
 .. SPDX-License-Identifier: GPL-3.0-only
 
 debops.docker_service

--- a/docs/ansible/roles/docker_service/man_synopsis.rst
+++ b/docs/ansible/roles/docker_service/man_synopsis.rst
@@ -1,0 +1,10 @@
+.. Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
+.. Copyright (C) 2024-2026 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+Synopsis
+========
+
+``debops run service/docker_service`` [**--limit** `group,host,`...] [**--diff**] [**--check**] [**--tags** `tag1,tag2,`...] [**--skip-tags** `tag1,tag2,`...] [<``ansible-playbook`` options>] ...
+
+``debops check service/docker_service`` [**--limit** `group,host,`...] [**--tags** `tag1,tag2,`...] [**--skip-tags** `tag1,tag2,`...] [<``ansible-playbook`` options>] ...

--- a/docs/ansible/roles/docker_service/man_synopsis.rst
+++ b/docs/ansible/roles/docker_service/man_synopsis.rst
@@ -1,5 +1,5 @@
-.. Copyright (C) 2024-2026 Patryk Ściborek <patryk@sciborek.com>
-.. Copyright (C) 2024-2026 DebOps <https://debops.org/>
+.. Copyright (C) 2026 Patryk Ściborek <patryk@sciborek.com>
+.. Copyright (C) 2026 DebOps <https://debops.org/>
 .. SPDX-License-Identifier: GPL-3.0-only
 
 Synopsis


### PR DESCRIPTION
## Summary

Add a new `docker_service` Ansible role that manages simple Docker container
services on hosts where Docker Engine is already installed by the
`docker_server` role. The role supports:

- Declarative container definitions with multi-level variable merge
  (default/all/group/host) following DebOps conventions
- Port mapping, volume mounts, environment variables, resource limits,
  healthchecks and other `community.docker.docker_container` parameters
- Automatic nginx reverse proxy configuration through dynamic template
  lookups integrated with the `debops.nginx` role
- Secret management via `debops.secret` integration -- service definitions
  can use `lookup("password", secret + "/...")` to auto-generate and store
  passwords in the DebOps secret directory
- Ansible local facts collecting container status information
- Full documentation in DebOps standards (getting-started, defaults-detailed,
  man pages)

### Files added

- `ansible/roles/docker_service/` -- role with 8 files:
  - `defaults/main.yml` -- global settings and service list variables
  - `tasks/main.yml` -- container lifecycle management via `community.docker`
  - `tasks/build_nginx_vars.yml` -- pre-task building nginx dependent
    variables in the correct role context (pattern from `debops.kibana`)
  - `meta/main.yml`, `COPYRIGHT`
  - `templates/lookup/` -- Jinja2 templates generating nginx upstream and
    server block configurations from service definitions
  - `templates/etc/ansible/facts.d/docker_service.fact.j2` -- local facts
- `ansible/playbooks/service/docker_service.yml` -- service playbook with
  `pre_tasks` for nginx variable generation, then keyring, apt_preferences,
  ferm, python, nginx, docker_service role chain
- `docs/ansible/roles/docker_service/` -- Sphinx documentation (6 rst files)

### Example usage

```yaml
docker_service__host_services:
  - name: 'victoriametrics'
    image: 'victoriametrics/victoria-metrics:v1.137.0'
    ports:
      - '127.0.0.1:8428:8428'
    volumes:
      - '/srv/docker/victoriametrics/data:/victoria-metrics-data'
    command: '-retentionPeriod=12 -selfScrapeInterval=10s'
    nginx:
      enabled: true
      fqdn: 'vmetrics.example.com'
      port: '8428'

  - name: 'grafana'
    image: 'grafana/grafana:12.0.10'
    ports:
      - '127.0.0.1:3000:3000'
    volumes:
      - '/srv/docker/grafana/data:/var/lib/grafana'
    env:
      GF_SERVER_ROOT_URL: 'https://grafana.example.com'
      GF_SECURITY_ADMIN_PASSWORD: '{{ lookup("password", secret
                                       + "/docker_service/grafana/admin_password") }}'
    nginx:
      enabled: true
      fqdn: 'grafana.example.com'
      port: '3000'
```

### Test plan

- [ ] Deploy a single container service (e.g. VictoriaMetrics) with nginx reverse proxy on a test host
- [ ] Verify nginx upstream and server block are generated correctly
- [ ] Test state: absent to confirm container removal
- [ ] Test state: ignore to confirm entry is skipped
- [ ] Verify persistent data directories are created for bind mounts
- [ ] Verify local facts are saved and contain container status
- [ ] Run playbook with --check --diff to confirm idempotency