### PR TITLE
feat(lookup_plugins): add global config dir fallback for Galaxy installs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -70,6 +70,14 @@ General
   installations should update their Ansible Collections to get the updated
   Community collection.
 
+- The ``debops.debops.file_src``, ``debops.debops.template_src`` and
+  ``debops.debops.task_src`` lookup plugins now fall back to reading override
+  paths from the global DebOps configuration directories
+  (:file:`~/.config/debops/conf.d/` and system-wide paths) when the
+  ``debops`` Python module is not available. This allows these plugins to work
+  when the collection is installed via Ansible Galaxy without the ``debops``
+  Python package.
+
 :ref:`debops.elasticsearch` role
 ''''''''''''''''''''''''''''''''
 

--- a/ansible/plugins/lookup/file_src.py
+++ b/ansible/plugins/lookup/file_src.py
@@ -113,6 +113,58 @@ if parse(__ansible_version__) < parse("2.0"):
                         places.append(os.path.join(
                             project_root, custom_path))
 
+            # Fallback when the debops Python module is not available
+            # (e.g. installed via Ansible Galaxy). Read override paths
+            # directly from the global DebOps configuration directories.
+            if not conf_section:
+                _xdg = os.environ.get(
+                    "XDG_CONFIG_HOME",
+                    os.path.join(os.path.expanduser("~"), ".config"))
+                _cfg_dirs = [
+                    "/usr/lib/debops/conf.d",
+                    "/usr/local/lib/debops/conf.d",
+                    "/etc/debops/conf.d",
+                    os.path.join(_xdg, "debops", "conf.d"),
+                ]
+                _found = None
+                for _cd in _cfg_dirs:
+                    if not os.path.isdir(_cd):
+                        continue
+                    for _f in sorted(os.listdir(_cd)):
+                        _fp = os.path.join(_cd, _f)
+                        if _f.startswith(".") or not os.path.isfile(_fp):
+                            continue
+                        try:
+                            if _f.endswith(".json"):
+                                with open(_fp) as _fh:
+                                    _parsed = json.load(_fh)
+                            elif _f.endswith(".toml"):
+                                import tomllib as _tl
+                                with open(_fp, "rb") as _fh:
+                                    _parsed = _tl.load(_fh)
+                            elif _f.endswith((".yaml", ".yml")):
+                                import yaml as _yl
+                                with open(_fp) as _fh:
+                                    _parsed = _yl.safe_load(_fh)
+                            else:
+                                continue
+                        except Exception:
+                            continue
+                        if isinstance(_parsed, dict):
+                            _v = _parsed.get(
+                                "override_paths", {}).get("files_path")
+                            if _v:
+                                _found = _v
+                                break
+                    if _found:
+                        break
+                if _found:
+                    for _p in _found.split(":"):
+                        if os.path.isabs(_p):
+                            places.append(_p)
+                        else:
+                            places.append(os.path.join(os.getcwd(), _p))
+
             for term in terms:
                 if '_original_file' in inject:
                     relative_path = utils.path_dwim_relative(
@@ -176,6 +228,58 @@ else:
                     else:
                         places.append(os.path.join(
                             project_root, custom_path))
+
+            # Fallback when the debops Python module is not available
+            # (e.g. installed via Ansible Galaxy). Read override paths
+            # directly from the global DebOps configuration directories.
+            if not conf_section:
+                _xdg = os.environ.get(
+                    "XDG_CONFIG_HOME",
+                    os.path.join(os.path.expanduser("~"), ".config"))
+                _cfg_dirs = [
+                    "/usr/lib/debops/conf.d",
+                    "/usr/local/lib/debops/conf.d",
+                    "/etc/debops/conf.d",
+                    os.path.join(_xdg, "debops", "conf.d"),
+                ]
+                _found = None
+                for _cd in _cfg_dirs:
+                    if not os.path.isdir(_cd):
+                        continue
+                    for _f in sorted(os.listdir(_cd)):
+                        _fp = os.path.join(_cd, _f)
+                        if _f.startswith(".") or not os.path.isfile(_fp):
+                            continue
+                        try:
+                            if _f.endswith(".json"):
+                                with open(_fp) as _fh:
+                                    _parsed = json.load(_fh)
+                            elif _f.endswith(".toml"):
+                                import tomllib as _tl
+                                with open(_fp, "rb") as _fh:
+                                    _parsed = _tl.load(_fh)
+                            elif _f.endswith((".yaml", ".yml")):
+                                import yaml as _yl
+                                with open(_fp) as _fh:
+                                    _parsed = _yl.safe_load(_fh)
+                            else:
+                                continue
+                        except Exception:
+                            continue
+                        if isinstance(_parsed, dict):
+                            _v = _parsed.get(
+                                "override_paths", {}).get("files_path")
+                            if _v:
+                                _found = _v
+                                break
+                    if _found:
+                        break
+                if _found:
+                    for _p in _found.split(":"):
+                        if os.path.isabs(_p):
+                            places.append(_p)
+                        else:
+                            places.append(os.path.join(os.getcwd(), _p))
 
             for term in terms:
                 if 'role_path' in variables:

--- a/ansible/plugins/lookup/file_src.py
+++ b/ansible/plugins/lookup/file_src.py
@@ -117,34 +117,22 @@ if parse(__ansible_version__) < parse("2.0"):
             # (e.g. installed via Ansible Galaxy). Read override paths
             # directly from the global DebOps configuration directories.
             if not conf_section:
-                _xdg = os.environ.get(
-                    "XDG_CONFIG_HOME",
-                    os.path.join(os.path.expanduser("~"), ".config"))
-                _cfg_dirs = [
-                    "/usr/lib/debops/conf.d",
-                    "/usr/local/lib/debops/conf.d",
-                    "/etc/debops/conf.d",
-                    os.path.join(_xdg, "debops", "conf.d"),
-                ]
                 _found = None
-                for _cd in _cfg_dirs:
-                    if not os.path.isdir(_cd):
-                        continue
-                    for _f in sorted(os.listdir(_cd)):
-                        _fp = os.path.join(_cd, _f)
-                        if _f.startswith(".") or not os.path.isfile(_fp):
-                            continue
+
+                for _ext in [".json", ".toml", ".yaml", ".yml"]:
+                    _pp = os.path.join(os.getcwd(), ".debops" + _ext)
+                    if os.path.isfile(_pp):
                         try:
-                            if _f.endswith(".json"):
-                                with open(_fp) as _fh:
+                            if _pp.endswith(".json"):
+                                with open(_pp) as _fh:
                                     _parsed = json.load(_fh)
-                            elif _f.endswith(".toml"):
+                            elif _pp.endswith(".toml"):
                                 import tomllib as _tl
-                                with open(_fp, "rb") as _fh:
+                                with open(_pp, "rb") as _fh:
                                     _parsed = _tl.load(_fh)
-                            elif _f.endswith((".yaml", ".yml")):
+                            elif _pp.endswith((".yaml", ".yml")):
                                 import yaml as _yl
-                                with open(_fp) as _fh:
+                                with open(_pp) as _fh:
                                     _parsed = _yl.safe_load(_fh)
                             else:
                                 continue
@@ -154,16 +142,63 @@ if parse(__ansible_version__) < parse("2.0"):
                             _v = _parsed.get(
                                 "override_paths", {}).get("files_path")
                             if _v:
+                                for _p in _v.split(":"):
+                                    if os.path.isabs(_p):
+                                        places.append(_p)
+                                    else:
+                                        places.append(
+                                            os.path.join(os.getcwd(), _p))
                                 _found = _v
-                                break
-                    if _found:
                         break
-                if _found:
-                    for _p in _found.split(":"):
-                        if os.path.isabs(_p):
-                            places.append(_p)
-                        else:
-                            places.append(os.path.join(os.getcwd(), _p))
+
+                if not _found:
+                    _xdg = os.environ.get(
+                        "XDG_CONFIG_HOME",
+                        os.path.join(os.path.expanduser("~"), ".config"))
+                    _cfg_dirs = [
+                        "/usr/lib/debops/conf.d",
+                        "/usr/local/lib/debops/conf.d",
+                        "/etc/debops/conf.d",
+                        os.path.join(_xdg, "debops", "conf.d"),
+                    ]
+                    for _cd in _cfg_dirs:
+                        if not os.path.isdir(_cd):
+                            continue
+                        for _f in sorted(os.listdir(_cd)):
+                            _fp = os.path.join(_cd, _f)
+                            if _f.startswith(".") or not os.path.isfile(_fp):
+                                continue
+                            try:
+                                if _f.endswith(".json"):
+                                    with open(_fp) as _fh:
+                                        _parsed = json.load(_fh)
+                                elif _f.endswith(".toml"):
+                                    import tomllib as _tl
+                                    with open(_fp, "rb") as _fh:
+                                        _parsed = _tl.load(_fh)
+                                elif _f.endswith((".yaml", ".yml")):
+                                    import yaml as _yl
+                                    with open(_fp) as _fh:
+                                        _parsed = _yl.safe_load(_fh)
+                                else:
+                                    continue
+                            except Exception:
+                                continue
+                            if isinstance(_parsed, dict):
+                                _v = _parsed.get(
+                                    "override_paths", {}).get("files_path")
+                                if _v:
+                                    _found = _v
+                                    break
+                        if _found:
+                            break
+                    if _found:
+                        for _p in _found.split(":"):
+                            if os.path.isabs(_p):
+                                places.append(_p)
+                            else:
+                                places.append(
+                                    os.path.join(os.getcwd(), _p))
 
             for term in terms:
                 if '_original_file' in inject:
@@ -233,34 +268,22 @@ else:
             # (e.g. installed via Ansible Galaxy). Read override paths
             # directly from the global DebOps configuration directories.
             if not conf_section:
-                _xdg = os.environ.get(
-                    "XDG_CONFIG_HOME",
-                    os.path.join(os.path.expanduser("~"), ".config"))
-                _cfg_dirs = [
-                    "/usr/lib/debops/conf.d",
-                    "/usr/local/lib/debops/conf.d",
-                    "/etc/debops/conf.d",
-                    os.path.join(_xdg, "debops", "conf.d"),
-                ]
                 _found = None
-                for _cd in _cfg_dirs:
-                    if not os.path.isdir(_cd):
-                        continue
-                    for _f in sorted(os.listdir(_cd)):
-                        _fp = os.path.join(_cd, _f)
-                        if _f.startswith(".") or not os.path.isfile(_fp):
-                            continue
+
+                for _ext in [".json", ".toml", ".yaml", ".yml"]:
+                    _pp = os.path.join(os.getcwd(), ".debops" + _ext)
+                    if os.path.isfile(_pp):
                         try:
-                            if _f.endswith(".json"):
-                                with open(_fp) as _fh:
+                            if _pp.endswith(".json"):
+                                with open(_pp) as _fh:
                                     _parsed = json.load(_fh)
-                            elif _f.endswith(".toml"):
+                            elif _pp.endswith(".toml"):
                                 import tomllib as _tl
-                                with open(_fp, "rb") as _fh:
+                                with open(_pp, "rb") as _fh:
                                     _parsed = _tl.load(_fh)
-                            elif _f.endswith((".yaml", ".yml")):
+                            elif _pp.endswith((".yaml", ".yml")):
                                 import yaml as _yl
-                                with open(_fp) as _fh:
+                                with open(_pp) as _fh:
                                     _parsed = _yl.safe_load(_fh)
                             else:
                                 continue
@@ -270,16 +293,63 @@ else:
                             _v = _parsed.get(
                                 "override_paths", {}).get("files_path")
                             if _v:
+                                for _p in _v.split(":"):
+                                    if os.path.isabs(_p):
+                                        places.append(_p)
+                                    else:
+                                        places.append(
+                                            os.path.join(os.getcwd(), _p))
                                 _found = _v
-                                break
-                    if _found:
                         break
-                if _found:
-                    for _p in _found.split(":"):
-                        if os.path.isabs(_p):
-                            places.append(_p)
-                        else:
-                            places.append(os.path.join(os.getcwd(), _p))
+
+                if not _found:
+                    _xdg = os.environ.get(
+                        "XDG_CONFIG_HOME",
+                        os.path.join(os.path.expanduser("~"), ".config"))
+                    _cfg_dirs = [
+                        "/usr/lib/debops/conf.d",
+                        "/usr/local/lib/debops/conf.d",
+                        "/etc/debops/conf.d",
+                        os.path.join(_xdg, "debops", "conf.d"),
+                    ]
+                    for _cd in _cfg_dirs:
+                        if not os.path.isdir(_cd):
+                            continue
+                        for _f in sorted(os.listdir(_cd)):
+                            _fp = os.path.join(_cd, _f)
+                            if _f.startswith(".") or not os.path.isfile(_fp):
+                                continue
+                            try:
+                                if _f.endswith(".json"):
+                                    with open(_fp) as _fh:
+                                        _parsed = json.load(_fh)
+                                elif _f.endswith(".toml"):
+                                    import tomllib as _tl
+                                    with open(_fp, "rb") as _fh:
+                                        _parsed = _tl.load(_fh)
+                                elif _f.endswith((".yaml", ".yml")):
+                                    import yaml as _yl
+                                    with open(_fp) as _fh:
+                                        _parsed = _yl.safe_load(_fh)
+                                else:
+                                    continue
+                            except Exception:
+                                continue
+                            if isinstance(_parsed, dict):
+                                _v = _parsed.get(
+                                    "override_paths", {}).get("files_path")
+                                if _v:
+                                    _found = _v
+                                    break
+                        if _found:
+                            break
+                    if _found:
+                        for _p in _found.split(":"):
+                            if os.path.isabs(_p):
+                                places.append(_p)
+                            else:
+                                places.append(
+                                    os.path.join(os.getcwd(), _p))
 
             for term in terms:
                 if 'role_path' in variables:

--- a/ansible/plugins/lookup/file_src.py
+++ b/ansible/plugins/lookup/file_src.py
@@ -119,7 +119,7 @@ if parse(__ansible_version__) < parse("2.0"):
             if not conf_section:
                 _found = None
 
-                for _ext in [".json", ".toml", ".yaml", ".yml"]:
+                for _ext in [".yaml", ".yml", ".json", ".toml"]:
                     _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
                     if os.path.isfile(_project_path):
                         try:
@@ -156,10 +156,10 @@ if parse(__ansible_version__) < parse("2.0"):
                         "XDG_CONFIG_HOME",
                         os.path.join(os.path.expanduser("~"), ".config"))
                     _cfg_dirs = [
-                        "/usr/lib/debops/conf.d",
-                        "/usr/local/lib/debops/conf.d",
-                        "/etc/debops/conf.d",
                         os.path.join(_xdg, "debops", "conf.d"),
+                        "/etc/debops/conf.d",
+                        "/usr/local/lib/debops/conf.d",
+                        "/usr/lib/debops/conf.d",
                     ]
                     for _cfg_dir in _cfg_dirs:
                         if not os.path.isdir(_cfg_dir):
@@ -270,7 +270,7 @@ else:
             if not conf_section:
                 _found = None
 
-                for _ext in [".json", ".toml", ".yaml", ".yml"]:
+                for _ext in [".yaml", ".yml", ".json", ".toml"]:
                     _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
                     if os.path.isfile(_project_path):
                         try:
@@ -307,10 +307,10 @@ else:
                         "XDG_CONFIG_HOME",
                         os.path.join(os.path.expanduser("~"), ".config"))
                     _cfg_dirs = [
-                        "/usr/lib/debops/conf.d",
-                        "/usr/local/lib/debops/conf.d",
-                        "/etc/debops/conf.d",
                         os.path.join(_xdg, "debops", "conf.d"),
+                        "/etc/debops/conf.d",
+                        "/usr/local/lib/debops/conf.d",
+                        "/usr/lib/debops/conf.d",
                     ]
                     for _cfg_dir in _cfg_dirs:
                         if not os.path.isdir(_cfg_dir):

--- a/ansible/plugins/lookup/file_src.py
+++ b/ansible/plugins/lookup/file_src.py
@@ -166,7 +166,8 @@ if parse(__ansible_version__) < parse("2.0"):
                             continue
                         for _filename in sorted(os.listdir(_cfg_dir)):
                             _filepath = os.path.join(_cfg_dir, _filename)
-                            if _filename.startswith(".") or not os.path.isfile(_filepath):
+                            if (_filename.startswith(".")
+                                    or not os.path.isfile(_filepath)):
                                 continue
                             try:
                                 if _filename.endswith(".json"):
@@ -317,7 +318,8 @@ else:
                             continue
                         for _filename in sorted(os.listdir(_cfg_dir)):
                             _filepath = os.path.join(_cfg_dir, _filename)
-                            if _filename.startswith(".") or not os.path.isfile(_filepath):
+                            if (_filename.startswith(".")
+                                    or not os.path.isfile(_filepath)):
                                 continue
                             try:
                                 if _filename.endswith(".json"):

--- a/ansible/plugins/lookup/file_src.py
+++ b/ansible/plugins/lookup/file_src.py
@@ -120,35 +120,35 @@ if parse(__ansible_version__) < parse("2.0"):
                 _found = None
 
                 for _ext in [".json", ".toml", ".yaml", ".yml"]:
-                    _pp = os.path.join(os.getcwd(), ".debops" + _ext)
-                    if os.path.isfile(_pp):
+                    _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
+                    if os.path.isfile(_project_path):
                         try:
-                            if _pp.endswith(".json"):
-                                with open(_pp) as _fh:
+                            if _project_path.endswith(".json"):
+                                with open(_project_path) as _fh:
                                     _parsed = json.load(_fh)
-                            elif _pp.endswith(".toml"):
+                            elif _project_path.endswith(".toml"):
                                 import tomllib as _tl
-                                with open(_pp, "rb") as _fh:
+                                with open(_project_path, "rb") as _fh:
                                     _parsed = _tl.load(_fh)
-                            elif _pp.endswith((".yaml", ".yml")):
+                            elif _project_path.endswith((".yaml", ".yml")):
                                 import yaml as _yl
-                                with open(_pp) as _fh:
+                                with open(_project_path) as _fh:
                                     _parsed = _yl.safe_load(_fh)
                             else:
                                 continue
                         except Exception:
                             continue
                         if isinstance(_parsed, dict):
-                            _v = _parsed.get(
+                            _override_value = _parsed.get(
                                 "override_paths", {}).get("files_path")
-                            if _v:
-                                for _p in _v.split(":"):
-                                    if os.path.isabs(_p):
-                                        places.append(_p)
+                            if _override_value:
+                                for _path_item in _override_value.split(":"):
+                                    if os.path.isabs(_path_item):
+                                        places.append(_path_item)
                                     else:
                                         places.append(
-                                            os.path.join(os.getcwd(), _p))
-                                _found = _v
+                                            os.path.join(os.getcwd(), _path_item))
+                                _found = _override_value
                         break
 
                 if not _found:
@@ -161,44 +161,44 @@ if parse(__ansible_version__) < parse("2.0"):
                         "/etc/debops/conf.d",
                         os.path.join(_xdg, "debops", "conf.d"),
                     ]
-                    for _cd in _cfg_dirs:
-                        if not os.path.isdir(_cd):
+                    for _cfg_dir in _cfg_dirs:
+                        if not os.path.isdir(_cfg_dir):
                             continue
-                        for _f in sorted(os.listdir(_cd)):
-                            _fp = os.path.join(_cd, _f)
-                            if _f.startswith(".") or not os.path.isfile(_fp):
+                        for _filename in sorted(os.listdir(_cfg_dir)):
+                            _filepath = os.path.join(_cfg_dir, _filename)
+                            if _filename.startswith(".") or not os.path.isfile(_filepath):
                                 continue
                             try:
-                                if _f.endswith(".json"):
-                                    with open(_fp) as _fh:
+                                if _filename.endswith(".json"):
+                                    with open(_filepath) as _fh:
                                         _parsed = json.load(_fh)
-                                elif _f.endswith(".toml"):
+                                elif _filename.endswith(".toml"):
                                     import tomllib as _tl
-                                    with open(_fp, "rb") as _fh:
+                                    with open(_filepath, "rb") as _fh:
                                         _parsed = _tl.load(_fh)
-                                elif _f.endswith((".yaml", ".yml")):
+                                elif _filename.endswith((".yaml", ".yml")):
                                     import yaml as _yl
-                                    with open(_fp) as _fh:
+                                    with open(_filepath) as _fh:
                                         _parsed = _yl.safe_load(_fh)
                                 else:
                                     continue
                             except Exception:
                                 continue
                             if isinstance(_parsed, dict):
-                                _v = _parsed.get(
+                                _override_value = _parsed.get(
                                     "override_paths", {}).get("files_path")
-                                if _v:
-                                    _found = _v
+                                if _override_value:
+                                    _found = _override_value
                                     break
                         if _found:
                             break
                     if _found:
-                        for _p in _found.split(":"):
-                            if os.path.isabs(_p):
-                                places.append(_p)
+                        for _path_item in _found.split(":"):
+                            if os.path.isabs(_path_item):
+                                places.append(_path_item)
                             else:
                                 places.append(
-                                    os.path.join(os.getcwd(), _p))
+                                    os.path.join(os.getcwd(), _path_item))
 
             for term in terms:
                 if '_original_file' in inject:
@@ -271,35 +271,35 @@ else:
                 _found = None
 
                 for _ext in [".json", ".toml", ".yaml", ".yml"]:
-                    _pp = os.path.join(os.getcwd(), ".debops" + _ext)
-                    if os.path.isfile(_pp):
+                    _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
+                    if os.path.isfile(_project_path):
                         try:
-                            if _pp.endswith(".json"):
-                                with open(_pp) as _fh:
+                            if _project_path.endswith(".json"):
+                                with open(_project_path) as _fh:
                                     _parsed = json.load(_fh)
-                            elif _pp.endswith(".toml"):
+                            elif _project_path.endswith(".toml"):
                                 import tomllib as _tl
-                                with open(_pp, "rb") as _fh:
+                                with open(_project_path, "rb") as _fh:
                                     _parsed = _tl.load(_fh)
-                            elif _pp.endswith((".yaml", ".yml")):
+                            elif _project_path.endswith((".yaml", ".yml")):
                                 import yaml as _yl
-                                with open(_pp) as _fh:
+                                with open(_project_path) as _fh:
                                     _parsed = _yl.safe_load(_fh)
                             else:
                                 continue
                         except Exception:
                             continue
                         if isinstance(_parsed, dict):
-                            _v = _parsed.get(
+                            _override_value = _parsed.get(
                                 "override_paths", {}).get("files_path")
-                            if _v:
-                                for _p in _v.split(":"):
-                                    if os.path.isabs(_p):
-                                        places.append(_p)
+                            if _override_value:
+                                for _path_item in _override_value.split(":"):
+                                    if os.path.isabs(_path_item):
+                                        places.append(_path_item)
                                     else:
                                         places.append(
-                                            os.path.join(os.getcwd(), _p))
-                                _found = _v
+                                            os.path.join(os.getcwd(), _path_item))
+                                _found = _override_value
                         break
 
                 if not _found:
@@ -312,44 +312,44 @@ else:
                         "/etc/debops/conf.d",
                         os.path.join(_xdg, "debops", "conf.d"),
                     ]
-                    for _cd in _cfg_dirs:
-                        if not os.path.isdir(_cd):
+                    for _cfg_dir in _cfg_dirs:
+                        if not os.path.isdir(_cfg_dir):
                             continue
-                        for _f in sorted(os.listdir(_cd)):
-                            _fp = os.path.join(_cd, _f)
-                            if _f.startswith(".") or not os.path.isfile(_fp):
+                        for _filename in sorted(os.listdir(_cfg_dir)):
+                            _filepath = os.path.join(_cfg_dir, _filename)
+                            if _filename.startswith(".") or not os.path.isfile(_filepath):
                                 continue
                             try:
-                                if _f.endswith(".json"):
-                                    with open(_fp) as _fh:
+                                if _filename.endswith(".json"):
+                                    with open(_filepath) as _fh:
                                         _parsed = json.load(_fh)
-                                elif _f.endswith(".toml"):
+                                elif _filename.endswith(".toml"):
                                     import tomllib as _tl
-                                    with open(_fp, "rb") as _fh:
+                                    with open(_filepath, "rb") as _fh:
                                         _parsed = _tl.load(_fh)
-                                elif _f.endswith((".yaml", ".yml")):
+                                elif _filename.endswith((".yaml", ".yml")):
                                     import yaml as _yl
-                                    with open(_fp) as _fh:
+                                    with open(_filepath) as _fh:
                                         _parsed = _yl.safe_load(_fh)
                                 else:
                                     continue
                             except Exception:
                                 continue
                             if isinstance(_parsed, dict):
-                                _v = _parsed.get(
+                                _override_value = _parsed.get(
                                     "override_paths", {}).get("files_path")
-                                if _v:
-                                    _found = _v
+                                if _override_value:
+                                    _found = _override_value
                                     break
                         if _found:
                             break
                     if _found:
-                        for _p in _found.split(":"):
-                            if os.path.isabs(_p):
-                                places.append(_p)
+                        for _path_item in _found.split(":"):
+                            if os.path.isabs(_path_item):
+                                places.append(_path_item)
                             else:
                                 places.append(
-                                    os.path.join(os.getcwd(), _p))
+                                    os.path.join(os.getcwd(), _path_item))
 
             for term in terms:
                 if 'role_path' in variables:

--- a/ansible/plugins/lookup/file_src.py
+++ b/ansible/plugins/lookup/file_src.py
@@ -121,8 +121,13 @@ class LookupModule(LookupBase):
                     ret.append(template)
                     break
             else:
-                raise AnsibleError(
-                        "could not locate file in lookup: %s"
-                        % term)
+                msg = "could not locate file in lookup: %s" % term
+                if not places:
+                    msg += (". No override paths configured. Install"
+                            " the debops Python module, create a"
+                            " .debops.{yaml,yml,json,toml} file,"
+                            " or add config to"
+                            " ~/.config/debops/conf.d/")
+                raise AnsibleError(msg)
 
         return ret

--- a/ansible/plugins/lookup/file_src.py
+++ b/ansible/plugins/lookup/file_src.py
@@ -107,7 +107,7 @@ class LookupModule(LookupBase):
         # Fallback when the debops Python module is not available
         # (e.g. installed via Ansible Galaxy). Read override paths
         # directly from the global DebOps configuration directories.
-        if not conf_section:
+        if not places:
             places.extend(debops_config.load_fallback_paths('files_path'))
 
         for term in terms:

--- a/ansible/plugins/lookup/file_src.py
+++ b/ansible/plugins/lookup/file_src.py
@@ -58,81 +58,118 @@ try:
 except ImportError:
     LookupBase = object
 
-from packaging.version import parse
-from ansible import __version__ as __ansible_version__
+from ansible.errors import AnsibleError
 
 
-if parse(__ansible_version__) < parse("2.0"):
-    from ansible import utils, errors
+class LookupModule(LookupBase):
 
-    class LookupModule(object):
+    def run(self, terms, variables=None, **kwargs):
+        ret = []
+        config = {}
+        places = []
 
-        def __init__(self, basedir, *args, **kwargs):
-            self.basedir = basedir
+        # this can happen if the variable contains a string,
+        # strictly not desired for lookup plugins, but users may
+        # try it, so make it work.
+        if not isinstance(terms, list):
+            terms = [terms]
 
-        def run(self, terms, inject=None, **kwargs):
-
-            terms = utils.listify_lookup_plugin_terms(
-                    terms, self.basedir, inject)
-            ret = []
-            config = {}
-            places = []
-
-            # this can happen if the variable contains a string,
-            # strictly not desired for lookup plugins, but users may
-            # try it, so make it work.
-            if not isinstance(terms, list):
-                terms = [terms]
-
+        try:
+            project_config = debops.config.Configuration()
+            project_dir = debops.projectdir.ProjectDir(
+                    config=project_config)
+            project_root = project_dir.path
+            if project_dir.config.get(['project', 'type']) == 'modern':
+                config = project_dir.config.get([])
+            else:
+                config = project_dir.config.get(['views', 'system'])
+        except NameError:
             try:
