### PR TITLE
Draft: fix(nsswitch): allow systemd to shadow and gshadow to support dynamic users

### DIFF
--- a/ansible/roles/nsswitch/defaults/main.yml
+++ b/ansible/roles/nsswitch/defaults/main.yml
@@ -95,8 +95,8 @@ nsswitch__combined_services: '{{ lookup("flattened", (nsswitch__default_services
 nsswitch__default_database_map:
   'passwd':     [ 'compat', 'mymachines', 'systemd', 'sss', 'ldap', 'winbind' ]
   'group':      [ 'compat', 'mymachines', 'systemd', 'sss', 'ldap', 'winbind' ]
-  'shadow':     [ 'compat', 'sss' ]
-  'gshadow':    [ 'files' ]
+  'shadow':     [ 'compat', 'systemd', 'sss' ]
+  'gshadow':    [ 'files', 'systemd' ]
   'initgroups': []
 
   'hosts':


### PR DESCRIPTION
Gnome gdm v49 requires nss systemd for passwd, group, shadow and gshadow.


I believe a check ofr libnss-systemd to be installed is missing in this PR. But I cannot fix this for now. So marking as draft.