### PR TITLE
add an rsyslog__shell variable and change the default shell to /usr/s…

### DIFF
--- a/ansible/roles/rsyslog/defaults/main.yml
+++ b/ansible/roles/rsyslog/defaults/main.yml
@@ -124,6 +124,12 @@ rsyslog__home: '{{ "/home/syslog"
                    if (ansible_distribution in ["Ubuntu"])
                    else "/var/log" }}'
 
+ # .. envvar:: rsyslog__shell [[[
+#
+# The shell of the :envvar:`rsyslog__user` user.
+# Takes effect only when the unprivileged mode is enabled.
+rsyslog__shell: /usr/sbin/nologin
+
                                                                    # ]]]
 # .. envvar:: rsyslog__file_owner [[[
 #

--- a/ansible/roles/rsyslog/tasks/main.yml
+++ b/ansible/roles/rsyslog/tasks/main.yml
@@ -56,7 +56,7 @@
     groups: '{{ rsyslog__append_groups | join(",") | default(omit) }}'
     append: True
     home: '{{ rsyslog__home }}'
-    shell: '/bin/false'
+    shell: '{{ rsyslog__shell }}'
     state: 'present'
     createhome: False
     system: True


### PR DESCRIPTION
When rolling out the rsyslog role it changes the shell of the already present syslog user from /usr/sbin/nologin to /bin/false. I would rather keep it the /usr/sbin/nologin shell which is the default shell according to the adduser manpage:

> Unless  a  shell  is explicitly set with the --shell option, the new system user will have the shell set to /usr/sbin/nologin.

The rsyslog.postinst doesn't specify the shell thus it is created with the /usr/sbin/nologin shell when the package is installed

```
case "$1" in
    configure)
        adduser --system --group --no-create-home --quiet syslog || true
```

To make the shell configurable I have added the `rsyslog__shell` variable with the default /usr/sbin/nologin but this could also be /bin/false if you prefer that.