### PR TITLE
[machine] mode option for machine__motd_combined_scripts

### DIFF
--- a/ansible/roles/machine/tasks/main.yml
+++ b/ansible/roles/machine/tasks/main.yml
@@ -110,7 +110,7 @@
               + (item.filename | d(("%02d" | format(item.weight | int)) | string + "-" + item.name)) }}'
     owner: 'root'
     group: 'root'
-    mode: '0755'
+    mode: '{{ item.mode | d("0755") }}'
   loop: '{{ machine__motd_combined_scripts | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ item.filename | d() or item.name }}'

--- a/docs/ansible/roles/machine/defaults-detailed.rst
+++ b/docs/ansible/roles/machine/defaults-detailed.rst
@@ -98,6 +98,12 @@ Each list entry is a YAML dictionary with specific parameters:
   - ``revert``: if a given entry has the ``divert: True`` parameter, the
     specified script will be reverted to its original state.
 
+``mode``
+  Optional. Define the permissions of a particula script. Default to ``0755``.
+  If the script is not executable, it will not be included directly in the
+  dynamic MOTD but could be referenced as a source or resource in others
+  scripts.
+
 Examples
 ~~~~~~~~
 


### PR DESCRIPTION
Only executables files will be executed by run-parts in the `/etc/update-motd.d`
directory, however, nothing is wrong to put there non-executable files that can
be sourced or used as additionnal ressources for the executable files.

This is a convenience to deploy external motd scripts such as
https://github.com/ldidry/dynamic-motd which relies on source files.
Otherwise source files have to be deployed via others means such as
`debops.resources`.