### PR TITLE
rabbitmq_server: required/opt-in feature flags and automatic cluster formation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -113,6 +113,16 @@ General
   command options and their arguments are separated with a spaca. This fixes an
   issue with ACME DNS-01 challenge not being processed correctly.
 
+:ref:`debops.rabbitmq_server` role
+''''''''''''''''''''''''''''''''''
+
+- The ``Manage RabbitMQ feature flags`` task no longer fails when the
+  inventory references feature flags that have become ``required`` in the
+  running RabbitMQ version. Required flags are auto-enabled and no longer
+  appear in ``rabbitmqctl list_feature_flags`` output; they are now detected
+  and skipped. Fixes a hard failure observed with RabbitMQ 4.x on Debian
+  Trixie where ``detailed_queues_endpoint`` was required.
+
 
 `debops v3.3.0`_ - 2026-03-13
 -----------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,23 @@ Added
   --default-queue-type`` for the vhost. Useful on RabbitMQ 3.13+/4.x where
   ``quorum`` queues can be made the default without resorting to policies.
 
+- The role can now form a RabbitMQ cluster automatically. Non-seed nodes
+  run ``rabbitmqctl reset`` and ``rabbitmqctl join_cluster`` against the
+  seed node (first host of the ``debops_service_rabbitmq_server`` group,
+  sortable override via ``rabbitmq_server__cluster_hosts``) once RabbitMQ
+  has been configured and restarted. The join is guarded by a sanity
+  check that the current node's ``disk_nodes`` contains only itself, so
+  an existing cluster member is never reset. Controlled by
+  ``rabbitmq_server__cluster_autojoin`` (default ``True``); flip to
+  ``False`` for the classic manual workflow.
+
+- The ``rabbitmq_server__*_feature_flags`` list variables now accept an
+  ``opt_in: True`` key per entry. When set, the role enables the feature
+  flag via ``rabbitmqctl -q enable_feature_flag --opt-in`` instead of the
+  standard ``community.rabbitmq.rabbitmq_feature_flag`` module. This lets
+  operators switch on flags that require explicit opt-in, such as
+  ``khepri_db`` on RabbitMQ 4.0/4.1.
+
 Changed
 ~~~~~~~
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,13 +43,19 @@ Added
 
 - The role can now form a RabbitMQ cluster automatically. Non-seed nodes
   run ``rabbitmqctl reset`` and ``rabbitmqctl join_cluster`` against the
-  seed node (first host of the ``debops_service_rabbitmq_server`` group,
-  sortable override via ``rabbitmq_server__cluster_hosts``) once RabbitMQ
-  has been configured and restarted. The join is guarded by a sanity
-  check that the current node's ``disk_nodes`` contains only itself, so
-  an existing cluster member is never reset. Controlled by
-  ``rabbitmq_server__cluster_autojoin`` (default ``True``); flip to
-  ``False`` for the classic manual workflow.
+  seed node (first host of ``rabbitmq_server__cluster_hosts``, which
+  defaults to the ``debops_service_rabbitmq_server`` inventory group
+  sorted alphabetically) once RabbitMQ has been configured and restarted.
+  The join is guarded by a sanity check that the current node's
+  ``disk_nodes`` contains only itself, so an existing cluster member is
+  never reset. Controlled by ``rabbitmq_server__cluster_autojoin``
+  (default ``False``, opt-in) so that upgrading the role on existing
+  deployments never alters cluster membership on its own; in particular,
+  several independent single-node RabbitMQ instances that happen to share
+  the ``debops_service_rabbitmq_server`` group stay independent until
+  auto-join is explicitly enabled on the groups that should form a
+  cluster. See the role documentation for a multi-cluster inventory
+  layout example.
 
 - The ``rabbitmq_server__*_feature_flags`` list variables now accept an
   ``opt_in: True`` key per entry. When set, the role enables the feature

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -61,13 +61,19 @@ General
 
 - The role can now form a RabbitMQ cluster automatically. Non-seed nodes
   run ``rabbitmqctl reset`` and ``rabbitmqctl join_cluster`` against the
-  seed node (first host of the ``debops_service_rabbitmq_server`` group,
-  sortable override via ``rabbitmq_server__cluster_hosts``) once RabbitMQ
-  has been configured and restarted. The join is guarded by a sanity
-  check that the current node's ``disk_nodes`` contains only itself, so
-  an existing cluster member is never reset. Controlled by
-  ``rabbitmq_server__cluster_autojoin`` (default ``True``); flip to
-  ``False`` for the classic manual workflow.
+  seed node (first host of ``rabbitmq_server__cluster_hosts``, which
+  defaults to the ``debops_service_rabbitmq_server`` inventory group
+  sorted alphabetically) once RabbitMQ has been configured and restarted.
+  The join is guarded by a sanity check that the current node's
+  ``disk_nodes`` contains only itself, so an existing cluster member is
+  never reset. Controlled by ``rabbitmq_server__cluster_autojoin``
+  (default ``False``, opt-in) so that upgrading the role on existing
+  deployments never alters cluster membership on its own; in particular,
+  several independent single-node RabbitMQ instances that happen to share
+  the ``debops_service_rabbitmq_server`` group stay independent until
+  auto-join is explicitly enabled on the groups that should form a
+  cluster. See the role documentation for a multi-cluster inventory
+  layout example.
 
 - The ``rabbitmq_server__*_feature_flags`` list variables now accept an
   ``opt_in: True`` key per entry. When set, the role enables the feature

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -226,6 +226,16 @@ General
   will no longer restart the :command:`systemd-logind` service automatically
   (file changes are handled automatically since Debian Bookworm).
 
+:ref:`debops.rabbitmq_server` role
+''''''''''''''''''''''''''''''''''
+
+- The ``Manage RabbitMQ feature flags`` task no longer fails when the
+  inventory references feature flags that have become ``required`` in the
+  running RabbitMQ version. Required flags are auto-enabled and no longer
+  appear in ``rabbitmqctl list_feature_flags`` output; they are now detected
+  and skipped. Fixes a hard failure observed with RabbitMQ 4.x on Debian
+  Trixie where ``detailed_queues_endpoint`` was required.
+
 :ref:`debops.sshd` role
 '''''''''''''''''''''''
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -59,6 +59,23 @@ General
   --default-queue-type`` for the vhost. Useful on RabbitMQ 3.13+/4.x where
   ``quorum`` queues can be made the default without resorting to policies.
 
+- The role can now form a RabbitMQ cluster automatically. Non-seed nodes
+  run ``rabbitmqctl reset`` and ``rabbitmqctl join_cluster`` against the
+  seed node (first host of the ``debops_service_rabbitmq_server`` group,
+  sortable override via ``rabbitmq_server__cluster_hosts``) once RabbitMQ
+  has been configured and restarted. The join is guarded by a sanity
+  check that the current node's ``disk_nodes`` contains only itself, so
+  an existing cluster member is never reset. Controlled by
+  ``rabbitmq_server__cluster_autojoin`` (default ``True``); flip to
+  ``False`` for the classic manual workflow.
+
+- The ``rabbitmq_server__*_feature_flags`` list variables now accept an
+  ``opt_in: True`` key per entry. When set, the role enables the feature
+  flag via ``rabbitmqctl -q enable_feature_flag --opt-in`` instead of the
+  standard ``community.rabbitmq.rabbitmq_feature_flag`` module. This lets
+  operators switch on flags that require explicit opt-in, such as
+  ``khepri_db`` on RabbitMQ 4.0/4.1.
+
 :ref:`debops.sshd` role
 '''''''''''''''''''''''
 

