### PR TITLE
Add prometheus_exporter role for Debian-packaged Prometheus exporters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,13 @@ New DebOps roles
   services using Docker containers, and can integrate with the
   :ref:`debops.nginx` role to manage the :command:`nginx` reverse proxy.
 
+- The :ref:`debops.prometheus_exporter` role can install and configure
+  Prometheus exporters from Debian packages (the ``prometheus-*-exporter``
+  family). Each exporter is managed via a systemd drop-in that rewrites
+  ``ExecStart``/``Environment``, so the role works uniformly across
+  exporters and Debian releases. Exporters bind to loopback and are meant to
+  be scraped by :ref:`debops.vmagent`.
+
 General
 '''''''
 

--- a/ansible/playbooks/layer/agent.yml
+++ b/ansible/playbooks/layer/agent.yml
@@ -15,5 +15,8 @@
 - name: Configure Telegraf service
   import_playbook: '../service/telegraf.yml'
 
+- name: Configure Prometheus exporters
+  import_playbook: '../service/prometheus_exporter.yml'
+
 - name: Configure Zabbix Agent
   import_playbook: '../service/zabbix_agent.yml'

--- a/ansible/playbooks/service/prometheus_exporter.yml
+++ b/ansible/playbooks/service/prometheus_exporter.yml
@@ -1,0 +1,18 @@
+---
+# Copyright (C) 2026 Patryk Sciborek <patryk@sciborek.com>
+# Copyright (C) 2026 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+- name: Manage Prometheus exporters
+  collections: [ 'debops.debops' ]
+  hosts: [ 'debops_service_prometheus_exporter' ]
+  become: True
+
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
+
+  roles:
+
+    - role: prometheus_exporter
+      tags: [ 'role::prometheus_exporter', 'skip::prometheus_exporter' ]

--- a/ansible/roles/prometheus_exporter/COPYRIGHT
+++ b/ansible/roles/prometheus_exporter/COPYRIGHT
@@ -1,0 +1,19 @@
+debops.prometheus_exporter - Manage Prometheus exporters from Debian packages using Ansible
+
+Copyright (C) 2026 Patryk Sciborek <patryk@sciborek.com>
+Copyright (C) 2026 DebOps <https://debops.org/>
+SPDX-License-Identifier: GPL-3.0-only
+
+This Ansible role is part of DebOps.
+
+DebOps is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 3, as
+published by the Free Software Foundation.
+
+DebOps is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with DebOps. If not, see https://www.gnu.org/licenses/.

--- a/ansible/roles/prometheus_exporter/defaults/main.yml
+++ b/ansible/roles/prometheus_exporter/defaults/main.yml
@@ -17,12 +17,6 @@
 # General [[[
 # -----------
 
-# .. envvar:: prometheus_exporter__enabled [[[
-#
-# Enable or disable the role.
-prometheus_exporter__enabled: True
-
-                                                                   # ]]]
 # .. envvar:: prometheus_exporter__config_dir [[[
 #
 # Directory for exporter configuration files (e.g. blackbox.yml, sql.yml).

