### PR TITLE
[apt] Align the comments in sources.list.j2

### DIFF
--- a/ansible/roles/apt/templates/etc/apt/sources.list.j2
+++ b/ansible/roles/apt/templates/etc/apt/sources.list.j2
@@ -68,9 +68,9 @@
 {%         for suite in suites %}
 {%           for type in types %}
 {%             if type == 'deb-src' and apt__archive_sources_disabled | bool %}
-{%                 set element_comment = '#' %}
+{%                 set element_comment = '# ' %}
 {%               else %}
-{%                 set element_comment = ('#' if (element.state == 'comment') else '') %}
+{%                 set element_comment = ('# ' if (element.state == 'comment') else '') %}
 {%             endif %}
 {{             '{}{}{} {} {} {}'.format(element_comment, type, source_options, uri, suite, components | join(' ')) }}
 {%           endfor %}


### PR DESCRIPTION
The ansible.builtin.apt_repository module aggressively rewrites the /etc/apt/sources.list file with its own preferred formatting of the commented-out APT repository lines. Let's use that formatting instead of our own to preserve idempotency.