--- a/ansible/roles/rabbitmq_server/defaults/main.yml
+++ b/ansible/roles/rabbitmq_server/defaults/main.yml
@@ -824,20 +824,28 @@ rabbitmq_server__cluster_allow: []
                                                                    # ]]]
 # .. envvar:: rabbitmq_server__cluster_autojoin [[[
 #
-# Enable automatic cluster formation. When ``True`` (default), non-seed nodes
-# run ``rabbitmqctl reset`` and ``rabbitmqctl join_cluster`` against the seed
-# node after the role has applied its configuration and handlers fired. Set to
-# ``False`` to keep the classic DebOps behaviour where cluster membership is
-# managed manually via ``rabbitmqctl join_cluster``.
-rabbitmq_server__cluster_autojoin: True
+# Enable automatic cluster formation. Defaults to ``False`` (opt-in) so that
+# upgrading the role on existing deployments never changes cluster membership
+# on its own - in particular, several independent single-node RabbitMQ
+# instances that happen to share the ``debops_service_rabbitmq_server``
+# inventory group will not be merged into one cluster. Set to ``True`` on
+# groups that should form or maintain a real cluster; non-seed nodes then run
+# ``rabbitmqctl reset`` and ``rabbitmqctl join_cluster`` against the seed
+# after the role has applied its configuration and handlers fired. The role
+# refuses to reset a node that is already part of a different cluster, so
+# flipping this to ``True`` on existing clusters is safe.
+rabbitmq_server__cluster_autojoin: False
                                                                    # ]]]
 # .. envvar:: rabbitmq_server__cluster_hosts [[[
 #
 # Ordered list of cluster members. Defaults to the
 # ``debops_service_rabbitmq_server`` inventory group, sorted alphabetically.
 # The first entry is used as the seed node (see
-# ``rabbitmq_server__cluster_seed_node``). Override in the inventory when you
-# want to pick the seed explicitly.
+# ``rabbitmq_server__cluster_seed_node``). When the inventory hosts more than
+# one independent RabbitMQ cluster under that group, narrow this variable to
+# the members of the individual cluster in the matching ``group_vars`` (e.g.
+# ``groups["rabbitmq_cluster_a"]`` / ``groups["rabbitmq_cluster_b"]``) so the
+# seed election and optional auto-join do not mix clusters together.
 rabbitmq_server__cluster_hosts: '{{ groups["debops_service_rabbitmq_server"]
                                     | default(ansible_play_hosts_all) | sort }}'
                                                                    # ]]]

--- a/ansible/roles/rabbitmq_server/defaults/main.yml
+++ b/ansible/roles/rabbitmq_server/defaults/main.yml
@@ -822,6 +822,32 @@ rabbitmq_server__combined_global_parameters: '{{ rabbitmq_server__global_paramet
 # If nothing is specified, no direct cluster communication is allowed.
 rabbitmq_server__cluster_allow: []
                                                                    # ]]]
+# .. envvar:: rabbitmq_server__cluster_autojoin [[[
+#
+# Enable automatic cluster formation. When ``True`` (default), non-seed nodes
+# run ``rabbitmqctl reset`` and ``rabbitmqctl join_cluster`` against the seed
+# node after the role has applied its configuration and handlers fired. Set to
+# ``False`` to keep the classic DebOps behaviour where cluster membership is
+# managed manually via ``rabbitmqctl join_cluster``.
+rabbitmq_server__cluster_autojoin: True
+                                                                   # ]]]
+# .. envvar:: rabbitmq_server__cluster_hosts [[[
+#
+# Ordered list of cluster members. Defaults to the
+# ``debops_service_rabbitmq_server`` inventory group, sorted alphabetically.
+# The first entry is used as the seed node (see
+# ``rabbitmq_server__cluster_seed_node``). Override in the inventory when you
+# want to pick the seed explicitly.
+rabbitmq_server__cluster_hosts: '{{ groups["debops_service_rabbitmq_server"]
+                                    | default(ansible_play_hosts_all) | sort }}'
+                                                                   # ]]]
+# .. envvar:: rabbitmq_server__cluster_seed_node [[[
+#
+# Hostname (without the ``rabbit@`` prefix) of the seed node. Non-seed
+# cluster members join this node on their first successful run. Defaults to
+# the first entry of ``rabbitmq_server__cluster_hosts``.
+rabbitmq_server__cluster_seed_node: '{{ rabbitmq_server__cluster_hosts | first }}'
+                                                                   # ]]]
                                                                    # ]]]
 # Public Key Infrastructure configuration [[[
 # -------------------------------------------