--- a/ansible/roles/prometheus_exporter/defaults/main.yml
+++ b/ansible/roles/prometheus_exporter/defaults/main.yml
@@ -1,0 +1,104 @@
+---
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+
+# .. Copyright (C) 2026 Patryk Sciborek <patryk@sciborek.com>
+# .. Copyright (C) 2026 DebOps <https://debops.org/>
+# .. SPDX-License-Identifier: GPL-3.0-only
+
+# .. _prometheus_exporter__ref_defaults:
+
+# debops.prometheus_exporter default variables
+# ============================================
+
+# .. contents:: Sections
+#    :local:
+
+
+# General [[[
+# -----------
+
+# .. envvar:: prometheus_exporter__enabled [[[
+#
+# Enable or disable the role.
+prometheus_exporter__enabled: True
+
+                                                                   # ]]]
+# .. envvar:: prometheus_exporter__config_dir [[[
+#
+# Directory for exporter configuration files (e.g. blackbox.yml, sql.yml).
+prometheus_exporter__config_dir: '/etc/prometheus'
+
+                                                                   # ]]]
+# .. envvar:: prometheus_exporter__dropin_dir [[[
+#
+# Base directory for systemd drop-in override files.
+prometheus_exporter__dropin_dir: '/etc/systemd/system'
+
+                                                                   # ]]]
+# .. envvar:: prometheus_exporter__default_listen_host [[[
+#
+# Default host/IP exporters bind to. Loopback keeps exporters private; the
+# local vmagent scrapes them and forwards samples.
+prometheus_exporter__default_listen_host: '127.0.0.1'
+
+                                                                   # ]]]
+# .. envvar:: prometheus_exporter__purge_on_absent [[[
+#
+# When True, exporters with ``state: absent`` also have their APT package
+# purged.
+prometheus_exporter__purge_on_absent: False
+                                                                   # ]]]
+                                                                   # ]]]
+# Known default ports [[[
+# -----------------------
+
+# .. envvar:: prometheus_exporter__known_ports [[[
+#
+# Mapping of exporter ``name`` to its default listen port. Used to build
+# ``listen_address`` when an exporter does not set it explicitly.
+prometheus_exporter__known_ports:
+  node: 9100
+  blackbox: 9115
+  apache: 9117
+  postgres: 9187
+  sql: 9237
+  mysqld: 9104
+  redis: 9121
+  memcached: 9150
+  nginx: 9113
+  elasticsearch: 9114
+  ipmi: 9290
+                                                                   # ]]]
+                                                                   # ]]]
+# Exporter definitions [[[
+# ------------------------
+
+# The lists below define managed exporters. Each element is a dict; see
+# :ref:`prometheus_exporter__ref_exporters` for all supported keys.
+
+# .. envvar:: prometheus_exporter__exporters [[[
+#
+# Exporters applied to all hosts in the inventory.
+prometheus_exporter__exporters: []
+
+                                                                   # ]]]
+# .. envvar:: prometheus_exporter__group_exporters [[[
+#
+# Exporters applied to hosts in a specific inventory group.
+prometheus_exporter__group_exporters: []
+
+                                                                   # ]]]
+# .. envvar:: prometheus_exporter__host_exporters [[[
+#
+# Exporters applied to specific hosts.
+prometheus_exporter__host_exporters: []
+
+                                                                   # ]]]
+# .. envvar:: prometheus_exporter__combined_exporters [[[
+#
+# Combined list consumed by the role tasks.
+prometheus_exporter__combined_exporters: '{{ prometheus_exporter__exporters
+                                             + prometheus_exporter__group_exporters
+                                             + prometheus_exporter__host_exporters }}'
+                                                                   # ]]]
+                                                                   # ]]]

--- a/ansible/roles/prometheus_exporter/meta/main.yml
+++ b/ansible/roles/prometheus_exporter/meta/main.yml
@@ -1,0 +1,30 @@
+---
+# Copyright (C) 2026 Patryk Sciborek <patryk@sciborek.com>
+# Copyright (C) 2026 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+collections: [ 'debops.debops' ]
+
+dependencies: []
+
+galaxy_info:
+
+  author: 'Patryk Sciborek'
+  description: 'Install and configure Prometheus exporters from Debian packages'
+  company: 'DebOps'
+  license: 'GPL-3.0-only'
+  min_ansible_version: '2.11.0'
+
+  platforms:
+
+    - name: 'Ubuntu'
+      versions: [ 'all' ]
+
+    - name: 'Debian'
+      versions: [ 'all' ]
+
+  galaxy_tags:
+    - prometheus
+    - exporter
+    - metrics
+    - monitoring

--- a/ansible/roles/prometheus_exporter/tasks/main.yml
+++ b/ansible/roles/prometheus_exporter/tasks/main.yml
@@ -11,6 +11,10 @@
   ansible.builtin.import_role:
     name: 'global_handlers'
 
+- name: Import DebOps secret role
+  ansible.builtin.import_role:
+    name: 'secret'
+
 - name: Pre hooks
   ansible.builtin.include_tasks: '{{ lookup("debops.debops.task_src", "prometheus_exporter/pre_main.yml") }}'
 

--- a/ansible/roles/prometheus_exporter/tasks/main.yml
+++ b/ansible/roles/prometheus_exporter/tasks/main.yml
@@ -31,7 +31,6 @@
     owner: 'root'
     group: 'root'
     mode: '0755'
-  when: prometheus_exporter__enabled | bool
 
 - name: Manage Prometheus exporters
   ansible.builtin.include_tasks: 'manage_exporter.yml'
@@ -39,7 +38,6 @@
   loop_control:
     loop_var: 'exporter'
     label: '{{ exporter.name | d("<unnamed>") }}'
-  when: prometheus_exporter__enabled | bool
 
 - name: Save prometheus_exporter local facts
   ansible.builtin.template:

