### PR TITLE
chore(sudo): ubuntu 26 use sudo-rs

### DIFF
--- a/ansible/roles/sudo/defaults/main.yml
+++ b/ansible/roles/sudo/defaults/main.yml
@@ -28,9 +28,14 @@ sudo__enabled: True
 # .. envvar:: sudo__base_packages [[[
 #
 # List of base APT packages to install for :command:`sudo` support.
-sudo__base_packages: '{{ ["sudo-ldap"]
-                         if sudo__ldap_enabled | bool
-                         else ["sudo"] }}'
+sudo__base_packages: >-
+  {{ ["sudo-ldap"] if sudo__ldap_enabled is truthy
+                   else
+     ["sudo-rs"]   if (ansible_distribution == "Ubuntu"
+                       and ansible_facts.distribution_major_version is version_compare('26', '>='))
+                   else
+     ["sudo"]
+  }}
 
                                                                    # ]]]
 # .. envvar:: sudo__packages [[[

--- a/ansible/roles/system_groups/defaults/main.yml
+++ b/ansible/roles/system_groups/defaults/main.yml
@@ -107,8 +107,11 @@ system_groups__default_list:
   - name: '{{ system_groups__prefix }}admins'
     sudoers_filename: 'system_groups-admins'
     sudoers: |
+      {% if not (ansible_distribution == "Ubuntu"
+                 and ansible_facts.distribution_major_version is version_compare('26', '>=')) %}
       # This might be required to allow Ansible pipelining connections
       Defaults: %{{ system_groups__prefix }}admins !requiretty
+      {% endif %}
 
       # This variable is used to configure access by Ansible Controller hosts
       Defaults: %{{ system_groups__prefix }}admins env_check += "SSH_CLIENT"


### PR DESCRIPTION
As ubuntu 26 use `sudo-rs` now, we should avoid to install the old `sudo`
alongside.

Unfortunately `sudo-rs` does not support all `sudo` configurations and using
'!requiretty' would not pass the validation of the sudoers files.

Note that I did not test sudo with ldap, so further attention may be required.

https://ubuntu.com/server/docs/reference/other-tools/sudo-rs/