### PR TITLE
[PKI] Extend ACME DNS support to other providers

### DIFF
--- a/ansible/roles/pki/files/usr/local/lib/pki/pki-realm
+++ b/ansible/roles/pki/files/usr/local/lib/pki/pki-realm
@@ -1244,13 +1244,23 @@ request_acme_dns_certificate() {
     # shellcheck disable=SC2086
     all_dns_str=$(echo " "${all_dns_str} | sed 's/ / -d /g')
 
-    if test "${config['acme_ca']}" == 'le-live-v2'; then
-      # shellcheck disable=SC2086
-      certbot certonly -n --authenticator ${config['acme_type']} --expand --agree-tos "${email}" --${config['acme_type']}-credentials ${credentials} ${all_dns_str}
-    elif test "${config['acme_ca']}" == 'le-staging-v2'; then
-      # shellcheck disable=SC2086
-      certbot certonly --test-cert -n --authenticator ${config['acme_type']} --expand --agree-tos "${email}" --${config['acme_type']}-credentials ${credentials} ${all_dns_str}
-    fi
+    local acme_extra
+
+    case "${config['acme_ca']}" in
+        *"live"*)
+            acme_extra=""
+            ;;
+        *"staging"*)
+            acme_extra="--test-cert"
+            ;;
+        *)
+            log_message "Invalid 'acme_ca' value: $acme_ca"
+            return
+            ;;
+    esac
+
+    # shellcheck disable=SC2086
+    certbot certonly $acme_extra -n --authenticator ${config['acme_type']} --expand --agree-tos "${email}" --${config['acme_type']}-credentials ${credentials} --server "${config['acme_ca_api']}" ${all_dns_str}
 
     local folder
     local letsencrypt

--- a/docs/ansible/roles/pki/acme-certbot-integration.rst
+++ b/docs/ansible/roles/pki/acme-certbot-integration.rst
@@ -215,4 +215,18 @@ certificates themselves were registered successfully, but take care otherwise.
 To avoid rate limiting, you might want to consider enabling the staging CA for
 testing purposes.
 
+The DNS propagation wait time can be a common issue when using the DNS-01 challenge, 
+especially if your DNS provider has a long propagation time or the default wait time
+is overly conservative.
+You can adjust the wait time by adding the appropriate configuration variable 
+(e.g. dns-cloudflare_propagation_seconds) to :envvar:`pki_certbot_configuration`.
+
+Additional ACME Authority providers may be supported by the role.  
+To enable additional ACME providers, you can update 
+the :envvar:`pki_acme_ca_api_map` variable to the appropriate map entry. The name must
+contain 'live' for the production CA and 'staging' for the staging CA.  The value must be the API URL for the ACME provider.
+The --test-cert option will be passed to :command:`certbot` when the CA name contains 'staging'; 
+ACME providers may not honor the option and still issue a valid certificate, 
+so be sure to check the documentation for your ACME provider.
+
 .. __: https://letsencrypt.org/docs/rate-limits/

--- a/docs/ansible/roles/pki/acme-integration.rst
+++ b/docs/ansible/roles/pki/acme-integration.rst
@@ -16,10 +16,10 @@ certificate renewal. It was designed to enable easy deployment of X.509
 certificates from `Let's Encrypt`_.
 
 The ``debops.pki`` Ansible role provides support for the ACMEv2 protocol which
-is used by default with the Let's Encrypt (there is a possibility to integrate
-other similar services in the future). Interaction with the ACME Certificate
-Authority is performed using the acme-tiny_ alternative client written in
-Python.
+is used by default with the Let's Encrypt.  Many Certificate Authorities have added
+support for the ACMEv2 protocol; therefore, the role may work with them as well.
+Interaction with the ACME Certificate Authority is performed using the Python-based 
+acme-tiny_ client for HTTP challenges and the certbot client for DNS challenges.
 
 Let's Encrypt rate limits
 -------------------------


### PR DESCRIPTION
Added support for ACME DNS-01 for other providers; ACME HTTP-01 already passes the "--server" flag.  Additional providers must be added to pki_acme_ca_api_map variable.  

Documentation, including a warnings that "staging" may result in a **valid** certificate, has been updated.