-                project_config = debops.config.Configuration()
-                project_dir = debops.projectdir.ProjectDir(
-                        config=project_config)
-                project_root = project_dir.path
-                if project_dir.config.get(['project', 'type']) == 'modern':
-                    config = project_dir.config.get([])
-                else:
-                    config = project_dir.config.get(['views', 'system'])
+                project_root = find_debops_project(required=False)
+                config = read_config(project_root)
             except NameError:
-                try:
-                    project_root = find_debops_project(required=False)
-                    config = read_config(project_root)
-                except NameError:
-                    pass
-            except NotADirectoryError:
-                # This is not a DebOps project directory, so continue as normal
                 pass
+        except NotADirectoryError:
+            # This is not a DebOps project directory, so continue as normal
+            pass
 
-            if conf_section in config and conf_key in config[conf_section]:
-                custom_places = (
-                        config[conf_section][conf_key].split(':'))
-                for custom_path in custom_places:
-                    if os.path.isabs(custom_path):
-                        places.append(custom_path)
-                    else:
-                        places.append(os.path.join(
-                            project_root, custom_path))
+        if conf_section in config and conf_key in config[conf_section]:
+            custom_places = (
+                    config[conf_section][conf_key].split(':'))
+            for custom_path in custom_places:
+                if os.path.isabs(custom_path):
+                    places.append(custom_path)
+                else:
+                    places.append(os.path.join(
+                        project_root, custom_path))
 
-            # Fallback when the debops Python module is not available
-            # (e.g. installed via Ansible Galaxy). Read override paths
-            # directly from the global DebOps configuration directories.
-            if not conf_section:
-                _found = None
+        # Fallback when the debops Python module is not available
+        # (e.g. installed via Ansible Galaxy). Read override paths
+        # directly from the global DebOps configuration directories.
+        if not conf_section:
+            _found = None
 
-                for _ext in [".yaml", ".yml", ".json", ".toml"]:
-                    _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
-                    if os.path.isfile(_project_path):
+            for _ext in [".yaml", ".yml", ".json", ".toml"]:
+                _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
+                if os.path.isfile(_project_path):
+                    try:
+                        if _project_path.endswith(".json"):
+                            with open(_project_path) as _fh:
+                                _parsed = json.load(_fh)
+                        elif _project_path.endswith(".toml"):
+                            import tomllib as _tl
+                            with open(_project_path, "rb") as _fh:
+                                _parsed = _tl.load(_fh)
+                        elif _project_path.endswith((".yaml", ".yml")):
+                            import yaml as _yl
+                            with open(_project_path) as _fh:
+                                _parsed = _yl.safe_load(_fh)
+                        else:
+                            continue
+                    except Exception:
+                        continue
+                    if isinstance(_parsed, dict):
+                        _override_value = _parsed.get(
+                            "override_paths", {}).get("files_path")
+                        if _override_value:
+                            for _path_item in _override_value.split(":"):
+                                if os.path.isabs(_path_item):
+                                    places.append(_path_item)
+                                else:
+                                    places.append(
+                                        os.path.join(os.getcwd(), _path_item))
+                            _found = _override_value
+                    break
+
+            if not _found:
+                _xdg = os.environ.get(
+                    "XDG_CONFIG_HOME",
+                    os.path.join(os.path.expanduser("~"), ".config"))
+                _cfg_dirs = [
+                    os.path.join(_xdg, "debops", "conf.d"),
+                    "/etc/debops/conf.d",
+                    "/usr/local/lib/debops/conf.d",
+                    "/usr/lib/debops/conf.d",
+                ]
+                for _cfg_dir in _cfg_dirs:
+                    if not os.path.isdir(_cfg_dir):
+                        continue
+                    for _filename in sorted(os.listdir(_cfg_dir)):
+                        _filepath = os.path.join(_cfg_dir, _filename)
+                        if (_filename.startswith(".")
+                                or not os.path.isfile(_filepath)):
+                            continue
                         try:
-                            if _project_path.endswith(".json"):
-                                with open(_project_path) as _fh:
+                            if _filename.endswith(".json"):
+                                with open(_filepath) as _fh:
                                     _parsed = json.load(_fh)
-                            elif _project_path.endswith(".toml"):
+                            elif _filename.endswith(".toml"):
                                 import tomllib as _tl
-                                with open(_project_path, "rb") as _fh:
+                                with open(_filepath, "rb") as _fh:
                                     _parsed = _tl.load(_fh)
-                            elif _project_path.endswith((".yaml", ".yml")):
+                            elif _filename.endswith((".yaml", ".yml")):
                                 import yaml as _yl
-                                with open(_project_path) as _fh:
+                                with open(_filepath) as _fh:
                                     _parsed = _yl.safe_load(_fh)
                             else:
                                 continue
@@ -142,230 +179,31 @@ if parse(__ansible_version__) < parse("2.0"):
                             _override_value = _parsed.get(
                                 "override_paths", {}).get("files_path")
                             if _override_value:
-                                for _path_item in _override_value.split(":"):
-                                    if os.path.isabs(_path_item):
-                                        places.append(_path_item)
-                                    else:
-                                        places.append(
-                                            os.path.join(os.getcwd(), _path_item))
                                 _found = _override_value
-                        break
-
-                if not _found:
-                    _xdg = os.environ.get(
-                        "XDG_CONFIG_HOME",
-                        os.path.join(os.path.expanduser("~"), ".config"))
-                    _cfg_dirs = [
-                        os.path.join(_xdg, "debops", "conf.d"),
-                        "/etc/debops/conf.d",
-                        "/usr/local/lib/debops/conf.d",
-                        "/usr/lib/debops/conf.d",
-                    ]
-                    for _cfg_dir in _cfg_dirs:
-                        if not os.path.isdir(_cfg_dir):
-                            continue
-                        for _filename in sorted(os.listdir(_cfg_dir)):
-                            _filepath = os.path.join(_cfg_dir, _filename)
-                            if (_filename.startswith(".")
-                                    or not os.path.isfile(_filepath)):
-                                continue
-                            try:
-                                if _filename.endswith(".json"):
-                                    with open(_filepath) as _fh:
-                                        _parsed = json.load(_fh)
-                                elif _filename.endswith(".toml"):
-                                    import tomllib as _tl
-                                    with open(_filepath, "rb") as _fh:
-                                        _parsed = _tl.load(_fh)
-                                elif _filename.endswith((".yaml", ".yml")):
-                                    import yaml as _yl
-                                    with open(_filepath) as _fh:
-                                        _parsed = _yl.safe_load(_fh)
-                                else:
-                                    continue
-                            except Exception:
-                                continue
-                            if isinstance(_parsed, dict):
-                                _override_value = _parsed.get(
-                                    "override_paths", {}).get("files_path")
-                                if _override_value:
-                                    _found = _override_value
-                                    break
-                        if _found:
-                            break
+                                break
                     if _found:
-                        for _path_item in _found.split(":"):
-                            if os.path.isabs(_path_item):
-                                places.append(_path_item)
-                            else:
-                                places.append(
-                                    os.path.join(os.getcwd(), _path_item))
-
-            for term in terms:
-                if '_original_file' in inject:
-                    relative_path = utils.path_dwim_relative(
-                            inject['_original_file'], 'files',
-                            '', self.basedir, check=False)
-                    places.append(relative_path)
-                for path in places:
-                    template = os.path.join(path, term)
-                    if template and os.path.exists(template):
-                        ret.append(template)
                         break
-                else:
-                    raise errors.AnsibleError(
-                            "could not locate file in lookup: %s"
-                            % term)
+                if _found:
+                    for _path_item in _found.split(":"):
+                        if os.path.isabs(_path_item):
+                            places.append(_path_item)
+                        else:
+                            places.append(
+                                os.path.join(os.getcwd(), _path_item))
 
-            return ret
+        for term in terms:
+            if 'role_path' in variables:
+                relative_path = self._loader.path_dwim_relative(
+                        variables['role_path'], 'files', '')
+                places.append(relative_path)
+            for path in places:
+                template = os.path.join(path, term)
+                if template and os.path.exists(template):
+                    ret.append(template)
+                    break
+            else:
+                raise AnsibleError(
+                        "could not locate file in lookup: %s"
+                        % term)
 
-else:
-    from ansible.errors import AnsibleError
-    from ansible.plugins.lookup import LookupBase
-
-    class LookupModule(LookupBase):
-
-        def run(self, terms, variables=None, **kwargs):
-            ret = []
-            config = {}
-            places = []
-
-            # this can happen if the variable contains a string,
-            # strictly not desired for lookup plugins, but users may
-            # try it, so make it work.
-            if not isinstance(terms, list):
-                terms = [terms]
-
-            try:
-                project_config = debops.config.Configuration()
-                project_dir = debops.projectdir.ProjectDir(
-                        config=project_config)
-                project_root = project_dir.path
-                if project_dir.config.get(['project', 'type']) == 'modern':
-                    config = project_dir.config.get([])
-                else:
-                    config = project_dir.config.get(['views', 'system'])
-            except NameError:
-                try:
-                    project_root = find_debops_project(required=False)
-                    config = read_config(project_root)
-                except NameError:
-                    pass
-            except NotADirectoryError:
-                # This is not a DebOps project directory, so continue as normal
-                pass
-
-            if conf_section in config and conf_key in config[conf_section]:
-                custom_places = (
-                        config[conf_section][conf_key].split(':'))
-                for custom_path in custom_places:
-                    if os.path.isabs(custom_path):
-                        places.append(custom_path)
-                    else:
-                        places.append(os.path.join(
-                            project_root, custom_path))
-
-            # Fallback when the debops Python module is not available
-            # (e.g. installed via Ansible Galaxy). Read override paths
-            # directly from the global DebOps configuration directories.
-            if not conf_section:
-                _found = None
-
-                for _ext in [".yaml", ".yml", ".json", ".toml"]:
-                    _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
-                    if os.path.isfile(_project_path):
-                        try:
-                            if _project_path.endswith(".json"):
-                                with open(_project_path) as _fh:
-                                    _parsed = json.load(_fh)
-                            elif _project_path.endswith(".toml"):
-                                import tomllib as _tl
-                                with open(_project_path, "rb") as _fh:
-                                    _parsed = _tl.load(_fh)
-                            elif _project_path.endswith((".yaml", ".yml")):
-                                import yaml as _yl
-                                with open(_project_path) as _fh:
-                                    _parsed = _yl.safe_load(_fh)
-                            else:
-                                continue
-                        except Exception:
-                            continue
-                        if isinstance(_parsed, dict):
-                            _override_value = _parsed.get(
-                                "override_paths", {}).get("files_path")
-                            if _override_value:
-                                for _path_item in _override_value.split(":"):
-                                    if os.path.isabs(_path_item):
-                                        places.append(_path_item)
-                                    else:
-                                        places.append(
-                                            os.path.join(os.getcwd(), _path_item))
-                                _found = _override_value
-                        break
-
-                if not _found:
-                    _xdg = os.environ.get(
-                        "XDG_CONFIG_HOME",
-                        os.path.join(os.path.expanduser("~"), ".config"))
-                    _cfg_dirs = [
-                        os.path.join(_xdg, "debops", "conf.d"),
-                        "/etc/debops/conf.d",
-                        "/usr/local/lib/debops/conf.d",
-                        "/usr/lib/debops/conf.d",
-                    ]
-                    for _cfg_dir in _cfg_dirs:
-                        if not os.path.isdir(_cfg_dir):
-                            continue
-                        for _filename in sorted(os.listdir(_cfg_dir)):
-                            _filepath = os.path.join(_cfg_dir, _filename)
-                            if (_filename.startswith(".")
-                                    or not os.path.isfile(_filepath)):
-                                continue
-                            try:
-                                if _filename.endswith(".json"):
-                                    with open(_filepath) as _fh:
-                                        _parsed = json.load(_fh)
-                                elif _filename.endswith(".toml"):
-                                    import tomllib as _tl
-                                    with open(_filepath, "rb") as _fh:
-                                        _parsed = _tl.load(_fh)
-                                elif _filename.endswith((".yaml", ".yml")):
-                                    import yaml as _yl
-                                    with open(_filepath) as _fh:
-                                        _parsed = _yl.safe_load(_fh)
-                                else:
-                                    continue
-                            except Exception:
-                                continue
-                            if isinstance(_parsed, dict):
-                                _override_value = _parsed.get(
-                                    "override_paths", {}).get("files_path")
-                                if _override_value:
-                                    _found = _override_value
-                                    break
-                        if _found:
-                            break
-                    if _found:
-                        for _path_item in _found.split(":"):
-                            if os.path.isabs(_path_item):
-                                places.append(_path_item)
-                            else:
-                                places.append(
-                                    os.path.join(os.getcwd(), _path_item))
-
-            for term in terms:
-                if 'role_path' in variables:
-                    relative_path = self._loader.path_dwim_relative(
-                            variables['role_path'], 'files', '')
-                    places.append(relative_path)
-                for path in places:
-                    template = os.path.join(path, term)
-                    if template and os.path.exists(template):
-                        ret.append(template)
-                        break
-                else:
-                    raise AnsibleError(
-                            "could not locate file in lookup: %s"
-                            % term)
-
-            return ret
+        return ret

--- a/ansible/plugins/lookup/file_src.py
+++ b/ansible/plugins/lookup/file_src.py
@@ -59,6 +59,7 @@ except ImportError:
     LookupBase = object
 
 from ansible.errors import AnsibleError
+from ansible_collections.debops.debops.plugins.plugin_utils import debops_config
 
 
 class LookupModule(LookupBase):
@@ -107,89 +108,7 @@ class LookupModule(LookupBase):
         # (e.g. installed via Ansible Galaxy). Read override paths
         # directly from the global DebOps configuration directories.
         if not conf_section:
-            _found = None
-
-            for _ext in [".yaml", ".yml", ".json", ".toml"]:
-                _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
-                if os.path.isfile(_project_path):
-                    try:
-                        if _project_path.endswith(".json"):
-                            with open(_project_path) as _fh:
-                                _parsed = json.load(_fh)
-                        elif _project_path.endswith(".toml"):
-                            import tomllib as _tl
-                            with open(_project_path, "rb") as _fh:
-                                _parsed = _tl.load(_fh)
-                        elif _project_path.endswith((".yaml", ".yml")):
-                            import yaml as _yl
-                            with open(_project_path) as _fh:
-                                _parsed = _yl.safe_load(_fh)
-                        else:
-                            continue
-                    except Exception:
-                        continue
-                    if isinstance(_parsed, dict):
-                        _override_value = _parsed.get(
-                            "override_paths", {}).get("files_path")
-                        if _override_value:
-                            for _path_item in _override_value.split(":"):
-                                if os.path.isabs(_path_item):
-                                    places.append(_path_item)
-                                else:
-                                    places.append(
-                                        os.path.join(os.getcwd(), _path_item))
-                            _found = _override_value
-                    break
-
-            if not _found:
-                _xdg = os.environ.get(
-                    "XDG_CONFIG_HOME",
-                    os.path.join(os.path.expanduser("~"), ".config"))
-                _cfg_dirs = [
-                    os.path.join(_xdg, "debops", "conf.d"),
-                    "/etc/debops/conf.d",
-                    "/usr/local/lib/debops/conf.d",
-                    "/usr/lib/debops/conf.d",
-                ]
-                for _cfg_dir in _cfg_dirs:
-                    if not os.path.isdir(_cfg_dir):
-                        continue
-                    for _filename in sorted(os.listdir(_cfg_dir)):
-                        _filepath = os.path.join(_cfg_dir, _filename)
-                        if (_filename.startswith(".")
-                                or not os.path.isfile(_filepath)):
-                            continue
-                        try:
-                            if _filename.endswith(".json"):
-                                with open(_filepath) as _fh:
-                                    _parsed = json.load(_fh)
-                            elif _filename.endswith(".toml"):
-                                import tomllib as _tl
-                                with open(_filepath, "rb") as _fh:
-                                    _parsed = _tl.load(_fh)
-                            elif _filename.endswith((".yaml", ".yml")):
-                                import yaml as _yl
-                                with open(_filepath) as _fh:
-                                    _parsed = _yl.safe_load(_fh)
-                            else:
-                                continue
-                        except Exception:
-                            continue
-                        if isinstance(_parsed, dict):
-                            _override_value = _parsed.get(
-                                "override_paths", {}).get("files_path")
-                            if _override_value:
-                                _found = _override_value
-                                break
-                    if _found:
-                        break
-                if _found:
-                    for _path_item in _found.split(":"):
-                        if os.path.isabs(_path_item):
-                            places.append(_path_item)
-                        else:
-                            places.append(
-                                os.path.join(os.getcwd(), _path_item))
+            places.extend(debops_config.load_fallback_paths('files_path'))
 
         for term in terms:
             if 'role_path' in variables:

--- a/ansible/plugins/lookup/task_src.py
+++ b/ansible/plugins/lookup/task_src.py
@@ -119,7 +119,7 @@ if parse(__ansible_version__) < parse("2.0"):
             if not conf_section:
                 _found = None
 
-                for _ext in [".json", ".toml", ".yaml", ".yml"]:
+                for _ext in [".yaml", ".yml", ".json", ".toml"]:
                     _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
                     if os.path.isfile(_project_path):
                         try:
@@ -156,10 +156,10 @@ if parse(__ansible_version__) < parse("2.0"):
                         "XDG_CONFIG_HOME",
                         os.path.join(os.path.expanduser("~"), ".config"))
                     _cfg_dirs = [
-                        "/usr/lib/debops/conf.d",
-                        "/usr/local/lib/debops/conf.d",
-                        "/etc/debops/conf.d",
                         os.path.join(_xdg, "debops", "conf.d"),
+                        "/etc/debops/conf.d",
+                        "/usr/local/lib/debops/conf.d",
+                        "/usr/lib/debops/conf.d",
                     ]
                     for _cfg_dir in _cfg_dirs:
                         if not os.path.isdir(_cfg_dir):
@@ -270,7 +270,7 @@ else:
             if not conf_section:
                 _found = None
 
-                for _ext in [".json", ".toml", ".yaml", ".yml"]:
+                for _ext in [".yaml", ".yml", ".json", ".toml"]:
                     _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
                     if os.path.isfile(_project_path):
                         try:
@@ -307,10 +307,10 @@ else:
                         "XDG_CONFIG_HOME",
                         os.path.join(os.path.expanduser("~"), ".config"))
                     _cfg_dirs = [
-                        "/usr/lib/debops/conf.d",
-                        "/usr/local/lib/debops/conf.d",
-                        "/etc/debops/conf.d",
                         os.path.join(_xdg, "debops", "conf.d"),
+                        "/etc/debops/conf.d",
+                        "/usr/local/lib/debops/conf.d",
+                        "/usr/lib/debops/conf.d",
                     ]
                     for _cfg_dir in _cfg_dirs:
                         if not os.path.isdir(_cfg_dir):

--- a/ansible/plugins/lookup/task_src.py
+++ b/ansible/plugins/lookup/task_src.py
@@ -120,35 +120,35 @@ if parse(__ansible_version__) < parse("2.0"):
                 _found = None
 
                 for _ext in [".json", ".toml", ".yaml", ".yml"]:
-                    _pp = os.path.join(os.getcwd(), ".debops" + _ext)
-                    if os.path.isfile(_pp):
+                    _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
+                    if os.path.isfile(_project_path):
                         try:
-                            if _pp.endswith(".json"):
-                                with open(_pp) as _fh:
+                            if _project_path.endswith(".json"):
+                                with open(_project_path) as _fh:
                                     _parsed = json.load(_fh)
-                            elif _pp.endswith(".toml"):
+                            elif _project_path.endswith(".toml"):
                                 import tomllib as _tl
-                                with open(_pp, "rb") as _fh:
+                                with open(_project_path, "rb") as _fh:
                                     _parsed = _tl.load(_fh)
-                            elif _pp.endswith((".yaml", ".yml")):
+                            elif _project_path.endswith((".yaml", ".yml")):
                                 import yaml as _yl
-                                with open(_pp) as _fh:
+                                with open(_project_path) as _fh:
                                     _parsed = _yl.safe_load(_fh)
                             else:
                                 continue
                         except Exception:
                             continue
                         if isinstance(_parsed, dict):
-                            _v = _parsed.get(
+                            _override_value = _parsed.get(
                                 "override_paths", {}).get("tasks_path")
-                            if _v:
-                                for _p in _v.split(":"):
-                                    if os.path.isabs(_p):
-                                        places.append(_p)
+                            if _override_value:
+                                for _path_item in _override_value.split(":"):
+                                    if os.path.isabs(_path_item):
+                                        places.append(_path_item)
                                     else:
                                         places.append(
-                                            os.path.join(os.getcwd(), _p))
-                                _found = _v
+                                            os.path.join(os.getcwd(), _path_item))
+                                _found = _override_value
                         break
 
                 if not _found:
@@ -161,44 +161,44 @@ if parse(__ansible_version__) < parse("2.0"):
                         "/etc/debops/conf.d",
                         os.path.join(_xdg, "debops", "conf.d"),
                     ]
-                    for _cd in _cfg_dirs:
-                        if not os.path.isdir(_cd):
+                    for _cfg_dir in _cfg_dirs:
+                        if not os.path.isdir(_cfg_dir):
                             continue
-                        for _f in sorted(os.listdir(_cd)):
-                            _fp = os.path.join(_cd, _f)
-                            if _f.startswith(".") or not os.path.isfile(_fp):
+                        for _filename in sorted(os.listdir(_cfg_dir)):
+                            _filepath = os.path.join(_cfg_dir, _filename)
+                            if _filename.startswith(".") or not os.path.isfile(_filepath):
                                 continue
                             try:
-                                if _f.endswith(".json"):
-                                    with open(_fp) as _fh:
+                                if _filename.endswith(".json"):
+                                    with open(_filepath) as _fh:
                                         _parsed = json.load(_fh)
-                                elif _f.endswith(".toml"):
+                                elif _filename.endswith(".toml"):
                                     import tomllib as _tl
-                                    with open(_fp, "rb") as _fh:
+                                    with open(_filepath, "rb") as _fh:
                                         _parsed = _tl.load(_fh)
-                                elif _f.endswith((".yaml", ".yml")):
+                                elif _filename.endswith((".yaml", ".yml")):
                                     import yaml as _yl
-                                    with open(_fp) as _fh:
+                                    with open(_filepath) as _fh:
                                         _parsed = _yl.safe_load(_fh)
                                 else:
                                     continue
                             except Exception:
                                 continue
                             if isinstance(_parsed, dict):
-                                _v = _parsed.get(
+                                _override_value = _parsed.get(
                                     "override_paths", {}).get("tasks_path")
-                                if _v:
-                                    _found = _v
+                                if _override_value:
+                                    _found = _override_value
                                     break
                         if _found:
                             break
                     if _found:
-                        for _p in _found.split(":"):
-                            if os.path.isabs(_p):
-                                places.append(_p)
+                        for _path_item in _found.split(":"):
+                            if os.path.isabs(_path_item):
+                                places.append(_path_item)
                             else:
                                 places.append(
-                                    os.path.join(os.getcwd(), _p))
+                                    os.path.join(os.getcwd(), _path_item))
 
             for term in terms:
                 if '_original_file' in inject:
@@ -271,35 +271,35 @@ else:
                 _found = None
 
                 for _ext in [".json", ".toml", ".yaml", ".yml"]:
-                    _pp = os.path.join(os.getcwd(), ".debops" + _ext)
-                    if os.path.isfile(_pp):
+                    _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
+                    if os.path.isfile(_project_path):
                         try:
-                            if _pp.endswith(".json"):
-                                with open(_pp) as _fh:
+                            if _project_path.endswith(".json"):
+                                with open(_project_path) as _fh:
                                     _parsed = json.load(_fh)
-                            elif _pp.endswith(".toml"):
+                            elif _project_path.endswith(".toml"):
                                 import tomllib as _tl
-                                with open(_pp, "rb") as _fh:
+                                with open(_project_path, "rb") as _fh:
                                     _parsed = _tl.load(_fh)
-                            elif _pp.endswith((".yaml", ".yml")):
+                            elif _project_path.endswith((".yaml", ".yml")):
                                 import yaml as _yl
-                                with open(_pp) as _fh:
+                                with open(_project_path) as _fh:
                                     _parsed = _yl.safe_load(_fh)
                             else:
                                 continue
                         except Exception:
                             continue
                         if isinstance(_parsed, dict):
-                            _v = _parsed.get(
+                            _override_value = _parsed.get(
                                 "override_paths", {}).get("tasks_path")
-                            if _v:
-                                for _p in _v.split(":"):
-                                    if os.path.isabs(_p):
-                                        places.append(_p)
+                            if _override_value:
+                                for _path_item in _override_value.split(":"):
+                                    if os.path.isabs(_path_item):
+                                        places.append(_path_item)
                                     else:
                                         places.append(
-                                            os.path.join(os.getcwd(), _p))
-                                _found = _v
+                                            os.path.join(os.getcwd(), _path_item))
+                                _found = _override_value
                         break
 
                 if not _found:
@@ -312,44 +312,44 @@ else:
                         "/etc/debops/conf.d",
                         os.path.join(_xdg, "debops", "conf.d"),
                     ]
-                    for _cd in _cfg_dirs:
-                        if not os.path.isdir(_cd):
+                    for _cfg_dir in _cfg_dirs:
+                        if not os.path.isdir(_cfg_dir):
                             continue
-                        for _f in sorted(os.listdir(_cd)):
-                            _fp = os.path.join(_cd, _f)
-                            if _f.startswith(".") or not os.path.isfile(_fp):
+                        for _filename in sorted(os.listdir(_cfg_dir)):
+                            _filepath = os.path.join(_cfg_dir, _filename)
+                            if _filename.startswith(".") or not os.path.isfile(_filepath):
                                 continue
                             try:
-                                if _f.endswith(".json"):
-                                    with open(_fp) as _fh:
+                                if _filename.endswith(".json"):
+                                    with open(_filepath) as _fh:
                                         _parsed = json.load(_fh)
-                                elif _f.endswith(".toml"):
+                                elif _filename.endswith(".toml"):
                                     import tomllib as _tl
-                                    with open(_fp, "rb") as _fh:
+                                    with open(_filepath, "rb") as _fh:
                                         _parsed = _tl.load(_fh)
-                                elif _f.endswith((".yaml", ".yml")):
+                                elif _filename.endswith((".yaml", ".yml")):
                                     import yaml as _yl
-                                    with open(_fp) as _fh:
+                                    with open(_filepath) as _fh:
                                         _parsed = _yl.safe_load(_fh)
                                 else:
                                     continue
                             except Exception:
                                 continue
                             if isinstance(_parsed, dict):
-                                _v = _parsed.get(
+                                _override_value = _parsed.get(
                                     "override_paths", {}).get("tasks_path")
-                                if _v:
-                                    _found = _v
+                                if _override_value:
+                                    _found = _override_value
                                     break
                         if _found:
                             break
                     if _found:
-                        for _p in _found.split(":"):
-                            if os.path.isabs(_p):
-                                places.append(_p)
+                        for _path_item in _found.split(":"):
+                            if os.path.isabs(_path_item):
+                                places.append(_path_item)
                             else:
                                 places.append(
-                                    os.path.join(os.getcwd(), _p))
+                                    os.path.join(os.getcwd(), _path_item))
 
             for term in terms:
                 if 'role_path' in variables:

--- a/ansible/plugins/lookup/task_src.py
+++ b/ansible/plugins/lookup/task_src.py
@@ -117,34 +117,22 @@ if parse(__ansible_version__) < parse("2.0"):
             # (e.g. installed via Ansible Galaxy). Read override paths
             # directly from the global DebOps configuration directories.
             if not conf_section:
-                _xdg = os.environ.get(
-                    "XDG_CONFIG_HOME",
-                    os.path.join(os.path.expanduser("~"), ".config"))
-                _cfg_dirs = [
-                    "/usr/lib/debops/conf.d",
-                    "/usr/local/lib/debops/conf.d",
-                    "/etc/debops/conf.d",
-                    os.path.join(_xdg, "debops", "conf.d"),
-                ]
                 _found = None