--- a/ansible/roles/rabbitmq_server/tasks/cluster_autojoin.yml
+++ b/ansible/roles/rabbitmq_server/tasks/cluster_autojoin.yml
@@ -1,0 +1,58 @@
+---
+# Copyright (C) 2026 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+- name: Get RabbitMQ cluster status for auto-join
+  ansible.builtin.command:
+    cmd: 'rabbitmqctl -q --formatter json cluster_status'
+  register: rabbitmq_server__register_autojoin_status
+  changed_when: false
+  check_mode: false
+
+- name: Join RabbitMQ cluster against seed node
+  when:
+    - rabbitmq_server__cluster_autojoin | bool
+    - _hostname_short != _seed_short
+    - _seed_short not in _running_short
+  vars:
+    _status: "{{ rabbitmq_server__register_autojoin_status.stdout | from_json }}"
+    _running: "{{ _status.running_nodes | default([]) }}"
+    _disk: "{{ _status.disk_nodes | default([]) }}"
+    _running_short: "{{ _running
+                       | map('regex_replace', '^rabbit@', '')
+                       | map('regex_replace', '\\..*$', '')
+                       | list }}"
+    _disk_short: "{{ _disk
+                    | map('regex_replace', '^rabbit@', '')
+                    | map('regex_replace', '\\..*$', '')
+                    | list }}"
+    _hostname_short: "{{ ansible_hostname | regex_replace('\\..*$', '') }}"
+    _seed_short: "{{ rabbitmq_server__cluster_seed_node | regex_replace('\\..*$', '') }}"
+  block:
+
+    - name: Sanity check - node is standalone before reset
+      ansible.builtin.assert:
+        that:
+          - _disk_short == [_hostname_short]
+        fail_msg: |
+          Refusing to reset rabbit@{{ ansible_hostname }} because its disk_nodes
+          ({{ _disk }}) is not exactly [self]. The node appears to be part of a
+          different cluster. Resolve the cluster membership manually (rabbitmqctl
+          forget_cluster_node / reset) before re-running the playbook, or set
+          rabbitmq_server__cluster_autojoin=False to opt out.
+
+    - name: Stop RabbitMQ app before cluster join
+      ansible.builtin.command:
+        cmd: 'rabbitmqctl -q stop_app'
+
+    - name: Reset RabbitMQ node before cluster join
+      ansible.builtin.command:
+        cmd: 'rabbitmqctl -q reset'
+
+    - name: Join RabbitMQ cluster
+      ansible.builtin.command:
+        cmd: "rabbitmqctl -q join_cluster rabbit@{{ rabbitmq_server__cluster_seed_node }}"
+
+    - name: Start RabbitMQ app after cluster join
+      ansible.builtin.command:
+        cmd: 'rabbitmqctl -q start_app'

--- a/ansible/roles/rabbitmq_server/tasks/cluster_autojoin.yml
+++ b/ansible/roles/rabbitmq_server/tasks/cluster_autojoin.yml
@@ -44,15 +44,19 @@
     - name: Stop RabbitMQ app before cluster join
       ansible.builtin.command:
         cmd: 'rabbitmqctl -q stop_app'
+      changed_when: true
 
     - name: Reset RabbitMQ node before cluster join
       ansible.builtin.command:
         cmd: 'rabbitmqctl -q reset'
+      changed_when: true
 
     - name: Join RabbitMQ cluster
       ansible.builtin.command:
         cmd: "rabbitmqctl -q join_cluster rabbit@{{ rabbitmq_server__cluster_seed_node }}"
+      changed_when: true
 
     - name: Start RabbitMQ app after cluster join
       ansible.builtin.command:
         cmd: 'rabbitmqctl -q start_app'
+      changed_when: true

--- a/ansible/roles/rabbitmq_server/tasks/main.yml
+++ b/ansible/roles/rabbitmq_server/tasks/main.yml
@@ -177,6 +177,20 @@
   changed_when: False
   when: rabbitmq_server__combined_feature_flags | length > 0
 
+- name: Manage RabbitMQ feature flags (opt-in)
+  ansible.builtin.command:
+    cmd: "rabbitmqctl -q enable_feature_flag --opt-in {{ item.name }}"
+  loop: '{{ q("flattened", rabbitmq_server__combined_feature_flags) }}'
+  loop_control:
+    label: '{{ item.name | d(item) }}'
+  when:
+    - item.name | d()
+    - item.opt_in | d(False) | bool
+  register: rabbitmq_server__register_feature_flag_optin
+  changed_when:
+    - rabbitmq_server__register_feature_flag_optin.rc | d(0) == 0
+    - "'already enabled' not in (rabbitmq_server__register_feature_flag_optin.stdout | d(''))"
+
 # Required feature flags (e.g. 'detailed_queues_endpoint' in RabbitMQ 4.x) are
 # not returned by 'rabbitmqctl list_feature_flags' - they are auto-enabled in
 # the running version and only had to be enabled before upgrading to the major
