### PR TITLE
Allow global control of 'append' parameter in UNIX account configuration

### DIFF
--- a/ansible/roles/system_users/defaults/main.yml
+++ b/ansible/roles/system_users/defaults/main.yml
@@ -38,6 +38,17 @@ system_users__acl_enabled: '{{ True if ("acl" in system_users__base_packages) el
 # not specified, the shell won't be changed, but new accounts will not have
 # a defined shell either.
 system_users__default_shell: ''
+
+                                                                   # ]]]
+# .. envvar:: system_users__default_append [[[
+#
+# This variable ontrols the default behavior of 'append' setting in General
+# account parameters. Can be overridden per user.
+# If `True`, the specified UNIX groups will be added to the list of existing
+# groups the account belongs to.
+# If `False`, UNIX groups other than those present on the ``groups`` parameter
+# will be removed.
+system_users__default_append: True
                                                                    # ]]]
                                                                    # ]]]
 # APT packages [[[

--- a/ansible/roles/system_users/defaults/main.yml
+++ b/ansible/roles/system_users/defaults/main.yml
@@ -42,7 +42,7 @@ system_users__default_shell: ''
                                                                    # ]]]
 # .. envvar:: system_users__default_append [[[
 #
-# This variable ontrols the default behavior of 'append' setting in General
+# This variable controls the default behavior of 'append' setting in General
 # account parameters. Can be overridden per user.
 # If `True`, the specified UNIX groups will be added to the list of existing
 # groups the account belongs to.

--- a/ansible/roles/system_users/tasks/main.yml
+++ b/ansible/roles/system_users/tasks/main.yml
@@ -122,7 +122,7 @@
                  | intersect(getent_group.keys()))
                 if (item.groups is defined or (item.admin | d()) | bool)
                 else omit }}'
-    append: '{{ item.append | d(True) }}'
+    append: '{{ item.append | d(system_users__default_append) }}'
     state:  '{{ item.state | d("present") }}'
     create_home: '{{ item.create_home | d(omit) }}'
   loop: '{{ system_users__combined_accounts | debops.debops.parse_kv_items }}'

--- a/ansible/roles/users/defaults/main.yml
+++ b/ansible/roles/users/defaults/main.yml
@@ -38,6 +38,17 @@ users__acl_enabled: '{{ True if ("acl" in users__base_packages) else False }}'
 # not specified, the shell won't be changed, but new accounts will not have
 # a defined shell either.
 users__default_shell: ''
+
+                                                                   # ]]]
+# .. envvar:: users__default_append [[[
+#
+# This variable ontrols the default behavior of 'append' setting in General
+# account parameters. Can be overridden per user.
+# If `True`, the specified UNIX groups will be added to the list of existing
+# groups the account belongs to.
+# If `False`, UNIX groups other than those present on the ``groups`` parameter
+# will be removed.
+users__default_append: True
                                                                    # ]]]
                                                                    # ]]]
 # APT packages [[[

--- a/ansible/roles/users/defaults/main.yml
+++ b/ansible/roles/users/defaults/main.yml
@@ -42,7 +42,7 @@ users__default_shell: ''
                                                                    # ]]]
 # .. envvar:: users__default_append [[[
 #
-# This variable ontrols the default behavior of 'append' setting in General
+# This variable controls the default behavior of 'append' setting in General
 # account parameters. Can be overridden per user.
 # If `True`, the specified UNIX groups will be added to the list of existing
 # groups the account belongs to.

--- a/ansible/roles/users/tasks/main.yml
+++ b/ansible/roles/users/tasks/main.yml
@@ -108,7 +108,7 @@
                        | intersect(getent_group.keys()))
                       if (item.groups is defined or (item.chroot | d()) | bool)
                       else omit }}'
-    append:       '{{ item.append | d(True) }}'
+    append:       '{{ item.append | d(users__default_append) }}'
     state:        '{{ item.state | d("present") }}'
     create_home:  '{{ item.create_home | d(omit) }}'
   loop: '{{ users__combined_accounts | debops.debops.parse_kv_items }}'

--- a/docs/ansible/roles/system_users/defaults-detailed.rst
+++ b/docs/ansible/roles/system_users/defaults-detailed.rst
@@ -121,9 +121,10 @@ General account parameters
   Only existing groups will be added to the account.
 
 ``append``
-  Optional, boolean. If ``True`` (default), the specified groups will be added
-  to the list of existing groups the account belongs to. If ``False``, all
-  other groups than those present on the group list will be removed stripped.
+  Optional, boolean. If ``True``, the specified groups will be added to the
+  list of existing groups the account belongs to. If ``False``, all other
+  groups than those present on the group list will be removed stripped.
+  Defaults to the value of :envvar:`system_users__default_append` variable.
 
 ``comment``
   Optional. A comment, or GECOS field configured for a specified UNIX account.

--- a/docs/ansible/roles/users/defaults-detailed.rst
+++ b/docs/ansible/roles/users/defaults-detailed.rst
@@ -123,9 +123,10 @@ General account parameters
   Only existing groups will be added to the account.
 
 ``append``
-  Optional, boolean. If ``True`` (default), the specified groups will be added
-  to the list of existing groups the account belongs to. If ``False``, all
-  other groups than those present on the group list will be removed stripped.
+  Optional, boolean. If ``True``, the specified groups will be added to the
+  list of existing groups the account belongs to. If ``False``, all other
+  groups than those present on the group list will be removed stripped.
+  Defaults to the value of the :envvar:`users__default_append` variable.
 
 ``comment``
   Optional. A comment, or GECOS field configured for a specified UNIX account.


### PR DESCRIPTION
Fixes #2642 