### PR TITLE
elasticsearch: always emit xpack ssl.enabled settings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -111,6 +111,13 @@ General
 - The role should now correctly process the list of APT packages to install on
   Ansible v2.19+ instead of creating an empty list.
 
+:ref:`debops.elasticsearch` role
+''''''''''''''''''''''''''''''''
+
+- Elasticsearch v8.0+ now requires ``xpack.security.*.ssl.enabled`` settings to
+  be explicitly present in the configuration when any related SSL options are
+  configured.
+
 :ref:`debops.libvirt` role
 ''''''''''''''''''''''''''
 

--- a/ansible/roles/elasticsearch/defaults/main.yml
+++ b/ansible/roles/elasticsearch/defaults/main.yml
@@ -722,8 +722,8 @@ elasticsearch__default_configuration:
     state: '{{ "present" if elasticsearch__xpack_enabled | bool else "absent" }}'
 
   - name: 'xpack.security.http.ssl.enabled'
-    value: True
-    state: '{{ "present" if elasticsearch__xpack_enabled | bool else "absent" }}'
+    value: '{{ elasticsearch__xpack_enabled | bool }}'
+    state: 'present'
 
   - name: 'xpack.security.http.ssl.verification_mode'
     value: 'certificate'
@@ -749,8 +749,8 @@ elasticsearch__default_configuration:
     state: '{{ "present" if elasticsearch__xpack_enabled | bool else "absent" }}'
 
   - name: 'xpack.security.transport.ssl.enabled'
-    value: True
-    state: '{{ "present" if elasticsearch__xpack_enabled | bool else "absent" }}'
+    value: '{{ elasticsearch__xpack_enabled | bool }}'
+    state: 'present'
 
   - name: 'xpack.security.transport.ssl.verification_mode'
     value: 'certificate'


### PR DESCRIPTION
Elasticsearch 8.0+ requires all xpack.security.*.ssl.enabled settings to be explicitly present in the configuration when any related SSL options are configured. When elasticsearch__xpack_enabled evaluated to False, the role previously removed these entries entirely, which caused a fatal startup error if a user configured transport or HTTP SSL via other inventory variables (e.g. keystore passwords).

The enabled flags now always appear in the generated configuration, set to 'true' when xpack is enabled and 'false' when not. Users can override via host/group configuration if needed.