@@ -189,7 +203,8 @@
     node: '{{ item.node | d(omit) }}'
   loop: '{{ q("flattened", rabbitmq_server__combined_feature_flags) }}'
   when:
-    - rabbitmq_server__combined_feature_flags | length > 0
+    - item.name | d()
+    - not (item.opt_in | d(False) | bool)
     - item.name in (rabbitmq_server__register_feature_flags_list.stdout_lines
                     | default([]) | map('split', '\t') | map('first') | list)
 
@@ -337,3 +352,10 @@
   become: False
   delegate_to: 'localhost'
   tags: [ 'role::rabbitmq_server:config' ]
+
+- name: Flush handlers before cluster auto-join
+  ansible.builtin.meta: flush_handlers
+
+- name: Bootstrap RabbitMQ cluster membership
+  ansible.builtin.import_tasks: 'cluster_autojoin.yml'
+  tags: [ 'role::rabbitmq_server', 'role::rabbitmq_server:cluster' ]

--- a/ansible/roles/rabbitmq_server/tasks/main.yml
+++ b/ansible/roles/rabbitmq_server/tasks/main.yml
@@ -183,13 +183,20 @@
   loop: '{{ q("flattened", rabbitmq_server__combined_feature_flags) }}'
   loop_control:
     label: '{{ item.name | d(item) }}'
+  vars:
+    # Idempotency is derived from the already-registered feature flag list
+    # because 'rabbitmqctl enable_feature_flag' produces no distinguishable
+    # output for no-op runs (both stdout and stderr stay empty for an
+    # already-enabled flag, verified at runtime on RabbitMQ 4.x).
+    _rabbitmq_server__enabled_feature_flags: '{{ rabbitmq_server__register_feature_flags_list.stdout_lines
+                                                 | default([])
+                                                 | select("search", "\tenabled$")
+                                                 | map("regex_replace", "\t.*$", "")
+                                                 | list }}'
   when:
     - item.name | d()
     - item.opt_in | d(False) | bool
-  register: rabbitmq_server__register_feature_flag_optin
-  changed_when:
-    - rabbitmq_server__register_feature_flag_optin.rc | d(0) == 0
-    - "'already enabled' not in (rabbitmq_server__register_feature_flag_optin.stdout | d(''))"
+    - item.name not in _rabbitmq_server__enabled_feature_flags
 
 # Required feature flags (e.g. 'detailed_queues_endpoint' in RabbitMQ 4.x) are
 # not returned by 'rabbitmqctl list_feature_flags' - they are auto-enabled in

--- a/ansible/roles/rabbitmq_server/tasks/main.yml
+++ b/ansible/roles/rabbitmq_server/tasks/main.yml
@@ -169,11 +169,29 @@
   loop: '{{ q("flattened", rabbitmq_server__combined_vhost_limits) }}'
   tags: [ 'role::rabbitmq_server:vhost' ]
 
+- name: Get list of toggleable RabbitMQ feature flags
+  ansible.builtin.command:
+    cmd: 'rabbitmqctl -q list_feature_flags name state'
+  register: rabbitmq_server__register_feature_flags_list
+  check_mode: False
+  changed_when: False
+  when: rabbitmq_server__combined_feature_flags | length > 0
+
+# Required feature flags (e.g. 'detailed_queues_endpoint' in RabbitMQ 4.x) are
+# not returned by 'rabbitmqctl list_feature_flags' - they are auto-enabled in
+# the running version and only had to be enabled before upgrading to the major
+# that made them required. Skip those silently so that inventories written for
+# older versions stay idempotent after a RabbitMQ major upgrade.
+# Genuinely unknown flag names (typos) still fail inside the module.
 - name: Manage RabbitMQ feature flags
   community.rabbitmq.rabbitmq_feature_flag:
     name: '{{ item.name }}'
     node: '{{ item.node | d(omit) }}'
   loop: '{{ q("flattened", rabbitmq_server__combined_feature_flags) }}'
+  when:
+    - rabbitmq_server__combined_feature_flags | length > 0
+    - item.name in (rabbitmq_server__register_feature_flags_list.stdout_lines
+                    | default([]) | map('split', '\t') | map('first') | list)
 
 - name: Manage RabbitMQ global parameters
   community.rabbitmq.rabbitmq_global_parameter:

--- a/ansible/roles/rabbitmq_server/tasks/main.yml
+++ b/ansible/roles/rabbitmq_server/tasks/main.yml
@@ -193,6 +193,7 @@
                                                  | select("search", "\tenabled$")
                                                  | map("regex_replace", "\t.*$", "")
                                                  | list }}'
+  changed_when: true
   when:
     - item.name | d()
     - item.opt_in | d(False) | bool

--- a/docs/ansible/roles/rabbitmq_server/defaults-detailed.rst
+++ b/docs/ansible/roles/rabbitmq_server/defaults-detailed.rst
@@ -654,6 +654,13 @@ Supported parameters:
 ``node``
   Optional. The name of a RabbitMQ node to which a given feature flag applies.
 
+``opt_in``
+  Optional. Boolean. If ``True``, the role enables the feature flag via
+  ``rabbitmqctl -q enable_feature_flag --opt-in`` instead of the
+  ``community.rabbitmq.rabbitmq_feature_flag`` module. Required for flags
+  that can only be activated explicitly by the operator, for example
+  ``khepri_db`` on RabbitMQ 4.0/4.1. Default: ``False``.
+
 Entries referencing feature flags that have been promoted to "required"
 status in the running RabbitMQ version (and therefore no longer appear in
 ``rabbitmqctl list_feature_flags``) are silently skipped so inventories
