### PR TITLE
Add role quality scoring script and CI gate

### DIFF
--- a/.github/workflows/role-score.yml
+++ b/.github/workflows/role-score.yml
@@ -1,0 +1,41 @@
+---
+# Copyright (C) 2026 Maciej Delmanowski <drybjed@gmail.com>
+# Copyright (C) 2026 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: 'Role Quality Score'
+on: [ 'push', 'pull_request' ]
+
+jobs:
+  role-score:
+    runs-on: 'ubuntu-latest'
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed roles
+        id: roles
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.base_ref }}"
+          else
+            BASE="HEAD~1"
+          fi
+          CHANGED=$(git diff --name-only "origin/${BASE}...HEAD" \
+            | grep -E '^(roles|ansible/roles)/' \
+            | cut -d/ -f2 \
+            | sort -u \
+            | paste -sd ',')
+          echo "changed=${CHANGED}" >> "${GITHUB_OUTPUT}"
+
+      - name: Score changed roles
+        if: steps.roles.outputs.changed != ''
+        run: |
+          # Gate at 40% of the score ceiling, computed from current rule weights
+          bin/debops-role-score \
+            --roles "${{ steps.roles.outputs.changed }}" \
+            --min-score-fraction 0.40 \
+            --verbose

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,13 @@ General
   project requirements for contributions that use LLM and AI-assisted
   coding tools.
 