--- a/ansible/roles/prometheus_exporter/tasks/main.yml
+++ b/ansible/roles/prometheus_exporter/tasks/main.yml
@@ -1,0 +1,52 @@
+---
+# Copyright (C) 2026 Patryk Sciborek <patryk@sciborek.com>
+# Copyright (C) 2026 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+- name: Import custom Ansible plugins
+  ansible.builtin.import_role:
+    name: 'ansible_plugins'
+
+- name: Import DebOps global handlers
+  ansible.builtin.import_role:
+    name: 'global_handlers'
+
+- name: Pre hooks
+  ansible.builtin.include_tasks: '{{ lookup("debops.debops.task_src", "prometheus_exporter/pre_main.yml") }}'
+
+- name: Make sure that Ansible local fact directory exists
+  ansible.builtin.file:
+    path: '/etc/ansible/facts.d'
+    state: 'directory'
+    mode: '0755'
+
+- name: Ensure Prometheus configuration directory exists
+  ansible.builtin.file:
+    path: '{{ prometheus_exporter__config_dir }}'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+  when: prometheus_exporter__enabled | bool
+
+- name: Manage Prometheus exporters
+  ansible.builtin.include_tasks: 'manage_exporter.yml'
+  loop: '{{ prometheus_exporter__combined_exporters }}'
+  loop_control:
+    loop_var: 'exporter'
+    label: '{{ exporter.name | d("<unnamed>") }}'
+  when: prometheus_exporter__enabled | bool
+
+- name: Save prometheus_exporter local facts
+  ansible.builtin.template:
+    src: 'etc/ansible/facts.d/prometheus_exporter.fact.j2'
+    dest: '/etc/ansible/facts.d/prometheus_exporter.fact'
+    mode: '0644'
+  notify: [ 'Refresh host facts' ]
+  tags: [ 'meta::facts' ]
+
+- name: Reload Ansible local facts
+  ansible.builtin.meta: 'flush_handlers'
+
+- name: Post hooks
+  ansible.builtin.include_tasks: '{{ lookup("debops.debops.task_src", "prometheus_exporter/post_main.yml") }}'

--- a/ansible/roles/prometheus_exporter/tasks/manage_exporter.yml
+++ b/ansible/roles/prometheus_exporter/tasks/manage_exporter.yml
@@ -1,0 +1,128 @@
+---
+# Copyright (C) 2026 Patryk Sciborek <patryk@sciborek.com>
+# Copyright (C) 2026 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+# Manage one exporter. Included in a loop with loop_var 'exporter'.
+
+- name: Validate exporter {{ exporter.name | d("<unnamed>") }} definition
+  ansible.builtin.assert:
+    that:
+      - exporter.name is defined
+      - exporter.name | length > 0
+      - exporter.state | d('present') in ['present', 'absent']
+      - (exporter.state | d('present') == 'absent')
+        or (exporter.listen_address is defined)
+        or (exporter.name in prometheus_exporter__known_ports)
+    quiet: True
+    fail_msg: >-
+      Each exporter needs a non-empty 'name', 'state' present/absent, and
+      (for present) either 'listen_address' or a 'name' present in
+      prometheus_exporter__known_ports.
+
+- name: Resolve settings for exporter {{ exporter.name }}
+  ansible.builtin.set_fact:
+    prometheus_exporter__fact_service: "{{ exporter.service | d('prometheus-' ~ exporter.name ~ '-exporter') }}"
+    prometheus_exporter__fact_package: "{{ exporter.package | d('prometheus-' ~ exporter.name ~ '-exporter') }}"
+    prometheus_exporter__fact_bin: "{{ exporter.bin_path | d('/usr/bin/' ~ (exporter.service | d('prometheus-' ~ exporter.name ~ '-exporter'))) }}"
+    prometheus_exporter__fact_listen: "{{ exporter.listen_address | d(prometheus_exporter__default_listen_host ~ ':' ~ (prometheus_exporter__known_ports[exporter.name] | d('') | string)) }}"
+    prometheus_exporter__fact_config_path: "{{ exporter.config_path | d(prometheus_exporter__config_dir ~ '/' ~ exporter.name ~ '.yml') }}"
+    prometheus_exporter__fact_secret: "{{ (exporter.environment | d({}) | length > 0) | bool }}"
+
+- name: Deploy exporter {{ exporter.name }}
+  when: exporter.state | d('present') == 'present'
+  block:
+
+    - name: Install APT package for exporter {{ exporter.name }}
+      ansible.builtin.apt:
+        name: '{{ [prometheus_exporter__fact_package] + (exporter.packages | d([])) }}'
+        state: 'present'
+        update_cache: True
+        cache_valid_time: 3600
+
+    - name: Deploy config file for exporter {{ exporter.name }}
+      ansible.builtin.template:
+        src: 'etc/prometheus/exporter-config.yml.j2'
+        dest: '{{ prometheus_exporter__fact_config_path }}'
+        owner: 'root'
+        group: 'root'
+        mode: '{{ exporter.config_mode | d("0644") }}'
+      no_log: '{{ exporter.config_no_log | d(False) | bool }}'
+      register: prometheus_exporter__register_config
+      when: exporter.config is defined
+
+    - name: Deploy extra config files for exporter {{ exporter.name }}
+      ansible.builtin.copy:
+        content: '{{ item.content | d(omit) }}'
+        src: '{{ item.src | d(omit) }}'
+        dest: '{{ item.path }}'
+        owner: 'root'
+        group: 'root'
+        mode: '{{ item.mode | d("0644") }}'
+      loop: '{{ exporter.config_files | d([]) }}'
+      loop_control:
+        label: '{{ item.path }}'
+      no_log: '{{ exporter.config_no_log | d(False) | bool }}'
+      register: prometheus_exporter__register_configfiles
+
+    - name: Ensure systemd drop-in directory for exporter {{ exporter.name }}
+      ansible.builtin.file:
+        path: '{{ prometheus_exporter__dropin_dir }}/{{ prometheus_exporter__fact_service }}.service.d'
+        state: 'directory'
+        owner: 'root'
+        group: 'root'
+        mode: '0755'
+
+    - name: Deploy systemd drop-in for exporter {{ exporter.name }}
+      ansible.builtin.template:
+        src: 'etc/systemd/system/exporter-override.conf.j2'
+        dest: '{{ prometheus_exporter__dropin_dir }}/{{ prometheus_exporter__fact_service }}.service.d/override.conf'
+        owner: 'root'
+        group: 'root'
+        mode: '{{ "0600" if prometheus_exporter__fact_secret else "0644" }}'
+      no_log: '{{ prometheus_exporter__fact_secret }}'
+      register: prometheus_exporter__register_dropin
+
+    - name: Enable and start exporter {{ exporter.name }}
+      ansible.builtin.systemd:
+        name: '{{ prometheus_exporter__fact_service }}'
+        enabled: True
+        state: 'started'
+        daemon_reload: True
+
+    - name: Restart exporter {{ exporter.name }} on configuration change
+      ansible.builtin.systemd:  # noqa no-handler
+        name: '{{ prometheus_exporter__fact_service }}'
+        state: 'restarted'
+      when: (prometheus_exporter__register_config is changed) or
+            (prometheus_exporter__register_configfiles is changed) or
+            (prometheus_exporter__register_dropin is changed)
+
+- name: Remove exporter {{ exporter.name }}
+  when: exporter.state | d('present') == 'absent'
+  block:
+
+    - name: Stop and disable exporter {{ exporter.name }}
+      ansible.builtin.systemd:
+        name: '{{ prometheus_exporter__fact_service }}'
+        enabled: False
+        state: 'stopped'
+      failed_when: False
+
+    - name: Remove drop-in for exporter {{ exporter.name }}
+      ansible.builtin.file:
+        path: '{{ prometheus_exporter__dropin_dir }}/{{ prometheus_exporter__fact_service }}.service.d/override.conf'
+        state: 'absent'
+      register: prometheus_exporter__register_absent_dropin
+
+    - name: Reload systemd after removing drop-in {{ exporter.name }}
+      ansible.builtin.systemd:
+        daemon_reload: True
+      when: prometheus_exporter__register_absent_dropin is changed
+
+    - name: Purge APT package for exporter {{ exporter.name }}
+      ansible.builtin.apt:
+        name: '{{ prometheus_exporter__fact_package }}'
+        state: 'absent'
+        purge: True
+      when: prometheus_exporter__purge_on_absent | bool