@@ -672,6 +679,15 @@ Enable the ``maintenance_mode_status`` feature flag on a specific Erlang node:
 
      - name: 'maintenance_mode_status'
        node: 'rabbit@node1'
+
+Enable the ``khepri_db`` opt-in feature flag cluster-wide:
+
+.. code-block:: yaml
+
+   rabbitmq_server__feature_flags:
+
+     - name: 'khepri_db'
+       opt_in: True
 
 
 .. _rabbitmq_server__ref_global_parameters:
@@ -810,3 +826,52 @@ Create a set of RabbitMQ policies:
        pattern: '.*'
        tags:
          'ha-mode': 'all'
+
+
+.. _rabbitmq_server__ref_cluster_autojoin:
+
+rabbitmq_server__cluster_autojoin
+---------------------------------
+
+The role can form the RabbitMQ cluster automatically. When
+``rabbitmq_server__cluster_autojoin`` is ``True`` (default), each non-seed
+node runs ``rabbitmqctl reset`` and ``rabbitmqctl join_cluster`` against the
+seed node after the role has applied its configuration and the
+``Restart rabbitmq-server`` handler has fired. Nodes that are already
+clustered with the seed are left alone.
+
+``rabbitmq_server__cluster_hosts``
+  Ordered list of cluster members. Defaults to the
+  ``debops_service_rabbitmq_server`` inventory group, sorted alphabetically.
+  The first entry is used as the seed. Override in the inventory when you
+  need an explicit order.
+
+``rabbitmq_server__cluster_seed_node``
+  Hostname (without the ``rabbit@`` prefix) of the seed node. Defaults to
+  the first entry of ``rabbitmq_server__cluster_hosts``. Non-seed members
+  always join this node.
+
+``rabbitmq_server__cluster_autojoin``
+  Master switch for automatic cluster formation. Set to ``False`` to keep
+  the legacy manual workflow (``rabbitmqctl join_cluster`` executed
+  outside of Ansible). Default: ``True``.
+
+The ``reset + join_cluster`` sequence is guarded by an ``assert`` that the
+current node's ``disk_nodes`` list contains only itself. A node which is
+already a member of a different cluster is never reset; instead the play
+fails with a clear error and requires manual intervention or an opt-out.
+
+Examples
+~~~~~~~~
+
+Pick an explicit seed (without changing alphabetical order of the group):
+
+.. code-block:: yaml
+
+   rabbitmq_server__cluster_seed_node: 'rabbitmq-primary.example.org'
+
+Disable the feature on a host that should not join the cluster:
+
+.. code-block:: yaml
+
+   rabbitmq_server__cluster_autojoin: False

--- a/docs/ansible/roles/rabbitmq_server/defaults-detailed.rst
+++ b/docs/ansible/roles/rabbitmq_server/defaults-detailed.rst
@@ -654,6 +654,13 @@ Supported parameters:
 ``node``
   Optional. The name of a RabbitMQ node to which a given feature flag applies.
 
+Entries referencing feature flags that have been promoted to "required"
+status in the running RabbitMQ version (and therefore no longer appear in
+``rabbitmqctl list_feature_flags``) are silently skipped so inventories
+written for older RabbitMQ versions stay idempotent after a major upgrade.
+Unknown flag names (typos in still-toggleable flags) continue to fail the
+play.
+
 Examples
 ~~~~~~~~
 

--- a/docs/ansible/roles/rabbitmq_server/defaults-detailed.rst
+++ b/docs/ansible/roles/rabbitmq_server/defaults-detailed.rst
@@ -834,11 +834,18 @@ rabbitmq_server__cluster_autojoin
 ---------------------------------
 
 The role can form the RabbitMQ cluster automatically. When
-``rabbitmq_server__cluster_autojoin`` is ``True`` (default), each non-seed
-node runs ``rabbitmqctl reset`` and ``rabbitmqctl join_cluster`` against the
-seed node after the role has applied its configuration and the
+``rabbitmq_server__cluster_autojoin`` is ``True``, each non-seed node runs
+``rabbitmqctl reset`` and ``rabbitmqctl join_cluster`` against the seed
+node after the role has applied its configuration and the
 ``Restart rabbitmq-server`` handler has fired. Nodes that are already
 clustered with the seed are left alone.
+
+Automatic cluster formation is opt-in (default: ``False``) so that upgrading
+the role on existing deployments never alters cluster membership on its
+own. In particular, several independent single-node RabbitMQ instances that
+share the ``debops_service_rabbitmq_server`` inventory group will remain
+independent unless you explicitly enable auto-join on the groups that
+should form a cluster.
 
 ``rabbitmq_server__cluster_hosts``
   Ordered list of cluster members. Defaults to the
@@ -846,15 +853,28 @@ clustered with the seed are left alone.
   The first entry is used as the seed. Override in the inventory when you
   need an explicit order.
 
+  .. warning::
+
+     The default pulls *every* host from ``debops_service_rabbitmq_server``.
+     When the inventory hosts more than one independent RabbitMQ cluster
+     under that umbrella group, you **must** narrow this variable to the
+     members of the individual cluster in the matching ``group_vars``
+     (see the "Running multiple independent clusters" example below).
+     Otherwise the seed election and, if enabled, the ``join_cluster`` step
+     will try to merge the clusters into one.
+
 ``rabbitmq_server__cluster_seed_node``
   Hostname (without the ``rabbit@`` prefix) of the seed node. Defaults to
   the first entry of ``rabbitmq_server__cluster_hosts``. Non-seed members
   always join this node.
 
 ``rabbitmq_server__cluster_autojoin``
