### PR TITLE
fix(nginx): do not set nginx_tpl_robots_tag to an "omit array"

### DIFF
--- a/ansible/roles/nginx/templates/etc/nginx/sites-available/default.conf.j2
+++ b/ansible/roles/nginx/templates/etc/nginx/sites-available/default.conf.j2
@@ -17,7 +17,7 @@
  #   ---- HTTPS, ports to listen on, default server, HTTPS redirect ----
  #}
 {% set nginx_version            = ansible_local.nginx.version | d("0.0") %}
-{% set nginx_tpl_robots_tag     = [] if (item.robots_tag | d(nginx__http_robots_tag) is string and item.robots_tag | d(nginx__http_robots_tag) == omit)
+{% set nginx_tpl_robots_tag     = [] if (item.robots_tag | d(nginx__http_robots_tag) == omit)
     else (
         [ item.robots_tag | d(nginx__http_robots_tag) ]
         if (item.robots_tag | d(nginx__http_robots_tag) is string)


### PR DESCRIPTION
by checking for both a string and omit a value the condition to set nginx_tpl_robots_tag to an empty array when "item.robots_tag | d(nginx__http_robots_tag) == omit" never applied. Remove the check for string.

Fixes:
[ERROR]: Task failed: Error rendering template: '_OmitType' object is not iterable on:
{%     for robots_tag in nginx_tpl_robots_tag                   %}
        add_header                X-Robots-Tag "{{ robots_tag }}";
{%     endfor                                                   %}

Error while running under ansible 2.20.4, error was not visible with earlier ansible version it seems.

----
I might be wrong, but to me checking the same expression to be a string and to be omit was a bug.