--- a/ansible/roles/prometheus_exporter/tasks/prometheus_exporter/post_main.yml
+++ b/ansible/roles/prometheus_exporter/tasks/prometheus_exporter/post_main.yml
@@ -1,0 +1,8 @@
+---
+# Copyright (C) 2026 Patryk Sciborek <patryk@sciborek.com>
+# Copyright (C) 2026 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+# Custom tasks executed after the main role tasks. Override at the project
+# level by providing a file with the same path resolved via
+# ``debops.debops.task_src``.

--- a/ansible/roles/prometheus_exporter/tasks/prometheus_exporter/pre_main.yml
+++ b/ansible/roles/prometheus_exporter/tasks/prometheus_exporter/pre_main.yml
@@ -1,0 +1,8 @@
+---
+# Copyright (C) 2026 Patryk Sciborek <patryk@sciborek.com>
+# Copyright (C) 2026 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-only
+
+# Custom tasks executed before the main role tasks. Override at the project
+# level by providing a file with the same path resolved via
+# ``debops.debops.task_src``.

--- a/ansible/roles/prometheus_exporter/templates/etc/ansible/facts.d/prometheus_exporter.fact.j2
+++ b/ansible/roles/prometheus_exporter/templates/etc/ansible/facts.d/prometheus_exporter.fact.j2
@@ -1,0 +1,13 @@
+{# Copyright (C) 2026 Patryk Sciborek <patryk@sciborek.com>
+ # Copyright (C) 2026 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-only
+ #}
+{{ {'managed_by': 'debops.prometheus_exporter',
+    'configured': prometheus_exporter__combined_exporters
+                  | selectattr('state', 'undefined')
+                  | map(attribute='name') | list
+                + prometheus_exporter__combined_exporters
+                  | selectattr('state', 'defined')
+                  | selectattr('state', 'equalto', 'present')
+                  | map(attribute='name') | list}
+   | to_nice_json }}

--- a/ansible/roles/prometheus_exporter/templates/etc/prometheus/exporter-config.yml.j2
+++ b/ansible/roles/prometheus_exporter/templates/etc/prometheus/exporter-config.yml.j2
@@ -1,0 +1,6 @@
+{# Copyright (C) 2026 Patryk Sciborek <patryk@sciborek.com>
+ # Copyright (C) 2026 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-only
+ #}
+# {{ ansible_managed }}
+{{ exporter.config | to_nice_yaml(indent=2, width=120) }}

--- a/ansible/roles/prometheus_exporter/templates/etc/systemd/system/exporter-override.conf.j2
+++ b/ansible/roles/prometheus_exporter/templates/etc/systemd/system/exporter-override.conf.j2
@@ -1,0 +1,26 @@
+{# Copyright (C) 2026 Patryk Sciborek <patryk@sciborek.com>
+ # Copyright (C) 2026 DebOps <https://debops.org/>
+ # SPDX-License-Identifier: GPL-3.0-only
+ #}
+{% set pe_args = [] %}
+{% set _ = pe_args.append((exporter.web_listen_flag | d('--web.listen-address')) ~ '=' ~ prometheus_exporter__fact_listen) %}
+{% if exporter.config is defined %}
+{%   set _ = pe_args.append((exporter.config_flag | d('--config.file')) ~ '=' ~ prometheus_exporter__fact_config_path) %}
+{% endif %}
+{% for a in exporter.args | d([]) %}
+{%   set _ = pe_args.append(a) %}
+{% endfor %}
+# {{ ansible_managed }}
+[Service]
+EnvironmentFile=
+{% if exporter.environment | d({}) | length > 0 %}
+Environment=
+{% for key, value in exporter.environment | dictsort %}
+Environment="{{ key }}={{ value }}"
+{% endfor %}
+{% endif %}
+ExecStart=
+ExecStart={{ prometheus_exporter__fact_bin }} {{ pe_args | join(' ') }}
+{% for line in exporter.systemd_overrides | d([]) %}
+{{ line }}
+{% endfor %}

--- a/docs/ansible/role-index.rst
+++ b/docs/ansible/role-index.rst
@@ -259,6 +259,7 @@ Monitoring
 - :ref:`debops.metricbeat`
 - :ref:`debops.monit`
 - :ref:`debops.proc_hidepid`
+- :ref:`debops.prometheus_exporter`
 - :ref:`debops.snmpd`
 - :ref:`debops.telegraf`
 - :ref:`debops.zabbix_agent`

--- a/docs/ansible/roles/prometheus_exporter/defaults-detailed.rst
+++ b/docs/ansible/roles/prometheus_exporter/defaults-detailed.rst
@@ -1,0 +1,93 @@
+.. Copyright (C) 2026 Patryk Sciborek <patryk@sciborek.com>
+.. Copyright (C) 2026 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+.. _prometheus_exporter__ref_defaults_detailed:
+
+Default variable details
+========================
+
+.. include:: ../../../includes/global.rst
+
+.. only:: html
+
+   .. contents::
+      :local:
+      :depth: 1
+
+
+.. _prometheus_exporter__ref_exporters:
+
+prometheus_exporter__exporters
+------------------------------
+
+The :envvar:`prometheus_exporter__exporters`,
+:envvar:`prometheus_exporter__group_exporters` and
+:envvar:`prometheus_exporter__host_exporters` lists define the managed
+exporters. They are combined into
+:envvar:`prometheus_exporter__combined_exporters`.
+
+Each entry is a dict with the following keys:
+
+``name``
+  Required. Short exporter name, e.g. ``node``, ``postgres``, ``sql``. Used
+  to derive defaults for ``package``, ``service``, ``bin_path`` and the
+  listen port.
+
+``state``
+  Optional, default ``present``. ``absent`` stops/disables the service and
+  removes the drop-in (and purges the package when
+  :envvar:`prometheus_exporter__purge_on_absent` is True).
+
+``package`` / ``packages``
+  Optional. APT package (default ``prometheus-<name>-exporter``) and a list
+  of extra packages.
+
+``service`` / ``bin_path``
+  Optional. systemd unit (default ``prometheus-<name>-exporter``) and binary
+  path (default ``/usr/bin/<service>``).
+
+``listen_address``
+  Optional. ``host:port`` for ``--web.listen-address``. Defaults to
+  ``prometheus_exporter__default_listen_host`` plus the port from
+  :envvar:`prometheus_exporter__known_ports` for this ``name``.
+
+``web_listen_flag``
+  Optional, default ``--web.listen-address``. Override for exporters that use
+  a different flag name.
+
+``args``
+  Optional list of extra command-line flags appended verbatim.
+
+``environment``
+  Optional dict of environment variables placed in the drop-in (e.g.
+  ``DATA_SOURCE_NAME``). When non-empty, the drop-in is written with mode
+  ``0600`` and ``no_log``.
+
+``config`` / ``config_path`` / ``config_flag`` / ``config_mode`` / ``config_no_log``
+  Optional. When ``config`` (a dict) is set, it is rendered as YAML to
+  ``config_path`` (default ``/etc/prometheus/<name>.yml``) and
+  ``<config_flag>=<config_path>`` (default ``--config.file``) is added to
+  the command line. Use ``config_mode: '0600'`` and ``config_no_log: true``
+  when the file contains secrets (e.g. ``prometheus-sql-exporter`` DSN).
+
+``config_files``
+  Optional list of extra files (``{ path, content|src, mode }``) for
+  exporters split across multiple files.
+
+``systemd_overrides``
+  Optional list of extra ``[Service]`` lines, e.g.
+  ``AmbientCapabilities=CAP_NET_RAW`` (blackbox ICMP) or ``User=root``
+  (local IPMI).
+
+Example:
+
+.. code-block:: yaml
+
+   prometheus_exporter__group_exporters:
+
+     - name: 'node'
+
+     - name: 'postgres'
+       environment:
+         DATA_SOURCE_NAME: 'host=127.0.0.1 port=5432 user=prometheus_exporter password=SECRET dbname=postgres sslmode=disable'

--- a/docs/ansible/roles/prometheus_exporter/getting-started.rst
+++ b/docs/ansible/roles/prometheus_exporter/getting-started.rst
@@ -1,0 +1,59 @@
+.. Copyright (C) 2026 Patryk Sciborek <patryk@sciborek.com>
+.. Copyright (C) 2026 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+Getting started
+===============
+
+.. only:: html
+
+   .. contents::
+      :local:
+
+
+What does this role do?
+-----------------------
+
+The role installs Prometheus exporters from Debian packages and manages
+each one via a systemd drop-in override. Exporters listen on the loopback
+interface; a local :ref:`debops.vmagent` instance scrapes them.
+
+
+Minimal inventory
+-----------------
+
+Add hosts to the ``[debops_service_prometheus_exporter]`` group and declare
+the exporters in a leaf group (not in the service group itself, to avoid
+variable precedence collisions):
+
+.. code-block:: yaml
+
+   # inventory groups
+   debops_service_prometheus_exporter:
+     children:
+       my_hosts:
+
+   # group_vars/my_hosts/prometheus_exporter.yml
+   prometheus_exporter__group_exporters:
+     - name: 'node'
+
+This installs ``prometheus-node-exporter`` and writes a drop-in so the
+service listens on ``127.0.0.1:9100``.
+
+
+Example playbook
+----------------
+
+.. literalinclude:: ../../../../ansible/playbooks/service/prometheus_exporter.yml
+   :language: yaml
+   :lines: 1,6-
+
+
+Ansible tags
+------------
+
+``role::prometheus_exporter``
+  Main role tag.
+
+``skip::prometheus_exporter``
+  Skip the main role tasks.

--- a/docs/ansible/roles/prometheus_exporter/guide-database-exporters.rst
+++ b/docs/ansible/roles/prometheus_exporter/guide-database-exporters.rst
@@ -1,0 +1,45 @@
+.. Copyright (C) 2026 Patryk Sciborek <patryk@sciborek.com>
+.. Copyright (C) 2026 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+.. _prometheus_exporter__ref_guide_database:
+
+Guide: database exporters (postgres, redis)
+===========================================
+
+Database exporters need credentials. Keep them out of world-readable files
+by passing them via ``environment`` (rendered into the ``0600`` drop-in).
+
+PostgreSQL example. Create a least-privilege monitoring role with the
+``pg_monitor`` built-in role (via :ref:`debops.postgresql`):
+
+.. code-block:: yaml
+
+   postgresql__roles:
+     - name: 'prometheus_exporter'
+       flags: [ 'LOGIN', 'INHERIT' ]
+       password: '{{ lookup("password", secret + "/postgresql/prometheus_exporter_password chars=ascii_letters,digits length=32") }}'
+
+   postgresql__groups:
+     - roles: [ 'prometheus_exporter' ]
+       groups: [ 'pg_monitor' ]
+       database: 'postgres'
+
+Then the exporter:
+
+.. code-block:: yaml
+
+   prometheus_exporter__group_exporters:
+     - name: 'postgres'
+       environment:
+         DATA_SOURCE_NAME: 'host=127.0.0.1 port=5432 user=prometheus_exporter password={{ lookup("password", secret + "/postgresql/prometheus_exporter_password chars=ascii_letters,digits length=32") }} dbname=postgres sslmode=disable'
+
+Redis example (password via environment):
+
+.. code-block:: yaml
+
+   prometheus_exporter__group_exporters:
+     - name: 'redis'
+       args: [ '--redis.addr=redis://127.0.0.1:6379' ]
+       environment:
+         REDIS_PASSWORD: '{{ lookup("password", secret + "/redis/exporter_password") }}'

--- a/docs/ansible/roles/prometheus_exporter/guide-vmagent-integration.rst
+++ b/docs/ansible/roles/prometheus_exporter/guide-vmagent-integration.rst
@@ -1,0 +1,32 @@
+.. Copyright (C) 2026 Patryk Sciborek <patryk@sciborek.com>
+.. Copyright (C) 2026 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+.. _prometheus_exporter__ref_guide_vmagent:
+
+Guide: scraping exporters with vmagent
+======================================
+
+Exporters managed by this role listen on ``127.0.0.1``. Add a matching
+scrape job to the local :ref:`debops.vmagent` instance, for example:
+
+.. code-block:: yaml
+
+   vmagent__default_remote_write_urls:
+     - 'https://vmetrics.example.org/api/v1/write'
+
+   vmagent__default_scrape_configs: '{{ [{
+       "job_name": "node",
+       "static_configs": [ { "targets": [ "127.0.0.1:9100" ] } ]
+     }] + vmagent__extra_scrape_configs }}'
+
+   vmagent__extra_scrape_configs: []
+
+Per-group extra scrape jobs (e.g. for postgres on database hosts):
+
+.. code-block:: yaml
+
+   vmagent__extra_scrape_configs:
+     - job_name: 'postgres'
+       static_configs:
+         - targets: [ '127.0.0.1:9187' ]

