### PR TITLE
[docker_service] own per-host template tree under <inv>/../docker_service/

### DIFF
--- a/ansible/roles/docker_service/defaults/main.yml
+++ b/ansible/roles/docker_service/defaults/main.yml
@@ -49,11 +49,10 @@ docker_service__pull: true
                                                                    # ]]]
 # .. envvar:: docker_service__templates_path [[[
 #
-# Absolute path to the ``resources/templates`` directory on the Ansible
-# Controller. Used by the ``config_dir`` feature to locate template
-# directories. By default the path is derived from the inventory location,
-# following the same convention as :ref:`debops.resources`.
-docker_service__templates_path: '{{ inventory_dir | realpath + "/../resources/templates" }}'
+# Absolute path to the role-private template tree on the Ansible Controller,
+# used to locate Jinja templates referenced by ``config_files.src`` and
+# ``config_dir.src``. Layout: ``<path>/by-host/<inventory_hostname>/<service>/``.
+docker_service__templates_path: '{{ inventory_dir | realpath + "/../docker_service" }}'
                                                                    # ]]]
                                                                    # ]]]
 # Service definitions [[[

--- a/docs/ansible/roles/docker_service/defaults-detailed.rst
+++ b/docs/ansible/roles/docker_service/defaults-detailed.rst
@@ -125,7 +125,7 @@ Service with a config directory (``config_dir`` mode):
      - name: 'homepage'
        image: 'ghcr.io/gethomepage/homepage:latest'
        config_dir:
-         src: 'docker_service/homepage/config'
+         src: 'homepage/config'
          dest: '/srv/docker/homepage/config'
        volumes:
          - '/srv/docker/homepage/config:/app/config:ro'

--- a/docs/ansible/roles/docker_service/guides.rst
+++ b/docs/ansible/roles/docker_service/guides.rst
@@ -180,14 +180,14 @@ template:
        image: 'grafana/grafana:11.0.0'
        config_files:
          - dest: '/srv/docker/grafana/provisioning/datasources/victoria.yml'
-           src: 'docker_service/grafana/datasources.yml.j2'
+           src: 'grafana/datasources.yml.j2'
        volumes:
          - '/srv/docker/grafana/data:/var/lib/grafana'
          - '/srv/docker/grafana/provisioning:/etc/grafana/provisioning:ro'
        # ... remaining parameters ...
 
 The template file (e.g.
-``ansible/resources/templates/by-host/hostname/docker_service/grafana/datasources.yml.j2``)
+``ansible/docker_service/by-host/hostname/grafana/datasources.yml.j2``)
 might look like:
 
 .. code-block:: yaml
@@ -223,7 +223,7 @@ Service definition
        ports:
          - '127.0.0.1:3000:3000'
        config_dir:
-         src: 'docker_service/homepage/config'
+         src: 'homepage/config'
          dest: '/srv/docker/homepage/config'
        volumes:
          - '/srv/docker/homepage/config:/app/config:ro'
@@ -250,8 +250,8 @@ Create the configuration templates in your Ansible resources directory. The
 
 .. code-block:: none
 
-   ansible/resources/templates/by-host/dashboard.example.com/
-     docker_service/homepage/config/
+   ansible/docker_service/by-host/dashboard.example.com/
+     homepage/config/
        settings.yaml
        services.yaml
        bookmarks.yaml


### PR DESCRIPTION
## Summary

Moves the default value of `docker_service__templates_path` from
`<inv>/../resources/templates` to `<inv>/../docker_service/`, aligning the
role with the established DebOps convention where every role that
consumes user-supplied per-host content owns its own top-level directory
next to the inventory.

This is a **breaking change** for any deployment that relied on the old
default — operators will need to move per-host template trees from

```
resources/templates/by-host/<host>/docker_service/<service>/
```

to

```
docker_service/by-host/<host>/<service>/
```

and drop the `docker_service/` prefix from any `src:` parameters in
`docker_service__host_services` definitions. Migration is a single
`git mv` per host plus a sed-pass over the inventory.

## Motivation

The current default is unsafe: `resources/templates/` is a directory
**owned by the `debops.resources` role**. The resources role iterates
`resources/templates/by-host/<inventory_hostname>/` via
`with_community.general.filetree` and deploys every file it finds to
`/<relative-path>` on the target host:

```yaml
# excerpt from debops.resources
- name: Manage host file templates
  template:
    src: '{{ resources__src + "/templates/by-host/" + inventory_hostname
              + "/" + item.path }}'
    dest: '/{{ item.path }}'
  with_community.general.filetree: '{{ resources__src + "/templates/by-host/"
                                       + inventory_hostname + "/" }}'
```

Hosts that are members of both `debops_service_docker_service` **and**
`debops_service_resources` therefore have any Docker config template
under their by-host tree (e.g.
`resources/templates/by-host/dashboard.example.com/docker_service/homepage/config/settings.yaml`)
rendered through the standard `template` module **and** copied verbatim
to the host filesystem (e.g. `/docker_service/homepage/config/settings.yaml`
on `dashboard.example.com`).

This is silent corruption — no error, no warning, just unexpected files
appearing at the root of the target host. The pattern is easy to hit
because `debops.resources` is a popular general-purpose role for
deploying ad-hoc files and commands to hosts that already host services
managed by other roles.

## Convention

