### PR TITLE
[telegraf] Update default configuration options

### DIFF
--- a/ansible/roles/telegraf/defaults/main.yml
+++ b/ansible/roles/telegraf/defaults/main.yml
@@ -74,6 +74,7 @@ telegraf__default_configuration:
         precision: ''
         hostname: ''
         omit_hostname: False
+        skip_processors_after_aggregators: True
 
                                                                    # ]]]
 # .. envvar:: telegraf__configuration [[[
@@ -165,6 +166,7 @@ telegraf__default_plugins:
       inputs:
         influxdb_v2_listener:
           service_address: '127.0.0.1:38086'
+          use_internal_statistics: True
     state: 'present'
 
   - name: 'output_discard'


### PR DESCRIPTION
This change fixes the warning messages from Telegraf about changes to the default configuration of implicit options and suggestions to make them explicit.