### PR TITLE
fix(postgresql_server): postgresql-contrib is no more for trixie

### DIFF
--- a/ansible/roles/postgresql_server/defaults/main.yml
+++ b/ansible/roles/postgresql_server/defaults/main.yml
@@ -41,8 +41,8 @@ postgresql_server__upstream_apt_repo: 'deb [signed-by=/etc/apt/keyrings/pgdg.asc
 # .. envvar:: postgresql_server__base_packages [[[
 #
 # List of base PostgreSQL packages to install.
-postgresql_server__base_packages: [ 'postgresql', 'postgresql-client',
-                                    'postgresql-contrib', 'pgtop' ]
+postgresql_server__base_packages: '{{ [ "postgresql", "postgresql-client", "pgtop" ] +
+                                      [ "postgresql-contrib" ] if postgresql_server__version is version("15","<=") else [] }}'
 
                                                                    # ]]]
 # .. envvar:: postgresql_server__python_packages [[[


### PR DESCRIPTION
Since postgresql-common 269 (Trixie postgresql 17+278) postgresql-contrib meta package has been replaced by a postgresql-contrib provides from the postgresql package, so it cannot be installed anymore since bookworm postgresql 15. See:
https://salsa.debian.org/postgresql/postgresql-common/-/commit/a63259a149bd70f080b8d3129c5364b6ceff3ac8

---

On a Trixie host:

