### PR TITLE
[mount] fix ansible 2.19 "broken conditionals" and refactor `if:` as list

### DIFF
--- a/ansible/roles/mount/tasks/main.yml
+++ b/ansible/roles/mount/tasks/main.yml
@@ -24,8 +24,10 @@
              + mount__group_devices
              + mount__host_devices)
             | flatten }}'
-  when: (mount__enabled | bool and item.state | d('mounted') in ['mounted', 'present', 'unmounted'] and
-         (item.device | d(item.src)) not in (ansible_mounts | map(attribute='device') | list))
+  when:
+    - mount__enabled | bool
+    - item.state | d('mounted') in ['mounted', 'present', 'unmounted']
+    - (item.device | d(item.src)) not in (ansible_mounts | map(attribute='device') | list)
 
 - name: Stop devices automounted by systemd if requested
   ansible.builtin.systemd:
@@ -35,10 +37,12 @@
              + mount__group_devices
              + mount__host_devices)
             | flatten }}'
-  when: (mount__enabled | bool and ansible_service_mgr == 'systemd' and
-         item.state | d('mounted') in ['unmounted', 'absent'] and
-         (((item.opts if (item.opts is string) else item.opts | join(','))
-           if item.opts | d() else 'defaults') is match(".*x-systemd.automount.*")))
+  when:
+    - mount__enabled | bool
+    - ansible_service_mgr == 'systemd'
+    - item.state | d('mounted') in ['unmounted', 'absent']
+    - (((item.opts if (item.opts is string) else item.opts | join(','))
+        if item.opts is defined else 'defaults') is match(".*x-systemd.automount.*"))
 
 # Manage custom files [[[1
 - name: Copy files to remote hosts
@@ -62,10 +66,11 @@
   loop: '{{ q("flattened", mount__files
                            + mount__group_files
                            + mount__host_files) }}'
-  when: (mount__enabled | bool and
-         (item.src | d() or item.content is defined) and
-         (item.dest | d() or item.path | d() or item.name | d()) and
-         (item.state | d('present') != 'absent'))
+  when:
+    - mount__enabled | bool
+    - item.src is defined or item.content is defined
+    - item.dest is defined or item.path is defined or item.name is defined
+    - item.state | d('present') != 'absent'
 
 - name: Manage device mounts
   ansible.posix.mount:
@@ -73,7 +78,7 @@
     path:   '{{ item.path | d(item.dest | d(item.name)) }}'
     fstype: '{{ item.fstype | d("auto") }}'
     opts:   '{{ ((item.opts if (item.opts is string) else (item.opts | join(",")))
-                 if item.opts | d() else "defaults") }}'
+                 if item.opts is defined else "defaults") }}'
     dump:   '{{ item.dump | d(omit) }}'
     passno: '{{ item.passno | d(omit) }}'
     state:  '{{ item.state | d("mounted") }}'
@@ -83,8 +88,10 @@
              + mount__host_devices)
             | flatten }}'
   register: mount__register_devices
-  when: (mount__enabled | bool and
-         (item.name | d() or item.dest | d() or item.path | d()) and item.src)
+  when:
+    - mount__enabled | bool
+    - item.name is defined or item.dest is defined or item.path is defined
+    - item.src is defined
 
 - name: Restart 'local-fs.target' systemd unit
   ansible.builtin.systemd:  # noqa no-handler
@@ -92,9 +99,12 @@
     state: 'restarted'
     daemon_reload: True
   loop: '{{ mount__register_devices.results }}'
-  when: (mount__enabled | bool and ansible_service_mgr == 'systemd' and item is changed and
-         (((item.opts if (item.opts is string) else item.opts | join(','))
-           if item.opts | d() else 'defaults') is match(".*x-systemd.automount.*")))
+  when:
+    - mount__enabled | bool
+    - ansible_service_mgr == 'systemd'
+    - item is changed
+    - ((item.opts if (item.opts is string) else item.opts | join(','))
+        if item.opts is defined else 'defaults') is match(".*x-systemd.automount.*")
 
 - name: Restart 'remote-fs.target' systemd unit
   ansible.builtin.systemd:  # noqa no-handler
@@ -102,9 +112,12 @@
     state: 'restarted'
     daemon_reload: True
   loop: '{{ mount__register_devices.results }}'
-  when: (mount__enabled | bool and ansible_service_mgr == 'systemd' and item is changed and
-         (((item.opts if (item.opts is string) else item.opts | join(','))
-           if item.opts | d() else 'defaults') is match(".*x-systemd.automount.*")))
+  when:
+    - mount__enabled | bool
+    - ansible_service_mgr == 'systemd'
+    - item is changed
+    - ((item.opts if (item.opts is string) else item.opts | join(','))
+        if item.opts is defined else 'defaults') is match(".*x-systemd.automount.*")
 
 - name: Manage directories
   ansible.builtin.file:
@@ -118,8 +131,10 @@
              + mount__group_directories
              + mount__host_directories)
             | flatten }}'
-  when: mount__enabled | bool and (item.path | d() or item.dest | d() or item.name | d()) and
-        item.state | d('directory') in ['directory', 'absent']
+  when:
+    - mount__enabled | bool
+    - item.path is defined or item.dest is defined or item.name is defined
+    - item.state | d('directory') in ['directory', 'absent']
 
 - name: Manage directory ACLs
   ansible.posix.acl:
@@ -138,15 +153,18 @@
              | subelements("acl") }}'
   loop_control:
     label: '{{ {"name": item.0.name, "acl": item.1} }}'
-  when: mount__enabled | bool and (item.0.path | d() or item.0.dest | d() or item.0.name | d()) and
-        item.0.state | d('directory') == 'directory' and item.0.acl | d()
+  when:
+    - mount__enabled | bool
+    - item.0.path is defined or item.0.dest is defined or item.0.name is defined
+    - item.0.state | d('directory') == 'directory'
+    - item.0.acl is defined
 
 - name: Manage bind mounts
   ansible.posix.mount:
     src:    '{{ item.src }}'
     path:   '{{ item.path | d(item.dest | d(item.name)) }}'
     fstype: '{{ item.fstype | d("none") }}'
-    opts:   '{{ ((item.opts if (item.opts is string) else (item.opts | join(","))) if item.opts | d() else "bind") }}'
+    opts:   '{{ ((item.opts if (item.opts is string) else (item.opts | join(","))) if item.opts is defined else "bind") }}'
     dump:   '{{ item.dump | d(omit) }}'
     passno: '{{ item.passno | d(omit) }}'
     state:  '{{ item.state | d("mounted") }}'
@@ -155,9 +173,10 @@
              + mount__group_binds
              + mount__host_binds)
             | flatten }}'
-  when: (mount__enabled | bool and
-         (item.name | d() or item.dest | d() or item.path | d()) and
-         item.src | d())
+  when:
+    - mount__enabled | bool
+    - item.name is defined or item.dest is defined or item.path is defined
+    - item.src is defined
 
 - name: Make sure that Ansible local facts directory exists
   ansible.builtin.file:


### PR DESCRIPTION
- Similar to https://github.com/debops/debops/pull/2648, changes `| d()` syntax to `is defined` for compatibility with Ansible 2.19
- Refactor `if: ((a) and (b) and (c))` as YAML list syntax, improving readability

Changes have been tried and work on my production system.