-                for _cd in _cfg_dirs:
-                    if not os.path.isdir(_cd):
-                        continue
-                    for _f in sorted(os.listdir(_cd)):
-                        _fp = os.path.join(_cd, _f)
-                        if _f.startswith(".") or not os.path.isfile(_fp):
-                            continue
+
+                for _ext in [".json", ".toml", ".yaml", ".yml"]:
+                    _pp = os.path.join(os.getcwd(), ".debops" + _ext)
+                    if os.path.isfile(_pp):
                         try:
-                            if _f.endswith(".json"):
-                                with open(_fp) as _fh:
+                            if _pp.endswith(".json"):
+                                with open(_pp) as _fh:
                                     _parsed = json.load(_fh)
-                            elif _f.endswith(".toml"):
+                            elif _pp.endswith(".toml"):
                                 import tomllib as _tl
-                                with open(_fp, "rb") as _fh:
+                                with open(_pp, "rb") as _fh:
                                     _parsed = _tl.load(_fh)
-                            elif _f.endswith((".yaml", ".yml")):
+                            elif _pp.endswith((".yaml", ".yml")):
                                 import yaml as _yl
-                                with open(_fp) as _fh:
+                                with open(_pp) as _fh:
                                     _parsed = _yl.safe_load(_fh)
                             else:
                                 continue
@@ -154,16 +142,63 @@ if parse(__ansible_version__) < parse("2.0"):
                             _v = _parsed.get(
                                 "override_paths", {}).get("tasks_path")
                             if _v:
+                                for _p in _v.split(":"):
+                                    if os.path.isabs(_p):
+                                        places.append(_p)
+                                    else:
+                                        places.append(
+                                            os.path.join(os.getcwd(), _p))
                                 _found = _v
-                                break
-                    if _found:
                         break
-                if _found:
-                    for _p in _found.split(":"):
-                        if os.path.isabs(_p):
-                            places.append(_p)
-                        else:
-                            places.append(os.path.join(os.getcwd(), _p))
+
+                if not _found:
+                    _xdg = os.environ.get(
+                        "XDG_CONFIG_HOME",
+                        os.path.join(os.path.expanduser("~"), ".config"))
+                    _cfg_dirs = [
+                        "/usr/lib/debops/conf.d",
+                        "/usr/local/lib/debops/conf.d",
+                        "/etc/debops/conf.d",
+                        os.path.join(_xdg, "debops", "conf.d"),
+                    ]
+                    for _cd in _cfg_dirs:
+                        if not os.path.isdir(_cd):
+                            continue
+                        for _f in sorted(os.listdir(_cd)):
+                            _fp = os.path.join(_cd, _f)
+                            if _f.startswith(".") or not os.path.isfile(_fp):
+                                continue
+                            try:
+                                if _f.endswith(".json"):
+                                    with open(_fp) as _fh:
+                                        _parsed = json.load(_fh)
+                                elif _f.endswith(".toml"):
+                                    import tomllib as _tl
+                                    with open(_fp, "rb") as _fh:
+                                        _parsed = _tl.load(_fh)
+                                elif _f.endswith((".yaml", ".yml")):
+                                    import yaml as _yl
+                                    with open(_fp) as _fh:
+                                        _parsed = _yl.safe_load(_fh)
+                                else:
+                                    continue
+                            except Exception:
+                                continue
+                            if isinstance(_parsed, dict):
+                                _v = _parsed.get(
+                                    "override_paths", {}).get("tasks_path")
+                                if _v:
+                                    _found = _v
+                                    break
+                        if _found:
+                            break
+                    if _found:
+                        for _p in _found.split(":"):
+                            if os.path.isabs(_p):
+                                places.append(_p)
+                            else:
+                                places.append(
+                                    os.path.join(os.getcwd(), _p))
 
             for term in terms:
                 if '_original_file' in inject:
@@ -233,34 +268,22 @@ else:
             # (e.g. installed via Ansible Galaxy). Read override paths
             # directly from the global DebOps configuration directories.
             if not conf_section:
-                _xdg = os.environ.get(
-                    "XDG_CONFIG_HOME",
-                    os.path.join(os.path.expanduser("~"), ".config"))
-                _cfg_dirs = [
-                    "/usr/lib/debops/conf.d",
-                    "/usr/local/lib/debops/conf.d",
-                    "/etc/debops/conf.d",
-                    os.path.join(_xdg, "debops", "conf.d"),
-                ]
                 _found = None
-                for _cd in _cfg_dirs:
-                    if not os.path.isdir(_cd):
-                        continue
-                    for _f in sorted(os.listdir(_cd)):
-                        _fp = os.path.join(_cd, _f)
-                        if _f.startswith(".") or not os.path.isfile(_fp):
-                            continue
+
+                for _ext in [".json", ".toml", ".yaml", ".yml"]:
+                    _pp = os.path.join(os.getcwd(), ".debops" + _ext)
+                    if os.path.isfile(_pp):
                         try:
-                            if _f.endswith(".json"):
-                                with open(_fp) as _fh:
+                            if _pp.endswith(".json"):
+                                with open(_pp) as _fh:
                                     _parsed = json.load(_fh)
-                            elif _f.endswith(".toml"):
+                            elif _pp.endswith(".toml"):
                                 import tomllib as _tl
-                                with open(_fp, "rb") as _fh:
+                                with open(_pp, "rb") as _fh:
                                     _parsed = _tl.load(_fh)
-                            elif _f.endswith((".yaml", ".yml")):
+                            elif _pp.endswith((".yaml", ".yml")):
                                 import yaml as _yl
-                                with open(_fp) as _fh:
+                                with open(_pp) as _fh:
                                     _parsed = _yl.safe_load(_fh)
                             else:
                                 continue
@@ -270,16 +293,63 @@ else:
                             _v = _parsed.get(
                                 "override_paths", {}).get("tasks_path")
                             if _v:
+                                for _p in _v.split(":"):
+                                    if os.path.isabs(_p):
+                                        places.append(_p)
+                                    else:
+                                        places.append(
+                                            os.path.join(os.getcwd(), _p))
                                 _found = _v
-                                break
-                    if _found:
                         break
-                if _found:
-                    for _p in _found.split(":"):
-                        if os.path.isabs(_p):
-                            places.append(_p)
-                        else:
-                            places.append(os.path.join(os.getcwd(), _p))
+
+                if not _found:
+                    _xdg = os.environ.get(
+                        "XDG_CONFIG_HOME",
+                        os.path.join(os.path.expanduser("~"), ".config"))
+                    _cfg_dirs = [
+                        "/usr/lib/debops/conf.d",
+                        "/usr/local/lib/debops/conf.d",
+                        "/etc/debops/conf.d",
+                        os.path.join(_xdg, "debops", "conf.d"),
+                    ]
+                    for _cd in _cfg_dirs:
+                        if not os.path.isdir(_cd):
+                            continue
+                        for _f in sorted(os.listdir(_cd)):
+                            _fp = os.path.join(_cd, _f)
+                            if _f.startswith(".") or not os.path.isfile(_fp):
+                                continue
+                            try:
+                                if _f.endswith(".json"):
+                                    with open(_fp) as _fh:
+                                        _parsed = json.load(_fh)
+                                elif _f.endswith(".toml"):
+                                    import tomllib as _tl
+                                    with open(_fp, "rb") as _fh:
+                                        _parsed = _tl.load(_fh)
+                                elif _f.endswith((".yaml", ".yml")):
+                                    import yaml as _yl
+                                    with open(_fp) as _fh:
+                                        _parsed = _yl.safe_load(_fh)
+                                else:
+                                    continue
+                            except Exception:
+                                continue
+                            if isinstance(_parsed, dict):
+                                _v = _parsed.get(
+                                    "override_paths", {}).get("tasks_path")
+                                if _v:
+                                    _found = _v
+                                    break
+                        if _found:
+                            break
+                    if _found:
+                        for _p in _found.split(":"):
+                            if os.path.isabs(_p):
+                                places.append(_p)
+                            else:
+                                places.append(
+                                    os.path.join(os.getcwd(), _p))
 
             for term in terms:
                 if 'role_path' in variables:

--- a/ansible/plugins/lookup/task_src.py
+++ b/ansible/plugins/lookup/task_src.py
@@ -166,7 +166,8 @@ if parse(__ansible_version__) < parse("2.0"):
                             continue
                         for _filename in sorted(os.listdir(_cfg_dir)):
                             _filepath = os.path.join(_cfg_dir, _filename)
-                            if _filename.startswith(".") or not os.path.isfile(_filepath):
+                            if (_filename.startswith(".")
+                                    or not os.path.isfile(_filepath)):
                                 continue
                             try:
                                 if _filename.endswith(".json"):
@@ -317,7 +318,8 @@ else:
                             continue
                         for _filename in sorted(os.listdir(_cfg_dir)):
                             _filepath = os.path.join(_cfg_dir, _filename)
-                            if _filename.startswith(".") or not os.path.isfile(_filepath):
+                            if (_filename.startswith(".")
+                                    or not os.path.isfile(_filepath)):
                                 continue
                             try:
                                 if _filename.endswith(".json"):

--- a/ansible/plugins/lookup/task_src.py
+++ b/ansible/plugins/lookup/task_src.py
@@ -113,6 +113,58 @@ if parse(__ansible_version__) < parse("2.0"):
                         places.append(os.path.join(
                             project_root, custom_path))
 
+            # Fallback when the debops Python module is not available
+            # (e.g. installed via Ansible Galaxy). Read override paths
+            # directly from the global DebOps configuration directories.
+            if not conf_section:
+                _xdg = os.environ.get(
+                    "XDG_CONFIG_HOME",
+                    os.path.join(os.path.expanduser("~"), ".config"))
+                _cfg_dirs = [
+                    "/usr/lib/debops/conf.d",
+                    "/usr/local/lib/debops/conf.d",
+                    "/etc/debops/conf.d",
+                    os.path.join(_xdg, "debops", "conf.d"),
+                ]
+                _found = None
+                for _cd in _cfg_dirs:
+                    if not os.path.isdir(_cd):
+                        continue
+                    for _f in sorted(os.listdir(_cd)):
+                        _fp = os.path.join(_cd, _f)
+                        if _f.startswith(".") or not os.path.isfile(_fp):
+                            continue
+                        try:
+                            if _f.endswith(".json"):
+                                with open(_fp) as _fh:
+                                    _parsed = json.load(_fh)
+                            elif _f.endswith(".toml"):
+                                import tomllib as _tl
+                                with open(_fp, "rb") as _fh:
+                                    _parsed = _tl.load(_fh)
+                            elif _f.endswith((".yaml", ".yml")):
+                                import yaml as _yl
+                                with open(_fp) as _fh:
+                                    _parsed = _yl.safe_load(_fh)
+                            else:
+                                continue
+                        except Exception:
+                            continue
+                        if isinstance(_parsed, dict):
+                            _v = _parsed.get(
+                                "override_paths", {}).get("tasks_path")
+                            if _v:
+                                _found = _v
+                                break
+                    if _found:
+                        break
+                if _found:
+                    for _p in _found.split(":"):
+                        if os.path.isabs(_p):
+                            places.append(_p)
+                        else:
+                            places.append(os.path.join(os.getcwd(), _p))
+
             for term in terms:
                 if '_original_file' in inject:
                     relative_path = utils.path_dwim_relative(
@@ -176,6 +228,58 @@ else:
                     else:
                         places.append(os.path.join(
                             project_root, custom_path))
+
+            # Fallback when the debops Python module is not available
+            # (e.g. installed via Ansible Galaxy). Read override paths
+            # directly from the global DebOps configuration directories.
+            if not conf_section:
+                _xdg = os.environ.get(
+                    "XDG_CONFIG_HOME",
+                    os.path.join(os.path.expanduser("~"), ".config"))
+                _cfg_dirs = [
+                    "/usr/lib/debops/conf.d",
+                    "/usr/local/lib/debops/conf.d",
+                    "/etc/debops/conf.d",
+                    os.path.join(_xdg, "debops", "conf.d"),
+                ]
+                _found = None
+                for _cd in _cfg_dirs:
+                    if not os.path.isdir(_cd):
+                        continue
+                    for _f in sorted(os.listdir(_cd)):
+                        _fp = os.path.join(_cd, _f)
+                        if _f.startswith(".") or not os.path.isfile(_fp):
+                            continue
+                        try:
+                            if _f.endswith(".json"):
+                                with open(_fp) as _fh:
+                                    _parsed = json.load(_fh)
+                            elif _f.endswith(".toml"):
+                                import tomllib as _tl
+                                with open(_fp, "rb") as _fh:
+                                    _parsed = _tl.load(_fh)
+                            elif _f.endswith((".yaml", ".yml")):
+                                import yaml as _yl
+                                with open(_fp) as _fh:
+                                    _parsed = _yl.safe_load(_fh)
+                            else:
+                                continue
+                        except Exception:
+                            continue
+                        if isinstance(_parsed, dict):
+                            _v = _parsed.get(
+                                "override_paths", {}).get("tasks_path")
+                            if _v:
+                                _found = _v
+                                break
+                    if _found:
+                        break
+                if _found:
+                    for _p in _found.split(":"):
+                        if os.path.isabs(_p):
+                            places.append(_p)
+                        else:
+                            places.append(os.path.join(os.getcwd(), _p))
 
             for term in terms:
                 if 'role_path' in variables:

--- a/ansible/plugins/lookup/task_src.py
+++ b/ansible/plugins/lookup/task_src.py
@@ -58,81 +58,118 @@ try:
 except ImportError:
     LookupBase = object
 
-from packaging.version import parse
-from ansible import __version__ as __ansible_version__
+from ansible.errors import AnsibleError
 
 
-if parse(__ansible_version__) < parse("2.0"):
-    from ansible import utils, errors
+class LookupModule(LookupBase):
 
-    class LookupModule(object):
+    def run(self, terms, variables=None, **kwargs):
+        ret = []
+        config = {}
+        places = []
 
-        def __init__(self, basedir, *args, **kwargs):
-            self.basedir = basedir
+        # this can happen if the variable contains a string,
+        # strictly not desired for lookup plugins, but users may
+        # try it, so make it work.
+        if not isinstance(terms, list):
+            terms = [terms]
 
-        def run(self, terms, inject=None, **kwargs):
-
-            terms = utils.listify_lookup_plugin_terms(
-                    terms, self.basedir, inject)
-            ret = []
-            config = {}
-            places = []
-
-            # this can happen if the variable contains a string,
-            # strictly not desired for lookup plugins, but users may
-            # try it, so make it work.
-            if not isinstance(terms, list):
-                terms = [terms]
-
+        try:
+            project_config = debops.config.Configuration()
+            project_dir = debops.projectdir.ProjectDir(
+                    config=project_config)
+            project_root = project_dir.path
+            if project_dir.config.get(['project', 'type']) == 'modern':
+                config = project_dir.config.get([])
+            else:
+                config = project_dir.config.get(['views', 'system'])
+        except NameError:
             try:
-                project_config = debops.config.Configuration()
-                project_dir = debops.projectdir.ProjectDir(
-                        config=project_config)
-                project_root = project_dir.path
-                if project_dir.config.get(['project', 'type']) == 'modern':
-                    config = project_dir.config.get([])
-                else:
-                    config = project_dir.config.get(['views', 'system'])
+                project_root = find_debops_project(required=False)
+                config = read_config(project_root)
             except NameError:
-                try:
-                    project_root = find_debops_project(required=False)
-                    config = read_config(project_root)
-                except NameError:
-                    pass
-            except NotADirectoryError:
-                # This is not a DebOps project directory, so continue as normal
                 pass
+        except NotADirectoryError:
+            # This is not a DebOps project directory, so continue as normal
+            pass
 
-            if conf_section in config and conf_key in config[conf_section]:
-                custom_places = (
-                        config[conf_section][conf_key].split(':'))
-                for custom_path in custom_places:
-                    if os.path.isabs(custom_path):
-                        places.append(custom_path)
-                    else:
-                        places.append(os.path.join(
-                            project_root, custom_path))
+        if conf_section in config and conf_key in config[conf_section]:
+            custom_places = (
+                    config[conf_section][conf_key].split(':'))
+            for custom_path in custom_places:
+                if os.path.isabs(custom_path):
+                    places.append(custom_path)
+                else:
+                    places.append(os.path.join(
+                        project_root, custom_path))
 
-            # Fallback when the debops Python module is not available
-            # (e.g. installed via Ansible Galaxy). Read override paths
-            # directly from the global DebOps configuration directories.
-            if not conf_section:
-                _found = None
+        # Fallback when the debops Python module is not available
+        # (e.g. installed via Ansible Galaxy). Read override paths
+        # directly from the global DebOps configuration directories.
+        if not conf_section:
+            _found = None
 
-                for _ext in [".yaml", ".yml", ".json", ".toml"]:
-                    _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
-                    if os.path.isfile(_project_path):
+            for _ext in [".yaml", ".yml", ".json", ".toml"]:
+                _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
+                if os.path.isfile(_project_path):
+                    try:
+                        if _project_path.endswith(".json"):
+                            with open(_project_path) as _fh:
+                                _parsed = json.load(_fh)
+                        elif _project_path.endswith(".toml"):
+                            import tomllib as _tl
+                            with open(_project_path, "rb") as _fh:
+                                _parsed = _tl.load(_fh)
+                        elif _project_path.endswith((".yaml", ".yml")):
+                            import yaml as _yl
+                            with open(_project_path) as _fh:
+                                _parsed = _yl.safe_load(_fh)
+                        else:
+                            continue
+                    except Exception:
+                        continue
+                    if isinstance(_parsed, dict):
+                        _override_value = _parsed.get(
+                            "override_paths", {}).get("tasks_path")
+                        if _override_value:
+                            for _path_item in _override_value.split(":"):
+                                if os.path.isabs(_path_item):
+                                    places.append(_path_item)
+                                else:
+                                    places.append(
+                                        os.path.join(os.getcwd(), _path_item))
+                            _found = _override_value
+                    break
+
+            if not _found:
+                _xdg = os.environ.get(
+                    "XDG_CONFIG_HOME",
+                    os.path.join(os.path.expanduser("~"), ".config"))
+                _cfg_dirs = [
+                    os.path.join(_xdg, "debops", "conf.d"),
+                    "/etc/debops/conf.d",
+                    "/usr/local/lib/debops/conf.d",
+                    "/usr/lib/debops/conf.d",
+                ]
+                for _cfg_dir in _cfg_dirs:
+                    if not os.path.isdir(_cfg_dir):
+                        continue
+                    for _filename in sorted(os.listdir(_cfg_dir)):
+                        _filepath = os.path.join(_cfg_dir, _filename)
+                        if (_filename.startswith(".")
+                                or not os.path.isfile(_filepath)):
+                            continue
                         try:
-                            if _project_path.endswith(".json"):
-                                with open(_project_path) as _fh:
+                            if _filename.endswith(".json"):
+                                with open(_filepath) as _fh:
                                     _parsed = json.load(_fh)
-                            elif _project_path.endswith(".toml"):
+                            elif _filename.endswith(".toml"):
                                 import tomllib as _tl
-                                with open(_project_path, "rb") as _fh:
+                                with open(_filepath, "rb") as _fh:
                                     _parsed = _tl.load(_fh)
-                            elif _project_path.endswith((".yaml", ".yml")):
+                            elif _filename.endswith((".yaml", ".yml")):
                                 import yaml as _yl
-                                with open(_project_path) as _fh:
+                                with open(_filepath) as _fh:
                                     _parsed = _yl.safe_load(_fh)
                             else:
                                 continue
@@ -142,232 +179,33 @@ if parse(__ansible_version__) < parse("2.0"):
                             _override_value = _parsed.get(
                                 "override_paths", {}).get("tasks_path")
                             if _override_value:
-                                for _path_item in _override_value.split(":"):
-                                    if os.path.isabs(_path_item):
-                                        places.append(_path_item)
-                                    else:
-                                        places.append(
-                                            os.path.join(os.getcwd(), _path_item))
                                 _found = _override_value
-                        break
-
-                if not _found:
-                    _xdg = os.environ.get(
-                        "XDG_CONFIG_HOME",
-                        os.path.join(os.path.expanduser("~"), ".config"))
-                    _cfg_dirs = [
-                        os.path.join(_xdg, "debops", "conf.d"),
-                        "/etc/debops/conf.d",
-                        "/usr/local/lib/debops/conf.d",
-                        "/usr/lib/debops/conf.d",
-                    ]
-                    for _cfg_dir in _cfg_dirs:
-                        if not os.path.isdir(_cfg_dir):
-                            continue
-                        for _filename in sorted(os.listdir(_cfg_dir)):
-                            _filepath = os.path.join(_cfg_dir, _filename)
-                            if (_filename.startswith(".")
-                                    or not os.path.isfile(_filepath)):
-                                continue
-                            try:
-                                if _filename.endswith(".json"):
-                                    with open(_filepath) as _fh:
-                                        _parsed = json.load(_fh)
-                                elif _filename.endswith(".toml"):
-                                    import tomllib as _tl
-                                    with open(_filepath, "rb") as _fh:
-                                        _parsed = _tl.load(_fh)
-                                elif _filename.endswith((".yaml", ".yml")):
-                                    import yaml as _yl
-                                    with open(_filepath) as _fh:
-                                        _parsed = _yl.safe_load(_fh)
-                                else:
-                                    continue
-                            except Exception:
-                                continue
-                            if isinstance(_parsed, dict):
-                                _override_value = _parsed.get(
-                                    "override_paths", {}).get("tasks_path")
-                                if _override_value:
-                                    _found = _override_value
-                                    break
-                        if _found:
-                            break
+                                break
                     if _found:
-                        for _path_item in _found.split(":"):
-                            if os.path.isabs(_path_item):
-                                places.append(_path_item)
-                            else:
-                                places.append(
-                                    os.path.join(os.getcwd(), _path_item))
-
-            for term in terms:
-                if '_original_file' in inject:
-                    relative_path = utils.path_dwim_relative(
-                            inject['_original_file'], 'tasks', '',
-                            self.basedir, check=False)
-                    places.append(relative_path)
-                for path in places:
-                    template = os.path.join(path, term)
-                    if template and os.path.exists(template):
-                        ret.append(template)
                         break
-                else:
-                    raise errors.AnsibleError(
-                            "could not locate file in lookup: %s"
-                            % term)
+                if _found:
+                    for _path_item in _found.split(":"):
+                        if os.path.isabs(_path_item):
+                            places.append(_path_item)
+                        else:
+                            places.append(
+                                os.path.join(os.getcwd(), _path_item))
 
-            return ret
+        for term in terms:
+            if 'role_path' in variables:
+                relative_path = (
+                        self._loader.path_dwim_relative(
+                            variables['role_path'],
+                            'tasks', ''))
+                places.append(relative_path)
+            for path in places:
+                template = os.path.join(path, term)
+                if template and os.path.exists(template):
+                    ret.append(template)
+                    break
+            else:
+                raise AnsibleError(
+                        "could not locate file in lookup: %s"
+                        % term)
 
-else:
-    from ansible.errors import AnsibleError
-    from ansible.plugins.lookup import LookupBase
-
-    class LookupModule(LookupBase):
-
-        def run(self, terms, variables=None, **kwargs):
-            ret = []
-            config = {}
-            places = []
-
-            # this can happen if the variable contains a string,
-            # strictly not desired for lookup plugins, but users may
-            # try it, so make it work.
-            if not isinstance(terms, list):
-                terms = [terms]
-
-            try:
-                project_config = debops.config.Configuration()
-                project_dir = debops.projectdir.ProjectDir(
-                        config=project_config)
-                project_root = project_dir.path
-                if project_dir.config.get(['project', 'type']) == 'modern':
-                    config = project_dir.config.get([])
-                else:
-                    config = project_dir.config.get(['views', 'system'])
-            except NameError:
-                try:
-                    project_root = find_debops_project(required=False)
-                    config = read_config(project_root)
-                except NameError:
-                    pass
-            except NotADirectoryError:
-                # This is not a DebOps project directory, so continue as normal
-                pass
-
-            if conf_section in config and conf_key in config[conf_section]:
-                custom_places = (
-                        config[conf_section][conf_key].split(':'))
-                for custom_path in custom_places:
-                    if os.path.isabs(custom_path):
-                        places.append(custom_path)
-                    else:
-                        places.append(os.path.join(
-                            project_root, custom_path))
-
-            # Fallback when the debops Python module is not available
-            # (e.g. installed via Ansible Galaxy). Read override paths
-            # directly from the global DebOps configuration directories.
-            if not conf_section:
-                _found = None
-
-                for _ext in [".yaml", ".yml", ".json", ".toml"]:
-                    _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
-                    if os.path.isfile(_project_path):
-                        try:
-                            if _project_path.endswith(".json"):
-                                with open(_project_path) as _fh:
-                                    _parsed = json.load(_fh)
-                            elif _project_path.endswith(".toml"):
-                                import tomllib as _tl
-                                with open(_project_path, "rb") as _fh:
-                                    _parsed = _tl.load(_fh)
-                            elif _project_path.endswith((".yaml", ".yml")):
-                                import yaml as _yl
-                                with open(_project_path) as _fh:
-                                    _parsed = _yl.safe_load(_fh)
-                            else:
-                                continue
-                        except Exception:
-                            continue
-                        if isinstance(_parsed, dict):
-                            _override_value = _parsed.get(
-                                "override_paths", {}).get("tasks_path")
-                            if _override_value:
-                                for _path_item in _override_value.split(":"):
-                                    if os.path.isabs(_path_item):
-                                        places.append(_path_item)
-                                    else:
-                                        places.append(
-                                            os.path.join(os.getcwd(), _path_item))
-                                _found = _override_value
-                        break
-
-                if not _found:
-                    _xdg = os.environ.get(
-                        "XDG_CONFIG_HOME",
-                        os.path.join(os.path.expanduser("~"), ".config"))
-                    _cfg_dirs = [
-                        os.path.join(_xdg, "debops", "conf.d"),
-                        "/etc/debops/conf.d",
-                        "/usr/local/lib/debops/conf.d",
-                        "/usr/lib/debops/conf.d",
-                    ]
-                    for _cfg_dir in _cfg_dirs:
-                        if not os.path.isdir(_cfg_dir):
-                            continue
-                        for _filename in sorted(os.listdir(_cfg_dir)):
-                            _filepath = os.path.join(_cfg_dir, _filename)
-                            if (_filename.startswith(".")
-                                    or not os.path.isfile(_filepath)):
-                                continue
-                            try:
-                                if _filename.endswith(".json"):
-                                    with open(_filepath) as _fh:
-                                        _parsed = json.load(_fh)
-                                elif _filename.endswith(".toml"):
-                                    import tomllib as _tl
-                                    with open(_filepath, "rb") as _fh:
-                                        _parsed = _tl.load(_fh)
-                                elif _filename.endswith((".yaml", ".yml")):
-                                    import yaml as _yl
-                                    with open(_filepath) as _fh:
-                                        _parsed = _yl.safe_load(_fh)
-                                else:
-                                    continue
-                            except Exception:
-                                continue
-                            if isinstance(_parsed, dict):
-                                _override_value = _parsed.get(
-                                    "override_paths", {}).get("tasks_path")
-                                if _override_value:
-                                    _found = _override_value
-                                    break
-                        if _found:
-                            break
-                    if _found:
-                        for _path_item in _found.split(":"):
-                            if os.path.isabs(_path_item):
-                                places.append(_path_item)
-                            else:
-                                places.append(
-                                    os.path.join(os.getcwd(), _path_item))
-
-            for term in terms:
-                if 'role_path' in variables:
-                    relative_path = (
-                            self._loader.path_dwim_relative(
-                                variables['role_path'],
-                                'tasks', ''))
-                    places.append(relative_path)
-                for path in places:
-                    template = os.path.join(path, term)
-                    if template and os.path.exists(template):
-                        ret.append(template)
-                        break
-                else:
-                    raise AnsibleError(
-                            "could not locate file in lookup: %s"
-                            % term)
-
-            return ret
+        return ret

--- a/ansible/plugins/lookup/task_src.py
+++ b/ansible/plugins/lookup/task_src.py
@@ -59,6 +59,7 @@ except ImportError:
     LookupBase = object
 
 from ansible.errors import AnsibleError
+from ansible_collections.debops.debops.plugins.plugin_utils import debops_config
 
 
 class LookupModule(LookupBase):
@@ -107,89 +108,7 @@ class LookupModule(LookupBase):
         # (e.g. installed via Ansible Galaxy). Read override paths
         # directly from the global DebOps configuration directories.
         if not conf_section:
-            _found = None
-
-            for _ext in [".yaml", ".yml", ".json", ".toml"]:
-                _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
-                if os.path.isfile(_project_path):
-                    try:
-                        if _project_path.endswith(".json"):
-                            with open(_project_path) as _fh:
-                                _parsed = json.load(_fh)
-                        elif _project_path.endswith(".toml"):
-                            import tomllib as _tl
-                            with open(_project_path, "rb") as _fh:
-                                _parsed = _tl.load(_fh)
-                        elif _project_path.endswith((".yaml", ".yml")):
-                            import yaml as _yl
-                            with open(_project_path) as _fh:
-                                _parsed = _yl.safe_load(_fh)
-                        else:
-                            continue
-                    except Exception:
-                        continue
-                    if isinstance(_parsed, dict):
-                        _override_value = _parsed.get(
-                            "override_paths", {}).get("tasks_path")
-                        if _override_value:
-                            for _path_item in _override_value.split(":"):
-                                if os.path.isabs(_path_item):
-                                    places.append(_path_item)
-                                else:
-                                    places.append(
-                                        os.path.join(os.getcwd(), _path_item))
-                            _found = _override_value
-                    break
-
-            if not _found:
-                _xdg = os.environ.get(
-                    "XDG_CONFIG_HOME",
-                    os.path.join(os.path.expanduser("~"), ".config"))
-                _cfg_dirs = [
-                    os.path.join(_xdg, "debops", "conf.d"),
-                    "/etc/debops/conf.d",
-                    "/usr/local/lib/debops/conf.d",
-                    "/usr/lib/debops/conf.d",
-                ]
-                for _cfg_dir in _cfg_dirs:
-                    if not os.path.isdir(_cfg_dir):
-                        continue
-                    for _filename in sorted(os.listdir(_cfg_dir)):
-                        _filepath = os.path.join(_cfg_dir, _filename)
-                        if (_filename.startswith(".")
-                                or not os.path.isfile(_filepath)):
-                            continue
-                        try:
-                            if _filename.endswith(".json"):
-                                with open(_filepath) as _fh:
-                                    _parsed = json.load(_fh)
-                            elif _filename.endswith(".toml"):
-                                import tomllib as _tl
-                                with open(_filepath, "rb") as _fh:
-                                    _parsed = _tl.load(_fh)
-                            elif _filename.endswith((".yaml", ".yml")):
-                                import yaml as _yl
-                                with open(_filepath) as _fh:
-                                    _parsed = _yl.safe_load(_fh)
-                            else:
-                                continue
-                        except Exception:
-                            continue
-                        if isinstance(_parsed, dict):
-                            _override_value = _parsed.get(
-                                "override_paths", {}).get("tasks_path")
-                            if _override_value:
-                                _found = _override_value
-                                break
-                    if _found:
-                        break
-                if _found:
-                    for _path_item in _found.split(":"):
-                        if os.path.isabs(_path_item):
-                            places.append(_path_item)
-                        else:
-                            places.append(
-                                os.path.join(os.getcwd(), _path_item))
+            places.extend(debops_config.load_fallback_paths('tasks_path'))
 
         for term in terms:
             if 'role_path' in variables:

--- a/ansible/plugins/lookup/task_src.py
+++ b/ansible/plugins/lookup/task_src.py
@@ -123,8 +123,13 @@ class LookupModule(LookupBase):
                     ret.append(template)
                     break
             else:
-                raise AnsibleError(
-                        "could not locate file in lookup: %s"
-                        % term)
+                msg = "could not locate file in lookup: %s" % term
+                if not places:
+                    msg += (". No override paths configured. Install"
+                            " the debops Python module, create a"
+                            " .debops.{yaml,yml,json,toml} file,"
+                            " or add config to"
+                            " ~/.config/debops/conf.d/")
+                raise AnsibleError(msg)
 
         return ret

--- a/ansible/plugins/lookup/task_src.py
+++ b/ansible/plugins/lookup/task_src.py
@@ -107,7 +107,7 @@ class LookupModule(LookupBase):
         # Fallback when the debops Python module is not available
         # (e.g. installed via Ansible Galaxy). Read override paths
         # directly from the global DebOps configuration directories.
-        if not conf_section:
+        if not places:
             places.extend(debops_config.load_fallback_paths('tasks_path'))
 
         for term in terms:

--- a/ansible/plugins/lookup/template_src.py
+++ b/ansible/plugins/lookup/template_src.py
@@ -120,7 +120,7 @@ if parse(__ansible_version__) < parse("2.0"):
             if not conf_section:
                 _found = None
 
-                for _ext in [".json", ".toml", ".yaml", ".yml"]:
+                for _ext in [".yaml", ".yml", ".json", ".toml"]:
                     _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
                     if os.path.isfile(_project_path):
                         try:
@@ -157,10 +157,10 @@ if parse(__ansible_version__) < parse("2.0"):
                         "XDG_CONFIG_HOME",
                         os.path.join(os.path.expanduser("~"), ".config"))
                     _cfg_dirs = [
-                        "/usr/lib/debops/conf.d",
-                        "/usr/local/lib/debops/conf.d",
-                        "/etc/debops/conf.d",
                         os.path.join(_xdg, "debops", "conf.d"),
+                        "/etc/debops/conf.d",
+                        "/usr/local/lib/debops/conf.d",
+                        "/usr/lib/debops/conf.d",
                     ]
                     for _cfg_dir in _cfg_dirs:
                         if not os.path.isdir(_cfg_dir):
