### PR TITLE
rabbitmq_server: rolling restart with cluster health checks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,28 @@ Changed
   path of existing OpenLDAP servers managed by DebOps is not tested yet, check
   the changes in a test environment.
 
+:ref:`debops.rabbitmq_server` role
+''''''''''''''''''''''''''''''''''
+
+- The ``service/rabbitmq_server.yml`` playbook now restarts cluster nodes
+  one at a time (``serial: 1``, ``any_errors_fatal: true``,
+  ``max_fail_percentage: 0``) and verifies cluster health in
+  ``post_tasks`` via ``rabbitmqctl await_startup`` +
+  ``rabbitmqctl cluster_status``. This prevents the
+  ``timeout_waiting_for_leader`` boot deadlock observed with RabbitMQ 4.x
+  / Khepri when multiple nodes restart simultaneously.
+
+- The ``Restart rabbitmq-server`` handler now performs a graceful
+  ``rabbitmqctl stop_app`` before ``systemctl restart`` (avoids
+  ``duplicate_node_name`` races against EPMD) and waits for
+  ``rabbitmqctl await_startup`` to succeed. ``throttle: 1`` is applied as
+  a second-line guarantee that the handler does not fire in parallel on
+  multiple hosts.
+
+- The ``Manage RabbitMQ plugins`` task no longer triggers a server
+  restart; the ``community.rabbitmq.rabbitmq_plugin`` module already
+  enables/disables plugins online.
+
 Fixed
 ~~~~~
 

--- a/ansible/playbooks/service/rabbitmq_server.yml
+++ b/ansible/playbooks/service/rabbitmq_server.yml
@@ -7,6 +7,14 @@
   collections: [ 'debops.debops' ]
   hosts: [ 'debops_service_rabbitmq_server' ]
   become: True
+  # RabbitMQ 4.x with Khepri (Raft) metadata store deadlocks with
+  # 'timeout_waiting_for_leader' when a majority of cluster nodes restart
+  # in parallel. The three play-level options below force strictly
+  # sequential, one-node-at-a-time execution and abort on the first
+  # failure so that the cluster stays healthy.
+  # DO NOT REMOVE without reading the "Rolling restart and cluster
+  # bootstrap" section in
+  # docs/ansible/roles/rabbitmq_server/getting-started.rst
   serial: 1
   max_fail_percentage: 0
   any_errors_fatal: true

--- a/ansible/playbooks/service/rabbitmq_server.yml
+++ b/ansible/playbooks/service/rabbitmq_server.yml
@@ -61,10 +61,15 @@
     - name: Assert this node rejoined the cluster
       ansible.builtin.assert:
         that:
-          - "'rabbit@' + ansible_hostname in _running"
+          - _my_short in _running_short
         fail_msg: |
           Node rabbit@{{ ansible_hostname }} did not rejoin the cluster
           cleanly. running_nodes={{ _running }}.
       vars:
         _running: "{{ (rabbitmq_server__register_cluster_status.stdout
                      | from_json).running_nodes | default([]) }}"
+        _running_short: "{{ _running
+                          | map('regex_replace', '^rabbit@', '')
+                          | map('regex_replace', '\\..*$', '')
+                          | list }}"
+        _my_short: "{{ ansible_hostname | regex_replace('\\..*$', '') }}"

--- a/ansible/playbooks/service/rabbitmq_server.yml
+++ b/ansible/playbooks/service/rabbitmq_server.yml
@@ -7,6 +7,9 @@
   collections: [ 'debops.debops' ]
   hosts: [ 'debops_service_rabbitmq_server' ]
   become: True
+  serial: 1
+  max_fail_percentage: 0
+  any_errors_fatal: true
 
   environment: '{{ inventory__environment | d({})
                    | combine(inventory__group_environment | d({}))
@@ -39,3 +42,29 @@
 
     - role: rabbitmq_server
       tags: [ 'role::rabbitmq_server', 'skip::rabbitmq_server' ]
+
+  post_tasks:
+
+    - name: Wait for RabbitMQ node to become available
+      ansible.builtin.command:
+        cmd: 'rabbitmqctl -q await_startup --timeout 120'
+      changed_when: false
+      check_mode: false
+
+    - name: Get RabbitMQ cluster status
+      ansible.builtin.command:
+        cmd: 'rabbitmqctl -q --formatter json cluster_status'
+      register: rabbitmq_server__register_cluster_status
+      changed_when: false
+      check_mode: false
+
+    - name: Assert this node rejoined the cluster
+      ansible.builtin.assert:
+        that:
+          - "'rabbit@' + ansible_hostname in _running"
+        fail_msg: |
+          Node rabbit@{{ ansible_hostname }} did not rejoin the cluster
+          cleanly. running_nodes={{ _running }}.
+      vars:
+        _running: "{{ (rabbitmq_server__register_cluster_status.stdout
+                     | from_json).running_nodes | default([]) }}"

--- a/ansible/roles/global_handlers/handlers/rabbitmq_server.yml
+++ b/ansible/roles/global_handlers/handlers/rabbitmq_server.yml
@@ -12,5 +12,13 @@
       fi
       systemctl restart rabbitmq-server
       rabbitmqctl -q await_startup --timeout 120
+  # 'throttle: 1' is a second line of defence for cases when the role is
+  # used outside of service/rabbitmq_server.yml (which already enforces
+  # 'serial: 1'). Parallel restarts of RabbitMQ 4.x nodes trigger a
+  # Khepri 'timeout_waiting_for_leader' boot deadlock and
+  # 'duplicate_node_name' EPMD races.
+  # DO NOT REMOVE without reading the "Rolling restart and cluster
+  # bootstrap" section in
+  # docs/ansible/roles/rabbitmq_server/getting-started.rst
   throttle: 1
   changed_when: true

--- a/ansible/roles/global_handlers/handlers/rabbitmq_server.yml
+++ b/ansible/roles/global_handlers/handlers/rabbitmq_server.yml
@@ -4,6 +4,13 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 - name: Restart rabbitmq-server
-  ansible.builtin.service:
-    name: 'rabbitmq-server'
-    state: 'restarted'
+  ansible.builtin.shell:
+    cmd: |
+      set -e
+      if rabbitmqctl -q ping > /dev/null 2>&1; then
+        rabbitmqctl -q stop_app || true
+      fi
+      systemctl restart rabbitmq-server
+      rabbitmqctl -q await_startup --timeout 120
+  throttle: 1
+  changed_when: true

--- a/ansible/roles/rabbitmq_server/tasks/main.yml
+++ b/ansible/roles/rabbitmq_server/tasks/main.yml
@@ -136,7 +136,6 @@
     prefix: '{{ item.prefix | d(omit) }}'
     new_only: True
   loop: '{{ q("flattened", rabbitmq_server__combined_plugins) }}'
-  notify: [ 'Restart rabbitmq-server' ]
   tags: [ 'role::rabbitmq_server:config' ]
 
 - name: Manage RabbitMQ virtual hosts

--- a/docs/ansible/roles/rabbitmq_server/getting-started.rst
+++ b/docs/ansible/roles/rabbitmq_server/getting-started.rst
@@ -77,6 +77,49 @@ See the `RabbitMQ Clustering Guide <https://www.rabbitmq.com/clustering.html>`_
 for more details.
 
 
+Rolling restart and cluster bootstrap
+-------------------------------------
+
+Starting with RabbitMQ 4.2 the broker uses Khepri (Raft) for metadata
+storage by default (in 4.0 and 4.1 it is available as an opt-in feature
+flag), which means that restarting a majority of cluster nodes
+simultaneously causes a ``timeout_waiting_for_leader`` boot deadlock. To
+prevent this, the service playbook uses ``serial: 1`` together with
+``any_errors_fatal: true`` and ``max_fail_percentage: 0``, and runs a
+post-task health check (``rabbitmqctl await_startup`` +
+``cluster_status`` + ``assert`` that the current node is visible in
+``running_nodes``). Nodes are restarted one at a time and the play stops
+on the first failure.
+
+On top of that, the ``Restart rabbitmq-server`` handler first calls
+``rabbitmqctl stop_app`` (to avoid ``duplicate_node_name`` races with EPMD),
+restarts the systemd unit and waits for ``rabbitmqctl await_startup`` to
+return. The handler also carries ``throttle: 1`` as a second line of
+defense in case the role is used outside of the service playbook.
+
+Both invocation modes are supported out of the box:
+
+- Running the playbook against the whole group at once::
+
+      debops run service/rabbitmq_server
+
+  ``serial: 1`` forces sequential processing, so nodes are configured and
+  restarted one after another even if the inventory targets the whole
+  cluster.
+
+- Running the playbook per host via ``--limit`` (useful when the role is
+  not configured to form the cluster automatically and each node needs
+  a manual ``rabbitmqctl join_cluster`` in between)::
+
+      debops run service/rabbitmq_server --limit host1
+      debops run service/rabbitmq_server --limit host2
+      debops run service/rabbitmq_server --limit host3
+
+The post-task assertion only checks that the current node itself rejoined
+the cluster, so it does not trip up either scenario; peer availability is
+guaranteed by the sequential execution model.
+
+
 Inter-node communication is not encrypted
 -----------------------------------------
 


### PR DESCRIPTION
Restarting a majority of RabbitMQ 4.x cluster nodes at once triggers a `timeout_waiting_for_leader` boot deadlock once Khepri (Raft) is enabled for metadata storage (default since 4.2, opt-in in 4.0/4.1). The `duplicate_node_name` EPMD race also regularly breaks a plain `systemctl restart rabbitmq-server` in a loop.

Make node restarts safe by default while keeping both "whole cluster at once" and "one host at a time via --limit" invocations working:

- `service/rabbitmq_server.yml`: add `serial: 1`, `any_errors_fatal: true`, `max_fail_percentage: 0` and a post_tasks block that runs `rabbitmqctl await_startup` + `rabbitmqctl cluster_status` and asserts that the current node rejoined the cluster. Peer availability is guaranteed by the sequential execution model, so targeting the whole group stays green on fresh bootstraps as well.

- `global_handlers/handlers/rabbitmq_server.yml`: replace the plain service restart with a shell step that does `rabbitmqctl stop_app` (when the app is running), `systemctl restart rabbitmq-server` and `rabbitmqctl await_startup --timeout 120`. `throttle: 1` guarantees serial execution even when the role is used outside of the service playbook.

- `rabbitmq_server/tasks/main.yml`: drop the redundant `notify` from `Manage RabbitMQ plugins`; `community.rabbitmq.rabbitmq_plugin` already enables and disables plugins online.

- Document the new behaviour in getting-started.rst and add CHANGELOG entries under "debops master - unreleased / Changed / rabbitmq_server role".