### PR TITLE
[nsswitch] Update to not break libnss-systemd

### DIFF
--- a/ansible/roles/nsswitch/defaults/main.yml
+++ b/ansible/roles/nsswitch/defaults/main.yml
@@ -2,7 +2,7 @@
 # .. vim: foldmarker=[[[,]]]:foldmethod=marker
 
 # .. Copyright (C) 2017 Maciej Delmanowski <drybjed@gmail.com>
-# .. Copyright (C) 2017 DebOps <https://debops.org/>
+# .. Copyright (C) 2017-2026 DebOps <https://debops.org/>
 # .. SPDX-License-Identifier: GPL-3.0-only
 
 # .. _nsswitch__ref_defaults:
@@ -95,8 +95,8 @@ nsswitch__combined_services: '{{ lookup("flattened", (nsswitch__default_services
 nsswitch__default_database_map:
   'passwd':     [ 'compat', 'mymachines', 'systemd', 'sss', 'ldap', 'winbind' ]
   'group':      [ 'compat', 'mymachines', 'systemd', 'sss', 'ldap', 'winbind' ]
-  'shadow':     [ 'compat', 'sss' ]
-  'gshadow':    [ 'files' ]
+  'shadow':     [ 'compat', 'systemd', 'sss' ]
+  'gshadow':    [ 'files',  'systemd' ]
   'initgroups': []
 
   'hosts':
@@ -108,8 +108,7 @@ nsswitch__default_database_map:
     - [ 'mdns_minimal', '[NOTFOUND=return]' ]
 
     - replace: 'mdns4_minimal'
-      service: '{{ "mdns_minimal" if (ansible_local | d() and ansible_local.avahi | d() and
-                                      ansible_local.avahi.ipv6 | bool) else "mdns4_minimal" }}'
+      service: '{{ "mdns_minimal" if (ansible_local.avahi.ipv6 | d(False)) else "mdns4_minimal" }}'
       action:  '[NOTFOUND=return]'
 
     - [ 'resolve', '[!UNAVAIL=return]' ]

--- a/ansible/roles/nsswitch/tasks/main.yml
+++ b/ansible/roles/nsswitch/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # Copyright (C) 2017 Maciej Delmanowski <drybjed@gmail.com>
-# Copyright (C) 2017 DebOps <https://debops.org/>
+# Copyright (C) 2017-2026 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-only
 
 - name: Import DebOps global handlers
@@ -35,16 +35,4 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  register: nsswitch__register_config
-  when: nsswitch__enabled | bool
-
-  # systemd-logind service needs to be restarted for authentication of users
-  # from remote sources (ldap, sss) to work correctly. The NSS configuration is
-  # not reloaded automatically on changes.
-  # Ref: https://bugzilla.redhat.com/show_bug.cgi?id=132608#c4
-- name: Restart systemd-logind to fix NSS lookups
-  ansible.builtin.service:  # noqa no-handler
-    name: 'systemd-logind'
-    state: 'restarted'
-  when: ansible_service_mgr == 'systemd' and nsswitch__register_config is changed and
-        ansible_connection != 'local'
+  when: nsswitch__enabled

--- a/ansible/roles/nsswitch/templates/etc/ansible/facts.d/nsswitch.fact.j2
+++ b/ansible/roles/nsswitch/templates/etc/ansible/facts.d/nsswitch.fact.j2
@@ -2,12 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (C) 2017 Maciej Delmanowski <drybjed@gmail.com>
-# Copyright (C) 2017 DebOps <https://debops.org/>
+# Copyright (C) 2017-2026 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-only
 
 # {{ ansible_managed }}
 
-from __future__ import print_function
 from json import loads, dumps
 from sys import exit
 import os
@@ -18,7 +17,7 @@ nss_databases = loads('''{{ nsswitch__combined_database_map
                             | list | sort | to_nice_json }}''')
 
 output = loads('''{{ ({
-    "enabled": nsswitch__enabled | bool
+    "enabled": nsswitch__enabled
 }) | to_nice_json }}''')
 
 output_conf = {}

--- a/docs/ansible/roles/nsswitch/getting-started.rst
+++ b/docs/ansible/roles/nsswitch/getting-started.rst
@@ -1,5 +1,5 @@
 .. Copyright (C) 2017 Maciej Delmanowski <drybjed@gmail.com>
-.. Copyright (C) 2017 DebOps <https://debops.org/>
+.. Copyright (C) 2017-2026 DebOps <https://debops.org/>
 .. SPDX-License-Identifier: GPL-3.0-only
 
 Getting started
@@ -24,23 +24,12 @@ used in and if they should be used in a particular NSS database lookup.
 The default role configuration shouldn't affect the :file:`/etc/nsswitch.conf`
 configuration file provided by the OS distribution, apart from changing the
 mDNS service from IPv4 to both IPv6 and IPv4 (see :ref:`nsswitch__ref_mdns` for
-more details). The convention on Debian is that different packages which
+more details). The convention in Debian is that different packages which
 provide NSS services modify the :file:`/etc/nsswitch.conf` configuration file
 themselves, therefore the role tries to respect local modifications. A set of
 various NSS services (LDAP, SSS, Winbind) should be detected and enabled
 accordingly, however the order of the services comes from the role itself and
 might change from the one created by the Debian packages.
-
-According to the :man:`nsswitch.conf(5)`, processes that use the NSS
-configuration file read the :file:`/etc/nsswitch.conf` only once, therefore
-a restart of these processes (for example :command:`nscd` or :command:`sssd`)
-might be needed.
-
-At the moment the role restarts the :command:`systemd-logind` service on the
-configuration changes, but only when the playbook is executed against a remote
-host, to avoid breaking local user session. Changes on ``localhost`` might need
-the system to be restarted for :command:`systemd-logind` to reload the new
-configuration correctly.
 
 
 .. _nsswitch__ref_mdns:


### PR DESCRIPTION
First, systemd needs to be included for "shadow" and "gshadow" as well in order to handle users created via the /usr/lib/sysusers.d/ mechanism (since systemd 251.3-2). systemd (258.1-2) will automatically add these groups (to fix bug #1118640), but debops.nsswitch will undo that fix, which breaks any package using the /usr/lib/sysusers.d/ mechanism to create users (e.g. gdm3).

Second, since glibc 2.33 (Bookworm onwards), nsswitch.conf is automatically reloaded if the file is changed, so update the tasks and docs to remove an unnecessary restart.