@@ -272,7 +272,7 @@ else:
             if not conf_section:
                 _found = None
 
-                for _ext in [".json", ".toml", ".yaml", ".yml"]:
+                for _ext in [".yaml", ".yml", ".json", ".toml"]:
                     _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
                     if os.path.isfile(_project_path):
                         try:
@@ -309,10 +309,10 @@ else:
                         "XDG_CONFIG_HOME",
                         os.path.join(os.path.expanduser("~"), ".config"))
                     _cfg_dirs = [
-                        "/usr/lib/debops/conf.d",
-                        "/usr/local/lib/debops/conf.d",
-                        "/etc/debops/conf.d",
                         os.path.join(_xdg, "debops", "conf.d"),
+                        "/etc/debops/conf.d",
+                        "/usr/local/lib/debops/conf.d",
+                        "/usr/lib/debops/conf.d",
                     ]
                     for _cfg_dir in _cfg_dirs:
                         if not os.path.isdir(_cfg_dir):

--- a/ansible/plugins/lookup/template_src.py
+++ b/ansible/plugins/lookup/template_src.py
@@ -118,34 +118,22 @@ if parse(__ansible_version__) < parse("2.0"):
             # (e.g. installed via Ansible Galaxy). Read override paths
             # directly from the global DebOps configuration directories.
             if not conf_section:
-                _xdg = os.environ.get(
-                    "XDG_CONFIG_HOME",
-                    os.path.join(os.path.expanduser("~"), ".config"))
-                _cfg_dirs = [
-                    "/usr/lib/debops/conf.d",
-                    "/usr/local/lib/debops/conf.d",
-                    "/etc/debops/conf.d",
-                    os.path.join(_xdg, "debops", "conf.d"),
-                ]
                 _found = None
-                for _cd in _cfg_dirs:
-                    if not os.path.isdir(_cd):
-                        continue
-                    for _f in sorted(os.listdir(_cd)):
-                        _fp = os.path.join(_cd, _f)
-                        if _f.startswith(".") or not os.path.isfile(_fp):
-                            continue
+
+                for _ext in [".json", ".toml", ".yaml", ".yml"]:
+                    _pp = os.path.join(os.getcwd(), ".debops" + _ext)
+                    if os.path.isfile(_pp):
                         try:
-                            if _f.endswith(".json"):
-                                with open(_fp) as _fh:
+                            if _pp.endswith(".json"):
+                                with open(_pp) as _fh:
                                     _parsed = json.load(_fh)
-                            elif _f.endswith(".toml"):
+                            elif _pp.endswith(".toml"):
                                 import tomllib as _tl
-                                with open(_fp, "rb") as _fh:
+                                with open(_pp, "rb") as _fh:
                                     _parsed = _tl.load(_fh)
-                            elif _f.endswith((".yaml", ".yml")):
+                            elif _pp.endswith((".yaml", ".yml")):
                                 import yaml as _yl
-                                with open(_fp) as _fh:
+                                with open(_pp) as _fh:
                                     _parsed = _yl.safe_load(_fh)
                             else:
                                 continue
@@ -155,16 +143,63 @@ if parse(__ansible_version__) < parse("2.0"):
                             _v = _parsed.get(
                                 "override_paths", {}).get("templates_path")
                             if _v:
+                                for _p in _v.split(":"):
+                                    if os.path.isabs(_p):
+                                        places.append(_p)
+                                    else:
+                                        places.append(
+                                            os.path.join(os.getcwd(), _p))
                                 _found = _v
-                                break
-                    if _found:
                         break
-                if _found:
-                    for _p in _found.split(":"):
-                        if os.path.isabs(_p):
-                            places.append(_p)
-                        else:
-                            places.append(os.path.join(os.getcwd(), _p))
+
+                if not _found:
+                    _xdg = os.environ.get(
+                        "XDG_CONFIG_HOME",
+                        os.path.join(os.path.expanduser("~"), ".config"))
+                    _cfg_dirs = [
+                        "/usr/lib/debops/conf.d",
+                        "/usr/local/lib/debops/conf.d",
+                        "/etc/debops/conf.d",
+                        os.path.join(_xdg, "debops", "conf.d"),
+                    ]
+                    for _cd in _cfg_dirs:
+                        if not os.path.isdir(_cd):
+                            continue
+                        for _f in sorted(os.listdir(_cd)):
+                            _fp = os.path.join(_cd, _f)
+                            if _f.startswith(".") or not os.path.isfile(_fp):
+                                continue
+                            try:
+                                if _f.endswith(".json"):
+                                    with open(_fp) as _fh:
+                                        _parsed = json.load(_fh)
+                                elif _f.endswith(".toml"):
+                                    import tomllib as _tl
+                                    with open(_fp, "rb") as _fh:
+                                        _parsed = _tl.load(_fh)
+                                elif _f.endswith((".yaml", ".yml")):
+                                    import yaml as _yl
+                                    with open(_fp) as _fh:
+                                        _parsed = _yl.safe_load(_fh)
+                                else:
+                                    continue
+                            except Exception:
+                                continue
+                            if isinstance(_parsed, dict):
+                                _v = _parsed.get(
+                                    "override_paths", {}).get("templates_path")
+                                if _v:
+                                    _found = _v
+                                    break
+                        if _found:
+                            break
+                    if _found:
+                        for _p in _found.split(":"):
+                            if os.path.isabs(_p):
+                                places.append(_p)
+                            else:
+                                places.append(
+                                    os.path.join(os.getcwd(), _p))
 
             for term in terms:
                 if '_original_file' in inject:
@@ -235,34 +270,22 @@ else:
             # (e.g. installed via Ansible Galaxy). Read override paths
             # directly from the global DebOps configuration directories.
             if not conf_section:
-                _xdg = os.environ.get(
-                    "XDG_CONFIG_HOME",
-                    os.path.join(os.path.expanduser("~"), ".config"))
-                _cfg_dirs = [
-                    "/usr/lib/debops/conf.d",
-                    "/usr/local/lib/debops/conf.d",
-                    "/etc/debops/conf.d",
-                    os.path.join(_xdg, "debops", "conf.d"),
-                ]
                 _found = None
-                for _cd in _cfg_dirs:
-                    if not os.path.isdir(_cd):
-                        continue
-                    for _f in sorted(os.listdir(_cd)):
-                        _fp = os.path.join(_cd, _f)
-                        if _f.startswith(".") or not os.path.isfile(_fp):
-                            continue
+
+                for _ext in [".json", ".toml", ".yaml", ".yml"]:
+                    _pp = os.path.join(os.getcwd(), ".debops" + _ext)
+                    if os.path.isfile(_pp):
                         try:
-                            if _f.endswith(".json"):
-                                with open(_fp) as _fh:
+                            if _pp.endswith(".json"):
+                                with open(_pp) as _fh:
                                     _parsed = json.load(_fh)
-                            elif _f.endswith(".toml"):
+                            elif _pp.endswith(".toml"):
                                 import tomllib as _tl
-                                with open(_fp, "rb") as _fh:
+                                with open(_pp, "rb") as _fh:
                                     _parsed = _tl.load(_fh)
-                            elif _f.endswith((".yaml", ".yml")):
+                            elif _pp.endswith((".yaml", ".yml")):
                                 import yaml as _yl
-                                with open(_fp) as _fh:
+                                with open(_pp) as _fh:
                                     _parsed = _yl.safe_load(_fh)
                             else:
                                 continue
@@ -272,16 +295,63 @@ else:
                             _v = _parsed.get(
                                 "override_paths", {}).get("templates_path")
                             if _v:
+                                for _p in _v.split(":"):
+                                    if os.path.isabs(_p):
+                                        places.append(_p)
+                                    else:
+                                        places.append(
+                                            os.path.join(os.getcwd(), _p))
                                 _found = _v
-                                break
-                    if _found:
                         break
-                if _found:
-                    for _p in _found.split(":"):
-                        if os.path.isabs(_p):
-                            places.append(_p)
-                        else:
-                            places.append(os.path.join(os.getcwd(), _p))
+
+                if not _found:
+                    _xdg = os.environ.get(
+                        "XDG_CONFIG_HOME",
+                        os.path.join(os.path.expanduser("~"), ".config"))
+                    _cfg_dirs = [
+                        "/usr/lib/debops/conf.d",
+                        "/usr/local/lib/debops/conf.d",
+                        "/etc/debops/conf.d",
+                        os.path.join(_xdg, "debops", "conf.d"),
+                    ]
+                    for _cd in _cfg_dirs:
+                        if not os.path.isdir(_cd):
+                            continue
+                        for _f in sorted(os.listdir(_cd)):
+                            _fp = os.path.join(_cd, _f)
+                            if _f.startswith(".") or not os.path.isfile(_fp):
+                                continue
+                            try:
+                                if _f.endswith(".json"):
+                                    with open(_fp) as _fh:
+                                        _parsed = json.load(_fh)
+                                elif _f.endswith(".toml"):
+                                    import tomllib as _tl
+                                    with open(_fp, "rb") as _fh:
+                                        _parsed = _tl.load(_fh)
+                                elif _f.endswith((".yaml", ".yml")):
+                                    import yaml as _yl
+                                    with open(_fp) as _fh:
+                                        _parsed = _yl.safe_load(_fh)
+                                else:
+                                    continue
+                            except Exception:
+                                continue
+                            if isinstance(_parsed, dict):
+                                _v = _parsed.get(
+                                    "override_paths", {}).get("templates_path")
+                                if _v:
+                                    _found = _v
+                                    break
+                        if _found:
+                            break
+                    if _found:
+                        for _p in _found.split(":"):
+                            if os.path.isabs(_p):
+                                places.append(_p)
+                            else:
+                                places.append(
+                                    os.path.join(os.getcwd(), _p))
 
             for term in terms:
                 if 'role_path' in variables:

--- a/ansible/plugins/lookup/template_src.py
+++ b/ansible/plugins/lookup/template_src.py
@@ -167,7 +167,8 @@ if parse(__ansible_version__) < parse("2.0"):
                             continue
                         for _filename in sorted(os.listdir(_cfg_dir)):
                             _filepath = os.path.join(_cfg_dir, _filename)
-                            if _filename.startswith(".") or not os.path.isfile(_filepath):
+                            if (_filename.startswith(".")
+                                    or not os.path.isfile(_filepath)):
                                 continue
                             try:
                                 if _filename.endswith(".json"):
@@ -319,7 +320,8 @@ else:
                             continue
                         for _filename in sorted(os.listdir(_cfg_dir)):
                             _filepath = os.path.join(_cfg_dir, _filename)
-                            if _filename.startswith(".") or not os.path.isfile(_filepath):
+                            if (_filename.startswith(".")
+                                    or not os.path.isfile(_filepath)):
                                 continue
                             try:
                                 if _filename.endswith(".json"):

--- a/ansible/plugins/lookup/template_src.py
+++ b/ansible/plugins/lookup/template_src.py
@@ -121,35 +121,35 @@ if parse(__ansible_version__) < parse("2.0"):
                 _found = None
 
                 for _ext in [".json", ".toml", ".yaml", ".yml"]:
-                    _pp = os.path.join(os.getcwd(), ".debops" + _ext)
-                    if os.path.isfile(_pp):
+                    _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
+                    if os.path.isfile(_project_path):
                         try:
-                            if _pp.endswith(".json"):
-                                with open(_pp) as _fh:
+                            if _project_path.endswith(".json"):
+                                with open(_project_path) as _fh:
                                     _parsed = json.load(_fh)
-                            elif _pp.endswith(".toml"):
+                            elif _project_path.endswith(".toml"):
                                 import tomllib as _tl
-                                with open(_pp, "rb") as _fh:
+                                with open(_project_path, "rb") as _fh:
                                     _parsed = _tl.load(_fh)
-                            elif _pp.endswith((".yaml", ".yml")):
+                            elif _project_path.endswith((".yaml", ".yml")):
                                 import yaml as _yl
-                                with open(_pp) as _fh:
+                                with open(_project_path) as _fh:
                                     _parsed = _yl.safe_load(_fh)
                             else:
                                 continue
                         except Exception:
                             continue
                         if isinstance(_parsed, dict):
-                            _v = _parsed.get(
+                            _override_value = _parsed.get(
                                 "override_paths", {}).get("templates_path")
-                            if _v:
-                                for _p in _v.split(":"):
-                                    if os.path.isabs(_p):
-                                        places.append(_p)
+                            if _override_value:
+                                for _path_item in _override_value.split(":"):
+                                    if os.path.isabs(_path_item):
+                                        places.append(_path_item)
                                     else:
                                         places.append(
-                                            os.path.join(os.getcwd(), _p))
-                                _found = _v
+                                            os.path.join(os.getcwd(), _path_item))
+                                _found = _override_value
                         break
 
                 if not _found:
@@ -162,44 +162,44 @@ if parse(__ansible_version__) < parse("2.0"):
                         "/etc/debops/conf.d",
                         os.path.join(_xdg, "debops", "conf.d"),
                     ]
-                    for _cd in _cfg_dirs:
-                        if not os.path.isdir(_cd):
+                    for _cfg_dir in _cfg_dirs:
+                        if not os.path.isdir(_cfg_dir):
                             continue
-                        for _f in sorted(os.listdir(_cd)):
-                            _fp = os.path.join(_cd, _f)
-                            if _f.startswith(".") or not os.path.isfile(_fp):
+                        for _filename in sorted(os.listdir(_cfg_dir)):
+                            _filepath = os.path.join(_cfg_dir, _filename)
+                            if _filename.startswith(".") or not os.path.isfile(_filepath):
                                 continue
                             try:
-                                if _f.endswith(".json"):
-                                    with open(_fp) as _fh:
+                                if _filename.endswith(".json"):
+                                    with open(_filepath) as _fh:
                                         _parsed = json.load(_fh)
-                                elif _f.endswith(".toml"):
+                                elif _filename.endswith(".toml"):
                                     import tomllib as _tl
-                                    with open(_fp, "rb") as _fh:
+                                    with open(_filepath, "rb") as _fh:
                                         _parsed = _tl.load(_fh)
-                                elif _f.endswith((".yaml", ".yml")):
+                                elif _filename.endswith((".yaml", ".yml")):
                                     import yaml as _yl
-                                    with open(_fp) as _fh:
+                                    with open(_filepath) as _fh:
                                         _parsed = _yl.safe_load(_fh)
                                 else:
                                     continue
                             except Exception:
                                 continue
                             if isinstance(_parsed, dict):
-                                _v = _parsed.get(
+                                _override_value = _parsed.get(
                                     "override_paths", {}).get("templates_path")
-                                if _v:
-                                    _found = _v
+                                if _override_value:
+                                    _found = _override_value
                                     break
                         if _found:
                             break
                     if _found:
-                        for _p in _found.split(":"):
-                            if os.path.isabs(_p):
-                                places.append(_p)
+                        for _path_item in _found.split(":"):
+                            if os.path.isabs(_path_item):
+                                places.append(_path_item)
                             else:
                                 places.append(
-                                    os.path.join(os.getcwd(), _p))
+                                    os.path.join(os.getcwd(), _path_item))
 
             for term in terms:
                 if '_original_file' in inject:
@@ -273,35 +273,35 @@ else:
                 _found = None
 
                 for _ext in [".json", ".toml", ".yaml", ".yml"]:
-                    _pp = os.path.join(os.getcwd(), ".debops" + _ext)
-                    if os.path.isfile(_pp):
+                    _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
+                    if os.path.isfile(_project_path):
                         try:
-                            if _pp.endswith(".json"):
-                                with open(_pp) as _fh:
+                            if _project_path.endswith(".json"):
+                                with open(_project_path) as _fh:
                                     _parsed = json.load(_fh)
-                            elif _pp.endswith(".toml"):
+                            elif _project_path.endswith(".toml"):
                                 import tomllib as _tl
-                                with open(_pp, "rb") as _fh:
+                                with open(_project_path, "rb") as _fh:
                                     _parsed = _tl.load(_fh)
-                            elif _pp.endswith((".yaml", ".yml")):
+                            elif _project_path.endswith((".yaml", ".yml")):
                                 import yaml as _yl
-                                with open(_pp) as _fh:
+                                with open(_project_path) as _fh:
                                     _parsed = _yl.safe_load(_fh)
                             else:
                                 continue
                         except Exception:
                             continue
                         if isinstance(_parsed, dict):
-                            _v = _parsed.get(
+                            _override_value = _parsed.get(
                                 "override_paths", {}).get("templates_path")
-                            if _v:
-                                for _p in _v.split(":"):
-                                    if os.path.isabs(_p):
-                                        places.append(_p)
+                            if _override_value:
+                                for _path_item in _override_value.split(":"):
+                                    if os.path.isabs(_path_item):
+                                        places.append(_path_item)
                                     else:
                                         places.append(
-                                            os.path.join(os.getcwd(), _p))
-                                _found = _v
+                                            os.path.join(os.getcwd(), _path_item))
+                                _found = _override_value
                         break
 
                 if not _found:
@@ -314,44 +314,44 @@ else:
                         "/etc/debops/conf.d",
                         os.path.join(_xdg, "debops", "conf.d"),
                     ]
-                    for _cd in _cfg_dirs:
-                        if not os.path.isdir(_cd):
+                    for _cfg_dir in _cfg_dirs:
+                        if not os.path.isdir(_cfg_dir):
                             continue
-                        for _f in sorted(os.listdir(_cd)):
-                            _fp = os.path.join(_cd, _f)
-                            if _f.startswith(".") or not os.path.isfile(_fp):
+                        for _filename in sorted(os.listdir(_cfg_dir)):
+                            _filepath = os.path.join(_cfg_dir, _filename)
+                            if _filename.startswith(".") or not os.path.isfile(_filepath):
                                 continue
                             try:
-                                if _f.endswith(".json"):
-                                    with open(_fp) as _fh:
+                                if _filename.endswith(".json"):
+                                    with open(_filepath) as _fh:
                                         _parsed = json.load(_fh)
-                                elif _f.endswith(".toml"):
+                                elif _filename.endswith(".toml"):
                                     import tomllib as _tl
-                                    with open(_fp, "rb") as _fh:
+                                    with open(_filepath, "rb") as _fh:
                                         _parsed = _tl.load(_fh)
-                                elif _f.endswith((".yaml", ".yml")):
+                                elif _filename.endswith((".yaml", ".yml")):
                                     import yaml as _yl
-                                    with open(_fp) as _fh:
+                                    with open(_filepath) as _fh:
                                         _parsed = _yl.safe_load(_fh)
                                 else:
                                     continue
                             except Exception:
                                 continue
                             if isinstance(_parsed, dict):
-                                _v = _parsed.get(
+                                _override_value = _parsed.get(
                                     "override_paths", {}).get("templates_path")
-                                if _v:
-                                    _found = _v
+                                if _override_value:
+                                    _found = _override_value
                                     break
                         if _found:
                             break
                     if _found:
-                        for _p in _found.split(":"):
-                            if os.path.isabs(_p):
-                                places.append(_p)
+                        for _path_item in _found.split(":"):
+                            if os.path.isabs(_path_item):
+                                places.append(_path_item)
                             else:
                                 places.append(
-                                    os.path.join(os.getcwd(), _p))
+                                    os.path.join(os.getcwd(), _path_item))
 
             for term in terms:
                 if 'role_path' in variables:

--- a/ansible/plugins/lookup/template_src.py
+++ b/ansible/plugins/lookup/template_src.py
@@ -114,6 +114,58 @@ if parse(__ansible_version__) < parse("2.0"):
                         places.append(os.path.join(
                             project_root, custom_path))
 
