### PR TITLE
rabbitmq_server: set vhost default queue type via update_vhost_metadata

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,15 @@ Added
 - Add support for post-quantum key exchange algorithms in OpenSSH v9.0+. The
   role will enable a specific set of key exchange algorithms where available.
 
+:ref:`debops.rabbitmq_server` role
+''''''''''''''''''''''''''''''''''
+
+- Support for setting per-vhost default queue type via the
+  ``default_queue_type`` key in ``rabbitmq_server__*_vhosts`` list variables.
+  When defined, the role runs ``rabbitmqctl update_vhost_metadata
+  --default-queue-type`` for the vhost. Useful on RabbitMQ 3.13+/4.x where
+  ``quorum`` queues can be made the default without resorting to policies.
+
 Changed
 ~~~~~~~
 

--- a/ansible/roles/rabbitmq_server/tasks/main.yml
+++ b/ansible/roles/rabbitmq_server/tasks/main.yml
@@ -149,6 +149,17 @@
   tags: [ 'role::rabbitmq_server:vhost', 'role::rabbitmq_server:parameter',
           'role::rabbitmq_server:policy', 'role::rabbitmq_server:user' ]
 
+- name: Set RabbitMQ virtual host default queue type
+  ansible.builtin.command:
+    cmd: >-
+      rabbitmqctl update_vhost_metadata {{ item.name | d(item) }}
+      --default-queue-type {{ item.default_queue_type }}
+  when: item.default_queue_type | d()
+  loop: '{{ q("flattened", rabbitmq_server__combined_vhosts) }}'
+  register: rabbitmq_server__register_vhost_dqt
+  changed_when: rabbitmq_server__register_vhost_dqt.rc == 0
+  tags: [ 'role::rabbitmq_server:vhost' ]
+
 - name: Manage RabbitMQ virtual host limits
   community.rabbitmq.rabbitmq_vhost_limits:
     vhost: '{{ item.vhost }}'

--- a/docs/ansible/roles/rabbitmq_server/defaults-detailed.rst
+++ b/docs/ansible/roles/rabbitmq_server/defaults-detailed.rst
@@ -344,6 +344,14 @@ module. Some more common parameters:
 ``tracing``
   Optional. Enable message tracing in a given virtual host.
 
+``default_queue_type``
+  Optional. Sets the default queue type for the virtual host using
+  ``rabbitmqctl update_vhost_metadata --default-queue-type``. Supported values
+  on RabbitMQ 3.13+: ``classic``, ``quorum``, ``stream``. When unset, RabbitMQ
+  uses its built-in default (``classic`` unless overridden on the cluster).
+  Useful on RabbitMQ 4.x where ``quorum`` queues can be made the default
+  without resorting to policies.
+
 Examples
 ~~~~~~~~
 
@@ -359,6 +367,9 @@ Create a set of virtual hosts:
 
      - name: 'vhost3'
        state: 'absent'
+
+     - name: 'vhost4'
+       default_queue_type: 'quorum'
 
 
 .. _rabbitmq_server__ref_vhost_limits:


### PR DESCRIPTION
Adds a new task that runs `rabbitmqctl update_vhost_metadata VHOST --default-queue-type TYPE` for each vhost where the `default_queue_type` key is defined. Useful on RabbitMQ 3.13+/4.x where per-vhost default queue type (quorum/classic/stream) can be set without touching policies.