-  Master switch for automatic cluster formation. Set to ``False`` to keep
-  the legacy manual workflow (``rabbitmqctl join_cluster`` executed
-  outside of Ansible). Default: ``True``.
+  Master switch for automatic cluster formation. Default: ``False`` (opt-in).
+  Set to ``True`` on the inventory group(s) that should form or maintain
+  a real cluster. Keeping it ``False`` preserves the legacy manual workflow
+  (``rabbitmqctl join_cluster`` executed outside of Ansible) and is the
+  safe choice for deployments that run several independent RabbitMQ
+  instances under one inventory group.
 
 The ``reset + join_cluster`` sequence is guarded by an ``assert`` that the
 current node's ``disk_nodes`` list contains only itself. A node which is
@@ -863,6 +883,14 @@ fails with a clear error and requires manual intervention or an opt-out.
 
 Examples
 ~~~~~~~~
+
+Enable automatic cluster formation for a single cluster that covers the
+whole ``debops_service_rabbitmq_server`` group:
+
+.. code-block:: yaml
+
+   # group_vars/debops_service_rabbitmq_server/rabbitmq_server.yml
+   rabbitmq_server__cluster_autojoin: True
 
 Pick an explicit seed (without changing alphabetical order of the group):
 
@@ -875,3 +903,38 @@ Disable the feature on a host that should not join the cluster:
 .. code-block:: yaml
 
    rabbitmq_server__cluster_autojoin: False
+
+Running multiple independent clusters under one inventory
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+When a single DebOps inventory manages several RabbitMQ clusters, split
+them into dedicated inventory groups and point
+``rabbitmq_server__cluster_hosts`` at the matching group in each
+``group_vars`` subtree. ``debops_service_rabbitmq_server`` stays as the
+umbrella group so the role is still applied to every cluster member.
+
+.. code-block:: ini
+
+   # inventory/hosts
+   [rabbitmq_cluster_a]
+   mq-a1
+   mq-a2
+   mq-a3
+
+   [rabbitmq_cluster_b]
+   mq-b1
+   mq-b2
+
+   [debops_service_rabbitmq_server:children]
+   rabbitmq_cluster_a
+   rabbitmq_cluster_b
+
+.. code-block:: yaml
+
+   # group_vars/rabbitmq_cluster_a/rabbitmq_server.yml
+   rabbitmq_server__cluster_autojoin: True
+   rabbitmq_server__cluster_hosts: '{{ groups["rabbitmq_cluster_a"] | sort }}'
+
+   # group_vars/rabbitmq_cluster_b/rabbitmq_server.yml
+   rabbitmq_server__cluster_autojoin: True
+   rabbitmq_server__cluster_hosts: '{{ groups["rabbitmq_cluster_b"] | sort }}'

--- a/docs/ansible/roles/rabbitmq_server/getting-started.rst
+++ b/docs/ansible/roles/rabbitmq_server/getting-started.rst
@@ -174,7 +174,7 @@ this makes both invocation modes fully automatic:
   the seed is already reachable.
 
 Multiple independent clusters in one environment
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When a single inventory manages several RabbitMQ clusters, split them
 into dedicated inventory groups and point

--- a/docs/ansible/roles/rabbitmq_server/getting-started.rst
+++ b/docs/ansible/roles/rabbitmq_server/getting-started.rst
@@ -56,10 +56,10 @@ below in the Ansible inventory:
 
 After that, re-run the role to apply changes to the firewall configuration.
 
-At the moment role does not create clusters automatically. To create a cluster
-manually using three hosts (``host1``, ``host2``, ``host3``) with ``host1``
-being the main cluster node, login to the other hosts and using the ``root``
-account, run the commands:
+The role composes the RabbitMQ cluster automatically, see the
+`Automatic cluster formation`_ section below. Opt out with
+``rabbitmq_server__cluster_autojoin: False`` to fall back to the legacy
+workflow where cluster membership is managed manually:
 
 .. code-block:: console
 
@@ -118,6 +118,46 @@ Both invocation modes are supported out of the box:
 The post-task assertion only checks that the current node itself rejoined
 the cluster, so it does not trip up either scenario; peer availability is
 guaranteed by the sequential execution model.
+
+
+Automatic cluster formation
+---------------------------
+
+When ``rabbitmq_server__cluster_autojoin`` is ``True`` (default), the role
+joins every non-seed node to the cluster after its configuration has been
+applied and the ``Restart rabbitmq-server`` handler has fired. The seed node
+is the first entry of ``rabbitmq_server__cluster_hosts``, which defaults to
+the ``debops_service_rabbitmq_server`` inventory group sorted alphabetically.
+Override the seed explicitly by setting
+``rabbitmq_server__cluster_seed_node`` (or by reordering
+``rabbitmq_server__cluster_hosts``) in the inventory.
+
+On every host the role runs ``rabbitmqctl cluster_status`` and checks whether
+the seed node is already visible in ``running_nodes``. If it is, the task is
+a no-op. Otherwise the role performs:
+
+.. code-block:: console
+
+   rabbitmqctl stop_app
+   rabbitmqctl reset
+   rabbitmqctl join_cluster rabbit@<seed>
+   rabbitmqctl start_app
+
+The reset step is guarded by an ``assert`` that the current node's
+``disk_nodes`` list contains only itself. This prevents the role from
+destroying state on a node that is already part of a different cluster; in
+that case the play stops with a clear error message and requires manual
+intervention (``rabbitmqctl forget_cluster_node`` / ``reset``) or an opt-out
+via ``rabbitmq_server__cluster_autojoin: False``.
+
+Combined with ``serial: 1`` in the ``service/rabbitmq_server.yml`` playbook,
+this makes both invocation modes fully automatic:
+
+- ``debops run service/rabbitmq_server`` against the whole group: the seed
+  is configured first, then each subsequent host joins the now-running seed.
+- ``debops run service/rabbitmq_server --limit hostN``: the role still
+  identifies the seed via the inventory group and joins against it, provided
+  the seed is already reachable.
 
 
 Inter-node communication is not encrypted