+            # Fallback when the debops Python module is not available
+            # (e.g. installed via Ansible Galaxy). Read override paths
+            # directly from the global DebOps configuration directories.
+            if not conf_section:
+                _xdg = os.environ.get(
+                    "XDG_CONFIG_HOME",
+                    os.path.join(os.path.expanduser("~"), ".config"))
+                _cfg_dirs = [
+                    "/usr/lib/debops/conf.d",
+                    "/usr/local/lib/debops/conf.d",
+                    "/etc/debops/conf.d",
+                    os.path.join(_xdg, "debops", "conf.d"),
+                ]
+                _found = None
+                for _cd in _cfg_dirs:
+                    if not os.path.isdir(_cd):
+                        continue
+                    for _f in sorted(os.listdir(_cd)):
+                        _fp = os.path.join(_cd, _f)
+                        if _f.startswith(".") or not os.path.isfile(_fp):
+                            continue
+                        try:
+                            if _f.endswith(".json"):
+                                with open(_fp) as _fh:
+                                    _parsed = json.load(_fh)
+                            elif _f.endswith(".toml"):
+                                import tomllib as _tl
+                                with open(_fp, "rb") as _fh:
+                                    _parsed = _tl.load(_fh)
+                            elif _f.endswith((".yaml", ".yml")):
+                                import yaml as _yl
+                                with open(_fp) as _fh:
+                                    _parsed = _yl.safe_load(_fh)
+                            else:
+                                continue
+                        except Exception:
+                            continue
+                        if isinstance(_parsed, dict):
+                            _v = _parsed.get(
+                                "override_paths", {}).get("templates_path")
+                            if _v:
+                                _found = _v
+                                break
+                    if _found:
+                        break
+                if _found:
+                    for _p in _found.split(":"):
+                        if os.path.isabs(_p):
+                            places.append(_p)
+                        else:
+                            places.append(os.path.join(os.getcwd(), _p))
+
             for term in terms:
                 if '_original_file' in inject:
                     relative_path = (
@@ -178,6 +230,58 @@ else:
                     else:
                         places.append(os.path.join(
                             project_root, custom_path))
+
+            # Fallback when the debops Python module is not available
+            # (e.g. installed via Ansible Galaxy). Read override paths
+            # directly from the global DebOps configuration directories.
+            if not conf_section:
+                _xdg = os.environ.get(
+                    "XDG_CONFIG_HOME",
+                    os.path.join(os.path.expanduser("~"), ".config"))
+                _cfg_dirs = [
+                    "/usr/lib/debops/conf.d",
+                    "/usr/local/lib/debops/conf.d",
+                    "/etc/debops/conf.d",
+                    os.path.join(_xdg, "debops", "conf.d"),
+                ]
+                _found = None
+                for _cd in _cfg_dirs:
+                    if not os.path.isdir(_cd):
+                        continue
+                    for _f in sorted(os.listdir(_cd)):
+                        _fp = os.path.join(_cd, _f)
+                        if _f.startswith(".") or not os.path.isfile(_fp):
+                            continue
+                        try:
+                            if _f.endswith(".json"):
+                                with open(_fp) as _fh:
+                                    _parsed = json.load(_fh)
+                            elif _f.endswith(".toml"):
+                                import tomllib as _tl
+                                with open(_fp, "rb") as _fh:
+                                    _parsed = _tl.load(_fh)
+                            elif _f.endswith((".yaml", ".yml")):
+                                import yaml as _yl
+                                with open(_fp) as _fh:
+                                    _parsed = _yl.safe_load(_fh)
+                            else:
+                                continue
+                        except Exception:
+                            continue
+                        if isinstance(_parsed, dict):
+                            _v = _parsed.get(
+                                "override_paths", {}).get("templates_path")
+                            if _v:
+                                _found = _v
+                                break
+                    if _found:
+                        break
+                if _found:
+                    for _p in _found.split(":"):
+                        if os.path.isabs(_p):
+                            places.append(_p)
+                        else:
+                            places.append(os.path.join(os.getcwd(), _p))
 
             for term in terms:
                 if 'role_path' in variables:

--- a/ansible/plugins/lookup/template_src.py
+++ b/ansible/plugins/lookup/template_src.py
@@ -124,8 +124,13 @@ class LookupModule(LookupBase):
                     ret.append(template)
                     break
             else:
-                raise AnsibleError(
-                        "could not locate file in lookup: %s"
-                        % term)
+                msg = "could not locate file in lookup: %s" % term
+                if not places:
+                    msg += (". No override paths configured. Install"
+                            " the debops Python module, create a"
+                            " .debops.{yaml,yml,json,toml} file,"
+                            " or add config to"
+                            " ~/.config/debops/conf.d/")
+                raise AnsibleError(msg)
 
         return ret

--- a/ansible/plugins/lookup/template_src.py
+++ b/ansible/plugins/lookup/template_src.py
@@ -108,7 +108,7 @@ class LookupModule(LookupBase):
         # Fallback when the debops Python module is not available
         # (e.g. installed via Ansible Galaxy). Read override paths
         # directly from the global DebOps configuration directories.
-        if not conf_section:
+        if not places:
             places.extend(debops_config.load_fallback_paths('templates_path'))
 
         for term in terms:

--- a/ansible/plugins/lookup/template_src.py
+++ b/ansible/plugins/lookup/template_src.py
@@ -60,6 +60,7 @@ except ImportError:
     LookupBase = object
 
 from ansible.errors import AnsibleError
+from ansible_collections.debops.debops.plugins.plugin_utils import debops_config
 
 
 class LookupModule(LookupBase):
@@ -108,89 +109,7 @@ class LookupModule(LookupBase):
         # (e.g. installed via Ansible Galaxy). Read override paths
         # directly from the global DebOps configuration directories.
         if not conf_section:
-            _found = None
-
-            for _ext in [".yaml", ".yml", ".json", ".toml"]:
-                _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
-                if os.path.isfile(_project_path):
-                    try:
-                        if _project_path.endswith(".json"):
-                            with open(_project_path) as _fh:
-                                _parsed = json.load(_fh)
-                        elif _project_path.endswith(".toml"):
-                            import tomllib as _tl
-                            with open(_project_path, "rb") as _fh:
-                                _parsed = _tl.load(_fh)
-                        elif _project_path.endswith((".yaml", ".yml")):
-                            import yaml as _yl
-                            with open(_project_path) as _fh:
-                                _parsed = _yl.safe_load(_fh)
-                        else:
-                            continue
-                    except Exception:
-                        continue
-                    if isinstance(_parsed, dict):
-                        _override_value = _parsed.get(
-                            "override_paths", {}).get("templates_path")
-                        if _override_value:
-                            for _path_item in _override_value.split(":"):
-                                if os.path.isabs(_path_item):
-                                    places.append(_path_item)
-                                else:
-                                    places.append(
-                                        os.path.join(os.getcwd(), _path_item))
-                            _found = _override_value
-                    break
-
-            if not _found:
-                _xdg = os.environ.get(
-                    "XDG_CONFIG_HOME",
-                    os.path.join(os.path.expanduser("~"), ".config"))
-                _cfg_dirs = [
-                    os.path.join(_xdg, "debops", "conf.d"),
-                    "/etc/debops/conf.d",
-                    "/usr/local/lib/debops/conf.d",
-                    "/usr/lib/debops/conf.d",
-                ]
-                for _cfg_dir in _cfg_dirs:
-                    if not os.path.isdir(_cfg_dir):
-                        continue
-                    for _filename in sorted(os.listdir(_cfg_dir)):
-                        _filepath = os.path.join(_cfg_dir, _filename)
-                        if (_filename.startswith(".")
-                                or not os.path.isfile(_filepath)):
-                            continue
-                        try:
-                            if _filename.endswith(".json"):
-                                with open(_filepath) as _fh:
-                                    _parsed = json.load(_fh)
-                            elif _filename.endswith(".toml"):
-                                import tomllib as _tl
-                                with open(_filepath, "rb") as _fh:
-                                    _parsed = _tl.load(_fh)
-                            elif _filename.endswith((".yaml", ".yml")):
-                                import yaml as _yl
-                                with open(_filepath) as _fh:
-                                    _parsed = _yl.safe_load(_fh)
-                            else:
-                                continue
-                        except Exception:
-                            continue
-                        if isinstance(_parsed, dict):
-                            _override_value = _parsed.get(
-                                "override_paths", {}).get("templates_path")
-                            if _override_value:
-                                _found = _override_value
-                                break
-                    if _found:
-                        break
-                if _found:
-                    for _path_item in _found.split(":"):
-                        if os.path.isabs(_path_item):
-                            places.append(_path_item)
-                        else:
-                            places.append(
-                                os.path.join(os.getcwd(), _path_item))
+            places.extend(debops_config.load_fallback_paths('templates_path'))
 
         for term in terms:
             if 'role_path' in variables:

--- a/ansible/plugins/lookup/template_src.py
+++ b/ansible/plugins/lookup/template_src.py
@@ -59,81 +59,118 @@ try:
 except ImportError:
     LookupBase = object
 
-from packaging.version import parse
-from ansible import __version__ as __ansible_version__
+from ansible.errors import AnsibleError
 
 
-if parse(__ansible_version__) < parse("2.0"):
-    from ansible import utils, errors
+class LookupModule(LookupBase):
 
-    class LookupModule(object):
+    def run(self, terms, variables=None, **kwargs):
+        ret = []
+        config = {}
+        places = []
 
-        def __init__(self, basedir, *args, **kwargs):
-            self.basedir = basedir
+        # this can happen if the variable contains a string,
+        # strictly not desired for lookup plugins, but users may
+        # try it, so make it work.
+        if not isinstance(terms, list):
+            terms = [terms]
 
-        def run(self, terms, inject=None, **kwargs):
-
-            terms = utils.listify_lookup_plugin_terms(
-                    terms, self.basedir, inject)
-            ret = []
-            config = {}
-            places = []
-
-            # this can happen if the variable contains a string,
-            # strictly not desired for lookup plugins, but users may
-            # try it, so make it work.
-            if not isinstance(terms, list):
-                terms = [terms]
-
+        try:
+            project_config = debops.config.Configuration()
+            project_dir = debops.projectdir.ProjectDir(
+                    config=project_config)
+            project_root = project_dir.path
+            if project_dir.config.get(['project', 'type']) == 'modern':
+                config = project_dir.config.get([])
+            else:
+                config = project_dir.config.get(['views', 'system'])
+        except NameError:
             try:
-                project_config = debops.config.Configuration()
-                project_dir = debops.projectdir.ProjectDir(
-                        config=project_config)
-                project_root = project_dir.path
-                if project_dir.config.get(['project', 'type']) == 'modern':
-                    config = project_dir.config.get([])
-                else:
-                    config = project_dir.config.get(['views', 'system'])
+                project_root = find_debops_project(required=False)
+                config = read_config(project_root)
             except NameError:
-                try:
-                    project_root = find_debops_project(required=False)
-                    config = read_config(project_root)
-                except NameError:
-                    pass
-            except NotADirectoryError:
-                # This is not a DebOps project directory, so continue as normal
                 pass
+        except NotADirectoryError:
+            # This is not a DebOps project directory, so continue as normal
+            pass
 
-            if conf_section in config and conf_key in config[conf_section]:
-                custom_places = (
-                        config[conf_section][conf_key].split(':'))
-                for custom_path in custom_places:
-                    if os.path.isabs(custom_path):
-                        places.append(custom_path)
-                    else:
-                        places.append(os.path.join(
-                            project_root, custom_path))
+        if conf_section in config and conf_key in config[conf_section]:
+            custom_places = (
+                    config[conf_section][conf_key].split(':'))
+            for custom_path in custom_places:
+                if os.path.isabs(custom_path):
+                    places.append(custom_path)
+                else:
+                    places.append(os.path.join(
+                        project_root, custom_path))
 
-            # Fallback when the debops Python module is not available
-            # (e.g. installed via Ansible Galaxy). Read override paths
-            # directly from the global DebOps configuration directories.
-            if not conf_section:
-                _found = None
+        # Fallback when the debops Python module is not available
+        # (e.g. installed via Ansible Galaxy). Read override paths
+        # directly from the global DebOps configuration directories.
+        if not conf_section:
+            _found = None
 
-                for _ext in [".yaml", ".yml", ".json", ".toml"]:
-                    _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
-                    if os.path.isfile(_project_path):
+            for _ext in [".yaml", ".yml", ".json", ".toml"]:
+                _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
+                if os.path.isfile(_project_path):
+                    try:
+                        if _project_path.endswith(".json"):
+                            with open(_project_path) as _fh:
+                                _parsed = json.load(_fh)
+                        elif _project_path.endswith(".toml"):
+                            import tomllib as _tl
+                            with open(_project_path, "rb") as _fh:
+                                _parsed = _tl.load(_fh)
+                        elif _project_path.endswith((".yaml", ".yml")):
+                            import yaml as _yl
+                            with open(_project_path) as _fh:
+                                _parsed = _yl.safe_load(_fh)
+                        else:
+                            continue
+                    except Exception:
+                        continue
+                    if isinstance(_parsed, dict):
+                        _override_value = _parsed.get(
+                            "override_paths", {}).get("templates_path")
+                        if _override_value:
+                            for _path_item in _override_value.split(":"):
+                                if os.path.isabs(_path_item):
+                                    places.append(_path_item)
+                                else:
+                                    places.append(
+                                        os.path.join(os.getcwd(), _path_item))
+                            _found = _override_value
+                    break
+
+            if not _found:
+                _xdg = os.environ.get(
+                    "XDG_CONFIG_HOME",
+                    os.path.join(os.path.expanduser("~"), ".config"))
+                _cfg_dirs = [
+                    os.path.join(_xdg, "debops", "conf.d"),
+                    "/etc/debops/conf.d",
+                    "/usr/local/lib/debops/conf.d",
+                    "/usr/lib/debops/conf.d",
+                ]
+                for _cfg_dir in _cfg_dirs:
+                    if not os.path.isdir(_cfg_dir):
+                        continue
+                    for _filename in sorted(os.listdir(_cfg_dir)):
+                        _filepath = os.path.join(_cfg_dir, _filename)
+                        if (_filename.startswith(".")
+                                or not os.path.isfile(_filepath)):
+                            continue
                         try:
-                            if _project_path.endswith(".json"):
-                                with open(_project_path) as _fh:
+                            if _filename.endswith(".json"):
+                                with open(_filepath) as _fh:
                                     _parsed = json.load(_fh)
-                            elif _project_path.endswith(".toml"):
+                            elif _filename.endswith(".toml"):
                                 import tomllib as _tl
-                                with open(_project_path, "rb") as _fh:
+                                with open(_filepath, "rb") as _fh:
                                     _parsed = _tl.load(_fh)
-                            elif _project_path.endswith((".yaml", ".yml")):
+                            elif _filename.endswith((".yaml", ".yml")):
                                 import yaml as _yl
-                                with open(_project_path) as _fh:
+                                with open(_filepath) as _fh:
                                     _parsed = _yl.safe_load(_fh)
                             else:
                                 continue
@@ -143,233 +180,33 @@ if parse(__ansible_version__) < parse("2.0"):
                             _override_value = _parsed.get(
                                 "override_paths", {}).get("templates_path")
                             if _override_value:
-                                for _path_item in _override_value.split(":"):
-                                    if os.path.isabs(_path_item):
-                                        places.append(_path_item)
-                                    else:
-                                        places.append(
-                                            os.path.join(os.getcwd(), _path_item))
                                 _found = _override_value
-                        break
-
-                if not _found:
-                    _xdg = os.environ.get(
-                        "XDG_CONFIG_HOME",
-                        os.path.join(os.path.expanduser("~"), ".config"))
-                    _cfg_dirs = [
-                        os.path.join(_xdg, "debops", "conf.d"),
-                        "/etc/debops/conf.d",
-                        "/usr/local/lib/debops/conf.d",
-                        "/usr/lib/debops/conf.d",
-                    ]
-                    for _cfg_dir in _cfg_dirs:
-                        if not os.path.isdir(_cfg_dir):
-                            continue
-                        for _filename in sorted(os.listdir(_cfg_dir)):
-                            _filepath = os.path.join(_cfg_dir, _filename)
-                            if (_filename.startswith(".")
-                                    or not os.path.isfile(_filepath)):
-                                continue
-                            try:
-                                if _filename.endswith(".json"):
-                                    with open(_filepath) as _fh:
-                                        _parsed = json.load(_fh)
-                                elif _filename.endswith(".toml"):
-                                    import tomllib as _tl
-                                    with open(_filepath, "rb") as _fh:
-                                        _parsed = _tl.load(_fh)
-                                elif _filename.endswith((".yaml", ".yml")):
-                                    import yaml as _yl
-                                    with open(_filepath) as _fh:
-                                        _parsed = _yl.safe_load(_fh)
-                                else:
-                                    continue
-                            except Exception:
-                                continue
-                            if isinstance(_parsed, dict):
-                                _override_value = _parsed.get(
-                                    "override_paths", {}).get("templates_path")
-                                if _override_value:
-                                    _found = _override_value
-                                    break
-                        if _found:
-                            break
+                                break
                     if _found:
-                        for _path_item in _found.split(":"):
-                            if os.path.isabs(_path_item):
-                                places.append(_path_item)
-                            else:
-                                places.append(
-                                    os.path.join(os.getcwd(), _path_item))
-
-            for term in terms:
-                if '_original_file' in inject:
-                    relative_path = (
-                            utils.path_dwim_relative(
-                                inject['_original_file'], 'templates',
-                                '', self.basedir, check=False))
-                    places.append(relative_path)
-                for path in places:
-                    template = os.path.join(path, term)
-                    if template and os.path.exists(template):
-                        ret.append(template)
                         break
-                else:
-                    raise errors.AnsibleError(
-                            "could not locate file in lookup: %s"
-                            % term)
+                if _found:
+                    for _path_item in _found.split(":"):
+                        if os.path.isabs(_path_item):
+                            places.append(_path_item)
+                        else:
+                            places.append(
+                                os.path.join(os.getcwd(), _path_item))
 
-            return ret
+        for term in terms:
+            if 'role_path' in variables:
+                relative_path = (
+                        self._loader.path_dwim_relative(
+                            variables['role_path'], 'templates',
+                            ''))
+                places.append(relative_path)
+            for path in places:
+                template = os.path.join(path, term)
+                if template and os.path.exists(template):
+                    ret.append(template)
+                    break
+            else:
+                raise AnsibleError(
+                        "could not locate file in lookup: %s"
+                        % term)
 
-else:
-    from ansible.errors import AnsibleError
-    from ansible.plugins.lookup import LookupBase
-
-    class LookupModule(LookupBase):
-
-        def run(self, terms, variables=None, **kwargs):
-            ret = []
-            config = {}
-            places = []
-
-            # this can happen if the variable contains a string,
-            # strictly not desired for lookup plugins, but users may
-            # try it, so make it work.
-            if not isinstance(terms, list):
-                terms = [terms]
-
-            try:
-                project_config = debops.config.Configuration()
-                project_dir = debops.projectdir.ProjectDir(
-                        config=project_config)
-                project_root = project_dir.path
-                if project_dir.config.get(['project', 'type']) == 'modern':
-                    config = project_dir.config.get([])
-                else:
-                    config = project_dir.config.get(['views', 'system'])
-            except NameError:
-                try:
-                    project_root = find_debops_project(required=False)
-                    config = read_config(project_root)
-                except NameError:
-                    pass
-            except NotADirectoryError:
-                # This is not a DebOps project directory, so continue as normal
-                pass
-
-            if conf_section in config and conf_key in config[conf_section]:
-                custom_places = (
-                        config[conf_section][conf_key].split(':'))
-                for custom_path in custom_places:
-                    if os.path.isabs(custom_path):
-                        places.append(custom_path)
-                    else:
-                        places.append(os.path.join(
-                            project_root, custom_path))
-
-            # Fallback when the debops Python module is not available
-            # (e.g. installed via Ansible Galaxy). Read override paths
-            # directly from the global DebOps configuration directories.
-            if not conf_section:
-                _found = None
-
-                for _ext in [".yaml", ".yml", ".json", ".toml"]:
-                    _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
-                    if os.path.isfile(_project_path):
-                        try:
-                            if _project_path.endswith(".json"):
-                                with open(_project_path) as _fh:
-                                    _parsed = json.load(_fh)
-                            elif _project_path.endswith(".toml"):
-                                import tomllib as _tl
-                                with open(_project_path, "rb") as _fh:
-                                    _parsed = _tl.load(_fh)
-                            elif _project_path.endswith((".yaml", ".yml")):
-                                import yaml as _yl
-                                with open(_project_path) as _fh:
-                                    _parsed = _yl.safe_load(_fh)
-                            else:
-                                continue
-                        except Exception:
-                            continue
-                        if isinstance(_parsed, dict):
-                            _override_value = _parsed.get(
-                                "override_paths", {}).get("templates_path")
-                            if _override_value:
-                                for _path_item in _override_value.split(":"):
-                                    if os.path.isabs(_path_item):
-                                        places.append(_path_item)
-                                    else:
-                                        places.append(
-                                            os.path.join(os.getcwd(), _path_item))
-                                _found = _override_value
-                        break
-
-                if not _found:
-                    _xdg = os.environ.get(
-                        "XDG_CONFIG_HOME",
-                        os.path.join(os.path.expanduser("~"), ".config"))
-                    _cfg_dirs = [
-                        os.path.join(_xdg, "debops", "conf.d"),
-                        "/etc/debops/conf.d",
-                        "/usr/local/lib/debops/conf.d",
-                        "/usr/lib/debops/conf.d",
-                    ]
-                    for _cfg_dir in _cfg_dirs:
-                        if not os.path.isdir(_cfg_dir):
-                            continue
-                        for _filename in sorted(os.listdir(_cfg_dir)):
-                            _filepath = os.path.join(_cfg_dir, _filename)
-                            if (_filename.startswith(".")
-                                    or not os.path.isfile(_filepath)):
-                                continue
-                            try:
-                                if _filename.endswith(".json"):
-                                    with open(_filepath) as _fh:
-                                        _parsed = json.load(_fh)
-                                elif _filename.endswith(".toml"):
-                                    import tomllib as _tl
-                                    with open(_filepath, "rb") as _fh:
-                                        _parsed = _tl.load(_fh)
-                                elif _filename.endswith((".yaml", ".yml")):
-                                    import yaml as _yl
-                                    with open(_filepath) as _fh:
-                                        _parsed = _yl.safe_load(_fh)
-                                else:
-                                    continue
-                            except Exception:
-                                continue
-                            if isinstance(_parsed, dict):
-                                _override_value = _parsed.get(
-                                    "override_paths", {}).get("templates_path")
-                                if _override_value:
-                                    _found = _override_value
-                                    break
-                        if _found:
-                            break
-                    if _found:
-                        for _path_item in _found.split(":"):
-                            if os.path.isabs(_path_item):
-                                places.append(_path_item)
-                            else:
-                                places.append(
-                                    os.path.join(os.getcwd(), _path_item))
-
-            for term in terms:
-                if 'role_path' in variables:
-                    relative_path = (
-                            self._loader.path_dwim_relative(
-                                variables['role_path'], 'templates',
-                                ''))
-                    places.append(relative_path)
-                for path in places:
-                    template = os.path.join(path, term)
-                    if template and os.path.exists(template):
-                        ret.append(template)
-                        break
-                else:
-                    raise AnsibleError(
-                            "could not locate file in lookup: %s"
-                            % term)
-
-            return ret
+        return ret

--- a/ansible/plugins/plugin_utils/debops_config.py
+++ b/ansible/plugins/plugin_utils/debops_config.py
@@ -1,0 +1,121 @@
+# Copyright 2015-2026, Maciej Delmanowski <drybjed@drybjed.net>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+'''Fallback configuration loading for DebOps lookup plugins.
+
+When the debops Python module is not installed (e.g. collection
+installed via Ansible Galaxy), override paths are read from:
+
+1. A project-local ``.debops.{yaml,yml,json,toml}`` file.
+2. Global config directories (``~/.config/debops/conf.d/`` etc.).
+
+This module centralises that logic so that ``file_src``, ``template_src``,
+and ``task_src`` stay thin wrappers.
+'''
+
+import json
+import os
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    tomllib = None
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+
+def _load_file(path):
+    '''Parse a JSON, TOML, or YAML file and return the resulting dict,
+    or *None* on any failure.'''
+
+    try:
+        if path.endswith('.json'):
+            with open(path) as fh:
+                return json.load(fh)
+        if path.endswith('.toml') and tomllib is not None:
+            with open(path, 'rb') as fh:
+                return tomllib.load(fh)
+        if path.endswith(('.yaml', '.yml')) and yaml is not None:
+            with open(path) as fh:
+                return yaml.safe_load(fh)
+    except Exception:
+        pass
+
+    return None
+
+
+def _extract_paths(parsed, conf_key):
+    '''Return a list of absolute directory paths from *parsed* under
+    ``override_paths.<conf_key>``, or an empty list.'''
+
+    override_value = (
+        parsed.get('override_paths', {}).get(conf_key)
+        if isinstance(parsed, dict) else None
+    )
+    if not override_value:
+        return []
+
+    result = []
+    for path_item in override_value.split(':'):
+        if os.path.isabs(path_item):
+            result.append(path_item)
+        else:
+            result.append(os.path.join(os.getcwd(), path_item))
+    return result
+
+
+def load_fallback_paths(conf_key):
+    '''Return override directories when the debops Python module is absent.
+
+    *conf_key* is the config key name (e.g. ``"files_path"``,
+    ``"templates_path"``, ``"tasks_path"``).
+
+    Resolution order:
+
+    1. Project-local ``.debops.{yaml,yml,json,toml}`` in the current
+       working directory.
+    2. Global config directories (most-specific to least-specific):
+       ``$XDG_CONFIG_HOME/debops/conf.d/``, ``/etc/debops/conf.d/``,
+       ``/usr/local/lib/debops/conf.d/``, ``/usr/lib/debops/conf.d/``.
+
+    Returns a list of absolute directory paths.  An empty list means no
+    override paths were found.
+    '''
+
+    # 1. Project-local .debops.{yaml,yml,json,toml}
+    for ext in ('.yaml', '.yml', '.json', '.toml'):
+        project_path = os.path.join(os.getcwd(), '.debops' + ext)
+        if os.path.isfile(project_path):
+            parsed = _load_file(project_path)
+            paths = _extract_paths(parsed, conf_key)
+            if paths:
+                return paths
+            break
+
+    # 2. Global config directories (most → least specific)
+    xdg = os.environ.get(
+        'XDG_CONFIG_HOME',
+        os.path.join(os.path.expanduser('~'), '.config'))
+    cfg_dirs = [
+        os.path.join(xdg, 'debops', 'conf.d'),
+        '/etc/debops/conf.d',
+        '/usr/local/lib/debops/conf.d',
+        '/usr/lib/debops/conf.d',
+    ]
+
+    for cfg_dir in cfg_dirs:
+        if not os.path.isdir(cfg_dir):
+            continue
+        for filename in sorted(os.listdir(cfg_dir)):
+            filepath = os.path.join(cfg_dir, filename)
+            if filename.startswith('.') or not os.path.isfile(filepath):
+                continue
+            parsed = _load_file(filepath)
+            paths = _extract_paths(parsed, conf_key)
+            if paths:
+                return paths
+
+    return []

--- a/ansible/roles/ansible_plugins/lookup_plugins/file_src.py
+++ b/ansible/roles/ansible_plugins/lookup_plugins/file_src.py
@@ -119,7 +119,7 @@ if LooseVersion(__ansible_version__) < LooseVersion("2.0"):
             if not conf_section:
                 _found = None
 
-                for _ext in [".json", ".toml", ".yaml", ".yml"]:
+                for _ext in [".yaml", ".yml", ".json", ".toml"]:
                     _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
                     if os.path.isfile(_project_path):
                         try:
@@ -156,10 +156,10 @@ if LooseVersion(__ansible_version__) < LooseVersion("2.0"):
                         "XDG_CONFIG_HOME",
                         os.path.join(os.path.expanduser("~"), ".config"))
                     _cfg_dirs = [
-                        "/usr/lib/debops/conf.d",
-                        "/usr/local/lib/debops/conf.d",
-                        "/etc/debops/conf.d",
                         os.path.join(_xdg, "debops", "conf.d"),
+                        "/etc/debops/conf.d",
+                        "/usr/local/lib/debops/conf.d",
+                        "/usr/lib/debops/conf.d",
                     ]
                     for _cfg_dir in _cfg_dirs:
                         if not os.path.isdir(_cfg_dir):
@@ -270,7 +270,7 @@ else:
             if not conf_section:
                 _found = None
 
-                for _ext in [".json", ".toml", ".yaml", ".yml"]:
+                for _ext in [".yaml", ".yml", ".json", ".toml"]:
                     _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
                     if os.path.isfile(_project_path):
                         try:
@@ -307,10 +307,10 @@ else:
                         "XDG_CONFIG_HOME",
                         os.path.join(os.path.expanduser("~"), ".config"))
                     _cfg_dirs = [
-                        "/usr/lib/debops/conf.d",
-                        "/usr/local/lib/debops/conf.d",
-                        "/etc/debops/conf.d",
                         os.path.join(_xdg, "debops", "conf.d"),
+                        "/etc/debops/conf.d",
+                        "/usr/local/lib/debops/conf.d",
+                        "/usr/lib/debops/conf.d",
                     ]
                     for _cfg_dir in _cfg_dirs:
                         if not os.path.isdir(_cfg_dir):

--- a/ansible/roles/ansible_plugins/lookup_plugins/file_src.py
+++ b/ansible/roles/ansible_plugins/lookup_plugins/file_src.py
@@ -120,35 +120,35 @@ if LooseVersion(__ansible_version__) < LooseVersion("2.0"):
                 _found = None
 
                 for _ext in [".json", ".toml", ".yaml", ".yml"]:
-                    _pp = os.path.join(os.getcwd(), ".debops" + _ext)
-                    if os.path.isfile(_pp):
+                    _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
+                    if os.path.isfile(_project_path):
                         try:
-                            if _pp.endswith(".json"):
-                                with open(_pp) as _fh:
+                            if _project_path.endswith(".json"):
+                                with open(_project_path) as _fh:
                                     _parsed = json.load(_fh)
-                            elif _pp.endswith(".toml"):
+                            elif _project_path.endswith(".toml"):
                                 import tomllib as _tl
-                                with open(_pp, "rb") as _fh:
+                                with open(_project_path, "rb") as _fh:
                                     _parsed = _tl.load(_fh)
-                            elif _pp.endswith((".yaml", ".yml")):
+                            elif _project_path.endswith((".yaml", ".yml")):
                                 import yaml as _yl
-                                with open(_pp) as _fh:
+                                with open(_project_path) as _fh:
                                     _parsed = _yl.safe_load(_fh)
                             else:
                                 continue
                         except Exception:
                             continue
                         if isinstance(_parsed, dict):
-                            _v = _parsed.get(
+                            _override_value = _parsed.get(
                                 "override_paths", {}).get("files_path")
-                            if _v:
-                                for _p in _v.split(":"):
-                                    if os.path.isabs(_p):
-                                        places.append(_p)
+                            if _override_value:
+                                for _path_item in _override_value.split(":"):
+                                    if os.path.isabs(_path_item):
+                                        places.append(_path_item)
                                     else:
                                         places.append(
-                                            os.path.join(os.getcwd(), _p))
-                                _found = _v
+                                            os.path.join(os.getcwd(), _path_item))
+                                _found = _override_value
                         break
 
                 if not _found:
@@ -161,44 +161,44 @@ if LooseVersion(__ansible_version__) < LooseVersion("2.0"):
                         "/etc/debops/conf.d",
                         os.path.join(_xdg, "debops", "conf.d"),
                     ]
-                    for _cd in _cfg_dirs:
-                        if not os.path.isdir(_cd):
+                    for _cfg_dir in _cfg_dirs:
+                        if not os.path.isdir(_cfg_dir):
                             continue
-                        for _f in sorted(os.listdir(_cd)):
-                            _fp = os.path.join(_cd, _f)
-                            if _f.startswith(".") or not os.path.isfile(_fp):
+                        for _filename in sorted(os.listdir(_cfg_dir)):
+                            _filepath = os.path.join(_cfg_dir, _filename)
+                            if _filename.startswith(".") or not os.path.isfile(_filepath):
                                 continue
                             try:
-                                if _f.endswith(".json"):
-                                    with open(_fp) as _fh:
+                                if _filename.endswith(".json"):
+                                    with open(_filepath) as _fh:
                                         _parsed = json.load(_fh)
-                                elif _f.endswith(".toml"):
+                                elif _filename.endswith(".toml"):
                                     import tomllib as _tl
-                                    with open(_fp, "rb") as _fh:
+                                    with open(_filepath, "rb") as _fh:
                                         _parsed = _tl.load(_fh)
-                                elif _f.endswith((".yaml", ".yml")):
+                                elif _filename.endswith((".yaml", ".yml")):
                                     import yaml as _yl
-                                    with open(_fp) as _fh:
+                                    with open(_filepath) as _fh:
                                         _parsed = _yl.safe_load(_fh)
                                 else:
                                     continue
                             except Exception:
                                 continue
                             if isinstance(_parsed, dict):
-                                _v = _parsed.get(
+                                _override_value = _parsed.get(
                                     "override_paths", {}).get("files_path")
-                                if _v:
-                                    _found = _v
+                                if _override_value:
+                                    _found = _override_value
                                     break
                         if _found:
                             break
                     if _found:
-                        for _p in _found.split(":"):
-                            if os.path.isabs(_p):
-                                places.append(_p)
+                        for _path_item in _found.split(":"):
+                            if os.path.isabs(_path_item):
+                                places.append(_path_item)
                             else:
                                 places.append(
-                                    os.path.join(os.getcwd(), _p))
+                                    os.path.join(os.getcwd(), _path_item))
 
             for term in terms:
                 if '_original_file' in inject:
@@ -271,35 +271,35 @@ else:
                 _found = None
 
                 for _ext in [".json", ".toml", ".yaml", ".yml"]:
-                    _pp = os.path.join(os.getcwd(), ".debops" + _ext)
-                    if os.path.isfile(_pp):
+                    _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
+                    if os.path.isfile(_project_path):
                         try:
-                            if _pp.endswith(".json"):
-                                with open(_pp) as _fh:
+                            if _project_path.endswith(".json"):
+                                with open(_project_path) as _fh:
                                     _parsed = json.load(_fh)
-                            elif _pp.endswith(".toml"):
+                            elif _project_path.endswith(".toml"):
                                 import tomllib as _tl
-                                with open(_pp, "rb") as _fh:
+                                with open(_project_path, "rb") as _fh:
                                     _parsed = _tl.load(_fh)
-                            elif _pp.endswith((".yaml", ".yml")):
+                            elif _project_path.endswith((".yaml", ".yml")):
                                 import yaml as _yl
-                                with open(_pp) as _fh:
+                                with open(_project_path) as _fh:
                                     _parsed = _yl.safe_load(_fh)
                             else:
                                 continue
                         except Exception:
                             continue
                         if isinstance(_parsed, dict):
-                            _v = _parsed.get(
+                            _override_value = _parsed.get(
                                 "override_paths", {}).get("files_path")
-                            if _v:
-                                for _p in _v.split(":"):
-                                    if os.path.isabs(_p):
-                                        places.append(_p)
+                            if _override_value:
+                                for _path_item in _override_value.split(":"):
+                                    if os.path.isabs(_path_item):
+                                        places.append(_path_item)
                                     else:
                                         places.append(
-                                            os.path.join(os.getcwd(), _p))
-                                _found = _v
+                                            os.path.join(os.getcwd(), _path_item))
+                                _found = _override_value
                         break
 
                 if not _found:
@@ -312,44 +312,44 @@ else:
                         "/etc/debops/conf.d",
                         os.path.join(_xdg, "debops", "conf.d"),
                     ]
-                    for _cd in _cfg_dirs:
-                        if not os.path.isdir(_cd):
+                    for _cfg_dir in _cfg_dirs:
+                        if not os.path.isdir(_cfg_dir):
                             continue
-                        for _f in sorted(os.listdir(_cd)):
-                            _fp = os.path.join(_cd, _f)
-                            if _f.startswith(".") or not os.path.isfile(_fp):
+                        for _filename in sorted(os.listdir(_cfg_dir)):
+                            _filepath = os.path.join(_cfg_dir, _filename)
+                            if _filename.startswith(".") or not os.path.isfile(_filepath):
                                 continue
                             try:
-                                if _f.endswith(".json"):
-                                    with open(_fp) as _fh:
+                                if _filename.endswith(".json"):
+                                    with open(_filepath) as _fh:
                                         _parsed = json.load(_fh)
-                                elif _f.endswith(".toml"):
+                                elif _filename.endswith(".toml"):
                                     import tomllib as _tl
-                                    with open(_fp, "rb") as _fh:
+                                    with open(_filepath, "rb") as _fh:
                                         _parsed = _tl.load(_fh)
-                                elif _f.endswith((".yaml", ".yml")):
+                                elif _filename.endswith((".yaml", ".yml")):
                                     import yaml as _yl
-                                    with open(_fp) as _fh:
+                                    with open(_filepath) as _fh:
                                         _parsed = _yl.safe_load(_fh)
                                 else:
                                     continue
                             except Exception:
                                 continue
                             if isinstance(_parsed, dict):
-                                _v = _parsed.get(
+                                _override_value = _parsed.get(
                                     "override_paths", {}).get("files_path")
-                                if _v:
-                                    _found = _v
+                                if _override_value:
+                                    _found = _override_value
                                     break
                         if _found:
                             break
                     if _found:
-                        for _p in _found.split(":"):
-                            if os.path.isabs(_p):
-                                places.append(_p)
+                        for _path_item in _found.split(":"):
+                            if os.path.isabs(_path_item):
+                                places.append(_path_item)
                             else:
                                 places.append(
-                                    os.path.join(os.getcwd(), _p))
+                                    os.path.join(os.getcwd(), _path_item))
 
             for term in terms:
                 if 'role_path' in variables:

--- a/ansible/roles/ansible_plugins/lookup_plugins/file_src.py
+++ b/ansible/roles/ansible_plugins/lookup_plugins/file_src.py
@@ -166,7 +166,8 @@ if LooseVersion(__ansible_version__) < LooseVersion("2.0"):
                             continue
                         for _filename in sorted(os.listdir(_cfg_dir)):
                             _filepath = os.path.join(_cfg_dir, _filename)
-                            if _filename.startswith(".") or not os.path.isfile(_filepath):
+                            if (_filename.startswith(".")
+                                    or not os.path.isfile(_filepath)):
                                 continue
                             try:
                                 if _filename.endswith(".json"):
@@ -317,7 +318,8 @@ else:
                             continue
                         for _filename in sorted(os.listdir(_cfg_dir)):
                             _filepath = os.path.join(_cfg_dir, _filename)
-                            if _filename.startswith(".") or not os.path.isfile(_filepath):
+                            if (_filename.startswith(".")
+                                    or not os.path.isfile(_filepath)):
                                 continue
                             try:
                                 if _filename.endswith(".json"):

--- a/ansible/roles/ansible_plugins/lookup_plugins/file_src.py
+++ b/ansible/roles/ansible_plugins/lookup_plugins/file_src.py
@@ -117,34 +117,22 @@ if LooseVersion(__ansible_version__) < LooseVersion("2.0"):
             # (e.g. installed via Ansible Galaxy). Read override paths
             # directly from the global DebOps configuration directories.
             if not conf_section:
-                _xdg = os.environ.get(
-                    "XDG_CONFIG_HOME",
-                    os.path.join(os.path.expanduser("~"), ".config"))
-                _cfg_dirs = [
-                    "/usr/lib/debops/conf.d",
-                    "/usr/local/lib/debops/conf.d",
-                    "/etc/debops/conf.d",
-                    os.path.join(_xdg, "debops", "conf.d"),
-                ]
                 _found = None
-                for _cd in _cfg_dirs:
-                    if not os.path.isdir(_cd):
-                        continue
-                    for _f in sorted(os.listdir(_cd)):
-                        _fp = os.path.join(_cd, _f)
-                        if _f.startswith(".") or not os.path.isfile(_fp):
-                            continue
+
+                for _ext in [".json", ".toml", ".yaml", ".yml"]:
+                    _pp = os.path.join(os.getcwd(), ".debops" + _ext)
+                    if os.path.isfile(_pp):
                         try:
-                            if _f.endswith(".json"):
-                                with open(_fp) as _fh:
+                            if _pp.endswith(".json"):
+                                with open(_pp) as _fh:
                                     _parsed = json.load(_fh)
-                            elif _f.endswith(".toml"):
+                            elif _pp.endswith(".toml"):
                                 import tomllib as _tl
-                                with open(_fp, "rb") as _fh:
+                                with open(_pp, "rb") as _fh:
                                     _parsed = _tl.load(_fh)
-                            elif _f.endswith((".yaml", ".yml")):
+                            elif _pp.endswith((".yaml", ".yml")):
                                 import yaml as _yl
-                                with open(_fp) as _fh:
+                                with open(_pp) as _fh:
                                     _parsed = _yl.safe_load(_fh)
                             else:
                                 continue
@@ -154,16 +142,63 @@ if LooseVersion(__ansible_version__) < LooseVersion("2.0"):
                             _v = _parsed.get(
                                 "override_paths", {}).get("files_path")
                             if _v:
+                                for _p in _v.split(":"):
+                                    if os.path.isabs(_p):
+                                        places.append(_p)
+                                    else:
+                                        places.append(
+                                            os.path.join(os.getcwd(), _p))
                                 _found = _v
-                                break
-                    if _found:
                         break
-                if _found:
-                    for _p in _found.split(":"):
-                        if os.path.isabs(_p):
-                            places.append(_p)
-                        else:
-                            places.append(os.path.join(os.getcwd(), _p))
+
+                if not _found:
+                    _xdg = os.environ.get(
+                        "XDG_CONFIG_HOME",
+                        os.path.join(os.path.expanduser("~"), ".config"))
+                    _cfg_dirs = [
+                        "/usr/lib/debops/conf.d",
+                        "/usr/local/lib/debops/conf.d",
+                        "/etc/debops/conf.d",
+                        os.path.join(_xdg, "debops", "conf.d"),
+                    ]
+                    for _cd in _cfg_dirs:
+                        if not os.path.isdir(_cd):
+                            continue
+                        for _f in sorted(os.listdir(_cd)):
+                            _fp = os.path.join(_cd, _f)
+                            if _f.startswith(".") or not os.path.isfile(_fp):
+                                continue
+                            try:
+                                if _f.endswith(".json"):
+                                    with open(_fp) as _fh:
+                                        _parsed = json.load(_fh)
+                                elif _f.endswith(".toml"):
+                                    import tomllib as _tl
+                                    with open(_fp, "rb") as _fh:
+                                        _parsed = _tl.load(_fh)
+                                elif _f.endswith((".yaml", ".yml")):
+                                    import yaml as _yl
+                                    with open(_fp) as _fh:
+                                        _parsed = _yl.safe_load(_fh)
+                                else:
+                                    continue
+                            except Exception:
+                                continue
+                            if isinstance(_parsed, dict):
+                                _v = _parsed.get(
+                                    "override_paths", {}).get("files_path")
+                                if _v:
+                                    _found = _v
+                                    break
+                        if _found:
+                            break
+                    if _found:
+                        for _p in _found.split(":"):
+                            if os.path.isabs(_p):
+                                places.append(_p)
+                            else:
+                                places.append(
+                                    os.path.join(os.getcwd(), _p))
 
             for term in terms:
                 if '_original_file' in inject:
@@ -233,34 +268,22 @@ else:
             # (e.g. installed via Ansible Galaxy). Read override paths
             # directly from the global DebOps configuration directories.
             if not conf_section:
-                _xdg = os.environ.get(
-                    "XDG_CONFIG_HOME",
-                    os.path.join(os.path.expanduser("~"), ".config"))
-                _cfg_dirs = [
-                    "/usr/lib/debops/conf.d",
-                    "/usr/local/lib/debops/conf.d",
-                    "/etc/debops/conf.d",
-                    os.path.join(_xdg, "debops", "conf.d"),
-                ]
                 _found = None
-                for _cd in _cfg_dirs:
-                    if not os.path.isdir(_cd):
-                        continue
-                    for _f in sorted(os.listdir(_cd)):
-                        _fp = os.path.join(_cd, _f)
-                        if _f.startswith(".") or not os.path.isfile(_fp):
-                            continue
+
+                for _ext in [".json", ".toml", ".yaml", ".yml"]:
+                    _pp = os.path.join(os.getcwd(), ".debops" + _ext)
+                    if os.path.isfile(_pp):
                         try:
-                            if _f.endswith(".json"):
-                                with open(_fp) as _fh:
+                            if _pp.endswith(".json"):
+                                with open(_pp) as _fh:
                                     _parsed = json.load(_fh)
-                            elif _f.endswith(".toml"):
+                            elif _pp.endswith(".toml"):
                                 import tomllib as _tl
-                                with open(_fp, "rb") as _fh:
+                                with open(_pp, "rb") as _fh:
                                     _parsed = _tl.load(_fh)
-                            elif _f.endswith((".yaml", ".yml")):
+                            elif _pp.endswith((".yaml", ".yml")):
                                 import yaml as _yl
-                                with open(_fp) as _fh:
+                                with open(_pp) as _fh:
                                     _parsed = _yl.safe_load(_fh)
                             else:
                                 continue
@@ -270,16 +293,63 @@ else:
                             _v = _parsed.get(
                                 "override_paths", {}).get("files_path")
                             if _v:
+                                for _p in _v.split(":"):
+                                    if os.path.isabs(_p):
+                                        places.append(_p)
+                                    else:
+                                        places.append(
+                                            os.path.join(os.getcwd(), _p))
                                 _found = _v
-                                break
-                    if _found:
                         break
-                if _found:
-                    for _p in _found.split(":"):
-                        if os.path.isabs(_p):
-                            places.append(_p)
-                        else:
-                            places.append(os.path.join(os.getcwd(), _p))
+
+                if not _found:
+                    _xdg = os.environ.get(
+                        "XDG_CONFIG_HOME",
+                        os.path.join(os.path.expanduser("~"), ".config"))
+                    _cfg_dirs = [
+                        "/usr/lib/debops/conf.d",
+                        "/usr/local/lib/debops/conf.d",
+                        "/etc/debops/conf.d",
+                        os.path.join(_xdg, "debops", "conf.d"),
+                    ]
+                    for _cd in _cfg_dirs:
+                        if not os.path.isdir(_cd):
+                            continue
+                        for _f in sorted(os.listdir(_cd)):
+                            _fp = os.path.join(_cd, _f)
+                            if _f.startswith(".") or not os.path.isfile(_fp):
+                                continue
+                            try:
+                                if _f.endswith(".json"):
+                                    with open(_fp) as _fh:
+                                        _parsed = json.load(_fh)
+                                elif _f.endswith(".toml"):
+                                    import tomllib as _tl
+                                    with open(_fp, "rb") as _fh:
+                                        _parsed = _tl.load(_fh)
+                                elif _f.endswith((".yaml", ".yml")):
+                                    import yaml as _yl
+                                    with open(_fp) as _fh:
+                                        _parsed = _yl.safe_load(_fh)
+                                else:
+                                    continue
+                            except Exception:
+                                continue
+                            if isinstance(_parsed, dict):
+                                _v = _parsed.get(
+                                    "override_paths", {}).get("files_path")
+                                if _v:
+                                    _found = _v
+                                    break
+                        if _found:
+                            break
+                    if _found:
+                        for _p in _found.split(":"):
+                            if os.path.isabs(_p):
+                                places.append(_p)
+                            else:
+                                places.append(
+                                    os.path.join(os.getcwd(), _p))
 
             for term in terms:
                 if 'role_path' in variables:

--- a/ansible/roles/ansible_plugins/lookup_plugins/file_src.py
+++ b/ansible/roles/ansible_plugins/lookup_plugins/file_src.py
@@ -113,6 +113,58 @@ if LooseVersion(__ansible_version__) < LooseVersion("2.0"):
                         places.append(os.path.join(
                             project_root, custom_path))
 
+            # Fallback when the debops Python module is not available
+            # (e.g. installed via Ansible Galaxy). Read override paths
+            # directly from the global DebOps configuration directories.
+            if not conf_section:
+                _xdg = os.environ.get(
+                    "XDG_CONFIG_HOME",
+                    os.path.join(os.path.expanduser("~"), ".config"))
+                _cfg_dirs = [
+                    "/usr/lib/debops/conf.d",
+                    "/usr/local/lib/debops/conf.d",
+                    "/etc/debops/conf.d",
+                    os.path.join(_xdg, "debops", "conf.d"),
+                ]
+                _found = None
+                for _cd in _cfg_dirs:
+                    if not os.path.isdir(_cd):
+                        continue
+                    for _f in sorted(os.listdir(_cd)):
+                        _fp = os.path.join(_cd, _f)
+                        if _f.startswith(".") or not os.path.isfile(_fp):
+                            continue
+                        try:
+                            if _f.endswith(".json"):
+                                with open(_fp) as _fh:
+                                    _parsed = json.load(_fh)
+                            elif _f.endswith(".toml"):
+                                import tomllib as _tl
+                                with open(_fp, "rb") as _fh:
+                                    _parsed = _tl.load(_fh)
+                            elif _f.endswith((".yaml", ".yml")):
+                                import yaml as _yl
+                                with open(_fp) as _fh:
+                                    _parsed = _yl.safe_load(_fh)
+                            else:
+                                continue
+                        except Exception:
+                            continue
+                        if isinstance(_parsed, dict):
+                            _v = _parsed.get(
+                                "override_paths", {}).get("files_path")
+                            if _v:
+                                _found = _v
+                                break
+                    if _found:
+                        break
+                if _found:
+                    for _p in _found.split(":"):
+                        if os.path.isabs(_p):
+                            places.append(_p)
+                        else:
+                            places.append(os.path.join(os.getcwd(), _p))
+
             for term in terms:
                 if '_original_file' in inject:
                     relative_path = utils.path_dwim_relative(
@@ -176,6 +228,58 @@ else:
                     else:
                         places.append(os.path.join(
                             project_root, custom_path))
+
+            # Fallback when the debops Python module is not available
+            # (e.g. installed via Ansible Galaxy). Read override paths
+            # directly from the global DebOps configuration directories.
+            if not conf_section:
+                _xdg = os.environ.get(
+                    "XDG_CONFIG_HOME",
+                    os.path.join(os.path.expanduser("~"), ".config"))
+                _cfg_dirs = [
+                    "/usr/lib/debops/conf.d",
+                    "/usr/local/lib/debops/conf.d",
+                    "/etc/debops/conf.d",
+                    os.path.join(_xdg, "debops", "conf.d"),
+                ]
+                _found = None
+                for _cd in _cfg_dirs:
+                    if not os.path.isdir(_cd):
+                        continue
+                    for _f in sorted(os.listdir(_cd)):
+                        _fp = os.path.join(_cd, _f)
+                        if _f.startswith(".") or not os.path.isfile(_fp):
+                            continue
+                        try:
+                            if _f.endswith(".json"):
+                                with open(_fp) as _fh:
+                                    _parsed = json.load(_fh)
+                            elif _f.endswith(".toml"):
+                                import tomllib as _tl
+                                with open(_fp, "rb") as _fh:
+                                    _parsed = _tl.load(_fh)
+                            elif _f.endswith((".yaml", ".yml")):
+                                import yaml as _yl
+                                with open(_fp) as _fh:
+                                    _parsed = _yl.safe_load(_fh)
+                            else:
+                                continue
+                        except Exception:
+                            continue
+                        if isinstance(_parsed, dict):
+                            _v = _parsed.get(
+                                "override_paths", {}).get("files_path")
+                            if _v:
+                                _found = _v
+                                break
+                    if _found:
+                        break
+                if _found:
+                    for _p in _found.split(":"):
+                        if os.path.isabs(_p):
+                            places.append(_p)
+                        else:
+                            places.append(os.path.join(os.getcwd(), _p))
 
             for term in terms:
                 if 'role_path' in variables:

--- a/ansible/roles/ansible_plugins/lookup_plugins/task_src.py
+++ b/ansible/roles/ansible_plugins/lookup_plugins/task_src.py
@@ -114,6 +114,58 @@ if LooseVersion(__ansible_version__) < LooseVersion("2.0"):
                         places.append(os.path.join(
                             project_root, custom_path))
 
+            # Fallback when the debops Python module is not available
+            # (e.g. installed via Ansible Galaxy). Read override paths
+            # directly from the global DebOps configuration directories.
+            if not conf_section:
+                _xdg = os.environ.get(
+                    "XDG_CONFIG_HOME",
+                    os.path.join(os.path.expanduser("~"), ".config"))
+                _cfg_dirs = [
+                    "/usr/lib/debops/conf.d",
+                    "/usr/local/lib/debops/conf.d",
+                    "/etc/debops/conf.d",
+                    os.path.join(_xdg, "debops", "conf.d"),
+                ]
+                _found = None
+                for _cd in _cfg_dirs:
+                    if not os.path.isdir(_cd):
+                        continue
+                    for _f in sorted(os.listdir(_cd)):
+                        _fp = os.path.join(_cd, _f)
+                        if _f.startswith(".") or not os.path.isfile(_fp):
+                            continue
+                        try:
+                            if _f.endswith(".json"):
+                                with open(_fp) as _fh:
+                                    _parsed = json.load(_fh)
+                            elif _f.endswith(".toml"):
+                                import tomllib as _tl
+                                with open(_fp, "rb") as _fh:
+                                    _parsed = _tl.load(_fh)
+                            elif _f.endswith((".yaml", ".yml")):
+                                import yaml as _yl
+                                with open(_fp) as _fh:
+                                    _parsed = _yl.safe_load(_fh)
+                            else:
+                                continue
+                        except Exception:
+                            continue
+                        if isinstance(_parsed, dict):
+                            _v = _parsed.get(
+                                "override_paths", {}).get("tasks_path")
+                            if _v:
+                                _found = _v
+                                break
+                    if _found:
+                        break
+                if _found:
+                    for _p in _found.split(":"):
+                        if os.path.isabs(_p):
+                            places.append(_p)
+                        else:
+                            places.append(os.path.join(os.getcwd(), _p))
+
             for term in terms:
                 if '_original_file' in inject:
                     relative_path = utils.path_dwim_relative(
@@ -177,6 +229,58 @@ else:
                     else:
                         places.append(os.path.join(
                             project_root, custom_path))
+
+            # Fallback when the debops Python module is not available
+            # (e.g. installed via Ansible Galaxy). Read override paths
+            # directly from the global DebOps configuration directories.
+            if not conf_section:
+                _xdg = os.environ.get(
+                    "XDG_CONFIG_HOME",
+                    os.path.join(os.path.expanduser("~"), ".config"))
+                _cfg_dirs = [
+                    "/usr/lib/debops/conf.d",
+                    "/usr/local/lib/debops/conf.d",
+                    "/etc/debops/conf.d",
+                    os.path.join(_xdg, "debops", "conf.d"),
+                ]
+                _found = None
+                for _cd in _cfg_dirs:
+                    if not os.path.isdir(_cd):
+                        continue
+                    for _f in sorted(os.listdir(_cd)):
+                        _fp = os.path.join(_cd, _f)
+                        if _f.startswith(".") or not os.path.isfile(_fp):
+                            continue
+                        try:
+                            if _f.endswith(".json"):
+                                with open(_fp) as _fh:
+                                    _parsed = json.load(_fh)
+                            elif _f.endswith(".toml"):
+                                import tomllib as _tl
+                                with open(_fp, "rb") as _fh:
+                                    _parsed = _tl.load(_fh)
+                            elif _f.endswith((".yaml", ".yml")):
+                                import yaml as _yl
+                                with open(_fp) as _fh:
+                                    _parsed = _yl.safe_load(_fh)
+                            else:
+                                continue
+                        except Exception:
+                            continue
+                        if isinstance(_parsed, dict):
+                            _v = _parsed.get(
+                                "override_paths", {}).get("tasks_path")
+                            if _v:
+                                _found = _v
+                                break
+                    if _found:
+                        break
+                if _found:
+                    for _p in _found.split(":"):
+                        if os.path.isabs(_p):
+                            places.append(_p)
+                        else:
+                            places.append(os.path.join(os.getcwd(), _p))
 
             for term in terms:
                 if 'role_path' in variables:

--- a/ansible/roles/ansible_plugins/lookup_plugins/task_src.py
+++ b/ansible/roles/ansible_plugins/lookup_plugins/task_src.py
@@ -118,34 +118,22 @@ if LooseVersion(__ansible_version__) < LooseVersion("2.0"):
             # (e.g. installed via Ansible Galaxy). Read override paths
             # directly from the global DebOps configuration directories.
             if not conf_section:
-                _xdg = os.environ.get(
-                    "XDG_CONFIG_HOME",
-                    os.path.join(os.path.expanduser("~"), ".config"))
-                _cfg_dirs = [
-                    "/usr/lib/debops/conf.d",
-                    "/usr/local/lib/debops/conf.d",
-                    "/etc/debops/conf.d",
-                    os.path.join(_xdg, "debops", "conf.d"),
-                ]
                 _found = None
-                for _cd in _cfg_dirs:
-                    if not os.path.isdir(_cd):
-                        continue
-                    for _f in sorted(os.listdir(_cd)):
-                        _fp = os.path.join(_cd, _f)
-                        if _f.startswith(".") or not os.path.isfile(_fp):
-                            continue
+
+                for _ext in [".json", ".toml", ".yaml", ".yml"]:
+                    _pp = os.path.join(os.getcwd(), ".debops" + _ext)
+                    if os.path.isfile(_pp):
                         try:
-                            if _f.endswith(".json"):
-                                with open(_fp) as _fh:
+                            if _pp.endswith(".json"):
+                                with open(_pp) as _fh:
                                     _parsed = json.load(_fh)
-                            elif _f.endswith(".toml"):
+                            elif _pp.endswith(".toml"):
                                 import tomllib as _tl
-                                with open(_fp, "rb") as _fh:
+                                with open(_pp, "rb") as _fh:
                                     _parsed = _tl.load(_fh)
-                            elif _f.endswith((".yaml", ".yml")):
+                            elif _pp.endswith((".yaml", ".yml")):
                                 import yaml as _yl
-                                with open(_fp) as _fh:
+                                with open(_pp) as _fh:
                                     _parsed = _yl.safe_load(_fh)
                             else:
                                 continue
@@ -155,16 +143,63 @@ if LooseVersion(__ansible_version__) < LooseVersion("2.0"):
                             _v = _parsed.get(
                                 "override_paths", {}).get("tasks_path")
                             if _v:
+                                for _p in _v.split(":"):
+                                    if os.path.isabs(_p):
+                                        places.append(_p)
+                                    else:
+                                        places.append(
+                                            os.path.join(os.getcwd(), _p))
                                 _found = _v
-                                break
-                    if _found:
                         break
-                if _found:
-                    for _p in _found.split(":"):
-                        if os.path.isabs(_p):
-                            places.append(_p)
-                        else:
-                            places.append(os.path.join(os.getcwd(), _p))
+
+                if not _found:
+                    _xdg = os.environ.get(
+                        "XDG_CONFIG_HOME",
+                        os.path.join(os.path.expanduser("~"), ".config"))
+                    _cfg_dirs = [
+                        "/usr/lib/debops/conf.d",
+                        "/usr/local/lib/debops/conf.d",
+                        "/etc/debops/conf.d",
+                        os.path.join(_xdg, "debops", "conf.d"),
+                    ]
+                    for _cd in _cfg_dirs:
+                        if not os.path.isdir(_cd):
+                            continue
+                        for _f in sorted(os.listdir(_cd)):
+                            _fp = os.path.join(_cd, _f)
+                            if _f.startswith(".") or not os.path.isfile(_fp):
+                                continue
+                            try:
+                                if _f.endswith(".json"):
+                                    with open(_fp) as _fh:
+                                        _parsed = json.load(_fh)
+                                elif _f.endswith(".toml"):
+                                    import tomllib as _tl
+                                    with open(_fp, "rb") as _fh:
+                                        _parsed = _tl.load(_fh)
+                                elif _f.endswith((".yaml", ".yml")):
+                                    import yaml as _yl
+                                    with open(_fp) as _fh:
+                                        _parsed = _yl.safe_load(_fh)
+                                else:
+                                    continue
+                            except Exception:
+                                continue
+                            if isinstance(_parsed, dict):
+                                _v = _parsed.get(
+                                    "override_paths", {}).get("tasks_path")
+                                if _v:
+                                    _found = _v
+                                    break
+                        if _found:
+                            break
+                    if _found:
+                        for _p in _found.split(":"):
+                            if os.path.isabs(_p):
+                                places.append(_p)
+                            else:
+                                places.append(
+                                    os.path.join(os.getcwd(), _p))
 
             for term in terms:
                 if '_original_file' in inject:
@@ -234,34 +269,22 @@ else:
             # (e.g. installed via Ansible Galaxy). Read override paths
             # directly from the global DebOps configuration directories.
             if not conf_section:
-                _xdg = os.environ.get(
-                    "XDG_CONFIG_HOME",
-                    os.path.join(os.path.expanduser("~"), ".config"))
-                _cfg_dirs = [
-                    "/usr/lib/debops/conf.d",
-                    "/usr/local/lib/debops/conf.d",
-                    "/etc/debops/conf.d",
-                    os.path.join(_xdg, "debops", "conf.d"),
-                ]
                 _found = None
-                for _cd in _cfg_dirs:
-                    if not os.path.isdir(_cd):
-                        continue
-                    for _f in sorted(os.listdir(_cd)):
-                        _fp = os.path.join(_cd, _f)
-                        if _f.startswith(".") or not os.path.isfile(_fp):
-                            continue
+
+                for _ext in [".json", ".toml", ".yaml", ".yml"]:
+                    _pp = os.path.join(os.getcwd(), ".debops" + _ext)
+                    if os.path.isfile(_pp):
                         try:
-                            if _f.endswith(".json"):
-                                with open(_fp) as _fh:
+                            if _pp.endswith(".json"):
+                                with open(_pp) as _fh:
                                     _parsed = json.load(_fh)
-                            elif _f.endswith(".toml"):
+                            elif _pp.endswith(".toml"):
                                 import tomllib as _tl
-                                with open(_fp, "rb") as _fh:
+                                with open(_pp, "rb") as _fh:
                                     _parsed = _tl.load(_fh)
-                            elif _f.endswith((".yaml", ".yml")):
+                            elif _pp.endswith((".yaml", ".yml")):
                                 import yaml as _yl
-                                with open(_fp) as _fh:
+                                with open(_pp) as _fh:
                                     _parsed = _yl.safe_load(_fh)
                             else:
                                 continue
@@ -271,16 +294,63 @@ else:
                             _v = _parsed.get(
                                 "override_paths", {}).get("tasks_path")
                             if _v:
+                                for _p in _v.split(":"):
+                                    if os.path.isabs(_p):
+                                        places.append(_p)
+                                    else:
+                                        places.append(
+                                            os.path.join(os.getcwd(), _p))
                                 _found = _v
-                                break
-                    if _found:
                         break
-                if _found:
-                    for _p in _found.split(":"):
-                        if os.path.isabs(_p):
-                            places.append(_p)
-                        else:
-                            places.append(os.path.join(os.getcwd(), _p))
+
+                if not _found:
+                    _xdg = os.environ.get(
+                        "XDG_CONFIG_HOME",
+                        os.path.join(os.path.expanduser("~"), ".config"))
+                    _cfg_dirs = [
+                        "/usr/lib/debops/conf.d",
+                        "/usr/local/lib/debops/conf.d",
+                        "/etc/debops/conf.d",
+                        os.path.join(_xdg, "debops", "conf.d"),
+                    ]
+                    for _cd in _cfg_dirs:
+                        if not os.path.isdir(_cd):
+                            continue
+                        for _f in sorted(os.listdir(_cd)):
+                            _fp = os.path.join(_cd, _f)
+                            if _f.startswith(".") or not os.path.isfile(_fp):
+                                continue
+                            try:
+                                if _f.endswith(".json"):
+                                    with open(_fp) as _fh:
+                                        _parsed = json.load(_fh)
+                                elif _f.endswith(".toml"):
+                                    import tomllib as _tl
+                                    with open(_fp, "rb") as _fh:
+                                        _parsed = _tl.load(_fh)
+                                elif _f.endswith((".yaml", ".yml")):
+                                    import yaml as _yl
+                                    with open(_fp) as _fh:
+                                        _parsed = _yl.safe_load(_fh)
+                                else:
+                                    continue
+                            except Exception:
+                                continue
+                            if isinstance(_parsed, dict):
+                                _v = _parsed.get(
+                                    "override_paths", {}).get("tasks_path")
+                                if _v:
+                                    _found = _v
+                                    break
+                        if _found:
+                            break
+                    if _found:
+                        for _p in _found.split(":"):
+                            if os.path.isabs(_p):
+                                places.append(_p)
+                            else:
+                                places.append(
+                                    os.path.join(os.getcwd(), _p))
 
             for term in terms:
                 if 'role_path' in variables:

--- a/ansible/roles/ansible_plugins/lookup_plugins/task_src.py
+++ b/ansible/roles/ansible_plugins/lookup_plugins/task_src.py
@@ -120,7 +120,7 @@ if LooseVersion(__ansible_version__) < LooseVersion("2.0"):
             if not conf_section:
                 _found = None
 
-                for _ext in [".json", ".toml", ".yaml", ".yml"]:
+                for _ext in [".yaml", ".yml", ".json", ".toml"]:
                     _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
                     if os.path.isfile(_project_path):
                         try:
@@ -157,10 +157,10 @@ if LooseVersion(__ansible_version__) < LooseVersion("2.0"):
                         "XDG_CONFIG_HOME",
                         os.path.join(os.path.expanduser("~"), ".config"))
                     _cfg_dirs = [
-                        "/usr/lib/debops/conf.d",
-                        "/usr/local/lib/debops/conf.d",
-                        "/etc/debops/conf.d",
                         os.path.join(_xdg, "debops", "conf.d"),
+                        "/etc/debops/conf.d",
+                        "/usr/local/lib/debops/conf.d",
+                        "/usr/lib/debops/conf.d",
                     ]
                     for _cfg_dir in _cfg_dirs:
                         if not os.path.isdir(_cfg_dir):
@@ -271,7 +271,7 @@ else:
             if not conf_section:
                 _found = None
 
-                for _ext in [".json", ".toml", ".yaml", ".yml"]:
+                for _ext in [".yaml", ".yml", ".json", ".toml"]:
                     _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
                     if os.path.isfile(_project_path):
                         try:
@@ -308,10 +308,10 @@ else:
                         "XDG_CONFIG_HOME",
                         os.path.join(os.path.expanduser("~"), ".config"))
                     _cfg_dirs = [
-                        "/usr/lib/debops/conf.d",
-                        "/usr/local/lib/debops/conf.d",
-                        "/etc/debops/conf.d",
                         os.path.join(_xdg, "debops", "conf.d"),
+                        "/etc/debops/conf.d",
+                        "/usr/local/lib/debops/conf.d",
+                        "/usr/lib/debops/conf.d",
                     ]
                     for _cfg_dir in _cfg_dirs:
                         if not os.path.isdir(_cfg_dir):

--- a/ansible/roles/ansible_plugins/lookup_plugins/task_src.py
+++ b/ansible/roles/ansible_plugins/lookup_plugins/task_src.py
@@ -167,7 +167,8 @@ if LooseVersion(__ansible_version__) < LooseVersion("2.0"):
                             continue
                         for _filename in sorted(os.listdir(_cfg_dir)):
                             _filepath = os.path.join(_cfg_dir, _filename)
-                            if _filename.startswith(".") or not os.path.isfile(_filepath):
+                            if (_filename.startswith(".")
+                                    or not os.path.isfile(_filepath)):
                                 continue
                             try:
                                 if _filename.endswith(".json"):
@@ -318,7 +319,8 @@ else:
                             continue
                         for _filename in sorted(os.listdir(_cfg_dir)):
                             _filepath = os.path.join(_cfg_dir, _filename)
-                            if _filename.startswith(".") or not os.path.isfile(_filepath):
+                            if (_filename.startswith(".")
+                                    or not os.path.isfile(_filepath)):
                                 continue
                             try:
                                 if _filename.endswith(".json"):

--- a/ansible/roles/ansible_plugins/lookup_plugins/task_src.py
+++ b/ansible/roles/ansible_plugins/lookup_plugins/task_src.py
@@ -121,35 +121,35 @@ if LooseVersion(__ansible_version__) < LooseVersion("2.0"):
                 _found = None
 
                 for _ext in [".json", ".toml", ".yaml", ".yml"]:
-                    _pp = os.path.join(os.getcwd(), ".debops" + _ext)
-                    if os.path.isfile(_pp):
+                    _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
+                    if os.path.isfile(_project_path):
                         try:
-                            if _pp.endswith(".json"):
-                                with open(_pp) as _fh:
+                            if _project_path.endswith(".json"):
+                                with open(_project_path) as _fh:
                                     _parsed = json.load(_fh)
-                            elif _pp.endswith(".toml"):
+                            elif _project_path.endswith(".toml"):
                                 import tomllib as _tl
-                                with open(_pp, "rb") as _fh:
+                                with open(_project_path, "rb") as _fh:
                                     _parsed = _tl.load(_fh)
-                            elif _pp.endswith((".yaml", ".yml")):
+                            elif _project_path.endswith((".yaml", ".yml")):
                                 import yaml as _yl
-                                with open(_pp) as _fh:
+                                with open(_project_path) as _fh:
                                     _parsed = _yl.safe_load(_fh)
                             else:
                                 continue
                         except Exception:
                             continue
                         if isinstance(_parsed, dict):
-                            _v = _parsed.get(
+                            _override_value = _parsed.get(
                                 "override_paths", {}).get("tasks_path")
-                            if _v:
-                                for _p in _v.split(":"):
-                                    if os.path.isabs(_p):
-                                        places.append(_p)
+                            if _override_value:
+                                for _path_item in _override_value.split(":"):
+                                    if os.path.isabs(_path_item):
+                                        places.append(_path_item)
                                     else:
                                         places.append(
-                                            os.path.join(os.getcwd(), _p))
-                                _found = _v
+                                            os.path.join(os.getcwd(), _path_item))
+                                _found = _override_value
                         break
 
                 if not _found:
@@ -162,44 +162,44 @@ if LooseVersion(__ansible_version__) < LooseVersion("2.0"):
                         "/etc/debops/conf.d",
                         os.path.join(_xdg, "debops", "conf.d"),
                     ]
-                    for _cd in _cfg_dirs:
-                        if not os.path.isdir(_cd):
+                    for _cfg_dir in _cfg_dirs:
+                        if not os.path.isdir(_cfg_dir):
                             continue
-                        for _f in sorted(os.listdir(_cd)):
-                            _fp = os.path.join(_cd, _f)
-                            if _f.startswith(".") or not os.path.isfile(_fp):
+                        for _filename in sorted(os.listdir(_cfg_dir)):
+                            _filepath = os.path.join(_cfg_dir, _filename)
+                            if _filename.startswith(".") or not os.path.isfile(_filepath):
                                 continue
                             try:
-                                if _f.endswith(".json"):
-                                    with open(_fp) as _fh:
+                                if _filename.endswith(".json"):
+                                    with open(_filepath) as _fh:
                                         _parsed = json.load(_fh)
-                                elif _f.endswith(".toml"):
+                                elif _filename.endswith(".toml"):
                                     import tomllib as _tl
-                                    with open(_fp, "rb") as _fh:
+                                    with open(_filepath, "rb") as _fh:
                                         _parsed = _tl.load(_fh)
-                                elif _f.endswith((".yaml", ".yml")):
+                                elif _filename.endswith((".yaml", ".yml")):
                                     import yaml as _yl
-                                    with open(_fp) as _fh:
+                                    with open(_filepath) as _fh:
                                         _parsed = _yl.safe_load(_fh)
                                 else:
                                     continue
                             except Exception:
                                 continue
                             if isinstance(_parsed, dict):
-                                _v = _parsed.get(
+                                _override_value = _parsed.get(
                                     "override_paths", {}).get("tasks_path")
-                                if _v:
-                                    _found = _v
+                                if _override_value:
+                                    _found = _override_value
                                     break
                         if _found:
                             break
                     if _found:
-                        for _p in _found.split(":"):
-                            if os.path.isabs(_p):
-                                places.append(_p)
+                        for _path_item in _found.split(":"):
+                            if os.path.isabs(_path_item):
+                                places.append(_path_item)
                             else:
                                 places.append(
-                                    os.path.join(os.getcwd(), _p))
+                                    os.path.join(os.getcwd(), _path_item))
 
             for term in terms:
                 if '_original_file' in inject:
@@ -272,35 +272,35 @@ else:
                 _found = None
 
                 for _ext in [".json", ".toml", ".yaml", ".yml"]:
-                    _pp = os.path.join(os.getcwd(), ".debops" + _ext)
-                    if os.path.isfile(_pp):
+                    _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
+                    if os.path.isfile(_project_path):
                         try:
-                            if _pp.endswith(".json"):
-                                with open(_pp) as _fh:
+                            if _project_path.endswith(".json"):
+                                with open(_project_path) as _fh:
                                     _parsed = json.load(_fh)
-                            elif _pp.endswith(".toml"):
+                            elif _project_path.endswith(".toml"):
                                 import tomllib as _tl
-                                with open(_pp, "rb") as _fh:
+                                with open(_project_path, "rb") as _fh:
                                     _parsed = _tl.load(_fh)
-                            elif _pp.endswith((".yaml", ".yml")):
+                            elif _project_path.endswith((".yaml", ".yml")):
                                 import yaml as _yl
-                                with open(_pp) as _fh:
+                                with open(_project_path) as _fh:
                                     _parsed = _yl.safe_load(_fh)
                             else:
                                 continue
                         except Exception:
                             continue
                         if isinstance(_parsed, dict):
-                            _v = _parsed.get(
+                            _override_value = _parsed.get(
                                 "override_paths", {}).get("tasks_path")
-                            if _v:
-                                for _p in _v.split(":"):
-                                    if os.path.isabs(_p):
-                                        places.append(_p)
+                            if _override_value:
+                                for _path_item in _override_value.split(":"):
+                                    if os.path.isabs(_path_item):
+                                        places.append(_path_item)
                                     else:
                                         places.append(
-                                            os.path.join(os.getcwd(), _p))
-                                _found = _v
+                                            os.path.join(os.getcwd(), _path_item))
+                                _found = _override_value
                         break
 
                 if not _found:
@@ -313,44 +313,44 @@ else:
                         "/etc/debops/conf.d",
                         os.path.join(_xdg, "debops", "conf.d"),
                     ]
-                    for _cd in _cfg_dirs:
-                        if not os.path.isdir(_cd):
+                    for _cfg_dir in _cfg_dirs:
+                        if not os.path.isdir(_cfg_dir):
                             continue
-                        for _f in sorted(os.listdir(_cd)):
-                            _fp = os.path.join(_cd, _f)
-                            if _f.startswith(".") or not os.path.isfile(_fp):
+                        for _filename in sorted(os.listdir(_cfg_dir)):
+                            _filepath = os.path.join(_cfg_dir, _filename)
+                            if _filename.startswith(".") or not os.path.isfile(_filepath):
                                 continue
                             try:
-                                if _f.endswith(".json"):
-                                    with open(_fp) as _fh:
+                                if _filename.endswith(".json"):
+                                    with open(_filepath) as _fh:
                                         _parsed = json.load(_fh)
-                                elif _f.endswith(".toml"):
+                                elif _filename.endswith(".toml"):
                                     import tomllib as _tl
-                                    with open(_fp, "rb") as _fh:
+                                    with open(_filepath, "rb") as _fh:
                                         _parsed = _tl.load(_fh)
-                                elif _f.endswith((".yaml", ".yml")):
+                                elif _filename.endswith((".yaml", ".yml")):
                                     import yaml as _yl
-                                    with open(_fp) as _fh:
+                                    with open(_filepath) as _fh:
                                         _parsed = _yl.safe_load(_fh)
                                 else:
                                     continue
                             except Exception:
                                 continue
                             if isinstance(_parsed, dict):
-                                _v = _parsed.get(
+                                _override_value = _parsed.get(
                                     "override_paths", {}).get("tasks_path")
-                                if _v:
-                                    _found = _v
+                                if _override_value:
+                                    _found = _override_value
                                     break
                         if _found:
                             break
                     if _found:
-                        for _p in _found.split(":"):
-                            if os.path.isabs(_p):
-                                places.append(_p)
+                        for _path_item in _found.split(":"):
+                            if os.path.isabs(_path_item):
+                                places.append(_path_item)
                             else:
                                 places.append(
-                                    os.path.join(os.getcwd(), _p))
+                                    os.path.join(os.getcwd(), _path_item))
 
             for term in terms:
                 if 'role_path' in variables:

--- a/ansible/roles/ansible_plugins/lookup_plugins/template_src.py
+++ b/ansible/roles/ansible_plugins/lookup_plugins/template_src.py
@@ -119,7 +119,7 @@ if LooseVersion(__ansible_version__) < LooseVersion("2.0"):
             if not conf_section:
                 _found = None
 
-                for _ext in [".json", ".toml", ".yaml", ".yml"]:
+                for _ext in [".yaml", ".yml", ".json", ".toml"]:
                     _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
                     if os.path.isfile(_project_path):
                         try:
@@ -156,10 +156,10 @@ if LooseVersion(__ansible_version__) < LooseVersion("2.0"):
                         "XDG_CONFIG_HOME",
                         os.path.join(os.path.expanduser("~"), ".config"))
                     _cfg_dirs = [
-                        "/usr/lib/debops/conf.d",
-                        "/usr/local/lib/debops/conf.d",
-                        "/etc/debops/conf.d",
                         os.path.join(_xdg, "debops", "conf.d"),
+                        "/etc/debops/conf.d",
+                        "/usr/local/lib/debops/conf.d",
+                        "/usr/lib/debops/conf.d",
                     ]
                     for _cfg_dir in _cfg_dirs:
                         if not os.path.isdir(_cfg_dir):
@@ -271,7 +271,7 @@ else:
             if not conf_section:
                 _found = None
 
-                for _ext in [".json", ".toml", ".yaml", ".yml"]:
+                for _ext in [".yaml", ".yml", ".json", ".toml"]:
                     _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
                     if os.path.isfile(_project_path):
                         try:
@@ -308,10 +308,10 @@ else:
                         "XDG_CONFIG_HOME",
                         os.path.join(os.path.expanduser("~"), ".config"))
                     _cfg_dirs = [
-                        "/usr/lib/debops/conf.d",
-                        "/usr/local/lib/debops/conf.d",
-                        "/etc/debops/conf.d",
                         os.path.join(_xdg, "debops", "conf.d"),
+                        "/etc/debops/conf.d",
+                        "/usr/local/lib/debops/conf.d",
+                        "/usr/lib/debops/conf.d",
                     ]
                     for _cfg_dir in _cfg_dirs:
                         if not os.path.isdir(_cfg_dir):

--- a/ansible/roles/ansible_plugins/lookup_plugins/template_src.py
+++ b/ansible/roles/ansible_plugins/lookup_plugins/template_src.py
@@ -120,35 +120,35 @@ if LooseVersion(__ansible_version__) < LooseVersion("2.0"):
                 _found = None
 
                 for _ext in [".json", ".toml", ".yaml", ".yml"]:
-                    _pp = os.path.join(os.getcwd(), ".debops" + _ext)
-                    if os.path.isfile(_pp):
+                    _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
+                    if os.path.isfile(_project_path):
                         try:
-                            if _pp.endswith(".json"):
-                                with open(_pp) as _fh:
+                            if _project_path.endswith(".json"):
+                                with open(_project_path) as _fh:
                                     _parsed = json.load(_fh)
-                            elif _pp.endswith(".toml"):
+                            elif _project_path.endswith(".toml"):
                                 import tomllib as _tl
-                                with open(_pp, "rb") as _fh:
+                                with open(_project_path, "rb") as _fh:
                                     _parsed = _tl.load(_fh)
-                            elif _pp.endswith((".yaml", ".yml")):
+                            elif _project_path.endswith((".yaml", ".yml")):
                                 import yaml as _yl
-                                with open(_pp) as _fh:
+                                with open(_project_path) as _fh:
                                     _parsed = _yl.safe_load(_fh)
                             else:
                                 continue
                         except Exception:
                             continue
                         if isinstance(_parsed, dict):
-                            _v = _parsed.get(
+                            _override_value = _parsed.get(
                                 "override_paths", {}).get("templates_path")
-                            if _v:
-                                for _p in _v.split(":"):
-                                    if os.path.isabs(_p):
-                                        places.append(_p)
+                            if _override_value:
+                                for _path_item in _override_value.split(":"):
+                                    if os.path.isabs(_path_item):
+                                        places.append(_path_item)
                                     else:
                                         places.append(
-                                            os.path.join(os.getcwd(), _p))
-                                _found = _v
+                                            os.path.join(os.getcwd(), _path_item))
+                                _found = _override_value
                         break
 
                 if not _found:
@@ -161,44 +161,44 @@ if LooseVersion(__ansible_version__) < LooseVersion("2.0"):
                         "/etc/debops/conf.d",
                         os.path.join(_xdg, "debops", "conf.d"),
                     ]
-                    for _cd in _cfg_dirs:
-                        if not os.path.isdir(_cd):
+                    for _cfg_dir in _cfg_dirs:
+                        if not os.path.isdir(_cfg_dir):
                             continue
-                        for _f in sorted(os.listdir(_cd)):
-                            _fp = os.path.join(_cd, _f)
-                            if _f.startswith(".") or not os.path.isfile(_fp):
+                        for _filename in sorted(os.listdir(_cfg_dir)):
+                            _filepath = os.path.join(_cfg_dir, _filename)
+                            if _filename.startswith(".") or not os.path.isfile(_filepath):
                                 continue
                             try:
-                                if _f.endswith(".json"):
-                                    with open(_fp) as _fh:
+                                if _filename.endswith(".json"):
+                                    with open(_filepath) as _fh:
                                         _parsed = json.load(_fh)
-                                elif _f.endswith(".toml"):
+                                elif _filename.endswith(".toml"):
                                     import tomllib as _tl
-                                    with open(_fp, "rb") as _fh:
+                                    with open(_filepath, "rb") as _fh:
                                         _parsed = _tl.load(_fh)
-                                elif _f.endswith((".yaml", ".yml")):
+                                elif _filename.endswith((".yaml", ".yml")):
                                     import yaml as _yl
-                                    with open(_fp) as _fh:
+                                    with open(_filepath) as _fh:
                                         _parsed = _yl.safe_load(_fh)
                                 else:
                                     continue
                             except Exception:
                                 continue
                             if isinstance(_parsed, dict):
-                                _v = _parsed.get(
+                                _override_value = _parsed.get(
                                     "override_paths", {}).get("templates_path")
-                                if _v:
-                                    _found = _v
+                                if _override_value:
+                                    _found = _override_value
                                     break
                         if _found:
                             break
                     if _found:
-                        for _p in _found.split(":"):
-                            if os.path.isabs(_p):
-                                places.append(_p)
+                        for _path_item in _found.split(":"):
+                            if os.path.isabs(_path_item):
+                                places.append(_path_item)
                             else:
                                 places.append(
-                                    os.path.join(os.getcwd(), _p))
+                                    os.path.join(os.getcwd(), _path_item))
 
             for term in terms:
                 if '_original_file' in inject:
@@ -272,35 +272,35 @@ else:
                 _found = None
 
                 for _ext in [".json", ".toml", ".yaml", ".yml"]:
-                    _pp = os.path.join(os.getcwd(), ".debops" + _ext)
-                    if os.path.isfile(_pp):
+                    _project_path = os.path.join(os.getcwd(), ".debops" + _ext)
+                    if os.path.isfile(_project_path):
                         try:
-                            if _pp.endswith(".json"):
-                                with open(_pp) as _fh:
+                            if _project_path.endswith(".json"):
+                                with open(_project_path) as _fh:
                                     _parsed = json.load(_fh)
-                            elif _pp.endswith(".toml"):
+                            elif _project_path.endswith(".toml"):
                                 import tomllib as _tl
-                                with open(_pp, "rb") as _fh:
+                                with open(_project_path, "rb") as _fh:
                                     _parsed = _tl.load(_fh)
-                            elif _pp.endswith((".yaml", ".yml")):
+                            elif _project_path.endswith((".yaml", ".yml")):
                                 import yaml as _yl
-                                with open(_pp) as _fh:
+                                with open(_project_path) as _fh:
                                     _parsed = _yl.safe_load(_fh)
                             else:
                                 continue
                         except Exception:
                             continue
                         if isinstance(_parsed, dict):
-                            _v = _parsed.get(
+                            _override_value = _parsed.get(
                                 "override_paths", {}).get("templates_path")
-                            if _v:
-                                for _p in _v.split(":"):
-                                    if os.path.isabs(_p):
-                                        places.append(_p)
+                            if _override_value:
+                                for _path_item in _override_value.split(":"):
+                                    if os.path.isabs(_path_item):
+                                        places.append(_path_item)
                                     else:
                                         places.append(
-                                            os.path.join(os.getcwd(), _p))
-                                _found = _v
+                                            os.path.join(os.getcwd(), _path_item))
+                                _found = _override_value
                         break
 
                 if not _found:
@@ -313,44 +313,44 @@ else:
                         "/etc/debops/conf.d",
                         os.path.join(_xdg, "debops", "conf.d"),
                     ]
-                    for _cd in _cfg_dirs:
-                        if not os.path.isdir(_cd):
+                    for _cfg_dir in _cfg_dirs:
+                        if not os.path.isdir(_cfg_dir):
                             continue
-                        for _f in sorted(os.listdir(_cd)):
-                            _fp = os.path.join(_cd, _f)
-                            if _f.startswith(".") or not os.path.isfile(_fp):
+                        for _filename in sorted(os.listdir(_cfg_dir)):
+                            _filepath = os.path.join(_cfg_dir, _filename)
+                            if _filename.startswith(".") or not os.path.isfile(_filepath):
                                 continue
                             try:
-                                if _f.endswith(".json"):
-                                    with open(_fp) as _fh:
+                                if _filename.endswith(".json"):
+                                    with open(_filepath) as _fh:
                                         _parsed = json.load(_fh)
-                                elif _f.endswith(".toml"):
+                                elif _filename.endswith(".toml"):
                                     import tomllib as _tl
-                                    with open(_fp, "rb") as _fh:
+                                    with open(_filepath, "rb") as _fh:
                                         _parsed = _tl.load(_fh)
-                                elif _f.endswith((".yaml", ".yml")):
+                                elif _filename.endswith((".yaml", ".yml")):
                                     import yaml as _yl
-                                    with open(_fp) as _fh:
+                                    with open(_filepath) as _fh:
                                         _parsed = _yl.safe_load(_fh)
                                 else:
                                     continue
                             except Exception:
                                 continue
                             if isinstance(_parsed, dict):
-                                _v = _parsed.get(
+                                _override_value = _parsed.get(
                                     "override_paths", {}).get("templates_path")
-                                if _v:
-                                    _found = _v
+                                if _override_value:
+                                    _found = _override_value
                                     break
                         if _found:
                             break
                     if _found:
-                        for _p in _found.split(":"):
-                            if os.path.isabs(_p):
-                                places.append(_p)
+                        for _path_item in _found.split(":"):
+                            if os.path.isabs(_path_item):
+                                places.append(_path_item)
                             else:
                                 places.append(
-                                    os.path.join(os.getcwd(), _p))
+                                    os.path.join(os.getcwd(), _path_item))
 
             for term in terms:
                 if 'role_path' in variables:

--- a/ansible/roles/ansible_plugins/lookup_plugins/template_src.py
+++ b/ansible/roles/ansible_plugins/lookup_plugins/template_src.py
@@ -166,7 +166,8 @@ if LooseVersion(__ansible_version__) < LooseVersion("2.0"):
                             continue
                         for _filename in sorted(os.listdir(_cfg_dir)):
                             _filepath = os.path.join(_cfg_dir, _filename)
-                            if _filename.startswith(".") or not os.path.isfile(_filepath):
+                            if (_filename.startswith(".")
+                                    or not os.path.isfile(_filepath)):
                                 continue
                             try:
                                 if _filename.endswith(".json"):
@@ -318,7 +319,8 @@ else:
                             continue
                         for _filename in sorted(os.listdir(_cfg_dir)):
                             _filepath = os.path.join(_cfg_dir, _filename)
-                            if _filename.startswith(".") or not os.path.isfile(_filepath):
+                            if (_filename.startswith(".")
+                                    or not os.path.isfile(_filepath)):
                                 continue
                             try:
                                 if _filename.endswith(".json"):

--- a/ansible/roles/ansible_plugins/lookup_plugins/template_src.py
+++ b/ansible/roles/ansible_plugins/lookup_plugins/template_src.py
@@ -117,34 +117,22 @@ if LooseVersion(__ansible_version__) < LooseVersion("2.0"):
             # (e.g. installed via Ansible Galaxy). Read override paths
             # directly from the global DebOps configuration directories.
             if not conf_section:
-                _xdg = os.environ.get(
-                    "XDG_CONFIG_HOME",
-                    os.path.join(os.path.expanduser("~"), ".config"))
-                _cfg_dirs = [
-                    "/usr/lib/debops/conf.d",
-                    "/usr/local/lib/debops/conf.d",
-                    "/etc/debops/conf.d",
-                    os.path.join(_xdg, "debops", "conf.d"),
-                ]
                 _found = None
-                for _cd in _cfg_dirs:
-                    if not os.path.isdir(_cd):
-                        continue
-                    for _f in sorted(os.listdir(_cd)):
-                        _fp = os.path.join(_cd, _f)
-                        if _f.startswith(".") or not os.path.isfile(_fp):
-                            continue
+
+                for _ext in [".json", ".toml", ".yaml", ".yml"]:
+                    _pp = os.path.join(os.getcwd(), ".debops" + _ext)
+                    if os.path.isfile(_pp):
                         try:
-                            if _f.endswith(".json"):
-                                with open(_fp) as _fh:
+                            if _pp.endswith(".json"):
+                                with open(_pp) as _fh:
                                     _parsed = json.load(_fh)
-                            elif _f.endswith(".toml"):
+                            elif _pp.endswith(".toml"):
                                 import tomllib as _tl
-                                with open(_fp, "rb") as _fh:
+                                with open(_pp, "rb") as _fh:
                                     _parsed = _tl.load(_fh)
-                            elif _f.endswith((".yaml", ".yml")):
+                            elif _pp.endswith((".yaml", ".yml")):
                                 import yaml as _yl
-                                with open(_fp) as _fh:
+                                with open(_pp) as _fh:
                                     _parsed = _yl.safe_load(_fh)
                             else:
                                 continue
@@ -154,16 +142,63 @@ if LooseVersion(__ansible_version__) < LooseVersion("2.0"):
                             _v = _parsed.get(
                                 "override_paths", {}).get("templates_path")
                             if _v:
+                                for _p in _v.split(":"):
+                                    if os.path.isabs(_p):
+                                        places.append(_p)
+                                    else:
+                                        places.append(
+                                            os.path.join(os.getcwd(), _p))
                                 _found = _v
-                                break
-                    if _found:
                         break
-                if _found:
-                    for _p in _found.split(":"):
-                        if os.path.isabs(_p):
-                            places.append(_p)
-                        else:
-                            places.append(os.path.join(os.getcwd(), _p))
+
+                if not _found:
+                    _xdg = os.environ.get(
+                        "XDG_CONFIG_HOME",
+                        os.path.join(os.path.expanduser("~"), ".config"))
+                    _cfg_dirs = [
+                        "/usr/lib/debops/conf.d",
+                        "/usr/local/lib/debops/conf.d",
+                        "/etc/debops/conf.d",
+                        os.path.join(_xdg, "debops", "conf.d"),
+                    ]
+                    for _cd in _cfg_dirs:
+                        if not os.path.isdir(_cd):
+                            continue
+                        for _f in sorted(os.listdir(_cd)):
+                            _fp = os.path.join(_cd, _f)
+                            if _f.startswith(".") or not os.path.isfile(_fp):
+                                continue
+                            try:
+                                if _f.endswith(".json"):
+                                    with open(_fp) as _fh:
+                                        _parsed = json.load(_fh)
+                                elif _f.endswith(".toml"):
+                                    import tomllib as _tl
+                                    with open(_fp, "rb") as _fh:
+                                        _parsed = _tl.load(_fh)
+                                elif _f.endswith((".yaml", ".yml")):
+                                    import yaml as _yl
+                                    with open(_fp) as _fh:
+                                        _parsed = _yl.safe_load(_fh)
+                                else:
+                                    continue
+                            except Exception:
+                                continue
+                            if isinstance(_parsed, dict):
+                                _v = _parsed.get(
+                                    "override_paths", {}).get("templates_path")
+                                if _v:
+                                    _found = _v
+                                    break
+                        if _found:
+                            break
+                    if _found:
+                        for _p in _found.split(":"):
+                            if os.path.isabs(_p):
+                                places.append(_p)
+                            else:
+                                places.append(
+                                    os.path.join(os.getcwd(), _p))
 
             for term in terms:
                 if '_original_file' in inject:
@@ -234,34 +269,22 @@ else:
             # (e.g. installed via Ansible Galaxy). Read override paths
             # directly from the global DebOps configuration directories.
             if not conf_section:
-                _xdg = os.environ.get(
-                    "XDG_CONFIG_HOME",
-                    os.path.join(os.path.expanduser("~"), ".config"))
-                _cfg_dirs = [
-                    "/usr/lib/debops/conf.d",
-                    "/usr/local/lib/debops/conf.d",
-                    "/etc/debops/conf.d",
-                    os.path.join(_xdg, "debops", "conf.d"),
-                ]
                 _found = None
-                for _cd in _cfg_dirs:
-                    if not os.path.isdir(_cd):
-                        continue
-                    for _f in sorted(os.listdir(_cd)):
-                        _fp = os.path.join(_cd, _f)
-                        if _f.startswith(".") or not os.path.isfile(_fp):
-                            continue
+
+                for _ext in [".json", ".toml", ".yaml", ".yml"]:
+                    _pp = os.path.join(os.getcwd(), ".debops" + _ext)
+                    if os.path.isfile(_pp):
                         try:
-                            if _f.endswith(".json"):
-                                with open(_fp) as _fh:
+                            if _pp.endswith(".json"):
+                                with open(_pp) as _fh:
                                     _parsed = json.load(_fh)
-                            elif _f.endswith(".toml"):
+                            elif _pp.endswith(".toml"):
                                 import tomllib as _tl
-                                with open(_fp, "rb") as _fh:
+                                with open(_pp, "rb") as _fh:
                                     _parsed = _tl.load(_fh)
-                            elif _f.endswith((".yaml", ".yml")):
+                            elif _pp.endswith((".yaml", ".yml")):
                                 import yaml as _yl
-                                with open(_fp) as _fh:
+                                with open(_pp) as _fh:
                                     _parsed = _yl.safe_load(_fh)
                             else:
                                 continue
@@ -271,16 +294,63 @@ else:
                             _v = _parsed.get(
                                 "override_paths", {}).get("templates_path")
                             if _v:
+                                for _p in _v.split(":"):
+                                    if os.path.isabs(_p):
+                                        places.append(_p)
+                                    else:
+                                        places.append(
+                                            os.path.join(os.getcwd(), _p))
                                 _found = _v
-                                break
-                    if _found:
                         break
-                if _found:
-                    for _p in _found.split(":"):
-                        if os.path.isabs(_p):
-                            places.append(_p)
-                        else:
-                            places.append(os.path.join(os.getcwd(), _p))
+
+                if not _found:
+                    _xdg = os.environ.get(
+                        "XDG_CONFIG_HOME",
+                        os.path.join(os.path.expanduser("~"), ".config"))
+                    _cfg_dirs = [
+                        "/usr/lib/debops/conf.d",
+                        "/usr/local/lib/debops/conf.d",
+                        "/etc/debops/conf.d",
+                        os.path.join(_xdg, "debops", "conf.d"),
+                    ]
+                    for _cd in _cfg_dirs:
+                        if not os.path.isdir(_cd):
+                            continue
+                        for _f in sorted(os.listdir(_cd)):
+                            _fp = os.path.join(_cd, _f)
+                            if _f.startswith(".") or not os.path.isfile(_fp):
+                                continue
+                            try:
+                                if _f.endswith(".json"):
+                                    with open(_fp) as _fh:
+                                        _parsed = json.load(_fh)
+                                elif _f.endswith(".toml"):
+                                    import tomllib as _tl
+                                    with open(_fp, "rb") as _fh:
+                                        _parsed = _tl.load(_fh)
+                                elif _f.endswith((".yaml", ".yml")):
+                                    import yaml as _yl
+                                    with open(_fp) as _fh:
+                                        _parsed = _yl.safe_load(_fh)
+                                else:
+                                    continue
+                            except Exception:
+                                continue
+                            if isinstance(_parsed, dict):
+                                _v = _parsed.get(
+                                    "override_paths", {}).get("templates_path")
+                                if _v:
+                                    _found = _v
+                                    break
+                        if _found:
+                            break
+                    if _found:
+                        for _p in _found.split(":"):
+                            if os.path.isabs(_p):
+                                places.append(_p)
+                            else:
+                                places.append(
+                                    os.path.join(os.getcwd(), _p))
 
             for term in terms:
                 if 'role_path' in variables:

--- a/ansible/roles/ansible_plugins/lookup_plugins/template_src.py
+++ b/ansible/roles/ansible_plugins/lookup_plugins/template_src.py
@@ -113,6 +113,58 @@ if LooseVersion(__ansible_version__) < LooseVersion("2.0"):
                         places.append(os.path.join(
                             project_root, custom_path))
 
+            # Fallback when the debops Python module is not available
+            # (e.g. installed via Ansible Galaxy). Read override paths
+            # directly from the global DebOps configuration directories.
+            if not conf_section:
+                _xdg = os.environ.get(
+                    "XDG_CONFIG_HOME",
+                    os.path.join(os.path.expanduser("~"), ".config"))
+                _cfg_dirs = [
+                    "/usr/lib/debops/conf.d",
+                    "/usr/local/lib/debops/conf.d",
+                    "/etc/debops/conf.d",
+                    os.path.join(_xdg, "debops", "conf.d"),
+                ]
+                _found = None
+                for _cd in _cfg_dirs:
+                    if not os.path.isdir(_cd):
+                        continue
+                    for _f in sorted(os.listdir(_cd)):
+                        _fp = os.path.join(_cd, _f)
+                        if _f.startswith(".") or not os.path.isfile(_fp):
+                            continue
+                        try:
+                            if _f.endswith(".json"):
+                                with open(_fp) as _fh:
+                                    _parsed = json.load(_fh)
+                            elif _f.endswith(".toml"):
+                                import tomllib as _tl
+                                with open(_fp, "rb") as _fh:
+                                    _parsed = _tl.load(_fh)
+                            elif _f.endswith((".yaml", ".yml")):
+                                import yaml as _yl
+                                with open(_fp) as _fh:
+                                    _parsed = _yl.safe_load(_fh)
+                            else:
+                                continue
+                        except Exception:
+                            continue
+                        if isinstance(_parsed, dict):
+                            _v = _parsed.get(
+                                "override_paths", {}).get("templates_path")
+                            if _v:
+                                _found = _v
+                                break
+                    if _found:
+                        break
+                if _found:
+                    for _p in _found.split(":"):
+                        if os.path.isabs(_p):
+                            places.append(_p)
+                        else:
+                            places.append(os.path.join(os.getcwd(), _p))
+
             for term in terms:
                 if '_original_file' in inject:
                     relative_path = (
@@ -177,6 +229,58 @@ else:
                     else:
                         places.append(os.path.join(
                             project_root, custom_path))
+
+            # Fallback when the debops Python module is not available
+            # (e.g. installed via Ansible Galaxy). Read override paths
+            # directly from the global DebOps configuration directories.
+            if not conf_section:
+                _xdg = os.environ.get(
+                    "XDG_CONFIG_HOME",
+                    os.path.join(os.path.expanduser("~"), ".config"))
+                _cfg_dirs = [
+                    "/usr/lib/debops/conf.d",
+                    "/usr/local/lib/debops/conf.d",
+                    "/etc/debops/conf.d",
+                    os.path.join(_xdg, "debops", "conf.d"),
+                ]
+                _found = None
+                for _cd in _cfg_dirs:
+                    if not os.path.isdir(_cd):
+                        continue
+                    for _f in sorted(os.listdir(_cd)):
+                        _fp = os.path.join(_cd, _f)
+                        if _f.startswith(".") or not os.path.isfile(_fp):
+                            continue
+                        try:
+                            if _f.endswith(".json"):
+                                with open(_fp) as _fh:
+                                    _parsed = json.load(_fh)
+                            elif _f.endswith(".toml"):
+                                import tomllib as _tl
+                                with open(_fp, "rb") as _fh:
+                                    _parsed = _tl.load(_fh)
+                            elif _f.endswith((".yaml", ".yml")):
+                                import yaml as _yl
+                                with open(_fp) as _fh:
+                                    _parsed = _yl.safe_load(_fh)
+                            else:
+                                continue
+                        except Exception:
+                            continue
+                        if isinstance(_parsed, dict):
+                            _v = _parsed.get(
+                                "override_paths", {}).get("templates_path")
+                            if _v:
+                                _found = _v
+                                break
+                    if _found:
+                        break
+                if _found:
+                    for _p in _found.split(":"):
+                        if os.path.isabs(_p):
+                            places.append(_p)
+                        else:
+                            places.append(os.path.join(os.getcwd(), _p))
 
             for term in terms:
                 if 'role_path' in variables:

--- a/docs/ansible/roles/ansible_plugins/getting-started.rst
+++ b/docs/ansible/roles/ansible_plugins/getting-started.rst
@@ -218,8 +218,8 @@ project-local configuration file or the global DebOps configuration
 directories.
 
 Before reading the global directories, the plugins look for a file named
-:file:`.debops.json`, :file:`.debops.toml`, or :file:`.debops.yml` /
-:file:`.debops.yaml` in the current working directory (typically the project
+:file:`.debops.yaml` / :file:`.debops.yml`, :file:`.debops.json`, or
+:file:`.debops.toml` in the current working directory (typically the project
 root where :command:`ansible-playbook` is executed). The first readable file
 found is used. This allows you to keep the override configuration in your
 project repository, alongside the Ansible playbooks.
@@ -229,10 +229,10 @@ relevant ``override_paths`` key, the plugins fall through to the global
 configuration directories, which are checked in this order (first match
 wins):
 
-- :file:`/usr/lib/debops/conf.d/`
-- :file:`/usr/local/lib/debops/conf.d/`
-- :file:`/etc/debops/conf.d/`
 - :file:`~/.config/debops/conf.d/`
+- :file:`/etc/debops/conf.d/`
+- :file:`/usr/local/lib/debops/conf.d/`
+- :file:`/usr/lib/debops/conf.d/`
 
 Each directory can contain files with ``.toml``, ``.yaml``, ``.yml`` or
 ``.json`` extensions. The fallback reader supports all four formats. The

--- a/docs/ansible/roles/ansible_plugins/getting-started.rst
+++ b/docs/ansible/roles/ansible_plugins/getting-started.rst
@@ -164,9 +164,10 @@ Ansible roles:
 
 ``debops.debops.file_src``
   This lookup plugin allows "sideloading" files to copy into roles without the
-  need to modify the roles themselves. It requires the ``debops`` Python module
-  to be installed and uses configuration in :file:`.debops.cfg` to get a list
-  of directories that are bases to look for custom files.
+  need to modify the roles themselves. It uses configuration in
+  :file:`.debops.cfg` (via the ``debops`` Python module) or the global DebOps
+  configuration directory (via an embedded fallback) to get a list of
+  directories that are bases to look for custom files.
 
   If a file in specified subdirectory is found in one of the base directories,
   its path will be returned to Ansible to use as a file source. If no custom
@@ -181,9 +182,10 @@ Ansible roles:
 
 ``debops.debops.task_src``
   This lookup plugin allows injection of custom Ansible tasks into roles without
-  the need to modify the roles themselves. It requires the ``debops`` Python
-  module to be installed and uses configuration in :file:`.debops.cfg` to get
-  a list of directories that are bases to look for a list of Ansible tasks.
+  the need to modify the roles themselves. It uses configuration in
+  :file:`.debops.cfg` (via the ``debops`` Python module) or the global DebOps
+  configuration directory (via an embedded fallback) to get a list of
+  directories that are bases to look for a list of Ansible tasks.
 
   If a file with list of tasks is found, they will be added to the Ansible
   playbook execution, usually as "pre" or "post" tasks at the beginning or end
@@ -194,11 +196,62 @@ Ansible roles:
 
 ``debops.debops.template_src``
   This lookup plugin allows "sideloading" Jinja templates into roles without
-  the need to modify the roles themselves. It requires the ``debops`` Python
-  module to be installed and uses configuration in :file:`.debops.cfg` to get
-  a list of directories that are bases to look for templates.
+  the need to modify the roles themselves. It uses configuration in
+  :file:`.debops.cfg` (via the ``debops`` Python module) or the global DebOps
+  configuration directory (via an embedded fallback) to get a list of
+  directories that are bases to look for templates.
 
   If a template file in specified subdirectory is found in one of the base
   directories, its path will be returned to Ansible to use as a template. If no
   custom templates are found, the lookup plugin returns the original path which
   corresponds to the template included in the role itself.
+
+
+Global configuration fallback
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The lookup plugins described above normally require the ``debops`` Python
+module to read their configuration. When installed via Ansible Galaxy, the
+``debops`` Python module is not available. In that case the lookup plugins
+fall back to reading the ``override_paths`` section directly from the global
+DebOps configuration directories.
+
+The configuration directories are checked in this order (first match wins):
+
+- :file:`/usr/lib/debops/conf.d/`
+- :file:`/usr/local/lib/debops/conf.d/`
+- :file:`/etc/debops/conf.d/`
+- :file:`~/.config/debops/conf.d/`
+
+Each directory can contain files with ``.toml``, ``.yaml``, ``.yml`` or
+``.json`` extensions. The fallback reader supports all four formats. The
+relevant configuration keys are:
+
+``override_paths.files_path``
+  Custom directories for the ``debops.debops.file_src`` lookup plugin.
+``override_paths.tasks_path``
+  Custom directories for the ``debops.debops.task_src`` lookup plugin.
+``override_paths.templates_path``
+  Custom directories for the ``debops.debops.template_src`` lookup plugin.
+
+For example, to configure a custom files override directory for a project
+located at :file:`/home/alice/myansible/`:
+
+.. code-block:: json
+
+   {"override_paths": {"files_path": "/home/alice/myansible/resources/overrides/files"}}
+
+Or relative to the current working directory (typically the project root):
+
+.. code-block:: toml
+
+   [override_paths]
+   files_path = "resources/overrides/files"
+
+The lookup plugins will resolve relative paths against the directory where
+:command:`ansible-playbook` is executed.
+
+Note that the per-project :file:`.debops.cfg` configuration file is only
+supported when the ``debops`` Python module is installed. Users who install
+DebOps via Ansible Galaxy should use the global configuration directories
+described above.

--- a/docs/ansible/roles/ansible_plugins/getting-started.rst
+++ b/docs/ansible/roles/ansible_plugins/getting-started.rst
@@ -213,10 +213,21 @@ Global configuration fallback
 The lookup plugins described above normally require the ``debops`` Python
 module to read their configuration. When installed via Ansible Galaxy, the
 ``debops`` Python module is not available. In that case the lookup plugins
-fall back to reading the ``override_paths`` section directly from the global
-DebOps configuration directories.
+fall back to reading the ``override_paths`` section directly from a
+project-local configuration file or the global DebOps configuration
+directories.
 
-The configuration directories are checked in this order (first match wins):
+Before reading the global directories, the plugins look for a file named
+:file:`.debops.json`, :file:`.debops.toml`, or :file:`.debops.yml` /
+:file:`.debops.yaml` in the current working directory (typically the project
+root where :command:`ansible-playbook` is executed). The first readable file
+found is used. This allows you to keep the override configuration in your
+project repository, alongside the Ansible playbooks.
+
+If no project-local configuration file is found, or it does not contain the
+relevant ``override_paths`` key, the plugins fall through to the global
+configuration directories, which are checked in this order (first match
+wins):
 
 - :file:`/usr/lib/debops/conf.d/`
 - :file:`/usr/local/lib/debops/conf.d/`
@@ -253,5 +264,6 @@ The lookup plugins will resolve relative paths against the directory where
 
 Note that the per-project :file:`.debops.cfg` configuration file is only
 supported when the ``debops`` Python module is installed. Users who install
-DebOps via Ansible Galaxy should use the global configuration directories
-described above.
+DebOps via Ansible Galaxy should use a :file:`.debops.yml` file (or a
+:file:`.debops.json` / :file:`.debops.toml` alternative) described above, or
+the global configuration directories.

--- a/docs/user-guide/debops-for-ansible.rst
+++ b/docs/user-guide/debops-for-ansible.rst
@@ -103,10 +103,12 @@ By combining above techniques, you can very easily extend DebOps roles without
 losing the ability to update them, using :command:`git` without having merge
 conflicts.
 
-When using the global DebOps configuration path
-(:file:`~/.config/debops/conf.d/`), create a TOML, YAML, or JSON file with
-the ``override_paths`` section. For example, to override files and templates
-for a project at :file:`/home/alice/myansible/`:
+Alternatively, you can create a :file:`.debops.yml` (or
+:file:`.debops.json` / :file:`.debops.toml`) file in your project root
+directory. The lookup plugins will pick it up automatically without needing
+the ``debops`` Python module or any configuration directory setup. For
+example, to override files and templates for a project at
+:file:`/home/alice/myansible/`:
 
 .. code-block:: toml
 
@@ -116,7 +118,10 @@ for a project at :file:`/home/alice/myansible/`:
    tasks_path = "/home/alice/myansible/resources/overrides/tasks"
 
 Relative paths are resolved against the directory where
-:command:`ansible-playbook` is executed.
+:command:`ansible-playbook` is executed. You can also use the global DebOps
+configuration path (:file:`~/.config/debops/conf.d/`) as an alternative —
+create a TOML, YAML, or JSON file with the same ``override_paths`` section
+in any of the configuration directories.
 
 
 Ansible inventory is a source of truth

--- a/docs/user-guide/debops-for-ansible.rst
+++ b/docs/user-guide/debops-for-ansible.rst
@@ -87,18 +87,36 @@ templates according to your specific needs.
 
 Certain roles use ``debops.debops.file_src`` or ``debops.debops.template_src``
 to calculate path to files or templates used by a role. You can override these
-paths using ``.debops.cfg`` configuration file and provide your own versions of
-files and templates stored in DebOps project directory.
+paths using the global DebOps configuration at
+:file:`~/.config/debops/conf.d/` (works without the ``debops`` Python module)
+or the :file:`.debops.cfg` configuration file in the project directory
+(requires the ``debops`` Python module), and provide your own versions of
+files and templates stored in the project directory.
 
 Some roles provide "task hooks" at the beginning and end of task lists, which
 are empty files in a specific subdirectories. Using ``debops.debops.task_src``
-lookup plugin and settings defined in ``.debops.cfg`` configuration file you
-can "inject" your own tasks at the beginning or end of these roles, which gives
-you more control over the configuration.
+lookup plugin and the same override configuration you can "inject" your own
+tasks at the beginning or end of these roles, which gives you more control
+over the configuration.
 
 By combining above techniques, you can very easily extend DebOps roles without
 losing the ability to update them, using :command:`git` without having merge
 conflicts.
+
+When using the global DebOps configuration path
+(:file:`~/.config/debops/conf.d/`), create a TOML, YAML, or JSON file with
+the ``override_paths`` section. For example, to override files and templates
+for a project at :file:`/home/alice/myansible/`:
+
+.. code-block:: toml
+
+   [override_paths]
+   files_path = "/home/alice/myansible/resources/overrides/files"
+   templates_path = "/home/alice/myansible/resources/overrides/templates"
+   tasks_path = "/home/alice/myansible/resources/overrides/tasks"
+
+Relative paths are resolved against the directory where
+:command:`ansible-playbook` is executed.
 
 
 Ansible inventory is a source of truth

--- a/lib/ansible-galaxy/make-collection
+++ b/lib/ansible-galaxy/make-collection
@@ -244,7 +244,8 @@ mkdir -p "${workdir_map[${collections[0]}]}/playbooks" \
          "${workdir_map[${collections[0]}]}/plugins/connection" \
          "${workdir_map[${collections[0]}]}/plugins/filter" \
          "${workdir_map[${collections[0]}]}/plugins/lookup" \
-         "${workdir_map[${collections[0]}]}/plugins/modules"
+         "${workdir_map[${collections[0]}]}/plugins/modules" \
+         "${workdir_map[${collections[0]}]}/plugins/plugin_utils"
 
 # Copy DebOps roles to the Ansible Collection build directory.
 # Omit specific DebOps roles from Ansible Collections.
@@ -305,6 +306,7 @@ cp ansible/plugins/connection/*.py "${workdir_map[${collections[0]}]}/plugins/co
 cp ansible/plugins/filter/*.py "${workdir_map[${collections[0]}]}/plugins/filter"
 cp ansible/plugins/lookup/*.py "${workdir_map[${collections[0]}]}/plugins/lookup"
 cp ansible/plugins/modules/*.py "${workdir_map[${collections[0]}]}/plugins/modules"
+cp ansible/plugins/plugin_utils/*.py "${workdir_map[${collections[0]}]}/plugins/plugin_utils"
 
 for collection in "${collections[@]}" ; do
 


### PR DESCRIPTION
The `debops.debops.file_src`, `debops.debops.template_src`, and `debops.debops.task_src` lookup plugins now fall back to reading `override_paths` from the global DebOps configuration directories when the `debops` Python module is unavailable — needed when the collection is installed via Ansible Galaxy. Relative paths in those config files are resolved against the current working directory.