### PR TITLE
layer: move docker_server before Docker application roles in app.yml

### DIFF
--- a/ansible/playbooks/layer/app.yml
+++ b/ansible/playbooks/layer/app.yml
@@ -69,5 +69,8 @@
 - name: Configure Debconf-based application packages
   import_playbook: '../service/debconf.yml'
 
+- name: Configure Docker Engine service
+  import_playbook: '../service/docker_server.yml'
+
 - name: Manage Docker container services
   import_playbook: '../service/docker_service.yml'

--- a/ansible/playbooks/layer/virt.yml
+++ b/ansible/playbooks/layer/virt.yml
@@ -9,9 +9,6 @@
 - name: Configure LXD service
   import_playbook: '../service/lxd.yml'
 
-- name: Configure Docker Engine service
-  import_playbook: '../service/docker_server.yml'
-
 - name: Configure libvirt daemon service
   import_playbook: '../service/libvirtd.yml'
 


### PR DESCRIPTION
## Summary

Moves `docker_server` from `layer/virt.yml` to `layer/app.yml`, placing it
immediately before `docker_service` and `docker_compose_service`. This ensures
Docker Engine is installed before any Docker-based application role runs when
executing the full `site.yml` playbook.

## Motivation

`docker_service` and `docker_compose_service` in `layer/app.yml` depend on
Docker Engine being present in `PATH`. Previously, `docker_server` was placed
in `layer/virt.yml`, which is imported **after** `layer/app.yml` in `site.yml`.

On a fresh deployment, running `debops run site` therefore resulted in:

```
TASK [debops.debops.docker_service : ...] ***
fatal: [host]: FAILED! => {"msg": "Cannot find docker CLI in path ..."}
```

The workaround was to run `debops run service/docker_server` first, then
`debops run site`, which is not the expected behaviour for a first-time
`site.yml` run.

## Change

```diff
# ansible/playbooks/layer/app.yml
+- name: 'Manage Docker server'
+  import_playbook: '../service/docker_server.yml'
+
 - name: 'Manage Docker service'
   import_playbook: '../service/docker_service.yml'
```

```diff
# ansible/playbooks/layer/virt.yml
-- name: 'Manage Docker server'
-  import_playbook: '../service/docker_server.yml'
-
```

`docker_server` is placed directly before `docker_service` in `layer/app.yml`,
preserving the natural dependency order. The `layer/virt.yml` file is updated
to remove the now-redundant entry.

## Testing

Run a full `debops run site` against a fresh host with `docker_service` or
`docker_compose_service` in the inventory — Docker Engine installs cleanly
before either application role runs.