### PR TITLE
[docker_service] Add docker_service playbook import to layer/app.yml

### DIFF
--- a/ansible/playbooks/layer/app.yml
+++ b/ansible/playbooks/layer/app.yml
@@ -68,3 +68,6 @@
 
 - name: Configure Debconf-based application packages
   import_playbook: '../service/debconf.yml'
+
+- name: Manage Docker container services
+  import_playbook: '../service/docker_service.yml'


### PR DESCRIPTION
The service/docker_service.yml playbook was added in commit 5305a2850 ('Add docker_service role for managing Docker container services') and subsequently extended (postgresql/nginx pre_tasks, secret import, Docker network support, etc.) but was never wired into site.yml via any layer/*.yml.

This means hosts in the debops_service_docker_service group only get their Docker containers deployed when the playbook is invoked explicitly:

    debops run service/docker_service -l <host>

Adding the import to layer/app.yml at the end (after debconf) so that 'debops run site -l <host>' deploys docker_service-managed containers end-to-end (including nginx dependent_servers and postgresql dependent_roles which the playbook configures via pre_tasks).