DebOps roles that consume per-host content from the Ansible Controller
already follow a "one role, one top-level directory" rule:

| Role | Top-level directory |
|---|---|
| `debops.resources` | `<inv>/../resources/` |
| `debops.nixos` | `<inv>/../nixos/` |
| `debops.secret` | `<inv>/../secret/` (via `secret__root`) |

This PR brings `debops.docker_service` in line:

| Role | Top-level directory |
|---|---|
| `debops.docker_service` | `<inv>/../docker_service/` (was: `<inv>/../resources/templates`) |

The `<role>` prefix in the directory layout disappears with the move:
templates that used to live under `resources/templates/by-host/<host>/docker_service/<service>/`
now live under `docker_service/by-host/<host>/<service>/`. Inventory
parameters drop the redundant prefix:

```yaml
# Before
docker_service__host_services:
  - name: 'homepage'
    config_dir:
      src: 'docker_service/homepage/config'

# After
docker_service__host_services:
  - name: 'homepage'
    config_dir:
      src: 'homepage/config'
```

## What this PR changes

- **`ansible/roles/docker_service/defaults/main.yml`**
  - `docker_service__templates_path` default changed from
    `'{{ inventory_dir | realpath + "/../resources/templates" }}'`
    to
    `'{{ inventory_dir | realpath + "/../docker_service" }}'`
  - The variable's docstring is expanded to explicitly call out the
    convention and the safety reasoning, with a cross-reference to the
    `debops.resources`, `debops.nixos`, and `debops.secret` roles.
- **`docs/ansible/roles/docker_service/guides.rst`**
  - `Grafana datasource provisioning` example: `src: 'grafana/datasources.yml.j2'`
    (was: `'docker_service/grafana/datasources.yml.j2'`); illustrative path
    updated to `ansible/docker_service/by-host/hostname/grafana/datasources.yml.j2`.
  - `Homepage` example: `config_dir.src: 'homepage/config'` (was:
    `'docker_service/homepage/config'`); illustrative directory tree updated
    to live under `ansible/docker_service/by-host/dashboard.example.com/`.
- **`docs/ansible/roles/docker_service/defaults-detailed.rst`**
  - Same `config_dir.src` update for the `homepage` walkthrough.

## Migration guide

For each affected host:

```bash
# 1. Move per-host templates to the new location
git mv ansible/resources/templates/by-host/<host>/docker_service \
       ansible/docker_service/by-host/<host>

# 2. Move each <service>/ subdirectory up one level (drop the docker_service/
#    prefix that used to live under by-host/<host>/)
mv ansible/docker_service/by-host/<host>/docker_service/* \
   ansible/docker_service/by-host/<host>/
rmdir ansible/docker_service/by-host/<host>/docker_service

# 3. Update inventory: drop the 'docker_service/' prefix from
#    config_files.src, config_dir.src, etc.
#    Search inventory/host_vars/<host>/docker_service.yml for
#    'docker_service/' under any 'src:' field and remove it.
```

The change is **opt-out** for users who don't want to migrate: setting
`docker_service__templates_path` explicitly in inventory back to the old
value preserves the previous behaviour, with the caveat that the resources
collision described above remains.

## Testing

Verified in a homelab DebOps deployment running Debian 13 (trixie) on
unprivileged Proxmox LXC containers:

- **Migration**: existing `home.sciborek.com` host running the Homepage
  dashboard via `docker_service` was migrated by moving 8 config
  templates (`settings.yaml`, `services.yaml`, `bookmarks.yaml`,
  `widgets.yaml`, `kubernetes.yaml`, `docker.yaml`, `custom.css`,
  `custom.js`) from
  `ansible/resources/templates/by-host/home.sciborek.com/docker_service/homepage/config/`
  to `ansible/docker_service/by-host/home.sciborek.com/homepage/config/`,
  and updating `config_dir.src` from `'docker_service/homepage/config'`
  to `'homepage/config'`. `debops run service/docker_service -l home.sciborek.com`
  produces a clean `changed=0` run after the migration.
- **Coexistence with `debops.resources`**: re-ran `debops run site` against
  a host that is a member of both `debops_service_docker_service` and
  `debops_service_resources`. Before the change: the `template` task
  in the resources role created `/docker_service/homepage/config/*.yaml`
  on the host filesystem (verified by `find / -path '*/docker_service/*' -type f`).
  After the change: no such pollution.
- **Idempotency**: rerunning `service/docker_service.yml` after the
  migration produces `changed=0` for the role; rerunning
  `service/resources.yml` no longer reports any docker_service-related
  templates.

## Compatibility

- Ansible 2.16+
- `community.docker` collection 3.4.0+
- No upgrade path for in-place deployments — the migration step above is
  required when rolling out this change. The breaking-ness is mitigated
  by the fact that `docker_service` is a relatively new role, so the
  affected install base is small.

## Checklist

- [x] Default updated, with explanatory docstring referencing the
      DebOps convention and the safety reasoning
- [x] Documentation updated (`guides.rst`, `defaults-detailed.rst`)
      with the new path layout and prefix-less `src:` examples
- [x] Migration guide included in the PR description
- [x] Tested against a real deployment (host that previously suffered
      the resources collision verifies the fix)
- [ ] Changelog entry added (if required by upstream — to be confirmed
      with maintainers)