```
 ____________________________________________________________
/ TASK [debops.debops.postgresql_server : Install PostgreSQL \
\ packages]                                                  /
 ------------------------------------------------------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||

FAILED - RETRYING: [uruk]: Install PostgreSQL packages (3 retries left).
FAILED - RETRYING: [uruk]: Install PostgreSQL packages (2 retries left).
FAILED - RETRYING: [uruk]: Install PostgreSQL packages (1 retries left).
fatal: [uruk]: FAILED! => {"attempts": 3, "cache_update_time": 1774657299, "cache_updated": false, "changed": false, "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"       install 'postgresql-contrib=15+248+deb12u1'' failed: E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.\nE: The following information from --solver 3.0 may provide additional context:\n   Unable to satisfy dependencies. Reached two conflicting decisions:\n   1. libssl3:armhf is selected for install because:\n      1. postgresql-contrib:armhf=15+248+deb12u1 is selected for install\n      2. postgresql-contrib:armhf Depends postgresql-contrib-15\n      3. postgresql-15:armhf Depends libssl3 (>= 3.0.0)\n   2. libssl3:armhf is available in versions 3.0.18-1~deb12u1, 3.0.17-1~deb12u2\n      but none of the choices are installable:\n      - libssl3:armhf=3.0.18-1~deb12u1 is not selected for install because:\n        1. coreutils:armhf is selected for install\n        2. coreutils:armhf is available in versions 9.7-3, 9.1-1\n           [selected coreutils:armhf=9.7-3 for install]\n        3. coreutils:armhf=9.7-3 PreDepends libssl3t64 (>= 3.0.0)\n        4. libssl3t64:armhf Depends openssl-provider-legacy\n        5. openssl-provider-legacy:armhf Breaks libssl3 (< 3.3.1-5)\n           [selected openssl-provider-legacy:armhf]\n        For context, additional choices that could not be installed:\n        * In coreutils:armhf is available in versions 9.7-3, 9.1-1:\n          - coreutils:armhf=9.1-1 is not selected for install\n      - libssl3:armhf=3.0.17-1~deb12u2 is not selected for install\n", "rc": 100, "stderr": "E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.\nE: The following information from --solver 3.0 may provide additional context:\n   Unable to satisfy dependencies. Reached two conflicting decisions:\n   1. libssl3:armhf is selected for install because:\n      1. postgresql-contrib:armhf=15+248+deb12u1 is selected for install\n      2. postgresql-contrib:armhf Depends postgresql-contrib-15\n      3. postgresql-15:armhf Depends libssl3 (>= 3.0.0)\n   2. libssl3:armhf is available in versions 3.0.18-1~deb12u1, 3.0.17-1~deb12u2\n      but none of the choices are installable:\n      - libssl3:armhf=3.0.18-1~deb12u1 is not selected for install because:\n        1. coreutils:armhf is selected for install\n        2. coreutils:armhf is available in versions 9.7-3, 9.1-1\n           [selected coreutils:armhf=9.7-3 for install]\n        3. coreutils:armhf=9.7-3 PreDepends libssl3t64 (>= 3.0.0)\n        4. libssl3t64:armhf Depends openssl-provider-legacy\n        5. openssl-provider-legacy:armhf Breaks libssl3 (< 3.3.1-5)\n           [selected openssl-provider-legacy:armhf]\n        For context, additional choices that could not be installed:\n        * In coreutils:armhf is available in versions 9.7-3, 9.1-1:\n          - coreutils:armhf=9.1-1 is not selected for install\n      - libssl3:armhf=3.0.17-1~deb12u2 is not selected for install\n", "stderr_lines": ["E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.", "E: The following information from --solver 3.0 may provide additional context:", "   Unable to satisfy dependencies. Reached two conflicting decisions:", "   1. libssl3:armhf is selected for install because:", "      1. postgresql-contrib:armhf=15+248+deb12u1 is selected for install", "      2. postgresql-contrib:armhf Depends postgresql-contrib-15", "      3. postgresql-15:armhf Depends libssl3 (>= 3.0.0)", "   2. libssl3:armhf is available in versions 3.0.18-1~deb12u1, 3.0.17-1~deb12u2", "      but none of the choices are installable:", "      - libssl3:armhf=3.0.18-1~deb12u1 is not selected for install because:", "        1. coreutils:armhf is selected for install", "        2. coreutils:armhf is available in versions 9.7-3, 9.1-1", "           [selected coreutils:armhf=9.7-3 for install]", "        3. coreutils:armhf=9.7-3 PreDepends libssl3t64 (>= 3.0.0)", "        4. libssl3t64:armhf Depends openssl-provider-legacy", "        5. openssl-provider-legacy:armhf Breaks libssl3 (< 3.3.1-5)", "           [selected openssl-provider-legacy:armhf]", "        For context, additional choices that could not be installed:", "        * In coreutils:armhf is available in versions 9.7-3, 9.1-1:", "          - coreutils:armhf=9.1-1 is not selected for install", "      - libssl3:armhf=3.0.17-1~deb12u2 is not selected for install"], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nSolving dependencies...\nSome packages could not be installed. This may mean that you have\nrequested an impossible situation or if you are using the unstable\ndistribution that some required packages have not yet been created\nor been moved out of Incoming.\nThe following information may help to resolve the situation:\n\nThe following packages have unmet dependencies:\n apt : Conflicts: libnettle8 (< 3.9.1-2.2~) but 3.8.1-2 is to be installed\n libapt-pkg7.0 : Conflicts: libnettle8 (< 3.9.1-2.2~) but 3.8.1-2 is to be installed\n libgnutls30t64 : Breaks: libgnutls30 (< 3.8.9-3+deb13u2) but 3.7.9-2+deb12u5 is to be installed\n libhogweed6t64 : Breaks: libhogweed6 (< 3.10.1-1) but 3.8.1-2 is to be installed\n libnettle8t64 : Breaks: libnettle8 (< 3.10.1-1) but 3.8.1-2 is to be installed\n libreadline8t64 : Breaks: libreadline8 (< 8.2-6) but 8.2-1.3 is to be installed\n libssl3t64 : Breaks: libssl3 (< 3.5.5-1~deb13u1) but 3.0.18-1~deb12u1 is to be installed\n openssl-provider-legacy : Breaks: libssl3 (< 3.3.1-5) but 3.0.18-1~deb12u1 is to be installed\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "Solving dependencies...", "Some packages could not be installed. This may mean that you have", "requested an impossible situation or if you are using the unstable", "distribution that some required packages have not yet been created", "or been moved out of Incoming.", "The following information may help to resolve the situation:", "", "The following packages have unmet dependencies:", " apt : Conflicts: libnettle8 (< 3.9.1-2.2~) but 3.8.1-2 is to be installed", " libapt-pkg7.0 : Conflicts: libnettle8 (< 3.9.1-2.2~) but 3.8.1-2 is to be installed", " libgnutls30t64 : Breaks: libgnutls30 (< 3.8.9-3+deb13u2) but 3.7.9-2+deb12u5 is to be installed", " libhogweed6t64 : Breaks: libhogweed6 (< 3.10.1-1) but 3.8.1-2 is to be installed", " libnettle8t64 : Breaks: libnettle8 (< 3.10.1-1) but 3.8.1-2 is to be installed", " libreadline8t64 : Breaks: libreadline8 (< 8.2-6) but 8.2-1.3 is to be installed", " libssl3t64 : Breaks: libssl3 (< 3.5.5-1~deb13u1) but 3.0.18-1~deb12u1 is to be installed", " openssl-provider-legacy : Breaks: libssl3 (< 3.3.1-5) but 3.0.18-1~deb12u1 is to be installed"]}
```