### PR TITLE
fix(rsyslog): update rsyslog__home for Ubuntu 24.04 and add rsyslog__shell

### DIFF
--- a/ansible/roles/rsyslog/defaults/main.yml
+++ b/ansible/roles/rsyslog/defaults/main.yml
@@ -120,9 +120,24 @@ rsyslog__append_groups: '{{ ["ssl-cert"] if (rsyslog__unprivileged | bool
 #
 # The home directory of the :envvar:`rsyslog__user` user, dependent on the OS
 # defaults. Takes effect only when the unprivileged mode is enabled.
-rsyslog__home: '{{ "/home/syslog"
-                   if (ansible_distribution in ["Ubuntu"])
-                   else "/var/log" }}'
+# On Ubuntu 24.04+, the ``syslog`` user is created by the package with
+# ``/nonexistent`` as the home directory (upstream change from ``/home/syslog``).
+rsyslog__home: '{{ "/nonexistent"
+                   if (ansible_distribution in ["Ubuntu"] and
+                       ansible_distribution_version is version("24.04", ">="))
+                   else ("/home/syslog"
+                         if (ansible_distribution in ["Ubuntu"])
+                         else "/var/log") }}'
+
+                                                                   # ]]]
+# .. envvar:: rsyslog__shell [[[
+#
+# The login shell of the :envvar:`rsyslog__user` user. Ubuntu creates the
+# ``syslog`` user with ``/usr/sbin/nologin`` on all versions; other systems
+# use ``/bin/false``. Both values prevent interactive login.
+rsyslog__shell: '{{ "/usr/sbin/nologin"
+                    if ansible_distribution in ["Ubuntu"]
+                    else "/bin/false" }}'
 
                                                                    # ]]]
 # .. envvar:: rsyslog__file_owner [[[

--- a/ansible/roles/rsyslog/tasks/main.yml
+++ b/ansible/roles/rsyslog/tasks/main.yml
@@ -56,7 +56,7 @@
     groups: '{{ rsyslog__append_groups | join(",") | default(omit) }}'
     append: True
     home: '{{ rsyslog__home }}'
-    shell: '/bin/false'
+    shell: '{{ rsyslog__shell }}'
     state: 'present'
     createhome: False
     system: True


### PR DESCRIPTION
## Summary

Fix the `common_playbook` CI failure in `debops.rsyslog` on Ubuntu 24.04.

On Ubuntu 24.04, the `rsyslogd` daemon starts early at boot (via socket
activation) and is already running when the **Create required system user**
task executes. The task called `usermod` to update three attributes
simultaneously, which fails with:

> `usermod: user syslog is currently used by process <PID>`

Root cause: Ubuntu 24.04 changed the `syslog` user's home directory from
`/home/syslog` to `/nonexistent` (fix for upstream packaging bug
[LP#1898753](https://bugs.launchpad.net/bugs/1898753)). Combined with the
shell mismatch (`/usr/sbin/nologin` vs `/bin/false`), this triggered
`usermod` for multiple attributes at once.

## Changes

**`defaults/main.yml`**

- `rsyslog__home`: add version check — Ubuntu >= 24.04 uses `/nonexistent`
  (matching the OS-installed value), Ubuntu < 24.04 keeps `/home/syslog`,
  other systems keep `/var/log`
- `rsyslog__shell`: new variable — Ubuntu has always created the `syslog`
  user with `/usr/sbin/nologin`; other systems use `/bin/false`. Both
  values prevent interactive login.

**`tasks/main.yml`**

- Replace hardcoded `shell: '/bin/false'` with `shell: '{{ rsyslog__shell }}'`

## Effect

With matching `home` and `shell` values, `ansible.builtin.user` on
Ubuntu 24.04 detects no changes to those attributes and calls `usermod`
only for supplementary group membership (`ssl-cert`). Unlike home/shell
changes, group-only `usermod` does not trigger the `user_busy()` lock and
succeeds even while `rsyslogd` is running.

## Test plan

- CI Pipeline: `common_playbook` job passes on Ubuntu 24.04
- All other CI jobs pass