--- a/docs/ansible/roles/prometheus_exporter/index.rst
+++ b/docs/ansible/roles/prometheus_exporter/index.rst
@@ -1,0 +1,31 @@
+.. Copyright (C) 2026 Patryk Sciborek <patryk@sciborek.com>
+.. Copyright (C) 2026 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+.. _debops.prometheus_exporter:
+
+debops.prometheus_exporter
+==========================
+
+.. include:: man_description.rst
+   :start-line: 7
+
+.. toctree::
+   :maxdepth: 2
+
+   getting-started
+   guide-vmagent-integration
+   guide-database-exporters
+   defaults/main
+   defaults-detailed
+
+Copyright
+---------
+
+.. literalinclude:: ../../../../ansible/roles/prometheus_exporter/COPYRIGHT
+
+..
+ Local Variables:
+ mode: rst
+ ispell-local-dictionary: "american"
+ End:

--- a/docs/ansible/roles/prometheus_exporter/man_description.rst
+++ b/docs/ansible/roles/prometheus_exporter/man_description.rst
@@ -1,0 +1,16 @@
+.. Copyright (C) 2026 Patryk Sciborek <patryk@sciborek.com>
+.. Copyright (C) 2026 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+Description
+===========
+
+This role installs and configures Prometheus exporters packaged in the
+Debian / Ubuntu repositories (the ``prometheus-*-exporter`` family, e.g.
+``prometheus-node-exporter``, ``prometheus-postgres-exporter``). Each
+exporter is configured through a dedicated systemd drop-in file that resets
+and rewrites ``ExecStart=`` (and, when needed, ``Environment=``), which makes
+the role independent of per-package and per-release differences in the
+shipped ``/etc/default/`` files. Exporters bind to the loopback interface by
+default and are intended to be scraped by a local agent such as
+:ref:`debops.vmagent`, which forwards the samples to a remote store.