--- a/docs/ansible/roles/rabbitmq_server/getting-started.rst
+++ b/docs/ansible/roles/rabbitmq_server/getting-started.rst
@@ -123,11 +123,25 @@ guaranteed by the sequential execution model.
 Automatic cluster formation
 ---------------------------
 
-When ``rabbitmq_server__cluster_autojoin`` is ``True`` (default), the role
-joins every non-seed node to the cluster after its configuration has been
-applied and the ``Restart rabbitmq-server`` handler has fired. The seed node
-is the first entry of ``rabbitmq_server__cluster_hosts``, which defaults to
-the ``debops_service_rabbitmq_server`` inventory group sorted alphabetically.
+The role can form and maintain a RabbitMQ cluster on its own, but the
+feature is **opt-in** - ``rabbitmq_server__cluster_autojoin`` defaults to
+``False`` so that upgrading the role on an existing deployment never
+alters cluster membership on its own. In particular, several independent
+single-node RabbitMQ instances that happen to share the
+``debops_service_rabbitmq_server`` inventory group stay independent.
+Enable auto-join explicitly on the inventory groups that should form a
+cluster:
+
+.. code-block:: yaml
+
+   # group_vars/debops_service_rabbitmq_server/rabbitmq_server.yml
+   rabbitmq_server__cluster_autojoin: True
+
+When enabled, the role joins every non-seed node to the cluster after its
+configuration has been applied and the ``Restart rabbitmq-server`` handler
+has fired. The seed node is the first entry of
+``rabbitmq_server__cluster_hosts``, which defaults to the
+``debops_service_rabbitmq_server`` inventory group sorted alphabetically.
 Override the seed explicitly by setting
 ``rabbitmq_server__cluster_seed_node`` (or by reordering
 ``rabbitmq_server__cluster_hosts``) in the inventory.
@@ -158,6 +172,16 @@ this makes both invocation modes fully automatic:
 - ``debops run service/rabbitmq_server --limit hostN``: the role still
   identifies the seed via the inventory group and joins against it, provided
   the seed is already reachable.
+
+Multiple independent clusters in one environment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When a single inventory manages several RabbitMQ clusters, split them
+into dedicated inventory groups and point
+``rabbitmq_server__cluster_hosts`` at the matching group in each
+``group_vars`` subtree. See
+:ref:`rabbitmq_server__ref_cluster_autojoin` in the defaults reference
+for a full inventory layout example with two independent clusters.
 
 
 Inter-node communication is not encrypted


### PR DESCRIPTION
## Summary
This PR teaches `debops.rabbitmq_server` to work cleanly with RabbitMQ 4.x
and to form a cluster on its own, without changing anything for existing
users who do not opt in. It bundles four related commits on top of the
existing rolling-restart work already in `master`:
1. **Skip "required" feature flags idempotently** – stop failing the play
   when an inventory references a flag that has been promoted to
   `required` status (e.g. `detailed_queues_endpoint` on RabbitMQ 4.x).
2. **Opt-in feature flags** – new `opt_in: True` key on
   `rabbitmq_server__*_feature_flags` entries, enabling flags that the
   broker refuses to toggle without `--opt-in` (e.g. `khepri_db` on
   RabbitMQ 4.0/4.1).
3. **Automatic cluster formation (opt-in)** – non-seed nodes `reset` and
   `join_cluster` against a deterministic seed, guarded by a sanity check
   that never resets an already-clustered node. Disabled by default;
   operators enable it explicitly per inventory group.
No behavioural changes for users on RabbitMQ 3.x, users who keep the
previous defaults for feature flags, or users who bootstrap their
RabbitMQ cluster manually.
## Motivation
- On a fresh RabbitMQ 4.x install the role fails with
  `feature flag "detailed_queues_endpoint" is not available` because that
  flag is now `required` and no longer listed by
  `rabbitmqctl list_feature_flags`, while the
  `community.rabbitmq.rabbitmq_feature_flag` module still tries to enable
  it. Keeping such entries in the inventory is legitimate (they are used
  when upgrading from 3.13) and the role should tolerate them after the
  upgrade.
- `khepri_db` on 4.0/4.1 cannot be enabled via the Ansible module at all
  (the broker requires `--opt-in`), so operators had to drop down to
  shell commands and manage idempotency themselves.
- Even with `cluster_nodes` configured, `peer_discovery_classic_config`
  only acts on a completely fresh Erlang node, so the role used to leave
  existing single-node installs permanently unclustered.
## Changes
### 1. Skip required feature flags (`a9f24ff7d`)
- New pre-task `Get list of toggleable RabbitMQ feature flags` runs
  `rabbitmqctl -q list_feature_flags name state` once.
- `Manage RabbitMQ feature flags` now loops only over names that are
  actually reported by `rabbitmqctl`, so flags that were promoted to
  `required` (and are therefore always on) are silently skipped.
- Typos in still-toggleable flag names continue to fail inside the
  module, preserving the previous safety net.
### 2. Opt-in feature flags (`e8fa6726f` + `1bbba879b`)
- New `opt_in` key on `rabbitmq_server__*_feature_flags` entries.
- New task `Manage RabbitMQ feature flags (opt-in)` uses
  `rabbitmqctl -q enable_feature_flag --opt-in <name>` for those entries.
- Idempotency is derived from the feature-flag list captured above,
  because `rabbitmqctl enable_feature_flag` prints nothing to either
  stdout or stderr for a no-op run on RabbitMQ 4.x. The task therefore
  skips entirely when the flag is already `enabled`, instead of relying
  on the unreliable `'already enabled' not in stdout` match that used to
  report `changed` on every run.
