### PR TITLE
fix(roundcube): cast _port to a string to avoid concatenation error

### DIFF
--- a/ansible/roles/roundcube/defaults/main.yml
+++ b/ansible/roles/roundcube/defaults/main.yml
@@ -597,7 +597,7 @@ roundcube__imap_fqdn: '{{ roundcube__imap_srv_rr[0]["target"] }}'
 # .. envvar:: roundcube__imap_port [[[
 #
 # The TCP port to use for IMAP connections.
-roundcube__imap_port: '{{ roundcube__imap_srv_rr[0]["port"] }}'
+roundcube__imap_port: '{{ roundcube__imap_srv_rr[0]["port"] | string }}'
 
                                                                    # ]]]
 # .. envvar:: roundcube__imap_server [[[
@@ -655,7 +655,7 @@ roundcube__smtp_fqdn: '{{ roundcube__smtp_srv_rr[0]["target"] }}'
 #
 # Common values include 25 for unencrypted communication, 587 for STARTTLS,
 # or 465 for SMTP over SSL (aka SMTPS).
-roundcube__smtp_port: '{{ roundcube__smtp_srv_rr[0]["port"] }}'
+roundcube__smtp_port: '{{ roundcube__smtp_srv_rr[0]["port"] | string }}'
 
                                                                    # ]]]
 # .. envvar:: roundcube__smtp_server [[[
@@ -722,7 +722,7 @@ roundcube__sieve_fqdn: '{{ roundcube__sieve_srv_rr[0]["target"] }}'
 # .. envvar:: roundcube__sieve_port [[[
 #
 # The TCP port used for Sieve connections.
-roundcube__sieve_port: '{{ roundcube__sieve_srv_rr[0]["port"] }}'
+roundcube__sieve_port: '{{ roundcube__sieve_srv_rr[0]["port"] | string }}'
 
                                                                    # ]]]
 # .. envvar:: roundcube__sieve_server [[[


### PR DESCRIPTION
All existing tests against roundcube__imap_port, roundcube__smtp_port and roundcube__sieve_port expect the port to be a string, so make it into a string instead of an AnsibleTaggedInt.

Fixes:
[ERROR]: Task failed: Error rendering template: can only concatenate str (not "_AnsibleTaggedInt") to str


Likely an issue only with newer ansible versions. Using ansible 2.20.4.