--- a/docs/ansible/roles/prometheus_exporter/man_index.rst
+++ b/docs/ansible/roles/prometheus_exporter/man_index.rst
@@ -1,0 +1,22 @@
+:orphan:
+
+.. Copyright (C) 2026 Patryk Sciborek <patryk@sciborek.com>
+.. Copyright (C) 2026 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+debops.prometheus_exporter
+==========================
+
+.. toctree::
+   :maxdepth: 2
+
+   man_synopsis
+   man_description
+   getting-started
+   defaults-detailed
+
+..
+ Local Variables:
+ mode: rst
+ ispell-local-dictionary: "american"
+ End:

--- a/docs/ansible/roles/prometheus_exporter/man_synopsis.rst
+++ b/docs/ansible/roles/prometheus_exporter/man_synopsis.rst
@@ -1,0 +1,10 @@
+.. Copyright (C) 2026 Patryk Sciborek <patryk@sciborek.com>
+.. Copyright (C) 2026 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-only
+
+Synopsis
+========
+
+``debops run service/prometheus_exporter`` [**--limit** `group,host,`...] [**--diff**] [**--check**] [**--tags** `tag1,tag2,`...] [**--skip-tags** `tag1,tag2,`...] [<``ansible-playbook`` options>] ...
+
+``debops check service/prometheus_exporter`` [**--limit** `group,host,`...] [**--tags** `tag1,tag2,`...] [**--skip-tags** `tag1,tag2,`...] [<``ansible-playbook`` options>] ...