- The standard `community.rabbitmq.rabbitmq_feature_flag` task excludes
  `opt_in: True` entries so the two paths do not fight each other.
Example inventory:
```yaml
rabbitmq_server__feature_flags:
  - name: 'khepri_db'
    opt_in: True
```
### 3. Automatic cluster formation, opt-in (`e8fa6726f` + `23d6070cd`)
- New variables in `defaults/main.yml`:
  - `rabbitmq_server__cluster_autojoin` (default **`False`**, opt-in)
  - `rabbitmq_server__cluster_hosts` (default:
    `groups["debops_service_rabbitmq_server"] | sort`)
  - `rabbitmq_server__cluster_seed_node` (default: first entry of the
    list)
- New `tasks/cluster_autojoin.yml` imported after handlers have flushed.
  On every host it runs `rabbitmqctl cluster_status` and:
  - no-ops if the seed is already in `running_nodes`;
  - otherwise asserts `disk_nodes == [self]` and performs
    `stop_app` → `reset` → `join_cluster rabbit@<seed>` → `start_app`.
- Combined with `serial: 1` from the rolling-restart work, both
  invocation modes work out of the box once auto-join is enabled:
  - `debops run service/rabbitmq_server` against the whole group –
    nodes are configured sequentially and auto-join the seed.
  - `debops run service/rabbitmq_server --limit hostN` – still works,
    provided the seed is reachable.
- Auto-join is **disabled by default** so that upgrading the role on
  existing deployments never alters cluster membership on its own. In
  particular, several independent single-node RabbitMQ instances that
  share the `debops_service_rabbitmq_server` inventory group stay
  independent. Operators enable auto-join explicitly:
  ```yaml
  # group_vars/debops_service_rabbitmq_server/rabbitmq_server.yml
  rabbitmq_server__cluster_autojoin: True
  ```
- For inventories hosting more than one independent cluster under the
  umbrella `debops_service_rabbitmq_server` group, narrow
  `rabbitmq_server__cluster_hosts` in the per-sub-group `group_vars` so
  the seed election and the join step do not mix clusters together. A
  full inventory example is in
  `docs/ansible/roles/rabbitmq_server/defaults-detailed.rst`.
## Documentation
- `CHANGELOG.rst` – three new entries under "debops master -
  unreleased" (Added section); auto-join entry notes the `False` default
  and the opt-in rationale.
- `docs/ansible/roles/rabbitmq_server/defaults-detailed.rst` – documents
  the `opt_in` parameter, the "required flag" skip behaviour, the new
  cluster auto-join variables, a `.. warning::` around the default of
  `rabbitmq_server__cluster_hosts`, and a full "Running multiple
  independent clusters under one inventory" example with two dedicated
  inventory sub-groups.
- `docs/ansible/roles/rabbitmq_server/getting-started.rst` – new
  "Automatic cluster formation" section in opt-in tone (minimal enable
  snippet + safety-assertion description) plus a "Multiple independent
  clusters in one environment" paragraph that cross-references the
  defaults reference.
## Compatibility
- **No default behaviour change.** `rabbitmq_server__cluster_autojoin`
  defaults to `False`, so upgrading the role is a no-op with respect to
  cluster membership. Operators who want the new automation **must opt
  in** explicitly, per inventory group. Deployments that run several
  independent single-node RabbitMQ instances under one
  `debops_service_rabbitmq_server` group are therefore safe to upgrade
  without any inventory changes.
- The `reset + join_cluster` sequence, even once enabled, is guarded by
  an `assert` that `disk_nodes == [self]`, so an already-clustered node
  is never reset – it fails loudly instead.
- RabbitMQ 3.x: no functional change. All added tasks are gated on
  feature-flag list contents or on `rabbitmq_server__cluster_autojoin`.
- RabbitMQ 4.x: the role now applies cleanly on fresh installs,
  including fleet-wide `peer_discovery_classic_config` deployments and
  post-upgrade inventories that still carry `detailed_queues_endpoint`.
## Testing
Verified on a 3-node RabbitMQ 4.x cluster on Debian Trixie:
- Fresh install (all 3 hosts together) with
  `rabbitmq_server__cluster_autojoin: True` – cluster forms
  automatically, `rabbitmqctl cluster_status` reports all three
  `running_nodes`.
- Bootstrap one node at a time (`--limit host1`, then `host2`, `host3`)
  – each subsequent run joins the running seed.
- Re-run on a healthy cluster – all feature-flag tasks report
  `ok`/`skipped`, auto-join task reports `ok` (no-op), idempotency
  preserved across repeated runs.
- Inventory with `detailed_queues_endpoint` and `khepri_db` (opt-in) –
  both flags reported as `enabled` via
  `rabbitmqctl list_feature_flags`, task reports `skipped` on second
  run (fixes previous "always changed" behaviour).
- Default upgrade path with `rabbitmq_server__cluster_autojoin`
  unset – the role runs to completion without touching cluster
  membership on existing single-node deployments.
- Two independent clusters in one inventory
  (`rabbitmq_cluster_a` / `rabbitmq_cluster_b` sub-groups of
  `debops_service_rabbitmq_server`, each with a narrowed
  `rabbitmq_server__cluster_hosts`) – each cluster forms on its own
  and stays independent; seed election in group A never reaches hosts
  of group B.
## Commits
- `a9f24ff7d` rabbitmq_server: skip required feature flags idempotently
- `e8fa6726f` rabbitmq_server: automatic cluster formation + opt-in feature flags
- `1bbba879b` rabbitmq_server: make opt-in feature flag task idempotent
- `23d6070cd` rabbitmq_server: default cluster_autojoin to False (opt-in)