+- Added the :command:`debops-role-score` script, a developer tool which
+  grades DebOps roles against the project's quality rules and reports a
+  per-rule breakdown of the result. A GitHub Actions workflow scores the
+  roles touched by a change and fails the build when any of them falls
+  below 40% of the computed score ceiling. See the :ref:`role_score`
+  documentation for details.
+
 :ref:`debops.java` role
 '''''''''''''''''''''''
 

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,18 @@ syntax: test-playbook-syntax
 lint:           ## Check Ansible roles using ansible-lint
 lint: test-ansible-lint
 
+.PHONY: role-score
+role-score:     ## Score Ansible roles against quality rules
+role-score:
+	@printf "%s\n" "Scoring Ansible roles against quality rules..."
+	@bin/debops-role-score
+
+.PHONY: role-score-verbose
+role-score-verbose: ## Score Ansible roles with per-rule details
+role-score-verbose:
+	@printf "%s\n" "Scoring Ansible roles against quality rules..."
+	@bin/debops-role-score --verbose
+
 .PHONY: test
 test:           ## Perform all DebOps tests
 test: test-all

--- a/bin/debops-role-score
+++ b/bin/debops-role-score
@@ -48,14 +48,20 @@ DEFAULT_WEIGHTS: dict[str, float] = {
     "file_src_lookup": 0.05,
     "collections_declared": 0.2,
     "dependencies_empty": 0.2,
+    "dependent_variables": 0.9,
+    "ansible_local_in_conditions": 0.8,
     "min_ansible_version": 0.5,
     "ansible_plugins_import": 0.5,
     "pre_post_hooks": 0.2,
     "task_tags": 0.3,
+    "task_file_organization": 0.3,
     "local_facts": 1.0,
     "flush_handlers": 0.4,
     "register_until": 0.2,
     "no_debug_ignore": 0.2,
+    "spdx_headers": 0.1,
+    "ansible_managed": 0.3,
+    "template_default_filter": 0.4,
 }
 
 DEFAULT_MIN_ANSIBLE: str = "2.10.0"
@@ -1132,6 +1138,216 @@ def rule_no_debug_ignore(
     )
 
 
+def _check_template_headers(
+    role_path: Path,
+    pattern: re.Pattern,
+) -> tuple[int, int]:
+    """Count templates where text matches *pattern*."""
+    templates = find_template_files(role_path)
+    matching = 0
+    for tpl in templates:
+        text = tpl.read_text(encoding="utf-8")
+        if pattern.search(text):
+            matching += 1
+    return matching, len(templates)
+
+
+def rule_spdx_headers(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Ratio of templates with SPDX-License-Identifier."""
+    w = weights.get("spdx_headers", 0.1)
+    # REUSE-IgnoreStart
+    pattern = re.compile(r"SPDX-License-Identifier:\s*\S+")
+    # REUSE-IgnoreEnd
+    matching, total = _check_template_headers(role_path, pattern)
+
+    if total == 0:
+        return RuleResult("spdx_headers", w, 0.0, 0.0, "no templates")
+
+    score = matching / total
+    return RuleResult(
+        "spdx_headers",
+        w,
+        score,
+        1.0,
+        f"{matching}/{total} with SPDX",
+    )
+
+
+def rule_ansible_managed(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Ratio of templates containing {{ ansible_managed }}."""
+    w = weights.get("ansible_managed", 0.3)
+    pattern = re.compile(r"\{\{.*ansible_managed.*}}")
+    matching, total = _check_template_headers(role_path, pattern)
+
+    if total == 0:
+        return RuleResult("ansible_managed", w, 0.0, 0.0, "no templates")
+
+    score = matching / total
+    return RuleResult(
+        "ansible_managed",
+        w,
+        score,
+        1.0,
+        f"{matching}/{total} with ansible_managed",
+    )
+
+
+def rule_dependent_variables(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Ratio of variables following the dependent variable pattern."""
+    w = weights.get("dependent_variables", 0.5)
+    defaults_file = role_path / "defaults" / "main.yml"
+    if not defaults_file.is_file():
+        return RuleResult("dependent_variables", w, 0.0, 0.0, "no defaults/main.yml")
+
+    data = load_yaml(defaults_file)
+    if isinstance(data, dict):
+        keys = list(data.keys())
+    else:
+        text = defaults_file.read_text(encoding="utf-8")
+        keys = re.findall(r"^([a-zA-Z_]\w*):", text, re.MULTILINE)
+
+    exclude = {"galaxy_info", "dependencies", "collections"}
+    keys = [k for k in keys if k not in exclude and not k.startswith(".")]
+
+    if not keys:
+        return RuleResult("dependent_variables", w, 0.0, 0.0, "no variables")
+
+    dependent = sum(1 for k in keys if "__dependent_" in k)
+    main_score = dependent / len(keys)
+    detail = f"{dependent}/{len(keys)} dependent"
+    total_score = main_score
+
+    # Inbound reference bonus: other roles reference this role's variables
+    inbound_refs: dict[str, set[str]] = kwargs.get("inbound_refs", {})
+    refs = inbound_refs.get(role_name, set())
+    if refs:
+        bonus = min(0.30, len(refs) * 0.03)
+        total_score = min(1.0, main_score + bonus)
+        detail += f", +{bonus:.2f} inbound ({len(refs)} roles)"
+
+    return RuleResult(
+        "dependent_variables",
+        w,
+        total_score,
+        1.0,
+        detail,
+    )
+
+
+def rule_ansible_local_in_conditions(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Ratio of tasks referencing ansible_local in when clauses."""
+    w = weights.get("ansible_local_in_conditions", 0.3)
+    if _is_minimal_surface(kwargs.get("surface"), role_path):
+        return RuleResult(
+            "ansible_local_in_conditions", w, 0.0, 0.0, "minimal role surface"
+        )
+    task_files = find_task_files(role_path)
+    if not task_files:
+        return RuleResult("ansible_local_in_conditions", w, 0.0, 0.0, "no task files")
+
+    total_when = 0
+    using_ansible_local = 0
+
+    for tf in task_files:
+        data = load_yaml(tf)
+        tasks = parse_tasks(data)
+        for task in tasks:
+            when_val = task.get("when")
+            if isinstance(when_val, str) and when_val.strip():
+                total_when += 1
+                if "ansible_local." in when_val:
+                    using_ansible_local += 1
+            elif isinstance(when_val, list):
+                total_when += 1
+                items_str = " ".join(str(v) for v in when_val)
+                if "ansible_local." in items_str:
+                    using_ansible_local += 1
+
+    if total_when == 0:
+        return RuleResult("ansible_local_in_conditions", w, 0.0, 0.0, "no when clauses")
+
+    score = using_ansible_local / total_when
+    return RuleResult(
+        "ansible_local_in_conditions",
+        w,
+        score,
+        1.0,
+        f"{using_ansible_local}/{total_when} with ansible_local",
+    )
+
+
+def rule_task_file_organization(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Reward splitting tasks into multiple files by concern."""
+    w = weights.get("task_file_organization", 0.3)
+    if _is_minimal_surface(kwargs.get("surface"), role_path):
+        return RuleResult("task_file_organization", w, 0.0, 0.0, "minimal role surface")
+    tasks_dir = role_path / "tasks"
+    if not tasks_dir.is_dir():
+        return RuleResult("task_file_organization", w, 0.0, 0.0, "no tasks directory")
+
+    # Count task files beyond main.yml, pre_main.yml, post_main.yml
+    all_yml = sorted(tasks_dir.rglob("*.yml"))
+    extra = [
+        f
+        for f in all_yml
+        if f.name not in ("main.yml", "pre_main.yml", "post_main.yml")
+    ]
+    score = min(1.0, len(extra) / 3.0)
+    return RuleResult(
+        "task_file_organization",
+        w,
+        score,
+        1.0,
+        f"{len(extra)} extra files",
+    )
+
+
+def rule_template_default_filter(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Ratio of Jinja expressions in templates using | d() / | default()."""
+    w = weights.get("template_default_filter", 0.4)
+    templates = find_template_files(role_path)
+    if not templates:
+        return RuleResult("template_default_filter", w, 0.0, 0.0, "no templates")
+
+    total_expr = 0
+    safe_expr = 0
+
+    for tpl in templates:
+        text = tpl.read_text(encoding="utf-8")
+        exprs = re.findall(r"\{\{[^}]+}}", text)
+        for expr in exprs:
+            if re.search(r"[a-zA-Z_]", expr):
+                total_expr += 1
+                if "| d(" in expr or "| default(" in expr:
+                    safe_expr += 1
+
+    if total_expr == 0:
+        return RuleResult(
+            "template_default_filter", w, 1.0, 1.0, "no Jinja expressions"
+        )
+
+    score = safe_expr / total_expr
+    return RuleResult(
+        "template_default_filter",
+        w,
+        score,
+        1.0,
+        f"{safe_expr}/{total_expr} safe",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Rule registry
 # ---------------------------------------------------------------------------
@@ -1145,14 +1361,20 @@ RULES: list[Any] = [
     rule_file_src_lookup,
     rule_collections_declared,
     rule_dependencies_empty,
+    rule_dependent_variables,
+    rule_ansible_local_in_conditions,
     rule_min_ansible_version,
     rule_ansible_plugins_import,
     rule_pre_post_hooks,
     rule_task_tags,
+    rule_task_file_organization,
     rule_local_facts,
     rule_flush_handlers,
     rule_register_until,
     rule_no_debug_ignore,
+    rule_spdx_headers,
+    rule_ansible_managed,
+    rule_template_default_filter,
 ]
 
 
@@ -1517,14 +1739,20 @@ def list_rules(weights: dict[str, float]) -> None:
         "file_src_lookup": "file_src lookup for copy/template src",
         "collections_declared": "'collections: [debops.debops]' in meta",
         "dependencies_empty": "'dependencies: []' in meta",
+        "dependent_variables": "dependent variable pattern (__dependent_)",
+        "ansible_local_in_conditions": "ansible_local references in when clauses",
         "min_ansible_version": "min_ansible_version relative to threshold",
         "ansible_plugins_import": "no ansible_plugins role import",
         "pre_post_hooks": "pre_main/post_main hook dirs present",
         "task_tags": "role::<name> / skip::<name> tags on tasks",
+        "task_file_organization": "multiple task files by concern",
         "local_facts": "local fact template with shebang",
         "flush_handlers": "flush_handlers after facts",
         "register_until": "package install uses register+until",
         "no_debug_ignore": "no unconditional debug/ignore_errors",
+        "spdx_headers": "SPDX headers in templates",
+        "ansible_managed": "{{ ansible_managed }} in templates",
+        "template_default_filter": "| d() default filter usage in templates",
     }
 
     print(f"{'Rule':<30} {'Weight':>6}  Description")

--- a/bin/debops-role-score
+++ b/bin/debops-role-score
@@ -27,7 +27,7 @@ import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 import yaml
 
@@ -40,6 +40,12 @@ DEFAULT_SKIP_ROLES: list[str] = []
 
 # Map: rule_id -> default_weight
 DEFAULT_WEIGHTS: dict[str, float] = {
+    "variable_naming": 1.0,
+    "default_filter_usage": 0.5,
+    "is_truthy_usage": 0.5,
+    "template_src_lookup": 0.1,
+    "task_src_lookup": 0.3,
+    "file_src_lookup": 0.05,
 }
 
 DEFAULT_MIN_ANSIBLE: str = "2.10.0"
@@ -87,6 +93,8 @@ BINARY_RULES: frozenset[str] = frozenset(
 # Binary negative rules contribute -weight if score >= 1.0, else 0.
 NEGATIVE_RULES: frozenset[str] = frozenset(
     {
+        "variable_naming",
+        "default_filter_usage",
     }
 )
 
@@ -205,6 +213,24 @@ def parse_tasks(data: Any) -> list[dict[str, Any]]:
         elif isinstance(item, list):
             result.extend(parse_tasks(item))
     return result
+
+
+# Ansible conditionals that must resolve to booleans. The | d() / | default()
+# filter breaks these in Ansible 2.19+, which requires is defined / is truthy.
+CONDITIONAL_KEYS: frozenset[str] = frozenset(
+    {"when", "changed_when", "failed_when", "until"}
+)
+
+
+def iter_conditionals(data: Any) -> Iterator[str]:
+    """Yield the string values of Ansible conditionals in parsed task data."""
+    for task in parse_tasks(data):
+        for key in CONDITIONAL_KEYS:
+            val = task.get(key)
+            if isinstance(val, str):
+                yield val
+            elif isinstance(val, list):
+                yield from (el for el in val if isinstance(el, str))
 
 
 # ---------------------------------------------------------------------------
@@ -529,11 +555,276 @@ def _is_minimal_surface(surface: dict[str, int] | None, role_path: Path) -> bool
 #   (role_path: Path, role_name: str, weights: dict, **kwargs) -> RuleResult
 
 
+def rule_variable_naming(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Penalize non-namespaced (single-underscore) variables.
+
+    Variables annotated with ``# noqa var-naming[no-role-prefix]`` are
+    intentional global variables (e.g., the ``secret`` role's ``secret``
+    variable) and are excluded from the check.
+    """
+    w = weights.get("variable_naming", 1.0)
+    defaults_file = role_path / "defaults" / "main.yml"
+    if not defaults_file.is_file():
+        return RuleResult("variable_naming", w, 0.0, 0.0, "no defaults/main.yml")
+
+    keys: list[str] = []
+    try:
+        lines = defaults_file.read_text(encoding="utf-8").splitlines()
+    except Exception:
+        return RuleResult("variable_naming", w, 0.0, 0.0, "unreadable defaults")
+
+    for line in lines:
+        m = re.match(r"^([a-zA-Z_]\w*):", line)
+        if not m:
+            continue
+        key = m.group(1)
+        if key in {"galaxy_info", "dependencies", "collections"} or key.startswith("."):
+            continue
+        if "noqa var-naming" in line:
+            continue
+        keys.append(key)
+
+    if not keys:
+        return RuleResult("variable_naming", w, 0.0, 0.0, "no variables")
+
+    double = sum(1 for k in keys if "__" in k)
+    single = sum(
+        1 for k in keys if "_" in k and "__" not in k and not k.startswith("_")
+    )
+    no_underscore = sum(1 for k in keys if "_" not in k)
+    total = double + single + no_underscore
+    score = (single + no_underscore) / total if total > 0 else 0.0
+    return RuleResult(
+        "variable_naming",
+        w,
+        score,
+        1.0,
+        f"{single}/{total} non-namespaced",
+    )
+
+
+def rule_default_filter_usage(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Penalize | d() / | default() in Ansible conditionals (negative).
+
+    The | d() / | default() filter returns the variable value (or its
+    default), which is usually a non-boolean — Ansible 2.19+ rejects such
+    conditionals. Use ``X is defined and X is truthy`` instead. Value
+    positions like ``{{ item.creates | d(omit) }}`` are not penalized.
+    """
+    w = weights.get("default_filter_usage", 0.5)
+    task_files = find_task_files(role_path)
+    if not task_files:
+        return RuleResult("default_filter_usage", w, 0.0, 0.0, "no task files")
+
+    total_cond = 0
+    bad_cond = 0
+
+    for tf in task_files:
+        data = load_yaml(tf)
+        for cond in iter_conditionals(data):
+            # Only count conditionals that reference a variable (not constants)
+            if re.search(r"[a-zA-Z_]", cond):
+                total_cond += 1
+                if "| d(" in cond or "| default(" in cond:
+                    bad_cond += 1
+
+    if total_cond == 0:
+        return RuleResult("default_filter_usage", w, 0.0, 1.0, "no conditionals")
+
+    score = bad_cond / total_cond
+    return RuleResult(
+        "default_filter_usage",
+        w,
+        score,
+        1.0,
+        f"{bad_cond}/{total_cond} use | d()",
+    )
+
+
+def rule_is_truthy_usage(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Ratio of Ansible conditionals using is truthy / is defined tests.
+
+    Rewards the Ansible 2.19+ idiom that replaces ``| d()`` in conditionals:
+    ``X is defined and X is truthy`` (or plain ``X is truthy`` for values
+    that are always defined, e.g. registered results).
+    """
+    w = weights.get("is_truthy_usage", 0.5)
+    task_files = find_task_files(role_path)
+    if not task_files:
+        return RuleResult("is_truthy_usage", w, 0.0, 0.0, "no task files")
+
+    total_cond = 0
+    good_cond = 0
+
+    for tf in task_files:
+        data = load_yaml(tf)
+        for cond in iter_conditionals(data):
+            if re.search(r"[a-zA-Z_]", cond):
+                total_cond += 1
+                if "is truthy" in cond or "is defined" in cond:
+                    good_cond += 1
+
+    if total_cond == 0:
+        return RuleResult("is_truthy_usage", w, 1.0, 1.0, "no conditionals")
+
+    score = good_cond / total_cond
+    return RuleResult(
+        "is_truthy_usage",
+        w,
+        score,
+        1.0,
+        f"{good_cond}/{total_cond} is truthy",
+    )
+
+
+def rule_template_src_lookup(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Ratio of template tasks using template_src lookup."""
+    w = weights.get("template_src_lookup", 0.3)
+    task_files = find_task_files(role_path)
+    lookup_count = 0
+    total = 0
+
+    for tf in task_files:
+        data = load_yaml(tf)
+        tasks = parse_tasks(data)
+        for task in tasks:
+            mod = task.get("ansible.builtin.template") or {}
+            if not isinstance(mod, dict):
+                continue
+            src = str(mod.get("src", ""))
+            if "template_src" in src:
+                lookup_count += 1
+                total += 1
+            elif src and "lookup" not in src:
+                total += 1
+
+    if total == 0:
+        return RuleResult("template_src_lookup", w, 0.0, 0.0, "no template tasks")
+
+    score = lookup_count / total
+    return RuleResult(
+        "template_src_lookup",
+        w,
+        score,
+        1.0,
+        f"{lookup_count}/{total} template_src",
+    )
+
+
+def _include_tasks_value(task: dict[str, Any], mod_key: str) -> str:
+    """Extract the file/value from an include_tasks task.
+
+    Handles both dict and string syntax::
+
+        ansible.builtin.include_tasks: 'file.yml'
+        ansible.builtin.include_tasks:
+          file: 'file.yml'
+    """
+    mod = task.get(mod_key)
+    if isinstance(mod, str):
+        return mod
+    if isinstance(mod, dict):
+        return str(mod.get("file", ""))
+    return ""
+
+
+def rule_task_src_lookup(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Ratio of include_tasks using task_src lookup."""
+    w = weights.get("task_src_lookup", 0.3)
+    task_files = find_task_files(role_path)
+    lookup_count = 0
+    total = 0
+
+    for tf in task_files:
+        data = load_yaml(tf)
+        tasks = parse_tasks(data)
+        for task in tasks:
+            inc_val = _include_tasks_value(task, "ansible.builtin.include_tasks")
+            if not inc_val:
+                inc_val = _include_tasks_value(task, "include_tasks")
+            if not inc_val:
+                continue
+
+            total += 1
+            if "task_src" in inc_val:
+                lookup_count += 1
+
+    if total == 0:
+        return RuleResult("task_src_lookup", w, 0.0, 0.0, "no include_tasks")
+
+    score = lookup_count / total
+    return RuleResult(
+        "task_src_lookup",
+        w,
+        score,
+        1.0,
+        f"{lookup_count}/{total} task_src",
+    )
+
+
+def rule_file_src_lookup(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Ratio of copy/template tasks using file_src lookup."""
+    w = weights.get("file_src_lookup", 0.05)
+    task_files = find_task_files(role_path)
+    lookup_count = 0
+    total = 0
+
+    for tf in task_files:
+        data = load_yaml(tf)
+        tasks = parse_tasks(data)
+        for task in tasks:
+            for mod_key in (
+                "ansible.builtin.copy",
+                "ansible.builtin.template",
+                "copy",
+                "template",
+            ):
+                mod = task.get(mod_key)
+                if not isinstance(mod, dict):
+                    continue
+                src = str(mod.get("src", ""))
+                if not src:
+                    continue
+                total += 1
+                if "file_src" in src:
+                    lookup_count += 1
+
+    if total == 0:
+        return RuleResult("file_src_lookup", w, 0.0, 0.0, "no copy/template tasks")
+
+    score = lookup_count / total
+    return RuleResult(
+        "file_src_lookup",
+        w,
+        score,
+        1.0,
+        f"{lookup_count}/{total} file_src",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Rule registry
 # ---------------------------------------------------------------------------
 
 RULES: list[Any] = [
+    rule_variable_naming,
+    rule_default_filter_usage,
+    rule_is_truthy_usage,
+    rule_template_src_lookup,
+    rule_task_src_lookup,
+    rule_file_src_lookup,
 ]
 
 
@@ -890,6 +1181,12 @@ def build_arg_parser() -> argparse.ArgumentParser:
 def list_rules(weights: dict[str, float]) -> None:
     """Print all rules with their weights and descriptions."""
     descriptions: dict[str, str] = {
+        "variable_naming": "non-namespaced variable naming (noqa-exempt)",
+        "default_filter_usage": "| d() / | default() in Ansible conditionals (negative)",
+        "is_truthy_usage": "is truthy / is defined tests in Ansible conditionals",
+        "template_src_lookup": "template_src lookup for templates",
+        "task_src_lookup": "task_src lookup for includes",
+        "file_src_lookup": "file_src lookup for copy/template src",
     }
 
     print(f"{'Rule':<30} {'Weight':>6}  Description")

--- a/bin/debops-role-score
+++ b/bin/debops-role-score
@@ -118,6 +118,23 @@ DOCS_DEPTH_CAP: int = 150
 # return N/A (max_score=0) for such roles.
 MINIMAL_TASK_COUNT: int = 3
 
+# Fraction of the score ceiling recommended for the CI gate.
+DEFAULT_MIN_SCORE_FRACTION: float = 0.40
+
+# Best-case ``score`` for the hypothetical "perfect" role used to derive the
+# score ceiling. Defaults: 1.0 for every rule, 0.0 for negative rules.
+# ``None`` means the rule is N/A (max_score=0) for a perfect role.
+# The era-based rules are mutually inconsistent for any single role (a role
+# can't both be Universal Configuration-era and pre-2022-stable), so these
+# values encode the reference lifecycle: Universal Configuration-era, steadily
+# maintained, and shipped in the Collection.
+CEILING_EXCEPTIONS: dict[str, float | None] = {
+    "role_era": 0.50,  # Universal Configuration era (+0.50 is the max)
+    "role_modernization": 0.20,  # maintained-role judgment call
+    "role_stability": None,  # conflicts with modern_stability (post-2022)
+    "collection_excluded": None,  # a perfect role is in the Collection
+}
+
 # Rules in this set contribute their full weight if passed, 0 if failed.
 # The pass condition is score >= 1.0 (i.e., 100% compliance for ratio rules).
 # Negative binary rules subtract their weight if violated.
@@ -597,6 +614,34 @@ def _is_minimal_surface(surface: dict[str, int] | None, role_path: Path) -> bool
     if surface is None:
         surface = compute_surface(role_path)
     return surface["tasks"] <= MINIMAL_TASK_COUNT and surface["templates"] == 0
+
+
+def compute_ceiling(weights: dict[str, float], rule_ids: list[str]) -> float:
+    """Best overall score a hypothetical "perfect" role can reach.
+
+    Uses the same binary/negative arithmetic as RoleScore.weighted_sum,
+    with the best-case per-rule score taken from CEILING_EXCEPTIONS (or
+    the rule-type default: 1.0, 0.0 for negative rules). Rules the perfect
+    role does not apply to (CEILING_EXCEPTIONS value ``None``) are N/A and
+    contribute nothing, matching how N/A rules behave when scoring.
+    """
+    weighted_sum = 0.0
+    total_weight = 0.0
+    for rid in rule_ids:
+        w = weights.get(rid, 0.0)
+        if w <= 0:
+            continue
+        score = CEILING_EXCEPTIONS.get(rid, 0.0 if rid in NEGATIVE_RULES else 1.0)
+        if score is None:
+            continue
+        if rid in NEGATIVE_RULES:
+            weighted_sum -= w if (rid in BINARY_RULES and score >= 1.0) else w * score
+        elif rid in BINARY_RULES:
+            weighted_sum += w if score >= 1.0 else 0.0
+        else:
+            weighted_sum += w * score
+        total_weight += w
+    return weighted_sum / total_weight * 10 if total_weight else 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -2388,6 +2433,8 @@ def build_arg_parser() -> argparse.ArgumentParser:
             "Examples:\n"
             "  %(prog)s\n"
             "  %(prog)s --json\n"
+            "  %(prog)s --ceiling\n"
+            "  %(prog)s --min-score-fraction 0.40\n"
             "  %(prog)s --weights weights.yml --threshold 0.7\n"
             "  %(prog)s --rule variable_naming,template_src_lookup\n"
         ),
@@ -2431,6 +2478,26 @@ def build_arg_parser() -> argparse.ArgumentParser:
         type=str,
         default=None,
         help="Comma-separated list of roles to score (default: all)",
+    )
+    parser.add_argument(
+        "--min-score",
+        type=float,
+        default=None,
+        help="Exit with code 1 if any scored role is below this score (absolute; "
+        "overrides --min-score-fraction)",
+    )
+    parser.add_argument(
+        "--min-score-fraction",
+        type=float,
+        default=None,
+        help=f"Exit with code 1 if any scored role is below this fraction of the "
+        f"score ceiling (recommended: {DEFAULT_MIN_SCORE_FRACTION:.2f})",
+    )
+    parser.add_argument(
+        "--ceiling",
+        action="store_true",
+        help=f"Print the theoretical score ceiling and its "
+        f"{int(DEFAULT_MIN_SCORE_FRACTION * 100)}%% gate value, then exit",
     )
     parser.add_argument(
         "--threshold",
@@ -2611,6 +2678,15 @@ def main() -> None:
             continue
         rule_ids.append(rid)
 
+    if args.ceiling:
+        ceiling = compute_ceiling(weights, rule_ids)
+        gate = ceiling * DEFAULT_MIN_SCORE_FRACTION
+        print(
+            f"score ceiling: {ceiling:.4f}/10 "
+            f"({DEFAULT_MIN_SCORE_FRACTION:.0%} gate: {gate:.4f}/10)"
+        )
+        return
+
     # Resolve roles directory
     roles_dir = Path(args.roles_dir)
     if not roles_dir.is_absolute():
@@ -2657,6 +2733,22 @@ def main() -> None:
         print_compact(results)
 
     sys.stdout.flush()
+
+    # CI gate: exit with code 1 if any role is below the target score.
+    # An absolute --min-score wins over --min-score-fraction.
+    min_score: float | None = args.min_score
+    if min_score is None and args.min_score_fraction is not None:
+        min_score = compute_ceiling(weights, rule_ids) * args.min_score_fraction
+    if min_score is not None:
+        failing = [rs for rs in results if rs.overall < min_score]
+        if failing:
+            names = ", ".join(rs.name for rs in failing)
+            print(
+                f"\nFAIL: {len(failing)} role(s) below min-score"
+                f" {min_score:.4f}: {names}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/bin/debops-role-score
+++ b/bin/debops-role-score
@@ -62,6 +62,15 @@ DEFAULT_WEIGHTS: dict[str, float] = {
     "spdx_headers": 0.1,
     "ansible_managed": 0.3,
     "template_default_filter": 0.4,
+    "fact_runtime_detection": 0.4,
+    "files_directory_absent": 0.4,
+    "meta_platforms_specific": 0.4,
+    "galaxy_tags_present": 0.1,
+    "legacy_vars_dir": 0.2,
+    "missing_meta": 0.2,
+    "static_json_facts": 0.3,
+    "unconditional_debug": 0.2,
+    "hardcoded_paths": 0.3,
 }
 
 DEFAULT_MIN_ANSIBLE: str = "2.10.0"
@@ -106,6 +115,8 @@ BINARY_RULES: frozenset[str] = frozenset(
         "dependencies_empty",
         "ansible_plugins_import",
         "flush_handlers",
+        "legacy_vars_dir",
+        "missing_meta",
     }
 )
 
@@ -116,6 +127,11 @@ NEGATIVE_RULES: frozenset[str] = frozenset(
     {
         "variable_naming",
         "default_filter_usage",
+        "legacy_vars_dir",
+        "missing_meta",
+        "static_json_facts",
+        "unconditional_debug",
+        "hardcoded_paths",
     }
 )
 
@@ -1348,6 +1364,227 @@ def rule_template_default_filter(
     )
 
 
+def rule_fact_runtime_detection(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Check fact templates use runtime detection (subprocess/os.access)."""
+    w = weights.get("fact_runtime_detection", 0.4)
+    fact_dir = role_path / "templates" / "etc" / "ansible" / "facts.d"
+    fact_files: list[Path] = []
+    if fact_dir.is_dir():
+        fact_files = sorted(fact_dir.glob("*.fact.j2"))
+
+    if not fact_files:
+        return RuleResult("fact_runtime_detection", w, 0.0, 0.0, "no fact template")
+
+    primary = fact_files[0]
+    text = primary.read_text(encoding="utf-8")
+
+    has_runtime = any(
+        keyword in text
+        for keyword in ("subprocess", "os.access", "cmd_exists", "os.path")
+    )
+
+    score = 1.0 if has_runtime else 0.0
+    detail = (
+        f"runtime ({Path(primary.name)})"
+        if has_runtime
+        else f"static ({Path(primary.name)})"
+    )
+    return RuleResult("fact_runtime_detection", w, score, 1.0, detail)
+
+
+def rule_files_directory_absent(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Binary: static files should go through templates, not files/."""
+    w = weights.get("files_directory_absent", 0.4)
+    files_dir = role_path / "files"
+    if files_dir.is_dir() and any(files_dir.iterdir()):
+        return RuleResult("files_directory_absent", w, 0.0, 1.0, "files/ present")
+    return RuleResult("files_directory_absent", w, 1.0, 1.0, "no files/")
+
+
+def rule_meta_platforms_specific(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Binary: meta/main.yml lists specific platform versions, not 'all'."""
+    w = weights.get("meta_platforms_specific", 0.4)
+    meta = load_yaml_robust(role_path / "meta" / "main.yml")
+    gi = meta.get("galaxy_info", {})
+    if not isinstance(gi, dict):
+        return RuleResult("meta_platforms_specific", w, 0.0, 1.0, "no galaxy_info")
+
+    platforms = gi.get("platforms", [])
+    if not isinstance(platforms, list) or not platforms:
+        return RuleResult("meta_platforms_specific", w, 0.0, 1.0, "no platforms")
+
+    for entry in platforms:
+        if not isinstance(entry, dict):
+            continue
+        versions = entry.get("versions", [])
+        if isinstance(versions, list) and "all" in versions:
+            return RuleResult(
+                "meta_platforms_specific", w, 0.0, 1.0, "uses 'all' version"
+            )
+        if isinstance(versions, str) and versions == "all":
+            return RuleResult(
+                "meta_platforms_specific", w, 0.0, 1.0, "uses 'all' version"
+            )
+
+    return RuleResult("meta_platforms_specific", w, 1.0, 1.0, "specific versions")
+
+
+def rule_galaxy_tags_present(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Binary: galaxy_tags is non-empty in meta/main.yml."""
+    w = weights.get("galaxy_tags_present", 0.1)
+    meta = load_yaml_robust(role_path / "meta" / "main.yml")
+    gi = meta.get("galaxy_info", {})
+    if not isinstance(gi, dict):
+        return RuleResult("galaxy_tags_present", w, 0.0, 1.0, "no galaxy_info")
+
+    tags = gi.get("galaxy_tags", [])
+    if isinstance(tags, list) and len(tags) > 0:
+        return RuleResult("galaxy_tags_present", w, 1.0, 1.0, f"{len(tags)} tags")
+    return RuleResult("galaxy_tags_present", w, 0.0, 1.0, "no tags")
+
+
+def rule_legacy_vars_dir(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Binary negative: vars/ directory indicates legacy structure."""
+    w = weights.get("legacy_vars_dir", 0.2)
+    vars_dir = role_path / "vars"
+    if vars_dir.is_dir() and any(vars_dir.iterdir()):
+        return RuleResult("legacy_vars_dir", w, 1.0, 1.0, "vars/ present")
+    return RuleResult("legacy_vars_dir", w, 0.0, 1.0, "no vars/")
+
+
+def rule_missing_meta(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Binary negative: missing meta/main.yml."""
+    w = weights.get("missing_meta", 0.2)
+    meta_file = role_path / "meta" / "main.yml"
+    if not meta_file.is_file():
+        return RuleResult("missing_meta", w, 1.0, 1.0, "missing meta/main.yml")
+    return RuleResult("missing_meta", w, 0.0, 1.0, "meta/main.yml present")
+
+
+def rule_static_json_facts(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Proportional negative: fact files without .j2 template (static JSON)."""
+    w = weights.get("static_json_facts", 0.3)
+    fact_dir = role_path / "files" / "etc" / "ansible" / "facts.d"
+    if not fact_dir.is_dir():
+        return RuleResult("static_json_facts", w, 0.0, 0.0, "no static facts dir")
+
+    static = sorted(fact_dir.glob("*.fact"))
+    if not static:
+        return RuleResult("static_json_facts", w, 0.0, 0.0, "no static fact files")
+
+    # Count non-json (Python fact scripts are ok, static JSON is penalized)
+    # Actually all .fact files in files/ are static — check if content is JSON
+    static_count = 0
+    for f in static:
+        text = f.read_text(encoding="utf-8").strip()
+        if text.startswith("{"):
+            static_count += 1
+
+    total = len(static)
+    # Also check templates/ for Jinja versions of the same facts
+    tpl_fact_dir = role_path / "templates" / "etc" / "ansible" / "facts.d"
+    if tpl_fact_dir.is_dir():
+        tpl_facts = list(tpl_fact_dir.glob("*.fact.j2"))
+        if tpl_facts:
+            total += len(tpl_facts)
+
+    if total == 0:
+        return RuleResult("static_json_facts", w, 0.0, 0.0, "no facts at all")
+
+    score = static_count / total if total > 0 else 0.0
+    return RuleResult(
+        "static_json_facts",
+        w,
+        score,
+        1.0,
+        f"{static_count}/{total} static JSON facts",
+    )
+
+
+def rule_unconditional_debug(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Proportional negative: debug tasks without verbosity:."""
+    w = weights.get("unconditional_debug", 0.2)
+    task_files = find_task_files(role_path)
+    total_debug = 0
+    unconditional = 0
+
+    for tf in task_files:
+        data = load_yaml(tf)
+        tasks = parse_tasks(data)
+        for task in tasks:
+            if not isinstance(task, dict):
+                continue
+            mod = task.get("ansible.builtin.debug") or task.get("debug")
+            if not isinstance(mod, dict):
+                continue
+            total_debug += 1
+            if not mod.get("verbosity"):
+                unconditional += 1
+
+    if total_debug == 0:
+        return RuleResult("unconditional_debug", w, 0.0, 0.0, "no debug tasks")
+
+    score = unconditional / total_debug
+    return RuleResult(
+        "unconditional_debug",
+        w,
+        score,
+        1.0,
+        f"{unconditional}/{total_debug} unconditional",
+    )
+
+
+def rule_hardcoded_paths(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Proportional negative: hardcoded paths in templates."""
+    w = weights.get("hardcoded_paths", 0.2)
+    templates = find_template_files(role_path)
+    if not templates:
+        return RuleResult("hardcoded_paths", w, 0.0, 0.0, "no templates")
+
+    path_pattern = re.compile(r"/etc/|/var/|/opt/|/usr/|/srv/")
+    jinja_expr = re.compile(r"\{\{.*?\}\}")
+    jinja_stmt = re.compile(r"\{%-?\s*.*?\s*-?%\}")
+    penalized = 0
+    for tpl in templates:
+        text = tpl.read_text(encoding="utf-8")
+        outside_jinja = jinja_expr.sub("", text)
+        outside_jinja = jinja_stmt.sub("", outside_jinja)
+        lines = outside_jinja.split("\n")
+        for line in lines:
+            stripped = line.strip()
+            if not stripped.startswith("#") and not stripped.startswith("{#"):
+                if path_pattern.search(stripped):
+                    penalized += 1
+                    break
+
+    score = penalized / len(templates)
+    return RuleResult(
+        "hardcoded_paths",
+        w,
+        score,
+        1.0,
+        f"{penalized}/{len(templates)} with hardcoded paths",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Rule registry
 # ---------------------------------------------------------------------------
@@ -1375,6 +1612,15 @@ RULES: list[Any] = [
     rule_spdx_headers,
     rule_ansible_managed,
     rule_template_default_filter,
+    rule_fact_runtime_detection,
+    rule_files_directory_absent,
+    rule_meta_platforms_specific,
+    rule_galaxy_tags_present,
+    rule_legacy_vars_dir,
+    rule_missing_meta,
+    rule_static_json_facts,
+    rule_unconditional_debug,
+    rule_hardcoded_paths,
 ]
 
 
@@ -1753,6 +1999,15 @@ def list_rules(weights: dict[str, float]) -> None:
         "spdx_headers": "SPDX headers in templates",
         "ansible_managed": "{{ ansible_managed }} in templates",
         "template_default_filter": "| d() default filter usage in templates",
+        "fact_runtime_detection": "fact templates use runtime detection",
+        "files_directory_absent": "no files/ directory (templates preferred)",
+        "meta_platforms_specific": "specific platform versions in meta",
+        "galaxy_tags_present": "non-empty galaxy_tags in meta",
+        "legacy_vars_dir": "vars/ directory present (legacy)",
+        "missing_meta": "missing meta/main.yml",
+        "static_json_facts": "static JSON fact files (not Jinja templates)",
+        "unconditional_debug": "debug tasks without verbosity:",
+        "hardcoded_paths": "hardcoded /etc/ /var/ paths in templates",
     }
 
     print(f"{'Rule':<30} {'Weight':>6}  Description")

--- a/bin/debops-role-score
+++ b/bin/debops-role-score
@@ -71,6 +71,11 @@ DEFAULT_WEIGHTS: dict[str, float] = {
     "static_json_facts": 0.3,
     "unconditional_debug": 0.2,
     "hardcoded_paths": 0.3,
+    "scoped_variables": 1.0,
+    "combined_variables": 0.8,
+    "parse_kv_items_usage": 0.6,
+    "task_description": 0.2,
+    "yaml_syntax": 0.2,
 }
 
 DEFAULT_MIN_ANSIBLE: str = "2.10.0"
@@ -1585,6 +1590,247 @@ def rule_hardcoded_paths(
     )
 
 
+def rule_scoped_variables(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Ratio of variables using the 3-level scoping pattern.
+
+    A scoped variable family consists of the base role variable
+    (``<role>__<suffix>``) plus its ``__group_`` and ``__host_`` override
+    levels. Variables carrying a ``__group_`` or ``__host_`` segment anchor
+    the family; the matching base variable completes the set.
+    """
+    w = weights.get("scoped_variables", 0.3)
+    defaults_file = role_path / "defaults" / "main.yml"
+    if not defaults_file.is_file():
+        return RuleResult("scoped_variables", w, 0.0, 0.0, "no defaults/main.yml")
+
+    data = load_yaml(defaults_file)
+    if isinstance(data, dict):
+        keys = list(data.keys())
+    else:
+        text = defaults_file.read_text(encoding="utf-8")
+        keys = re.findall(r"^([a-zA-Z_]\w*):", text, re.MULTILINE)
+
+    exclude = {"galaxy_info", "dependencies", "collections"}
+    keys = [k for k in keys if k not in exclude and not k.startswith(".")]
+
+    if not keys:
+        return RuleResult("scoped_variables", w, 0.0, 0.0, "no variables")
+
+    suffixes: set[str] = set()
+    for k in keys:
+        m = re.search(r"__group_(\w+)", k)
+        if m:
+            suffixes.add(m.group(1))
+        else:
+            m = re.search(r"__host_(\w+)", k)
+            if m:
+                suffixes.add(m.group(1))
+
+    scoped = sum(1 for k in keys if "__group_" in k or "__host_" in k)
+    base = sum(1 for s in suffixes if f"{role_name}__{s}" in keys)
+    score = (scoped + base) / len(keys)
+    return RuleResult(
+        "scoped_variables",
+        w,
+        score,
+        1.0,
+        f"{scoped + base}/{len(keys)} scoped ({base} base + {scoped} group/host)",
+    )
+
+
+def rule_combined_variables(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Ratio of variables using __combined_ merge pattern."""
+    w = weights.get("combined_variables", 0.2)
+    if _is_minimal_surface(kwargs.get("surface"), role_path):
+        return RuleResult("combined_variables", w, 0.0, 0.0, "minimal role surface")
+    defaults_file = role_path / "defaults" / "main.yml"
+    if not defaults_file.is_file():
+        return RuleResult("combined_variables", w, 0.0, 0.0, "no defaults/main.yml")
+
+    data = load_yaml(defaults_file)
+    if isinstance(data, dict):
+        keys = list(data.keys())
+    else:
+        text = defaults_file.read_text(encoding="utf-8")
+        keys = re.findall(r"^([a-zA-Z_]\w*):", text, re.MULTILINE)
+
+    exclude = {"galaxy_info", "dependencies", "collections"}
+    keys = [k for k in keys if k not in exclude and not k.startswith(".")]
+
+    if not keys:
+        return RuleResult("combined_variables", w, 0.0, 0.0, "no variables")
+
+    combined = sum(1 for k in keys if "__combined_" in k)
+    score = combined / len(keys)
+    return RuleResult(
+        "combined_variables",
+        w,
+        score,
+        1.0,
+        f"{combined}/{len(keys)} combined",
+    )
+
+
+def rule_parse_kv_items_usage(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Ratio of files using parse_kv_items filter for structured config."""
+    w = weights.get("parse_kv_items_usage", 0.2)
+    if _is_minimal_surface(kwargs.get("surface"), role_path):
+        return RuleResult("parse_kv_items_usage", w, 0.0, 0.0, "minimal role surface")
+    total = 0
+    using = 0
+
+    for subdir_name in ("tasks", "templates", "defaults", "handlers"):
+        subdir = role_path / subdir_name
+        if not subdir.is_dir():
+            continue
+        for f in sorted(subdir.rglob("*")):
+            if not f.is_file() or f.suffix not in (".yml", ".j2", ".yaml"):
+                continue
+            text = f.read_text(encoding="utf-8")
+            if re.search(r"\{\{.*\|.*parse_kv_items", text):
+                using += 1
+                total += 1
+            elif re.search(r"[a-zA-Z_]", text):
+                total += 1
+
+    if total == 0:
+        return RuleResult("parse_kv_items_usage", w, 0.0, 0.0, "no relevant files")
+
+    score = using / total
+    return RuleResult(
+        "parse_kv_items_usage",
+        w,
+        score,
+        1.0,
+        f"{using}/{total} using parse_kv_items",
+    )
+
+
+TASK_DIRECTIVES: frozenset[str] = frozenset(
+    {
+        "name",
+        "tags",
+        "when",
+        "register",
+        "notify",
+        "ignore_errors",
+        "changed_when",
+        "failed_when",
+        "delegate_to",
+        "run_once",
+        "become",
+        "become_user",
+        "become_method",
+        "check_mode",
+        "diff",
+        "environment",
+        "loop",
+        "until",
+        "retries",
+        "delay",
+        "no_log",
+        "connection",
+        "async",
+        "poll",
+        "throttle",
+        "timeout",
+        "block",
+        "rescue",
+        "always",
+        "include",
+        "import_tasks",
+        "include_tasks",
+        "import_role",
+        "include_role",
+        "collections",
+        "module_defaults",
+    }
+)
+
+
+def rule_task_description(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Ratio of tasks with a name: attribute."""
+    w = weights.get("task_description", 0.2)
+    tasks_dir = role_path / "tasks"
+    if not tasks_dir.is_dir():
+        return RuleResult("task_description", w, 0.0, 0.0, "no tasks/ dir")
+
+    total = 0
+    named = 0
+
+    for f in sorted(tasks_dir.rglob("*.yml")):
+        if not f.is_file():
+            continue
+        data = load_yaml(f)
+        items = parse_tasks(data)
+        for t in items:
+            total += 1
+            if "name" in t and isinstance(t["name"], str) and t["name"].strip():
+                named += 1
+
+    if total == 0:
+        return RuleResult("task_description", w, 0.0, 0.0, "no tasks found")
+
+    score = named / total
+    return RuleResult(
+        "task_description",
+        w,
+        score,
+        1.0,
+        f"{named}/{total} named",
+    )
+
+
+def rule_yaml_syntax(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Ratio of tasks using native YAML syntax (not key=value shorthand)."""
+    w = weights.get("yaml_syntax", 0.2)
+    tasks_dir = role_path / "tasks"
+    if not tasks_dir.is_dir():
+        return RuleResult("yaml_syntax", w, 0.0, 0.0, "no tasks/ dir")
+
+    total = 0
+    native = 0
+
+    for f in sorted(tasks_dir.rglob("*.yml")):
+        if not f.is_file():
+            continue
+        data = load_yaml(f)
+        items = parse_tasks(data)
+        for t in items:
+            total += 1
+            module_keys = [k for k in t if k not in TASK_DIRECTIVES]
+            is_native = True
+            for mk in module_keys:
+                val = t[mk]
+                if isinstance(val, str) and re.search(r"\w+=", val):
+                    is_native = False
+                    break
+            if is_native:
+                native += 1
+
+    if total == 0:
+        return RuleResult("yaml_syntax", w, 0.0, 0.0, "no tasks found")
+
+    score = native / total
+    return RuleResult(
+        "yaml_syntax",
+        w,
+        score,
+        1.0,
+        f"{native}/{total} native YAML",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Rule registry
 # ---------------------------------------------------------------------------
@@ -1621,6 +1867,11 @@ RULES: list[Any] = [
     rule_static_json_facts,
     rule_unconditional_debug,
     rule_hardcoded_paths,
+    rule_scoped_variables,
+    rule_combined_variables,
+    rule_parse_kv_items_usage,
+    rule_task_description,
+    rule_yaml_syntax,
 ]
 
 
@@ -2008,6 +2259,11 @@ def list_rules(weights: dict[str, float]) -> None:
         "static_json_facts": "static JSON fact files (not Jinja templates)",
         "unconditional_debug": "debug tasks without verbosity:",
         "hardcoded_paths": "hardcoded /etc/ /var/ paths in templates",
+        "scoped_variables": "3-level scoping (__base + __group_/__host_ overrides)",
+        "combined_variables": "variables using __combined_ merge pattern",
+        "parse_kv_items_usage": "usage of parse_kv_items filter for structured config",
+        "task_description": "tasks with meaningful name: attribute",
+        "yaml_syntax": "tasks using native YAML syntax (not key=value shorthand)",
     }
 
     print(f"{'Rule':<30} {'Weight':>6}  Description")

--- a/bin/debops-role-score
+++ b/bin/debops-role-score
@@ -46,6 +46,16 @@ DEFAULT_WEIGHTS: dict[str, float] = {
     "template_src_lookup": 0.1,
     "task_src_lookup": 0.3,
     "file_src_lookup": 0.05,
+    "collections_declared": 0.2,
+    "dependencies_empty": 0.2,
+    "min_ansible_version": 0.5,
+    "ansible_plugins_import": 0.5,
+    "pre_post_hooks": 0.2,
+    "task_tags": 0.3,
+    "local_facts": 1.0,
+    "flush_handlers": 0.4,
+    "register_until": 0.2,
+    "no_debug_ignore": 0.2,
 }
 
 DEFAULT_MIN_ANSIBLE: str = "2.10.0"
@@ -85,6 +95,11 @@ MINIMAL_TASK_COUNT: int = 3
 # Negative binary rules subtract their weight if violated.
 BINARY_RULES: frozenset[str] = frozenset(
     {
+        "local_facts",
+        "collections_declared",
+        "dependencies_empty",
+        "ansible_plugins_import",
+        "flush_handlers",
     }
 )
 
@@ -814,6 +829,309 @@ def rule_file_src_lookup(
     )
 
 
+def rule_collections_declared(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """meta/main.yml has collections: ['debops.debops']."""
+    w = weights.get("collections_declared", 0.2)
+    meta = load_yaml_robust(role_path / "meta" / "main.yml")
+    coll = meta.get("collections")
+    if isinstance(coll, list) and "debops.debops" in coll:
+        return RuleResult("collections_declared", w, 1.0, 1.0, "declared")
+    return RuleResult("collections_declared", w, 0.0, 1.0, "missing or incorrect")
+
+
+def rule_dependencies_empty(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """meta/main.yml has dependencies: []."""
+    w = weights.get("dependencies_empty", 0.2)
+    meta = load_yaml_robust(role_path / "meta" / "main.yml")
+    deps = meta.get("dependencies")
+    if isinstance(deps, list) and len(deps) == 0:
+        return RuleResult("dependencies_empty", w, 1.0, 1.0, "empty")
+    return RuleResult("dependencies_empty", w, 0.0, 1.0, "non-empty or missing")
+
+
+def _parse_version(ver_str: str) -> tuple[int, int, int]:
+    """Parse 'X.Y.Z' version string into a tuple."""
+    m = VERSION_RE.match(ver_str)
+    if m:
+        return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+    return (0, 0, 0)
+
+
+def rule_min_ansible_version(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Check min_ansible_version meets the configured threshold."""
+    w = weights.get("min_ansible_version", 0.4)
+    threshold = _parse_version(kwargs.get("min_ansible", DEFAULT_MIN_ANSIBLE))
+    meta = load_yaml_robust(role_path / "meta" / "main.yml")
+    gi = meta.get("galaxy_info", {})
+    if not isinstance(gi, dict):
+        return RuleResult("min_ansible_version", w, 0.0, 1.0, "no galaxy_info")
+
+    raw = gi.get("min_ansible_version", "")
+    if not isinstance(raw, str):
+        return RuleResult("min_ansible_version", w, 0.0, 1.0, "no min_ansible_version")
+
+    actual = _parse_version(raw)
+    threshold_val = threshold[0] * 10_000 + threshold[1] * 100 + threshold[2]
+    actual_val = actual[0] * 10_000 + actual[1] * 100 + actual[2]
+    score = (
+        1.0
+        if actual >= threshold
+        else (min(1.0, actual_val / threshold_val) if threshold_val > 0 else 1.0)
+    )
+    return RuleResult(
+        "min_ansible_version",
+        w,
+        score,
+        1.0,
+        f"{raw} / {kwargs.get('min_ansible', DEFAULT_MIN_ANSIBLE)}",
+    )
+
+
+def rule_ansible_plugins_import(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Score 1 if tasks do NOT import ansible_plugins role."""
+    w = weights.get("ansible_plugins_import", 0.5)
+    task_files = find_task_files(role_path)
+    import_re = re.compile(
+        r"(?:include_role|import_role)\s*:.*\n\s+name:\s*['\"]?ansible_plugins['\"]?",
+        re.DOTALL,
+    )
+    for tf in task_files:
+        text = tf.read_text(encoding="utf-8")
+        if import_re.search(text):
+            return RuleResult(
+                "ansible_plugins_import", w, 0.0, 1.0, "imports ansible_plugins"
+            )
+    return RuleResult("ansible_plugins_import", w, 1.0, 1.0, "no import")
+
+
+def rule_pre_post_hooks(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Check pre_main.yml and post_main.yml exist in tasks/<role>/."""
+    w = weights.get("pre_post_hooks", 0.2)
+    if _is_minimal_surface(kwargs.get("surface"), role_path):
+        return RuleResult("pre_post_hooks", w, 0.0, 0.0, "minimal role surface")
+    hook_dir = role_path / "tasks" / role_name
+    pre = hook_dir / "pre_main.yml"
+    post = hook_dir / "post_main.yml"
+    pre_ok = pre.is_file()
+    post_ok = post.is_file()
+    count = sum([pre_ok, post_ok])
+    score = count / 2.0
+    detail_parts = []
+    if pre_ok:
+        detail_parts.append("pre")
+    if post_ok:
+        detail_parts.append("post")
+    detail = ",".join(detail_parts) if detail_parts else "none"
+    return RuleResult("pre_post_hooks", w, score, 1.0, detail)
+
+
+def rule_task_tags(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Ratio of tasks carrying role::<name> or skip::<name> tags."""
+    w = weights.get("task_tags", 0.7)
+    if _is_minimal_surface(kwargs.get("surface"), role_path):
+        return RuleResult("task_tags", w, 0.0, 0.0, "minimal role surface")
+    task_files = find_task_files(role_path)
+    if not task_files:
+        return RuleResult("task_tags", w, 0.0, 0.0, "no task files")
+
+    total_tasks = 0
+    tagged = 0
+    for tf in task_files:
+        data = load_yaml(tf)
+        tasks = parse_tasks(data)
+        for task in tasks:
+            total_tasks += 1
+            tags = task.get("tags", [])
+            if isinstance(tags, str):
+                tags = [tags]
+            if isinstance(tags, list):
+                tag_str = " ".join(str(t) for t in tags)
+                if TAG_ROLE_RE.search(tag_str) or TAG_SKIP_RE.search(tag_str):
+                    tagged += 1
+
+    if total_tasks == 0:
+        return RuleResult("task_tags", w, 1.0, 1.0, "no tasks found")
+
+    score = tagged / total_tasks
+    return RuleResult(
+        "task_tags",
+        w,
+        score,
+        1.0,
+        f"{tagged}/{total_tasks} tagged",
+    )
+
+
+def rule_local_facts(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Check that a fact template exists with a shebang."""
+    w = weights.get("local_facts", 1.0)
+    # Look for fact templates: templates/etc/ansible/facts.d/<role>.fact.j2
+    # or any .fact.j2 file under templates/etc/ansible/facts.d/
+    fact_dir = role_path / "templates" / "etc" / "ansible" / "facts.d"
+    fact_files: list[Path] = []
+    if fact_dir.is_dir():
+        fact_files = sorted(fact_dir.glob("*.fact.j2"))
+
+    if not fact_files:
+        return RuleResult("local_facts", w, 0.0, 0.0, "no fact template")
+
+    # Check shebang on first fact file (primary role fact)
+    primary = fact_files[0]
+    first_line = primary.read_text(encoding="utf-8").split("\n")[0].strip()
+    has_shebang = first_line.startswith("#!")
+
+    score = 1.0 if has_shebang else 0.0
+    detail = (
+        f"exists + shebang ({Path(primary.name)})"
+        if has_shebang
+        else f"exists, no shebang ({Path(primary.name)})"
+    )
+
+    return RuleResult("local_facts", w, score, 1.0, detail)
+
+
+def rule_flush_handlers(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Check that flush_handlers appears after a facts task."""
+    w = weights.get("flush_handlers", 0.5)
+    if _is_minimal_surface(kwargs.get("surface"), role_path):
+        return RuleResult("flush_handlers", w, 0.0, 0.0, "minimal role surface")
+    task_files = find_task_files(role_path)
+    found_facts = False
+    found_flush = False
+
+    for tf in task_files:
+        data = load_yaml(tf)
+        tasks = parse_tasks(data)
+        for task in tasks:
+            # Check if this task is saving facts
+            dest = ""
+            for mod_key in ("ansible.builtin.template", "template"):
+                mod = task.get(mod_key)
+                if isinstance(mod, dict):
+                    dest = str(mod.get("dest", ""))
+            if "facts.d" in dest or "facts/" in dest:
+                found_facts = True
+
+            meta = task.get("ansible.builtin.meta") or task.get("meta")
+            if isinstance(meta, str) and "flush_handlers" in meta:
+                found_flush = True
+
+    score = 1.0 if found_flush and found_facts else 0.0
+    detail_parts = []
+    if found_facts:
+        detail_parts.append("facts")
+    if found_flush:
+        detail_parts.append("flush")
+    detail = "+".join(detail_parts) if detail_parts else "none"
+    return RuleResult("flush_handlers", w, score, 1.0, detail)
+
+
+def rule_register_until(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Ratio of package install tasks using register + until."""
+    w = weights.get("register_until", 0.6)
+    task_files = find_task_files(role_path)
+    package_modules = {
+        "ansible.builtin.package",
+        "ansible.builtin.apt",
+        "ansible.builtin.yum",
+        "ansible.builtin.dnf",
+        "package",
+        "apt",
+        "yum",
+        "dnf",
+    }
+    total_pkg = 0
+    compliant = 0
+
+    for tf in task_files:
+        data = load_yaml(tf)
+        tasks = parse_tasks(data)
+        for task in tasks:
+            for mod_key in package_modules:
+                if mod_key not in task:
+                    continue
+                total_pkg += 1
+                has_register = "register" in task
+                has_until = "until" in task
+                if has_register and has_until:
+                    compliant += 1
+                break  # only count once per task
+
+    if total_pkg == 0:
+        return RuleResult("register_until", w, 0.0, 0.0, "no package tasks")
+
+    score = compliant / total_pkg
+    return RuleResult(
+        "register_until",
+        w,
+        score,
+        1.0,
+        f"{compliant}/{total_pkg} register+until",
+    )
+
+
+def rule_no_debug_ignore(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Penalize unconditional debug and ignore_errors."""
+    w = weights.get("no_debug_ignore", 0.2)
+    task_files = find_task_files(role_path)
+    violations = 0
+    total_interesting = 0
+
+    for tf in task_files:
+        data = load_yaml(tf)
+        tasks = parse_tasks(data)
+        for task in tasks:
+            if not isinstance(task, dict):
+                continue
+            has_debug = "ansible.builtin.debug" in task or "debug" in task
+            has_ignore = task.get("ignore_errors", False) is True
+            has_verbosity = False
+            # Check for verbosity on debug tasks
+            if has_debug:
+                mod = task.get("ansible.builtin.debug") or task.get("debug") or {}
+                if isinstance(mod, dict) and mod.get("verbosity"):
+                    has_verbosity = True
+                total_interesting += 1
+
+            if has_debug and not has_verbosity:
+                violations += 1
+            if has_ignore:
+                violations += 1
+                total_interesting += 1
+
+    if total_interesting == 0:
+        return RuleResult("no_debug_ignore", w, 1.0, 1.0, "no debug/ignore_errors")
+
+    score = max(0.0, 1.0 - (violations / total_interesting))
+    return RuleResult(
+        "no_debug_ignore",
+        w,
+        score,
+        1.0,
+        f"{violations} violations",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Rule registry
 # ---------------------------------------------------------------------------
@@ -825,6 +1143,16 @@ RULES: list[Any] = [
     rule_template_src_lookup,
     rule_task_src_lookup,
     rule_file_src_lookup,
+    rule_collections_declared,
+    rule_dependencies_empty,
+    rule_min_ansible_version,
+    rule_ansible_plugins_import,
+    rule_pre_post_hooks,
+    rule_task_tags,
+    rule_local_facts,
+    rule_flush_handlers,
+    rule_register_until,
+    rule_no_debug_ignore,
 ]
 
 
@@ -1187,6 +1515,16 @@ def list_rules(weights: dict[str, float]) -> None:
         "template_src_lookup": "template_src lookup for templates",
         "task_src_lookup": "task_src lookup for includes",
         "file_src_lookup": "file_src lookup for copy/template src",
+        "collections_declared": "'collections: [debops.debops]' in meta",
+        "dependencies_empty": "'dependencies: []' in meta",
+        "min_ansible_version": "min_ansible_version relative to threshold",
+        "ansible_plugins_import": "no ansible_plugins role import",
+        "pre_post_hooks": "pre_main/post_main hook dirs present",
+        "task_tags": "role::<name> / skip::<name> tags on tasks",
+        "local_facts": "local fact template with shebang",
+        "flush_handlers": "flush_handlers after facts",
+        "register_until": "package install uses register+until",
+        "no_debug_ignore": "no unconditional debug/ignore_errors",
     }
 
     print(f"{'Rule':<30} {'Weight':>6}  Description")

--- a/bin/debops-role-score
+++ b/bin/debops-role-score
@@ -26,6 +26,7 @@ import re
 import subprocess
 import sys
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Iterator
 
@@ -76,6 +77,13 @@ DEFAULT_WEIGHTS: dict[str, float] = {
     "parse_kv_items_usage": 0.6,
     "task_description": 0.2,
     "yaml_syntax": 0.2,
+    "role_era": 1.0,
+    "role_modernization": 0.9,
+    "modern_stability": 0.3,
+    "role_stability": 0.3,
+    "foundational": 0.5,
+    "collection_excluded": 1.5,
+    "docs_presence": 0.4,
 }
 
 DEFAULT_MIN_ANSIBLE: str = "2.10.0"
@@ -122,6 +130,7 @@ BINARY_RULES: frozenset[str] = frozenset(
         "flush_handlers",
         "legacy_vars_dir",
         "missing_meta",
+        "collection_excluded",
     }
 )
 
@@ -137,6 +146,7 @@ NEGATIVE_RULES: frozenset[str] = frozenset(
         "static_json_facts",
         "unconditional_debug",
         "hardcoded_paths",
+        "collection_excluded",
     }
 )
 
@@ -1831,6 +1841,240 @@ def rule_yaml_syntax(
     )
 
 
+def _copyright_year_range(role_path: Path) -> tuple[int | None, int | None]:
+    """Find (min, max) Copyright (C) YYYY year in any role file."""
+    first_year: int | None = None
+    last_year: int | None = None
+    for f in role_path.rglob("*"):
+        if not f.is_file():
+            continue
+        try:
+            text = f.read_text()
+        except Exception:
+            continue
+        for m in re.finditer(r"Copyright \(C\) (\d{4})(?:-(\d{4}))?", text):
+            y1 = int(m.group(1))
+            y2 = int(m.group(2)) if m.group(2) else y1
+            if first_year is None or y1 < first_year:
+                first_year = y1
+            if last_year is None or y2 > last_year:
+                last_year = y2
+    return first_year, last_year
+
+
+def rule_role_era(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Score based on design era (early negative, exploration neutral,
+    Universal Configuration positive)."""
+    w = weights.get("role_era", 1.0)
+    first_year, _ = _copyright_year_range(role_path)
+
+    if first_year is None:
+        return RuleResult("role_era", w, 0.0, 0.0, "no copyright years")
+
+    if first_year >= 2021:
+        score = 0.50
+        label = "Universal Configuration"
+    elif first_year >= 2017:
+        score = 0.0
+        label = "exploration"
+    else:
+        score = -0.50
+        label = "early"
+
+    return RuleResult("role_era", w, score, 1.0, f"{label} ({first_year})")
+
+
+def rule_role_modernization(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Bonus for old roles substantially rewritten in the Universal Configuration era."""
+    w = weights.get("role_modernization", 0.9)
+    first_year, last_year = _copyright_year_range(role_path)
+
+    if first_year is None or last_year is None:
+        return RuleResult("role_modernization", w, 0.0, 0.0, "no copyright years")
+
+    if last_year < 2021:
+        return RuleResult(
+            "role_modernization",
+            w,
+            0.0,
+            0.0,
+            "not maintained into Universal Configuration era",
+        )
+
+    span = last_year - first_year
+    if span < 3:
+        return RuleResult("role_modernization", w, 0.0, 0.0, f"span {span}yr < 3yr")
+
+    bonus = min(0.50, span * 0.05)
+    return RuleResult(
+        "role_modernization",
+        w,
+        bonus,
+        1.0,
+        f"span {span}yr (first {first_year}, last {last_year})",
+    )
+
+
+def rule_modern_stability(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Bonus for post-2022 roles with low commit churn (well-designed from start)."""
+    w = weights.get("modern_stability", 0.3)
+    first_year, _ = _copyright_year_range(role_path)
+
+    if first_year is None or first_year < 2022:
+        return RuleResult("modern_stability", w, 0.0, 0.0, "pre-2022 role")
+
+    git_data = kwargs.get("git_data", {})
+    stats = git_data.get(role_name)
+    if not stats or "commit_count" not in stats:
+        return RuleResult("modern_stability", w, 0.0, 0.0, "no git data")
+
+    commit_count = stats["commit_count"]
+    age_years = max(
+        0.5,
+        (datetime.now() - datetime.fromtimestamp(stats["first_commit"])).days / 365.25,
+    )
+    commits_per_year = commit_count / age_years
+
+    score = max(0.0, 1.0 - commits_per_year / 10.0)
+    return RuleResult(
+        "modern_stability",
+        w,
+        score,
+        1.0,
+        f"{commit_count} commits over {age_years:.1f}yr ({commits_per_year:.1f}/yr)",
+    )
+
+
+def rule_role_stability(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Bonus for early-era roles with minimal recent change (stable/complete design).
+
+    The inverse of modern_stability — rewards roles that were designed so
+    well they haven't needed updates for years.
+    """
+    w = weights.get("role_stability", 0.3)
+    first_year, last_year = _copyright_year_range(role_path)
+
+    if first_year is None or last_year is None:
+        return RuleResult("role_stability", w, 0.0, 0.0, "no copyright years")
+
+    # Only applies to pre-Universal Configuration (early or exploration era) roles
+    if first_year >= 2022:
+        return RuleResult("role_stability", w, 0.0, 0.0, "modern role")
+
+    # Must have no Universal Configuration-era updates to qualify for stability bonus
+    if last_year >= 2021:
+        return RuleResult(
+            "role_stability", w, 0.0, 0.0, "maintained in Universal Configuration era"
+        )
+
+    # Check recent git churn as a stability signal
+    git_data: dict = kwargs.get("git_data", {})
+    stats = git_data.get(role_name)
+    commits_per_year = 0.0
+    if stats and "commit_count" in stats:
+        first = datetime.fromtimestamp(stats["first_commit"])
+        age_years = max(0.5, (datetime.now() - first).days / 365.25)
+        commits_per_year = stats["commit_count"] / age_years
+
+    current_year = datetime.now().year
+    years_since_last = current_year - last_year
+
+    if years_since_last >= 5 and commits_per_year < 5.0:
+        score = min(0.50, years_since_last * 0.03)
+        return RuleResult(
+            "role_stability", w, score, 0.50,
+            f"stable {years_since_last}yr, {commits_per_year:.1f} commits/yr",
+        )
+
+    return RuleResult(
+        "role_stability", w, 0.0, 0.0,
+        f"last modified {last_year} ({years_since_last}yr ago),"
+        f" {commits_per_year:.1f}/yr",
+    )
+
+
+def rule_foundational(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Bonus for roles whose variables are referenced by other roles.
+
+    A role that other roles depend on (via unnamespaced variables)
+    provides foundational infrastructure — a positive quality signal.
+    """
+    w = weights.get("foundational", 0.5)
+    inbound_refs: dict[str, set[str]] = kwargs.get("inbound_refs", {})
+    refs = inbound_refs.get(role_name, set())
+
+    if not refs:
+        return RuleResult("foundational", w, 0.0, 0.0, "no referencing roles")
+
+    score = min(1.0, len(refs) * 0.1)
+    return RuleResult(
+        "foundational", w, score, 1.0,
+        f"referenced by {len(refs)} roles",
+    )
+
+
+def rule_collection_excluded(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Penalize roles omitted from the DebOps Ansible Collection build.
+
+    Roles excluded by lib/ansible-galaxy/make-collection are not shipped
+    with the Collection — either not yet integrated or no longer usable.
+    The rule only applies to excluded roles (N/A for roles in Collection).
+    """
+    w = weights.get("collection_excluded", 1.5)
+    excluded = (
+        role_name.startswith("debops-contrib.") or role_name in COLLECTION_EXCLUDED
+    )
+    if not excluded:
+        return RuleResult("collection_excluded", w, 0.0, 0.0, "in Collection")
+    return RuleResult(
+        "collection_excluded", w, 1.0, 1.0, "excluded from Collection build"
+    )
+
+
+def rule_docs_presence(
+    role_path: Path, role_name: str, weights: dict, **kwargs: Any
+) -> RuleResult:
+    """Reward roles with substantive role documentation.
+
+    Documentation lives in ``docs/ansible/roles/<role>/getting-started.rst``.
+    The score is based on the depth of the body content (SPDX/copyright
+    headers excluded), capped at DOCS_DEPTH_CAP lines. Roles excluded from
+    the Ansible Collection build have no official docs by design and are N/A.
+    """
+    w = weights.get("docs_presence", 0.4)
+    if role_name.startswith("debops-contrib.") or role_name in COLLECTION_EXCLUDED:
+        return RuleResult("docs_presence", w, 0.0, 0.0, "excluded from Collection")
+
+    docs_dir: Path | None = kwargs.get("docs_dir")
+    if docs_dir is None:
+        docs_dir = Path(DOCS_DIR)
+    doc_path = docs_dir / role_name / "getting-started.rst"
+    if not doc_path.is_file():
+        return RuleResult("docs_presence", w, 0.0, 1.0, "no docs")
+
+    text = doc_path.read_text(encoding="utf-8")
+    body = re.sub(
+        r"^\.\. (Copyright|SPDX).*\n(  .*\n)*", "", text, flags=re.MULTILINE
+    )
+    lines = len(body.splitlines())
+    score = min(1.0, lines / DOCS_DEPTH_CAP)
+    return RuleResult(
+        "docs_presence", w, score, 1.0, f"{lines}/{DOCS_DEPTH_CAP} body lines"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Rule registry
 # ---------------------------------------------------------------------------
@@ -1872,6 +2116,13 @@ RULES: list[Any] = [
     rule_parse_kv_items_usage,
     rule_task_description,
     rule_yaml_syntax,
+    rule_role_era,
+    rule_role_modernization,
+    rule_modern_stability,
+    rule_role_stability,
+    rule_foundational,
+    rule_collection_excluded,
+    rule_docs_presence,
 ]
 
 
@@ -2264,6 +2515,23 @@ def list_rules(weights: dict[str, float]) -> None:
         "parse_kv_items_usage": "usage of parse_kv_items filter for structured config",
         "task_description": "tasks with meaningful name: attribute",
         "yaml_syntax": "tasks using native YAML syntax (not key=value shorthand)",
+        "role_era": (
+            "score based on design era (early/exploration/Universal Configuration)"
+        ),
+        "role_modernization": (
+            "bonus for old roles rewritten in Universal Configuration era"
+        ),
+        "modern_stability": "bonus for post-2022 roles with low commit churn",
+        "role_stability": (
+            "bonus for early-era roles with minimal change (stable design)"
+        ),
+        "foundational": "bonus for roles referenced by other roles via variables",
+        "collection_excluded": (
+            "excluded from Ansible Collection builds (make-collection omit list)"
+        ),
+        "docs_presence": (
+            "role documentation present with substantive getting-started content"
+        ),
     }
 
     print(f"{'Rule':<30} {'Weight':>6}  Description")

--- a/bin/debops-role-score
+++ b/bin/debops-role-score
@@ -1,0 +1,1021 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2026 Maciej Delmanowski <drybjed@gmail.com>
+# Copyright (C) 2026 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Deterministic quality scoring for DebOps Ansible roles.
+
+Scans roles/ and scores each role against a configured set of rules
+based on the DebOps style guide. Output is a table (default), JSON,
+or CSV.
+
+Usage::
+
+    bin/debops-role-score
+    bin/debops-role-score --roles-dir ansible/roles --json
+    bin/debops-role-score --weights my-weights.yml --threshold 0.7
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_SKIP_ROLES: list[str] = []
+
+# Map: rule_id -> default_weight
+DEFAULT_WEIGHTS: dict[str, float] = {
+}
+
+DEFAULT_MIN_ANSIBLE: str = "2.10.0"
+
+# Roles omitted from DebOps Ansible Collection builds by
+# lib/ansible-galaxy/make-collection (the "Omit specific DebOps roles"
+# section). Keep in sync with that script.
+COLLECTION_EXCLUDED: frozenset[str] = frozenset(
+    {
+        "boxbackup",
+        "btrfs",
+        "firejail",
+        "foodsoft",
+        "fuse",
+        "homeassistant",
+        "kodi",
+        "rails_deploy",
+        "snapshot_snapper",
+        "tor",
+        "x2go_server",
+    }
+)
+
+# Directory with role documentation (relative to the repository root).
+DOCS_DIR: str = "docs/ansible/roles"
+
+# Body lines of getting-started.rst at which the docs depth score saturates.
+DOCS_DEPTH_CAP: int = 150
+
+# Roles with this many tasks or fewer AND no templates have no meaningful
+# surface to adopt task-structure modernization patterns. Structural rules
+# return N/A (max_score=0) for such roles.
+MINIMAL_TASK_COUNT: int = 3
+
+# Rules in this set contribute their full weight if passed, 0 if failed.
+# The pass condition is score >= 1.0 (i.e., 100% compliance for ratio rules).
+# Negative binary rules subtract their weight if violated.
+BINARY_RULES: frozenset[str] = frozenset(
+    {
+    }
+)
+
+# Rules in this set subtract from the weighted sum.
+# Proportional negative rules contribute -weight * score.
+# Binary negative rules contribute -weight if score >= 1.0, else 0.
+NEGATIVE_RULES: frozenset[str] = frozenset(
+    {
+    }
+)
+
+TAG_ROLE_RE: re.Pattern = re.compile(r"role::[\w-]+")
+TAG_SKIP_RE: re.Pattern = re.compile(r"skip::[\w-]+")
+
+VERSION_RE: re.Pattern = re.compile(r"(\d+)\.(\d+)\.(\d+)")
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RuleResult:
+    """Score for a single rule applied to a single role."""
+
+    rule_id: str
+    weight: float
+    score: float  # 0.0 – 1.0
+    max_score: float  # 1.0 normally; 0.0 if N/A
+    detail: str = ""
+
+
+@dataclass
+class RoleScore:
+    """Aggregated score for one role."""
+
+    name: str
+    rules: dict[str, RuleResult] = field(default_factory=dict)
+    flags: list[str] = field(default_factory=list)
+
+    @property
+    def total_weight(self) -> float:
+        return sum(r.weight for r in self.rules.values() if r.max_score > 0)
+
+    @property
+    def weighted_sum(self) -> float:
+        total = 0.0
+        for r in self.rules.values():
+            if r.max_score == 0:
+                continue
+            if r.rule_id in NEGATIVE_RULES:
+                if r.rule_id in BINARY_RULES:
+                    total -= r.weight if r.score >= 1.0 else 0.0
+                else:
+                    total -= r.weight * r.score
+            elif r.rule_id in BINARY_RULES:
+                total += r.weight if r.score >= 1.0 else 0.0
+            else:
+                total += r.weight * r.score
+        return total
+
+    @property
+    def overall(self) -> float:
+        tw = self.total_weight
+        if tw <= 0:
+            return 0.0
+        val = self.weighted_sum / tw * 10
+        return max(0.0, val)
+
+
+# ---------------------------------------------------------------------------
+# YAML / file helpers
+# ---------------------------------------------------------------------------
+
+
+def load_yaml(path: Path) -> dict[str, Any] | list[Any] | None:
+    """Load a YAML file, returning None on failure."""
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            return yaml.safe_load(fh)
+    except (yaml.YAMLError, OSError):
+        return None
+
+
+def load_yaml_robust(path: Path) -> dict[str, Any]:
+    """Load a YAML mapping, returning {} on failure."""
+    data = load_yaml(path)
+    if isinstance(data, dict):
+        return data
+    return {}
+
+
+def find_task_files(role_path: Path) -> list[Path]:
+    """Return all YAML files under tasks/."""
+    tasks_dir = role_path / "tasks"
+    if not tasks_dir.is_dir():
+        return []
+    return sorted(tasks_dir.rglob("*.yml"))
+
+
+def find_template_files(role_path: Path) -> list[Path]:
+    """Return all .j2 files under templates/."""
+    templates_dir = role_path / "templates"
+    if not templates_dir.is_dir():
+        return []
+    return sorted(templates_dir.rglob("*.j2"))
+
+
+def parse_tasks(data: Any) -> list[dict[str, Any]]:
+    """Turn loaded YAML into a flat list of task dicts."""
+    if isinstance(data, dict):
+        data = [data]
+    if not isinstance(data, list):
+        return []
+    result: list[dict[str, Any]] = []
+    for item in data:
+        if isinstance(item, dict):
+            result.append(item)
+            # recurse into block/rescue/always
+            for key in ("block", "rescue", "always"):
+                if key in item:
+                    result.extend(parse_tasks(item[key]))
+        elif isinstance(item, list):
+            result.extend(parse_tasks(item))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Git helpers
+# ---------------------------------------------------------------------------
+
+
+def _git_log_roles(
+    rel_path: Path, repo_root: str
+) -> tuple[dict[str, int], dict[str, int], dict[str, set[str]]]:
+    """Run git log for *rel_path* and return (last_seen, first_seen, commit_set)."""
+    last_seen: dict[str, int] = {}
+    first_seen: dict[str, int] = {}
+    commit_set: dict[str, set[str]] = {}
+
+    try:
+        result = subprocess.run(
+            ["git", "log", "--format=%H %at", "--name-only", "--", f"{rel_path}/"],
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+            timeout=120,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return last_seen, first_seen, commit_set
+
+    if result.returncode != 0 or not result.stdout.strip():
+        return last_seen, first_seen, commit_set
+
+    current_hash: str | None = None
+    current_ts: int | None = None
+
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split(None, 1)
+        if len(parts) == 2 and parts[0].isalnum() and len(parts[0]) == 40:
+            current_hash, ts_str = parts
+            current_ts = int(ts_str)
+        elif (
+            current_ts is not None and current_hash and line.startswith(f"{rel_path}/")
+        ):
+            sub_parts = line.split("/")
+            if len(sub_parts) >= 3:
+                role_name = sub_parts[len(rel_path.parts)]
+                if role_name not in last_seen:
+                    last_seen[role_name] = current_ts
+                first_seen[role_name] = current_ts
+                if role_name not in commit_set:
+                    commit_set[role_name] = set()
+                commit_set[role_name].add(current_hash)
+
+    return last_seen, first_seen, commit_set
+
+
+def compute_git_stats(roles_dir: Path) -> dict[str, dict[str, int]]:
+    """Compute per-role git history stats from multiple paths.
+
+    Searches under *roles_dir* (usually ``roles/``) and, when that
+    yields no history, falls back to ``ansible/roles/`` (the original
+    path before a repo restructuring that broke git tracking).
+
+    Returns dict[role_name] -> {"last_commit", "first_commit", "commit_count"}.
+    Returns empty dict if git is unavailable or no data found.
+    """
+    real_dir = roles_dir.resolve()
+    try:
+        repo_root = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        ).stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return {}
+    if not repo_root:
+        return {}
+
+    try:
+        rel_path = real_dir.relative_to(Path(repo_root))
+    except ValueError:
+        return {}
+
+    last_seen, first_seen, commit_set = _git_log_roles(rel_path, repo_root)
+
+    # Fallback: roles/ has no history (moved from ansible/roles/ without git mv)
+    if not last_seen:
+        fallback = Path("ansible/roles/")
+        last_seen, first_seen, commit_set = _git_log_roles(fallback, repo_root)
+
+    return {
+        name: {
+            "last_commit": last_seen[name],
+            "first_commit": first_seen.get(name, last_seen[name]),
+            "commit_count": len(commit_set.get(name, [])),
+        }
+        for name in last_seen
+    }
+
+
+def _collect_unnamespaced_variables(role_path: Path) -> list[str]:
+    """Return variable names without ``__`` (potentially visible to other roles)."""
+    defaults_file = role_path / "defaults" / "main.yml"
+    if not defaults_file.is_file():
+        return []
+
+    data = load_yaml(defaults_file)
+    if isinstance(data, dict):
+        keys = list(data.keys())
+    else:
+        text = defaults_file.read_text(encoding="utf-8")
+        keys = re.findall(r"^([a-zA-Z_]\w*):", text, re.MULTILINE)
+
+    exclude = {"galaxy_info", "dependencies", "collections"}
+    return [
+        k
+        for k in keys
+        if k not in exclude and "__" not in k and not k.startswith(".")
+    ]
+
+
+_ROLE_IN_VAR_RE: re.Pattern = re.compile(r"__(\w+)__")
+
+
+def compute_inbound_references(roles_dir: Path) -> dict[str, set[str]]:
+    """Build reverse dependency map from cross-role references.
+
+    Two detection strategies:
+    1. Scan all roles' variable definitions for ``__ROLENAME__`` patterns
+       (the standard DebOps convention for cross-role references).
+    2. Scan templates, defaults, and tasks for standalone references to
+       unnamespaced variables (e.g., the ``secret`` variable).
+
+    Returns ``{referenced_role_name: {referencing_role_name, ...}}``.
+    """
+    role_names: set[str] = set()
+    entry_names: list[str] = []
+    for entry in sorted(roles_dir.iterdir()):
+        if not entry.is_dir() or not (entry / "tasks" / "main.yml").is_file():
+            continue
+        role_names.add(entry.name)
+        entry_names.append(entry.name)
+
+    referenced: dict[str, set[str]] = {}
+
+    def _add_ref(ref_role: str, by_role: str) -> None:
+        if ref_role == by_role or ref_role not in role_names:
+            return
+        if ref_role not in referenced:
+            referenced[ref_role] = set()
+        referenced[ref_role].add(by_role)
+
+    # --- Strategy 1: variable-name-based ---
+    # Scan each role's declared variables for __ROLENAME__ segments.
+    for entry in sorted(roles_dir.iterdir()):
+        if not entry.is_dir() or not (entry / "tasks" / "main.yml").is_file():
+            continue
+        name = entry.name
+        defaults_file = entry / "defaults" / "main.yml"
+        if not defaults_file.is_file():
+            continue
+        try:
+            text = defaults_file.read_text(encoding="utf-8")
+        except Exception:
+            continue
+        keys = re.findall(r"^([a-zA-Z_]\w*):", text, re.MULTILINE)
+        for key in keys:
+            for m in _ROLE_IN_VAR_RE.finditer(key):
+                _add_ref(m.group(1), name)
+
+    # --- Strategy 2: unnamespaced-variable-content-based ---
+    # Collect unnamespaced variables across all roles (owned by exactly one).
+    role_vars: dict[str, list[str]] = {}
+    var_owners: dict[str, str] = {}
+    occurrences: dict[str, list[str]] = {}
+
+    for entry in sorted(roles_dir.iterdir()):
+        if not entry.is_dir() or not (entry / "tasks" / "main.yml").is_file():
+            continue
+        name = entry.name
+        vars_ = _collect_unnamespaced_variables(entry)
+        role_vars[name] = vars_
+        for v in vars_:
+            if v not in occurrences:
+                occurrences[v] = []
+            occurrences[v].append(name)
+
+    for v, owners in occurrences.items():
+        if len(owners) == 1:
+            var_owners[v] = owners[0]
+
+    if var_owners:
+        sorted_vars = sorted(var_owners.keys(), key=len, reverse=True)
+        alt = "|".join(re.escape(v) for v in sorted_vars)
+        combined = re.compile(r"(?<![a-zA-Z_])(?:" + alt + r")(?![a-zA-Z_])")
+
+        own_var_set: dict[str, frozenset[str]] = {
+            n: frozenset(role_vars.get(n, [])) for n in entry_names
+        }
+        scan_dirs = {"templates", "defaults", "tasks"}
+
+        for entry in sorted(roles_dir.iterdir()):
+            if not entry.is_dir() or not (entry / "tasks" / "main.yml").is_file():
+                continue
+            name = entry.name
+            own_vars = own_var_set.get(name, frozenset())
+
+            found: set[str] = set()
+            for sd in scan_dirs:
+                sdir = entry / sd
+                if not sdir.is_dir():
+                    continue
+                for ext in ("*.j2", "*.yml", "*.yaml"):
+                    for fpath in sdir.rglob(ext):
+                        if not fpath.is_file():
+                            continue
+                        try:
+                            file_text = fpath.read_text(
+                                encoding="utf-8", errors="replace"
+                            )
+                        except Exception:
+                            continue
+                        for m in combined.finditer(file_text):
+                            var = m.group(0)
+                            if var in own_vars:
+                                continue
+                            owner = var_owners.get(var)
+                            if owner and owner != name:
+                                found.add(owner)
+
+            for ref in found:
+                _add_ref(ref, name)
+
+    return referenced
+
+
+def compute_playbook_signals(roles_dir: Path) -> dict[str, set[str]]:
+    """Identify roles wired into the sibling playbooks directory.
+
+    Returns two sets of role names:
+    - ``common``: roles applied to every host via layer/common.yml
+    - ``service``: roles with a playbook under service/ (variant playbooks
+      like ``<role>-plain.yml`` match their base role)
+
+    Returns empty sets if the playbooks directory is absent, so custom
+    ``--roles-dir`` usage outside the repository yields no flags.
+    """
+    common: set[str] = set()
+    service: set[str] = set()
+
+    playbooks_dir = roles_dir.parent / "playbooks"
+    if not playbooks_dir.is_dir():
+        return {"common": common, "service": service}
+
+    common_yml = playbooks_dir / "layer" / "common.yml"
+    if common_yml.is_file():
+        data = load_yaml(common_yml)
+        if isinstance(data, list):
+            for play in data:
+                if not isinstance(play, dict):
+                    continue
+                for role in play.get("roles") or []:
+                    if isinstance(role, dict) and isinstance(role.get("role"), str):
+                        common.add(role["role"])
+                    elif isinstance(role, str):
+                        common.add(role)
+                for task in play.get("pre_tasks") or []:
+                    if not isinstance(task, dict):
+                        continue
+                    for key in ("ansible.builtin.import_role", "import_role"):
+                        spec = task.get(key)
+                        if isinstance(spec, dict) and isinstance(spec.get("name"), str):
+                            common.add(spec["name"])
+
+    service_dir = playbooks_dir / "service"
+    if service_dir.is_dir():
+        for playbook in service_dir.glob("*.yml"):
+            service.add(playbook.stem.split("-")[0])
+
+    return {"common": common, "service": service}
+
+
+def compute_surface(role_path: Path) -> dict[str, int]:
+    """Count a role's structural surface: tasks, task files, templates."""
+    tasks = 0
+    task_files = 0
+    tasks_dir = role_path / "tasks"
+    if tasks_dir.is_dir():
+        for tf in sorted(tasks_dir.rglob("*.yml")):
+            if not tf.is_file():
+                continue
+            task_files += 1
+            try:
+                tasks += len(
+                    re.findall(
+                        r"^-\s+name:",
+                        tf.read_text(encoding="utf-8", errors="replace"),
+                        re.MULTILINE,
+                    )
+                )
+            except Exception:
+                pass
+    templates = 0
+    templates_dir = role_path / "templates"
+    if templates_dir.is_dir():
+        templates = len(list(templates_dir.rglob("*.j2")))
+    return {"tasks": tasks, "task_files": task_files, "templates": templates}
+
+
+def _is_minimal_surface(surface: dict[str, int] | None, role_path: Path) -> bool:
+    """True if the role is too small to adopt task-structure patterns."""
+    if surface is None:
+        surface = compute_surface(role_path)
+    return surface["tasks"] <= MINIMAL_TASK_COUNT and surface["templates"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Rule implementations
+# ---------------------------------------------------------------------------
+
+# Each rule function has signature:
+#   (role_path: Path, role_name: str, weights: dict, **kwargs) -> RuleResult
+
+
+# ---------------------------------------------------------------------------
+# Rule registry
+# ---------------------------------------------------------------------------
+
+RULES: list[Any] = [
+]
+
+
+# ---------------------------------------------------------------------------
+# Analysis
+# ---------------------------------------------------------------------------
+
+
+def score_role(
+    role_path: Path,
+    weights: dict[str, float],
+    skip_roles: list[str],
+    min_ansible: str,
+    git_data: dict[str, dict[str, int]] | None = None,
+    inbound_refs: dict[str, set[str]] | None = None,
+    docs_dir: Path | None = None,
+) -> RoleScore | None:
+    """Run all rules against a single role."""
+    role_name = role_path.name
+
+    if role_name in skip_roles:
+        return None
+
+    rs = RoleScore(name=role_name)
+    surface = compute_surface(role_path)
+    for rule_fn in RULES:
+        result = rule_fn(
+            role_path,
+            role_name,
+            weights,
+            min_ansible=min_ansible,
+            git_data=git_data,
+            inbound_refs=inbound_refs or {},
+            surface=surface,
+            docs_dir=docs_dir,
+        )
+        rs.rules[result.rule_id] = result
+    return rs
+
+
+def analyze_roles(
+    roles_dir: Path,
+    weights: dict[str, float],
+    skip_roles: list[str],
+    min_ansible: str,
+    only_rules: list[str] | None = None,
+    only_roles: list[str] | None = None,
+    docs_dir: Path | None = None,
+) -> list[RoleScore]:
+    """Score all roles in a directory."""
+    if not roles_dir.is_dir():
+        print(f"Error: roles directory not found: {roles_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    git_data = compute_git_stats(roles_dir)
+    inbound_refs = compute_inbound_references(roles_dir)
+    playbook_signals = compute_playbook_signals(roles_dir)
+    only_set = set(only_roles) if only_roles else None
+
+    results: list[RoleScore] = []
+    for entry in sorted(roles_dir.iterdir()):
+        if not entry.is_dir():
+            continue
+        if not (entry / "tasks" / "main.yml").is_file():
+            continue  # not an Ansible role
+        if only_set and entry.name not in only_set:
+            continue
+
+        rs = score_role(
+            entry, weights, skip_roles, min_ansible,
+            git_data=git_data, inbound_refs=inbound_refs,
+            docs_dir=docs_dir,
+        )
+        if rs is not None:
+            if playbook_signals:
+                if entry.name in playbook_signals["common"]:
+                    rs.flags.append("common")
+                if entry.name not in playbook_signals["service"]:
+                    rs.flags.append("no-service-playbook")
+            if only_rules:
+                rs.rules = {rid: r for rid, r in rs.rules.items() if rid in only_rules}
+            results.append(rs)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+
+def rule_table_header(rule_ids: list[str]) -> list[str]:
+    return ["Role", "Score"] + [rid[:12] for rid in rule_ids] + ["Flags"]
+
+
+def rule_table_row(rs: RoleScore, rule_ids: list[str]) -> list[str]:
+    row: list[str] = [
+        rs.name,
+        f"{rs.overall:.1f}",
+    ]
+    for rid in rule_ids:
+        r = rs.rules.get(rid)
+        if r is None:
+            row.append("")
+        elif r.max_score == 0:
+            row.append("-")
+        else:
+            row.append(f"{r.score:.2f}")
+    row.append(",".join(rs.flags) if rs.flags else "-")
+    return row
+
+
+def flag_suffix(rs: RoleScore) -> str:
+    """Render playbook flags as a bracketed name suffix, e.g. ' [common]'."""
+    return "".join(f" [{f}]" for f in rs.flags)
+
+
+def print_compact(results: list[RoleScore]) -> None:
+    """Print role name and overall score sorted descending."""
+    sorted_rs = sorted(results, key=lambda rs: rs.overall, reverse=True)
+    name_w = max(len(rs.name) + len(flag_suffix(rs)) for rs in sorted_rs)
+    print(f"{'Role':<{name_w}}  Score")
+    print("-" * (name_w + 8))
+    for rs in sorted_rs:
+        print(f"{rs.name}{flag_suffix(rs):<{name_w - len(rs.name)}}  {rs.overall:.2f}")
+
+    # Summary
+    scores = [rs.overall for rs in sorted_rs]
+    avg = sum(scores) / len(scores)
+    sorted_scores = sorted(scores)
+    median = sorted_scores[len(sorted_scores) // 2]
+    print()
+    print(f"Roles scored: {len(results)}")
+    print(f"Average:      {avg:.2f}")
+    print(f"Median:       {median:.2f}")
+
+
+def print_detailed(results: list[RoleScore], verbose: bool = False) -> None:
+    """Print role score plus per-rule weight, score and detail (impact-sorted).
+
+    In verbose mode only rules with significant impact are shown, skipping
+    N/A rules and negligible (|weight*score| < 0.10) contributions.
+    """
+    sorted_rs = sorted(results, key=lambda rs: rs.overall, reverse=True)
+    name_w = max(len(rs.name) + len(flag_suffix(rs)) for rs in sorted_rs)
+    print(f"{'Role':<{name_w}}  Score")
+    print("-" * (name_w + 8))
+    for rs in sorted_rs:
+        print(f"{rs.name}{flag_suffix(rs):<{name_w - len(rs.name)}}  {rs.overall:.2f}")
+
+        def impact(r: RuleResult) -> float:
+            return abs(r.weight * r.score) if r.max_score > 0 else 0.0
+
+        ordered = sorted(rs.rules.values(), key=impact, reverse=True)
+        if verbose:
+            ordered = [r for r in ordered if impact(r) >= 0.10]
+        if not ordered:
+            print()
+            continue
+        rid_w = max(len(r.rule_id) for r in ordered)
+        for r in ordered:
+            na = r.max_score <= 0
+            mark = "[N/A]" if na else "     "
+            penalized = (
+                r.rule_id in NEGATIVE_RULES
+                and not na
+                and (r.score >= 1.0 if r.rule_id in BINARY_RULES else r.score > 0)
+            )
+            sign = "-" if penalized else ""
+            print(
+                f"    {mark} {r.rule_id:<{rid_w}}  "
+                f"w={r.weight:.2f}  {sign}{r.score:.2f}/{r.max_score:.1f}  {r.detail}"
+            )
+        print()
+
+    # Summary
+    scores = [rs.overall for rs in sorted_rs]
+    avg = sum(scores) / len(scores)
+    sorted_scores = sorted(scores)
+    median = sorted_scores[len(sorted_scores) // 2]
+    print(f"Roles scored: {len(results)}")
+    print(f"Average:      {avg:.2f}")
+    print(f"Median:       {median:.2f}")
+
+
+def print_table(results: list[RoleScore], rule_ids: list[str]) -> None:
+    """Print a human-readable table to stdout."""
+    header = rule_table_header(rule_ids)
+    rows = [rule_table_row(rs, rule_ids) for rs in results]
+
+    # Calculate column widths
+    widths = [len(h) for h in header]
+    for row in rows:
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(cell))
+
+    # Build separator
+    sep = "-" * (sum(widths) + len(widths) + 1)
+
+    def fmt_row(row: list[str]) -> str:
+        parts: list[str] = []
+        for i, cell in enumerate(row):
+            parts.append(cell.ljust(widths[i]))
+        return "  ".join(parts)
+
+    print(sep)
+    print(fmt_row(header))
+    print(sep)
+    for row in rows:
+        print(fmt_row(row))
+    print(sep)
+
+    # Summary
+    scores = [rs.overall for rs in results]
+    if scores:
+        avg = sum(scores) / len(scores)
+        sorted_scores = sorted(scores)
+        median = sorted_scores[len(sorted_scores) // 2]
+        print(f"\nRoles scored: {len(results)}")
+        print(f"Average:      {avg:.2f}")
+        print(f"Median:       {median:.2f}")
+
+
+def print_json(results: list[RoleScore]) -> None:
+    """Print JSON to stdout."""
+    data: list[dict[str, Any]] = []
+    for rs in results:
+        entry: dict[str, Any] = {
+            "name": rs.name,
+            "overall": round(rs.overall, 4),
+            "flags": list(rs.flags),
+            "rules": {},
+        }
+        for rid, r in rs.rules.items():
+            entry["rules"][rid] = {
+                "score": round(r.score, 4),
+                "max": r.max_score,
+                "weight": r.weight,
+                "detail": r.detail,
+            }
+        data.append(entry)
+    json.dump(data, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+def print_csv(results: list[RoleScore], rule_ids: list[str]) -> None:
+    """Print CSV to stdout."""
+    writer = csv.writer(sys.stdout)
+    writer.writerow(rule_table_header(rule_ids))
+    for rs in results:
+        writer.writerow(rule_table_row(rs, rule_ids))
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Score DebOps Ansible roles against quality rules.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  %(prog)s\n"
+            "  %(prog)s --json\n"
+            "  %(prog)s --weights weights.yml --threshold 0.7\n"
+            "  %(prog)s --rule variable_naming,template_src_lookup\n"
+        ),
+    )
+    parser.add_argument(
+        "--roles-dir",
+        type=str,
+        default="ansible/roles",
+        help="Path to roles directory (default: ansible/roles/)",
+    )
+    parser.add_argument(
+        "--docs-dir",
+        type=str,
+        default=DOCS_DIR,
+        help="Path to role documentation directory (default: docs/ansible/roles)",
+    )
+    parser.add_argument(
+        "--weights",
+        type=str,
+        default=None,
+        help="YAML file with rule weights and skip_roles",
+    )
+    parser.add_argument(
+        "--min-ansible",
+        type=str,
+        default=DEFAULT_MIN_ANSIBLE,
+        help=f"Minimum ansible version threshold (default: {DEFAULT_MIN_ANSIBLE})",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output JSON instead of table",
+    )
+    parser.add_argument(
+        "--csv",
+        action="store_true",
+        help="Output CSV instead of table",
+    )
+    parser.add_argument(
+        "--roles",
+        type=str,
+        default=None,
+        help="Comma-separated list of roles to score (default: all)",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=None,
+        help="Only show roles below this score",
+    )
+    parser.add_argument(
+        "--rule",
+        type=str,
+        default=None,
+        help="Comma-separated list of rules to check",
+    )
+    parser.add_argument(
+        "--list-rules",
+        action="store_true",
+        help="List all rules with weights and descriptions",
+    )
+    parser.add_argument(
+        "--skip-roles",
+        type=str,
+        default=None,
+        help="Comma-separated list of roles to skip (appended to config)",
+    )
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Show full table with all rule columns",
+    )
+    parser.add_argument(
+        "--details",
+        action="store_true",
+        help="Show per-rule weight, score and detail after each role (compact mode)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help=(
+            "Show per-rule weight, score and detail for impactful rules only"
+            " (compact mode)"
+        ),
+    )
+    return parser
+
+
+def list_rules(weights: dict[str, float]) -> None:
+    """Print all rules with their weights and descriptions."""
+    descriptions: dict[str, str] = {
+    }
+
+    print(f"{'Rule':<30} {'Weight':>6}  Description")
+    print("-" * 70)
+    for rule_id in RULES:
+        rid = rule_id.__name__.removeprefix("rule_")
+        w = weights.get(rid, 0.0)
+        desc = descriptions.get(rid, "")
+        markers: list[str] = []
+        if rid in BINARY_RULES:
+            markers.append("binary")
+        if rid in NEGATIVE_RULES:
+            markers.append("negative")
+        mark = f" ({', '.join(markers)})" if markers else ""
+        print(f"{rid:<30} {w:>6.1f}  {desc}{mark}")
+    print()
+    print("Weights range 0.0–2.0. Set to 0 to disable a rule.")
+    print("Binary rules contribute full weight if passed, 0 if failed.")
+    print("Negative rules subtract from the weighted sum.")
+    print("Use --weights FILE to override.")
+
+
+def load_weights(weights_path: str | None) -> dict[str, Any]:
+    """Load weights and config from file, return combined config dict."""
+    config: dict[str, Any] = {
+        "weights": dict(DEFAULT_WEIGHTS),
+        "skip_roles": list(DEFAULT_SKIP_ROLES),
+    }
+    if weights_path:
+        path = Path(weights_path)
+        if path.is_file():
+            try:
+                user_cfg = load_yaml_robust(path)
+                user_weights = user_cfg.get("weights", {})
+                if isinstance(user_weights, dict):
+                    config["weights"].update(user_weights)
+                user_skip = user_cfg.get("skip_roles", [])
+                if isinstance(user_skip, list):
+                    config["skip_roles"].extend(user_skip)
+            except Exception as exc:
+                print(f"Warning: could not load weights file: {exc}", file=sys.stderr)
+    return config
+
+
+def main() -> None:
+    parser = build_arg_parser()
+    args = parser.parse_args()
+
+    # Load weights
+    config = load_weights(args.weights)
+    weights: dict[str, float] = config["weights"]
+    skip_roles: list[str] = config["skip_roles"]
+
+    # Append CLI skip-roles
+    if args.skip_roles:
+        skip_roles.extend([s.strip() for s in args.skip_roles.split(",")])
+
+    # Filter to specific rules
+    only_rules: list[str] | None = None
+    if args.rule:
+        only_rules = [r.strip() for r in args.rule.split(",")]
+
+    # Filter to specific roles
+    only_roles: list[str] | None = None
+    if args.roles:
+        only_roles = [r.strip() for r in args.roles.split(",")]
+
+    if args.list_rules:
+        list_rules(weights)
+        return
+
+    # Determine rule order (all rules in definition order, filtered to --rule)
+    rule_ids: list[str] = []
+    for rule_fn in RULES:
+        rid = rule_fn.__name__.removeprefix("rule_")
+        if only_rules and rid not in only_rules:
+            continue
+        rule_ids.append(rid)
+
+    # Resolve roles directory
+    roles_dir = Path(args.roles_dir)
+    if not roles_dir.is_absolute():
+        # Try relative to cwd
+        roles_dir = Path.cwd() / args.roles_dir
+
+    # Resolve documentation directory
+    docs_dir = Path(args.docs_dir)
+    if not docs_dir.is_absolute():
+        docs_dir = Path.cwd() / args.docs_dir
+
+    results = analyze_roles(
+        roles_dir,
+        weights,
+        skip_roles,
+        args.min_ansible,
+        only_rules,
+        only_roles,
+        docs_dir=docs_dir,
+    )
+
+    if not results:
+        print("No roles found to score.", file=sys.stderr)
+        sys.exit(1)
+
+    # Filter by threshold
+    if args.threshold is not None:
+        results = [rs for rs in results if rs.overall < args.threshold]
+        if not results:
+            print(f"No roles below threshold {args.threshold:.2f}")
+            return
+
+    if args.json:
+        print_json(results)
+    elif args.csv:
+        print_csv(results, rule_ids)
+    elif args.full:
+        print_table(results, rule_ids)
+    elif args.details:
+        print_detailed(results)
+    elif args.verbose:
+        print_detailed(results, verbose=True)
+    else:
+        print_compact(results)
+
+    sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/developer-guide/role-score.rst
+++ b/docs/developer-guide/role-score.rst
@@ -1,0 +1,328 @@
+.. Copyright (C) 2026 Maciej Delmanowski <drybjed@gmail.com>
+.. Copyright (C) 2026 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-or-later
+
+.. _role_score:
+
+Role Quality Score
+==================
+
+The ``debops-role-score`` script grades every DebOps role against the
+project's quality rules and makes CI fail on changes that drag a role's score
+below the gate. Read this before working on a role — the detail output tells
+you exactly what to fix.
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+How scoring works
+-----------------
+
+The script lives at :file:`bin/debops-role-score` and depends only on PyYAML.
+It is deterministic: the same repository state always produces the same
+scores — the property a CI gate needs.
+
+Each rule inspects one role and returns four values:
+
+``weight``
+  How much the rule is worth. Defaults come from ``DEFAULT_WEIGHTS``; you can
+  override them with :command:`--weights` or set a weight to ``0`` to disable
+  a rule.
+
+``score``
+  A value between ``0.0`` and ``1.0``, or negative for penalties — the
+  ``role_era`` rule, for example, scores an early-era role ``-0.50``.
+
+``max_score``
+  ``1.0`` when the rule applies to the role, ``0.0`` when it is **not
+  applicable** (N/A). N/A rules are excluded from the score entirely.
+
+``detail``
+  A short human-readable note explaining the result. This is the fastest way
+  to find out *why* a rule scored the way it did; it shows up in
+  :command:`--details` and :command:`--verbose` output and in the JSON.
+
+The overall score is the weighted sum of the applicable rules divided by
+their total weight, scaled to a ``0``--``10`` range:
+
+.. code-block:: text
+
+   overall = weighted_sum / total_weight * 10
+
+A rule counts toward ``total_weight`` only when it applies. A role with no
+applicable rules scores ``0``.
+
+The score ceiling
+~~~~~~~~~~~~~~~~~
+
+A perfect role would score ``10``, but the rules do not let it. The era rules
+reward contradictory lifecycles: a role cannot be both written in the
+Universal Configuration era *and* stable since 2015, so ``role_era``,
+``role_modernization``, ``role_stability`` and ``modern_stability`` can never
+all pay out at once. The script computes the highest achievable score — the
+**ceiling** — from the current rule weights every time you ask:
+
+.. code-block:: console
+
+   bin/debops-role-score --ceiling
+
+The ceiling changes whenever rules or weights change, so there is no
+hardcoded number to keep in sync. The CI gate is defined as a fraction of it
+(see :ref:`The CI gate <role_score_ci_gate>` below).
+
+Design eras
+~~~~~~~~~~~
+
+Three rules key off the first copyright year of the role, which groups roles
+into design eras:
+
+.. list-table::
+   :widths: 20 25 55
+   :header-rows: 1
+
+   * - Era
+     - First copyright year
+     - ``role_era`` score
+   * - early
+     - before 2017
+     - ``-0.50``
+   * - exploration
+     - 2017--2020
+     - ``0.00``
+   * - Universal Configuration
+     - 2021 and later
+     - ``+0.50``
+
+The newest era takes its name from the variable syntax the project
+standardized on — see :ref:`universal_configuration`. Roles written since
+2021 are expected to be built around that pattern, so ``role_era`` treats
+them as the baseline. Run :command:`--details` and the era row reads
+``Universal Configuration (2021)`` — the year in parentheses is the first
+copyright year the rule found.
+
+The other era rules fine-tune this:
+
+- ``role_modernization`` rewards an early-era role that was substantially
+  rewritten during the Universal Configuration era;
+- ``modern_stability`` rewards a post-2022 role with low commit churn;
+- ``role_stability`` is the inverse: an early-era role that barely needed
+  changes for years.
+
+No role can collect all three, which is why the ceiling sits below ``10``.
+
+
+Reading your role's score
+-------------------------
+
+Start with your role and the full rule breakdown:
+
+.. code-block:: console
+
+   bin/debops-role-score --roles samba --details
+
+You get one line per rule: the weight, the score earned, and the detail note.
+Rows prefixed with ``[N/A]`` do not apply to this role and are irrelevant.
+Rules that hurt — the negative ones — stand out, and the detail text says why
+they fired.
+
+The default output without :command:`--details` is a compact scoreboard
+sorted by score, with the role count, average and median. To compare a few
+roles:
+
+.. code-block:: console
+
+   bin/debops-role-score --roles samba,gitlab,tor --details
+
+Other output modes:
+
+- :command:`--verbose` shows only the rules that actually matter
+  (``|weight * score| >= 0.10``), skipping N/A and negligible rows. This is
+  what CI runs use, so pull request logs stay short.
+- :command:`--full` prints one column per rule; :command:`--csv` mirrors it.
+- :command:`--json` emits the full per-rule breakdown, ready for jq.
+- :command:`--rule LIST` restricts the run to specific rules, handy when you
+  are fixing one thing and want to check it in isolation.
+
+To try a rule at a different weight without editing the script, use a weights
+file:
+
+.. code-block:: yaml
+
+   ---
+   weights:
+     variable_naming: 0.5
+     docs_presence: 0.0
+   skip_roles:
+     - experimental_role
+
+Setting a weight to ``0`` disables the rule; roles listed in ``skip_roles``
+are not scored.
+
+
+What the rules reward
+---------------------
+
+The full rule reference lives in the script itself — run
+:command:`debops-role-score --list-rules` to see every rule with its current
+weight and a one-line description. The same rules, grouped by theme:
+
+Variables and naming
+~~~~~~~~~~~~~~~~~~~~
+
+The heaviest part of the score. Variables must use the ``<role>__`` prefix
+(``variable_naming``), full three-level scoping with ``__group_`` and
+``__host_`` overrides (``scoped_variables``), the ``__combined_`` merge
+pattern (``combined_variables``), and the ``parse_kv_items`` filter for
+structured values (``parse_kv_items_usage``). ``dependent_variables`` rewards
+the ``__dependent_`` pattern and pays a bonus when other roles reference your
+variables.
+
+Tasks
+~~~~~
+
+Task conditionals (``when:``, ``changed_when:``, ``failed_when:``,
+``until:``) must resolve to booleans: the ``| d()`` / ``| default()``
+filter returns the raw value and breaks Ansible 2.19+, so it is penalized
+(``default_filter_usage``) and the ``is defined`` / ``is truthy`` tests are
+rewarded (``is_truthy_usage``). Tasks load includes through ``task_src`` and
+templates through ``template_src``, and carry ``role::<name>`` /
+``skip::<name>`` tags (``task_tags``). Task files are split by concern instead
+of one big ``main.yml`` (``task_file_organization``), and small roles with up
+to three tasks and no templates are exempt from these structural rules
+entirely — there is nothing to reorganize yet.
+
+Templates and files
+~~~~~~~~~~~~~~~~~~~
+
+Templates carry SPDX license headers (``spdx_headers``), render
+``{{ ansible_managed }}`` (``ansible_managed``), use ``| d()`` defaults
+(``template_default_filter``), and build fact files at runtime instead of
+hardcoding values (``fact_runtime_detection``). Static ``files/`` directories
+are penalized (``files_directory_absent``) — ship a template instead — and
+hardcoded ``/etc/`` or ``/var/`` paths in templates are a penalty
+(``hardcoded_paths``).
+
+Metadata and packaging
+~~~~~~~~~~~~~~~~~~~~~~
+
+``meta/main.yml`` must exist (``missing_meta``), declare the
+``debops.debops`` collection (``collections_declared``), list explicit
+platforms (``meta_platforms_specific``) and galaxy tags
+(``galaxy_tags_present``), and carry a ``dependencies: []`` entry
+(``dependencies_empty``). The legacy ``vars/`` directory costs you points
+(``legacy_vars_dir``).
+
+Facts
+~~~~~
+
+Roles that use local facts keep them in a template with a shebang
+(``local_facts``), run ``flush_handlers`` after writing them
+(``flush_handlers``), and reference ``ansible_local`` in their ``when:``
+clauses (``ansible_local_in_conditions``). Static JSON fact files are a
+penalty (``static_json_facts``).
+
+Lifecycle and documentation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Beyond the era rules, ``foundational`` rewards roles that other roles
+reference through their variables, and ``collection_excluded`` penalizes
+roles that are deliberately omitted from the Collection build. Finally,
+``docs_presence`` checks that the role has real ``getting-started.rst``
+documentation — short placeholder pages score near zero.
+
+
+Making your role pass
+---------------------
+
+In order:
+
+1. **Score first.** Run
+   ``bin/debops-role-score --roles <name> --details`` and read the detail
+   notes. The penalty rows and the missing big-ticket rules are your list.
+2. **Fix the heavy hitters.** Start with the highest weights — variable
+   scoping, facts, documentation — not the 0.1-weight niceties. A change to
+   a 1.0-weight rule moves the score ten times as far as a 0.1 one.
+3. **Re-run and compare.** The compact scoreboard shows the average and
+   median, so you can tell whether your role is above or below the pack. The
+   script is deterministic: if the score moved, the role changed.
+4. **Leave N/A alone.** If a row is ``[N/A]``, the rule does not apply — do
+   not add fake structure to a role that is too small to need it.
+
+Two common surprises:
+
+- **Missing documentation.** ``docs_presence`` looks at body lines in
+  :file:`docs/ansible/roles/<name>/getting-started.rst`. A stub of a few
+  sentences scores almost nothing; write the doc properly and the rule
+  mostly pays out.
+- **Collection exclusion.** If the role is not shipped in the Collection, it
+  pays a fixed 1.5 penalty. Being in the Collection is usually the right
+  answer; if the exclusion is deliberate, accept the cost.
+
+The CI gate judges *changed* roles only. A legacy role that is never touched
+passes by default; touch it, and the change has to hold the gate.
+
+
+.. _role_score_ci_gate:
+
+The CI gate
+-----------
+
+The :file:`.github/workflows/role-score.yml` workflow runs on every push and
+pull request. It detects which roles the change touched, scores just those
+roles, and fails the build if any of them lands below the gate.
+
+The workflow defines the gate as a fraction of the score ceiling, computed
+from the current rule weights at run time:
+
+.. code-block:: console
+
+   bin/debops-role-score --roles <changed-roles> --min-score-fraction 0.40 --verbose
+
+The 40% bar is deliberately low: it stops the worst offenders and prevents
+regressions without demanding a full modernization of every role on day one.
+Because the fraction is applied to the live ceiling, adding or reweighting a
+rule automatically re-derives the gate — there is nothing to recompute by
+hand.
+
+For local runs:
+
+- :command:`--min-score-fraction 0.40` gates at 40% of the current ceiling;
+- :command:`--min-score 4.0` gates at a fixed absolute score instead, and
+  takes precedence if both are given;
+- :command:`--ceiling` prints the current ceiling and gate value, so you can
+  see what fraction means what on any given day.
+
+
+Reporting flags
+---------------
+
+The script attaches two non-scoring flags to each role. They never affect the
+score, but they tell you how the role is wired into the fleet:
+
+``common``
+  The role runs on every host via
+  :file:`ansible/playbooks/layer/common.yml`.
+
+``no-service-playbook``
+  No service playbook for the role exists under
+  :file:`ansible/playbooks/service/`.
+
+Flags appear as a ``[common]``-style suffix in the compact and detailed
+outputs, in a ``Flags`` column in :command:`--full` and :command:`--csv`
+output, and as a ``flags`` array in JSON. A role that runs on every host
+deserves more scrutiny than one deployed on demand. Find them with:
+
+.. code-block:: console
+
+   bin/debops-role-score --json | jq -r '.[] | select(.flags | index("common")) | "\(.name)\t\(.overall)"'
+
+
+See also
+--------
+
+- :ref:`universal_configuration` for the variable syntax that defines the
+  newest design era
+- :ref:`testing` for the other validation the project runs
+- :ref:`contributing_docs` for documentation contribution conventions

--- a/docs/developer-guide/role-score.rst
+++ b/docs/developer-guide/role-score.rst
@@ -128,8 +128,10 @@ Rules that hurt — the negative ones — stand out, and the detail text says wh
 they fired.
 
 The default output without :command:`--details` is a compact scoreboard
-sorted by score, with the role count, average and median. To compare a few
-roles:
+sorted by score, with the role count, average and median. To score the whole
+fleet, :command:`make role-score` prints that scoreboard and
+:command:`make role-score-verbose` adds the per-rule breakdown. To compare a
+few roles:
 
 .. code-block:: console
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -114,6 +114,7 @@ infrastructure environments.
    developer-guide/contributing-docs
    developer-guide/testing
    developer-guide/development-model
+   developer-guide/role-score
    dep/index
 
 .. toctree::


### PR DESCRIPTION
DebOps has no automated way to tell whether a role follows the project's own conventions, so role quality is judged by hand during review. This adds `bin/debops-role-score`, a deterministic tool that grades each role against the project's rules and prints a per-rule breakdown, plus a workflow that scores the roles a change touches and fails the build below 40% of the score ceiling. The ceiling is computed from the current rule weights rather than hardcoded, because the lifecycle rules are deliberately contradictory and no role can reach 10. Gating only changed roles keeps the score a ratchet: the roles below the bar today are left alone until someone touches them.