### PR DESCRIPTION
## Summary

Adds a new `debops.prometheus_exporter` role that installs Prometheus exporters
from the Debian/Ubuntu `prometheus-*-exporter` package family (e.g.
`prometheus-node-exporter`, `prometheus-postgres-exporter`) and configures each
one through a dedicated **systemd drop-in override** instead of editing the
per-package `/etc/default/` files. The drop-in resets and rewrites `ExecStart=`
(and, when needed, `Environment=`), which makes the role behave uniformly across
exporters and across Debian releases that ship different default files.

Exporters bind to the loopback interface by default and are meant to be scraped
by a local agent such as `debops.vmagent`, which forwards the samples to a
remote store. The playbook is wired into `layer/agent.yml` so `debops run site`
configures the exporters alongside the other observability agents.

## Motivation

The exporters shipped in Debian are convenient (APT-managed, security updates
for free), but configuring them is inconsistent: each package reads a different
`/etc/default/prometheus-*-exporter` file with a different variable name, and
those files change between releases. Managing them by templating each default
file is brittle.

Rewriting `ExecStart=`/`Environment=` via a systemd drop-in sidesteps all of
that: the role owns the command line and environment regardless of what the
package ships, while still relying on APT for the binary and its updates.

## Design

- **One include per exporter** (`manage_exporter.yml`, looped over
  `prometheus_exporter__combined_exporters`) with an `assert` that each entry
  has a non-empty `name`, a valid `state`, and — for `present` — either an
  explicit `listen_address` or a `name` known in
  `prometheus_exporter__known_ports`.
