### PR TITLE
Improve shellcheck jinja disabling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -65,6 +65,10 @@ General
   a certificate request. This fixes potential issues with the
   :command:`certbot` command setting wrong certificate name and signature.
 
+- In the :command:`pki-realm` script, ensure that certain :command:`certbot`
+  command options and their arguments are separated with a spaca. This fixes an
+  issue with ACME DNS-01 challenge not being processed correctly.
+
 
 `debops v3.3.0`_ - 2026-03-13
 -----------------------------

--- a/ansible/roles/dropbear_initramfs/templates/etc/initramfs-tools/scripts/local-bottom/debops_dropbear_initramfs.j2
+++ b/ansible/roles/dropbear_initramfs/templates/etc/initramfs-tools/scripts/local-bottom/debops_dropbear_initramfs.j2
@@ -17,6 +17,8 @@ prereqs)
     ;;
 esac
 
+# jinja templating is not supported by shellcheck
+# shellcheck disable=all
 {% for name, interface in dropbear_initramfs__combined_interfaces.items() %}
 {%   set interface_name = (interface.iface | d(name)) %}
 ip link    set   dev {{ interface_name | quote }} down

--- a/ansible/roles/grub/templates/etc/grub.d/01_users.j2
+++ b/ansible/roles/grub/templates/etc/grub.d/01_users.j2
@@ -8,6 +8,8 @@
 
 ## {{ ansible_managed }}
 cat <<EOF
+# jinja templating is not supported by shellcheck
+# shellcheck disable=all
 {% set superusers = grub__combined_users|rejectattr("superuser", "none") | map(attribute = 'name') | join(' ') %}
 {% if superusers | length == 0 %}
 ## No users have been defined.

--- a/ansible/roles/pki/files/usr/local/lib/pki/pki-realm
+++ b/ansible/roles/pki/files/usr/local/lib/pki/pki-realm
@@ -1199,7 +1199,7 @@ request_acme_dns_certificate() {
     local email=""
 
     if [ -n "${config['acme_contacts']}" ]; then
-        email="-m${config['acme_contacts']}"
+        email="-m ${config['acme_contacts']}"
     fi
 
     local req_domains="${config['domains']:-${config['pki_default_domain']}}"
@@ -1242,7 +1242,7 @@ request_acme_dns_certificate() {
     # remove duplicate lines without sorting
     all_dns_str=$(printf '%s\n' "${all_dns[@]}" | awk '!x[$0]++' | xargs)
     # shellcheck disable=SC2086
-    all_dns_str=$(echo " "${all_dns_str} | sed 's/ / -d/g')
+    all_dns_str=$(echo " "${all_dns_str} | sed 's/ / -d /g')
 
     if test "${config['acme_ca']}" == 'le-live-v2'; then
       # shellcheck disable=SC2086
@@ -1271,7 +1271,7 @@ request_acme_manual_certificate() {
     local email=""
 
     if [ -n "${config['acme_contacts']}" ]; then
-        email="-m${config['acme_contacts']}"
+        email="-m ${config['acme_contacts']}"
     fi
 
 
@@ -1315,7 +1315,7 @@ request_acme_manual_certificate() {
     # remove duplicate lines without sorting
     all_dns_str=$(printf '%s\n' "${all_dns[@]}" | awk '!x[$0]++' | xargs)
     # shellcheck disable=SC2086
-    all_dns_str=$(echo " "${all_dns_str} | sed 's/ / -d/g')
+    all_dns_str=$(echo " "${all_dns_str} | sed 's/ / -d /g')
 
     if test "${config['acme_ca']}" == 'le-live-v2'; then
       # shellcheck disable=SC2086

--- a/ansible/roles/slapd/templates/etc/ldap/slapacl-test-suite.j2
+++ b/ansible/roles/slapd/templates/etc/ldap/slapacl-test-suite.j2
@@ -120,6 +120,8 @@ if [ ! -t 2 ] && [ -t 1 ] ; then
     printf "Testing OpenLDAP ACL policies "
 fi
 
+# jinja templating is not supported by shellcheck
+# shellcheck disable=all
 {% for element in slapd__slapacl_combined_tests | debops.debops.parse_kv_items(merge_keys=['queries']) %}
 {%   if element.name | d() and element.dn | d() and element.state | d('present') not in [ 'absent', 'init', 'ignore' ] %}
 {%     if not loop.first %}

--- a/lib/tests/check-shell
+++ b/lib/tests/check-shell
@@ -29,10 +29,7 @@ while read -r in ; do
             printf "%s" "."
         fi
     fi
-done < <(find . -type f -not -iwholename "./.git/*" \
-    -not -wholename "./ansible/roles/grub/templates/etc/grub.d/01_users.j2" \
-    -not -wholename "./ansible/roles/slapd/templates/etc/ldap/slapacl-test-suite.j2" \
-    -not -wholename "./ansible/roles/dropbear_initramfs/templates/etc/initramfs-tools/scripts/local-bottom/debops_dropbear_initramfs.j2")
+done < <(find . -type f -not -iwholename "./.git/*")
 
 printf " %s\\n" "found ${#file_list[@]} shell scripts"
 


### PR DESCRIPTION
Embed shellcheck disabling into jinja templated shell scripts instead of blacklisting them one by one in the loop.

---
Edit : removed shellcheck disabling for autopostgresqlbackup as this commit is already in PR #2617 

This might be a no go, as this requires shellcheck >= 0.8 included only starting from bookworm.