### PR TITLE
postgresql_server: omit db_user_namespace on PostgreSQL 14+

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -80,6 +80,15 @@ General
   preferred key exchange, cipher and MAC algorithms. OpenSSH v10.x+ versions
   should now be detected correctly.
 
+:ref:`debops.postgresql_server` role
+''''''''''''''''''''''''''''''''''
+
+- The ``postgresql.conf`` template no longer emits the ``db_user_namespace``
+  parameter on PostgreSQL 14 and newer, where it was removed and causes the
+  server to refuse to start (e.g. Debian 13 / Trixie packages). The setting
+  is still rendered for older major versions so existing inventories can
+  override it via ``item.db_user_namespace``.
+
 :ref:`debops.pki` role
 ''''''''''''''''''''''
 

--- a/ansible/roles/postgresql_server/templates/etc/postgresql/postgresql.conf.j2
+++ b/ansible/roles/postgresql_server/templates/etc/postgresql/postgresql.conf.j2
@@ -76,7 +76,10 @@ password_encryption = {{ item.password_encryption | d('scram-sha-256') }}
 {% else %}
 password_encryption = {{ item.password_encryption | d('on') }}
 {% endif %}
+{% if (item.version | d(postgresql_server__version)) is version_compare('14','<') %}
+{# https://www.postgresql.org/docs/14/release-14.html - parameter removed in 14 #}
 db_user_namespace = {{ item.db_user_namespace | d('off') }}
+{% endif %}
 
 
 # - Kerberos and GSSAPI -


### PR DESCRIPTION
The db_user_namespace parameter was removed in PostgreSQL 14. Debian 13 (Trixie) ships PG 14+ and fails to start when the parameter is still present in postgresql.conf generated by the role template.

Gate the setting with a version_compare('< 14') block so older clusters keep the parameter (and can override it via item.db_user_namespace) while newer installs no longer receive an invalid line.