- **Sensible defaults derived from `name`**: service, package and binary path
  default to `prometheus-<name>-exporter`, and the listen address to
  `127.0.0.1:<known port>` using a built-in port map (node 9100, blackbox 9115,
  postgres 9187, ...). All overridable per exporter.
- **systemd drop-in** at
  `/etc/systemd/system/<service>.service.d/override.conf` that empties and
  rewrites `ExecStart=`, optionally injects `Environment=` entries, and can
  append arbitrary extra unit lines via `systemd_overrides`. Drop-ins with
  secrets in `Environment=` are written `0600` with `no_log`.
- **Optional config files**: an exporter can render a main config
  (`--config.file`) and/or drop extra files (e.g. `blackbox.yml`, `sql.yml`).
- **Idempotent restart-on-change**: an exporter is restarted only when its own
  config, extra files or drop-in changed.
- **Clean removal**: `state: 'absent'` stops/disables the unit, removes the
  drop-in and reloads systemd; the APT package is purged only when
  `prometheus_exporter__purge_on_absent` is set.

## What this PR adds

- **Role** `ansible/roles/prometheus_exporter/`: `defaults/main.yml`,
  `meta/main.yml`, `COPYRIGHT`, `tasks/main.yml`, `tasks/manage_exporter.yml`,
  `tasks/prometheus_exporter/{pre_main,post_main}.yml` hook placeholders, and
  templates for the systemd drop-in, an exporter config file and the
  `facts.d/prometheus_exporter.fact` local facts.
- **Playbook** `ansible/playbooks/service/prometheus_exporter.yml`.
- **Site integration**: import added to `ansible/playbooks/layer/agent.yml`.
- **Documentation** `docs/ansible/roles/prometheus_exporter/`: getting-started,
  defaults-detailed, `guide-vmagent-integration`, `guide-database-exporters`,
  man pages, plus an entry in `docs/ansible/role-index.rst`.
- **Changelog** entry under "New DebOps roles".

## Dependencies

This PR is part of a stack and depends on #2704 (the `debops.vmagent` role).

The role documentation cross-references vmagent via `` :ref:`debops.vmagent` ``.
That documentation label only exists once #2704 is merged into `master`, so
until then the `test-man` / `documentation` jobs (and the packaging jobs that
build the docs: `debops-sdist`, `debops-wheel`, `docker-image`) fail with:

    docs/ansible/roles/prometheus_exporter/man_description.rst: undefined label: 'debops.vmagent'

Suggested merge order: merge #2704 first, then re-run CI on this PR (rebase or
an empty commit) and the checks turn green. At runtime the role is independent
of vmagent - any Prometheus-compatible scraper can read the loopback endpoints.

## Testing

Tested in a homelab DebOps deployment on Debian (unprivileged Proxmox LXC):

- `prometheus-node-exporter` installed and bound to `127.0.0.1:9100`, scraped
  by a local `vmagent` instance; samples visible in the central store.
- `prometheus-postgres-exporter` with a secret DSN passed via `environment:`
  (drop-in written `0600`, `no_log`).
- Idempotency: a second run reports `changed=0`; editing one exporter's config
  restarts only that exporter.
- `state: 'absent'` removes the drop-in, reloads systemd and stops the unit.

## Checklist

- [x] Follows DebOps role conventions (defaults/meta/tasks layout,
      `prometheus_exporter__` namespace, `role::`/`skip::` tags)
- [x] Playbook follows the standard `service/<name>.yml` structure
- [x] Documentation with getting-started, defaults-detailed and two guides,
      listed in `role-index.rst`
- [x] SPDX-License-Identifier and Copyright headers on all new files
- [x] `pre_main`/`post_main` hook placeholders provided
- [ ] CI green (verified after push)
