### PR TITLE
[docs] Include role defaults in manual pages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,9 @@ General
   project requirements for contributions that use LLM and AI-assisted
   coding tools.
 
+- Manual pages for each Ansible role now include the role default
+  variables rendered from the :file:`defaults/main.yml` file.
+
 :ref:`debops.java` role
 '''''''''''''''''''''''
 

--- a/docs/_lib/manpages.py
+++ b/docs/_lib/manpages.py
@@ -1,0 +1,76 @@
+# Custom Sphinx translator for manual page output
+# Copyright (C) 2026 Maciej Delmanowski <drybjed@gmail.com>
+# Copyright (C) 2026 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from docutils import nodes
+
+from sphinx.writers.manpage import ManualPageTranslator
+
+
+class ManPagesTranslator(ManualPageTranslator):
+    """Custom man page translator.
+
+    Changes compared to the Sphinx default:
+
+    - the ``.. contents::`` table of contents rendered by the default
+      translator is a plain bullet list with no navigation value in
+      a manual page, so it is skipped entirely
+    - literal blocks are emitted with ``.nf`` (no-fill) which means groff
+      will not wrap long lines; lines are hard-wrapped here so that they
+      fit in a standard 80 column terminal
+    """
+
+    def __init__(self, document, builder):
+        super().__init__(document, builder)
+        self._in_literal_block = False
+
+    def visit_topic(self, node):
+        if 'contents' in node.get('classes', []):
+            raise nodes.SkipNode
+        super().visit_topic(node)
+
+    def visit_literal_block(self, node):
+        self._in_literal_block = True
+        super().visit_literal_block(node)
+
+    def depart_literal_block(self, node):
+        self._in_literal_block = False
+        super().depart_literal_block(node)
+
+    def visit_Text(self, node):
+        if self._in_literal_block:
+            text = node.astext()
+            wrapped = '\n'.join(
+                self._wrap_line(line) for line in text.split('\n')
+            )
+            node = nodes.Text(wrapped)
+        super().visit_Text(node)
+
+    def _wrap_line(self, line):
+        """Hard-wrap *line* to the available terminal width."""
+        width = max(1, int(78 - sum(self._indent)))
+        if len(line) <= width:
+            return line
+        indent = line[:len(line) - len(line.lstrip())]
+        wrapped = []
+        current = ''
+        for word in line[len(indent):].split():
+            candidate = word if not current else current + ' ' + word
+            if len(candidate) <= width:
+                current = candidate
+            else:
+                if current:
+                    wrapped.append(current)
+                if len(word) > width:
+                    while len(word) > width:
+                        wrapped.append(word[:width])
+                        word = word[width:]
+                current = indent + word
+        if current:
+            wrapped.append(current)
+        return '\n'.join(wrapped)
+
+
+def setup(app):
+    app.set_translator('man', ManPagesTranslator)

--- a/docs/_lib/yaml2rst/func.py
+++ b/docs/_lib/yaml2rst/func.py
@@ -38,6 +38,12 @@ STATE_YAML = 1
 ENVVAR_INDENT = '   '
 ENVVAR_VALUE_INDENT = ENVVAR_INDENT + '   '
 
+# A section title overline/underline: a single non-word character repeated
+# four or more times (``-``, ``~``, ``=``, ...). Such lines must not be
+# indented, even inside an ``.. envvar::`` body, because RST forbids section
+# titles inside directive bodies.
+SECTION_MARKUP = re.compile(r'^([^\w\s])\1{3,}$')
+
 
 def setup_patterns():
 
@@ -115,10 +121,12 @@ def convert(lines, strip_regex=None, yaml_strip_regex=None):
     last_text_line = ''
     last_indent = ''
     in_envvar = False
+    in_section = False
     for line in lines:
         line = line.rstrip()
         if is_envvar_end(line):
             in_envvar = False
+            in_section = False
             yield ''
             continue
         if not line:
@@ -130,11 +138,26 @@ def convert(lines, strip_regex=None, yaml_strip_regex=None):
             line = get_stripped_line(line, strip_regex)
             line = last_text_line = line[2:]
             if in_envvar and not line.startswith('.. envvar::'):
-                yield ENVVAR_INDENT + line
+                if SECTION_MARKUP.match(line):
+                    # Section title overline or underline: emit at column 0,
+                    # outside the directive body. The second such line closes
+                    # both the section and the envvar it was nested in.
+                    yield line
+                    if in_section:
+                        in_section = False
+                        in_envvar = False
+                    else:
+                        in_section = True
+                elif in_section:
+                    # Section title between its overline and underline
+                    yield line
+                else:
+                    yield ENVVAR_INDENT + line
             else:
                 yield line
             if line.startswith('.. envvar::'):
                 in_envvar = True
+                in_section = False
             last_indent = get_indent(line) * ' '
             state = STATE_TEXT
         elif line == '---':

--- a/docs/_lib/yaml2rst/func.py
+++ b/docs/_lib/yaml2rst/func.py
@@ -31,6 +31,13 @@ __version__ = "0.3dev"
 STATE_TEXT = 0
 STATE_YAML = 1
 
+# Indentation of a ``.. envvar::`` directive body (3 spaces) and of the
+# YAML value block nested inside it (6 spaces). Sphinx renders the body
+# as a definition list item, so descriptions and values have to be
+# indented to appear inside the directive.
+ENVVAR_INDENT = '   '
+ENVVAR_VALUE_INDENT = ENVVAR_INDENT + '   '
+
 
 def setup_patterns():
 
@@ -98,12 +105,22 @@ def get_stripped_line(line, strip_regex):
     return line
 
 
+def is_envvar_end(line):
+    """Return True if *line* is a closing vim fold marker ``# ]]]``."""
+    return re.match(r'^\s*#\s*\]{3}\d?\s*$', line) is not None
+
+
 def convert(lines, strip_regex=None, yaml_strip_regex=None):
     state = STATE_TEXT
     last_text_line = ''
     last_indent = ''
+    in_envvar = False
     for line in lines:
         line = line.rstrip()
+        if is_envvar_end(line):
+            in_envvar = False
+            yield ''
+            continue
         if not line:
             # do not change state if the line is empty
             yield ''
@@ -112,7 +129,12 @@ def convert(lines, strip_regex=None, yaml_strip_regex=None):
                 yield ''
             line = get_stripped_line(line, strip_regex)
             line = last_text_line = line[2:]
-            yield line
+            if in_envvar and not line.startswith('.. envvar::'):
+                yield ENVVAR_INDENT + line
+            else:
+                yield line
+            if line.startswith('.. envvar::'):
+                in_envvar = True
             last_indent = get_indent(line) * ' '
             state = STATE_TEXT
         elif line == '---':
@@ -122,10 +144,16 @@ def convert(lines, strip_regex=None, yaml_strip_regex=None):
                 line = line[3:]
             if state != STATE_YAML:
                 if not last_text_line.endswith('::'):
-                    yield last_indent + '\n.. code-block:: yaml'
+                    if in_envvar:
+                        yield '\n' + ENVVAR_INDENT + '.. code-block:: yaml'
+                    else:
+                        yield last_indent + '\n.. code-block:: yaml'
                 yield ''
             line = get_stripped_line(line, yaml_strip_regex)
-            yield last_indent + '  ' + line
+            if in_envvar:
+                yield ENVVAR_VALUE_INDENT + line
+            else:
+                yield last_indent + '  ' + line
             state = STATE_YAML
 
 

--- a/docs/ansible/roles/apache/man_index.rst
+++ b/docs/ansible/roles/apache/man_index.rst
@@ -14,6 +14,7 @@ debops.apache
    man_description
    getting-started
    ansible-integration
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/apt/man_index.rst
+++ b/docs/ansible/roles/apt/man_index.rst
@@ -14,6 +14,7 @@ debops.apt
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
    man_seealso
 

--- a/docs/ansible/roles/apt_install/man_index.rst
+++ b/docs/ansible/roles/apt_install/man_index.rst
@@ -14,6 +14,7 @@ debops.apt_install
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/apt_mark/man_index.rst
+++ b/docs/ansible/roles/apt_mark/man_index.rst
@@ -13,6 +13,7 @@ debops.apt_mark
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/apt_mirror/man_index.rst
+++ b/docs/ansible/roles/apt_mirror/man_index.rst
@@ -13,6 +13,7 @@ debops.apt_mirror
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/apt_preferences/man_index.rst
+++ b/docs/ansible/roles/apt_preferences/man_index.rst
@@ -14,6 +14,7 @@ debops.apt_preferences
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/authorized_keys/man_index.rst
+++ b/docs/ansible/roles/authorized_keys/man_index.rst
@@ -13,6 +13,7 @@ debops.authorized_keys
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/avahi/man_index.rst
+++ b/docs/ansible/roles/avahi/man_index.rst
@@ -13,6 +13,7 @@ debops.avahi
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/cran/man_index.rst
+++ b/docs/ansible/roles/cran/man_index.rst
@@ -13,6 +13,7 @@ debops.cran
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/cron/man_index.rst
+++ b/docs/ansible/roles/cron/man_index.rst
@@ -13,6 +13,7 @@ debops.cron
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/cryptsetup/man_index.rst
+++ b/docs/ansible/roles/cryptsetup/man_index.rst
@@ -14,6 +14,7 @@ debops.cryptsetup
    man_description
    getting-started
    guides
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/debconf/man_index.rst
+++ b/docs/ansible/roles/debconf/man_index.rst
@@ -13,6 +13,7 @@ debops.debconf
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/debops_legacy/man_index.rst
+++ b/docs/ansible/roles/debops_legacy/man_index.rst
@@ -13,6 +13,7 @@ debops.debops_legacy
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/dhcp_probe/man_index.rst
+++ b/docs/ansible/roles/dhcp_probe/man_index.rst
@@ -13,6 +13,7 @@ debops.dhcp_probe
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/dhcpd/man_index.rst
+++ b/docs/ansible/roles/dhcpd/man_index.rst
@@ -13,6 +13,7 @@ debops.dhcpd
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/dnsmasq/man_index.rst
+++ b/docs/ansible/roles/dnsmasq/man_index.rst
@@ -14,6 +14,7 @@ debops.dnsmasq
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/docker_registry/man_index.rst
+++ b/docs/ansible/roles/docker_registry/man_index.rst
@@ -13,6 +13,7 @@ debops.docker_registry
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/docker_server/man_index.rst
+++ b/docs/ansible/roles/docker_server/man_index.rst
@@ -14,6 +14,7 @@ debops.docker_server
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/docker_service/man_index.rst
+++ b/docs/ansible/roles/docker_service/man_index.rst
@@ -13,6 +13,7 @@ debops.docker_service
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/dovecot/man_index.rst
+++ b/docs/ansible/roles/dovecot/man_index.rst
@@ -14,6 +14,7 @@ debops.dovecot
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/dpkg_cleanup/man_index.rst
+++ b/docs/ansible/roles/dpkg_cleanup/man_index.rst
@@ -13,6 +13,7 @@ debops.dpkg_cleanup
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/dropbear_initramfs/man_index.rst
+++ b/docs/ansible/roles/dropbear_initramfs/man_index.rst
@@ -11,6 +11,7 @@ debops.ifupdown
 
    man_synopsis
    man_description
+   defaults/main
    defaults-detailed
    related-projects
    design

--- a/docs/ansible/roles/elasticsearch/man_index.rst
+++ b/docs/ansible/roles/elasticsearch/man_index.rst
@@ -18,6 +18,7 @@ debops.elasticsearch
    clustering
    dependency
    upgrade-notes
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/environment/man_index.rst
+++ b/docs/ansible/roles/environment/man_index.rst
@@ -13,6 +13,7 @@ debops.environment
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/etc_aliases/man_index.rst
+++ b/docs/ansible/roles/etc_aliases/man_index.rst
@@ -14,6 +14,7 @@ debops.etc_aliases
    man_description
    getting-started
    dependency
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/etc_services/man_index.rst
+++ b/docs/ansible/roles/etc_services/man_index.rst
@@ -14,6 +14,7 @@ debops.etc_services
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/etckeeper/man_index.rst
+++ b/docs/ansible/roles/etckeeper/man_index.rst
@@ -14,6 +14,7 @@ debops.etckeeper
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/extrepo/man_index.rst
+++ b/docs/ansible/roles/extrepo/man_index.rst
@@ -13,6 +13,7 @@ debops.extrepo
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/fail2ban/man_index.rst
+++ b/docs/ansible/roles/fail2ban/man_index.rst
@@ -13,6 +13,7 @@ debops.fail2ban
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/fcgiwrap/man_index.rst
+++ b/docs/ansible/roles/fcgiwrap/man_index.rst
@@ -13,6 +13,7 @@ debops.fcgiwrap
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/ferm/man_index.rst
+++ b/docs/ansible/roles/ferm/man_index.rst
@@ -15,6 +15,7 @@ debops.ferm
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
    rules
    guides

--- a/docs/ansible/roles/fhs/man_index.rst
+++ b/docs/ansible/roles/fhs/man_index.rst
@@ -13,6 +13,7 @@ debops.fhs
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
    man_seealso
 

--- a/docs/ansible/roles/filebeat/man_index.rst
+++ b/docs/ansible/roles/filebeat/man_index.rst
@@ -13,6 +13,7 @@ debops.filebeat
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/freeradius/man_index.rst
+++ b/docs/ansible/roles/freeradius/man_index.rst
@@ -14,6 +14,7 @@ debops.freeradius
    man_description
    getting-started
    example-eduroam
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/gitlab/man_index.rst
+++ b/docs/ansible/roles/gitlab/man_index.rst
@@ -13,6 +13,7 @@ debops.gitlab
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/golang/man_index.rst
+++ b/docs/ansible/roles/golang/man_index.rst
@@ -15,6 +15,7 @@ debops.golang
    man_description
    getting-started
    usage-examples
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/grub/man_index.rst
+++ b/docs/ansible/roles/grub/man_index.rst
@@ -15,6 +15,7 @@ debops.grub
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/gunicorn/man_index.rst
+++ b/docs/ansible/roles/gunicorn/man_index.rst
@@ -14,6 +14,7 @@ debops.gunicorn
    man_description
    getting-started
    virtualenv-support
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/icinga/man_index.rst
+++ b/docs/ansible/roles/icinga/man_index.rst
@@ -15,6 +15,7 @@ debops.icinga
    getting-started
    deployment
    dependency
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/icinga_web/man_index.rst
+++ b/docs/ansible/roles/icinga_web/man_index.rst
@@ -13,6 +13,7 @@ debops.icinga_web
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/ifupdown/man_index.rst
+++ b/docs/ansible/roles/ifupdown/man_index.rst
@@ -16,6 +16,7 @@ debops.ifupdown
    getting-started
    ifupdown-systemd
    custom-hooks
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/imapproxy/man_index.rst
+++ b/docs/ansible/roles/imapproxy/man_index.rst
@@ -13,6 +13,7 @@ debops.imapproxy
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/influxdb/man_index.rst
+++ b/docs/ansible/roles/influxdb/man_index.rst
@@ -15,6 +15,7 @@ debops.influxdb
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/influxdb2/man_index.rst
+++ b/docs/ansible/roles/influxdb2/man_index.rst
@@ -13,6 +13,7 @@ debops.influxdb2
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/influxdb_server/man_index.rst
+++ b/docs/ansible/roles/influxdb_server/man_index.rst
@@ -15,6 +15,7 @@ debops.influxdb_server
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/ipxe/man_index.rst
+++ b/docs/ansible/roles/ipxe/man_index.rst
@@ -13,6 +13,7 @@ debops.ipxe
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/iscsi/man_index.rst
+++ b/docs/ansible/roles/iscsi/man_index.rst
@@ -13,6 +13,7 @@ debops.iscsi
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/journald/man_index.rst
+++ b/docs/ansible/roles/journald/man_index.rst
@@ -13,6 +13,7 @@ debops.journald
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
    man_seealso
 

--- a/docs/ansible/roles/keepalived/man_index.rst
+++ b/docs/ansible/roles/keepalived/man_index.rst
@@ -13,6 +13,7 @@ debops.keepalived
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/keyring/man_index.rst
+++ b/docs/ansible/roles/keyring/man_index.rst
@@ -13,6 +13,7 @@ debops.keyring
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/kibana/man_index.rst
+++ b/docs/ansible/roles/kibana/man_index.rst
@@ -14,6 +14,7 @@ debops.kibana
    man_description
    getting-started
    dependency
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/kmod/man_index.rst
+++ b/docs/ansible/roles/kmod/man_index.rst
@@ -14,6 +14,7 @@ debops.kmod
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/ldap/man_index.rst
+++ b/docs/ansible/roles/ldap/man_index.rst
@@ -17,6 +17,7 @@ debops.ldap
    ldap-admin
    ldap-access
    dependency
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/librenms/man_index.rst
+++ b/docs/ansible/roles/librenms/man_index.rst
@@ -13,6 +13,7 @@ debops.librenms
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/libuser/man_index.rst
+++ b/docs/ansible/roles/libuser/man_index.rst
@@ -14,6 +14,7 @@ debops.libuser
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/libvirt/man_index.rst
+++ b/docs/ansible/roles/libvirt/man_index.rst
@@ -14,6 +14,7 @@ debops.libvirt
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/libvirtd/man_index.rst
+++ b/docs/ansible/roles/libvirtd/man_index.rst
@@ -14,6 +14,7 @@ debops.libvirtd
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/libvirtd_qemu/man_index.rst
+++ b/docs/ansible/roles/libvirtd_qemu/man_index.rst
@@ -13,6 +13,7 @@ debops.libvirtd_qemu
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/lldpd/man_index.rst
+++ b/docs/ansible/roles/lldpd/man_index.rst
@@ -13,6 +13,7 @@ debops.lldpd
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/logrotate/man_index.rst
+++ b/docs/ansible/roles/logrotate/man_index.rst
@@ -13,6 +13,7 @@ debops.logrotate
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/lvm/man_index.rst
+++ b/docs/ansible/roles/lvm/man_index.rst
@@ -13,6 +13,7 @@ debops.lvm
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/lxc/man_index.rst
+++ b/docs/ansible/roles/lxc/man_index.rst
@@ -14,6 +14,7 @@ debops.lxc
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/lxd/man_index.rst
+++ b/docs/ansible/roles/lxd/man_index.rst
@@ -13,6 +13,7 @@ debops.lxd
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/machine/man_index.rst
+++ b/docs/ansible/roles/machine/man_index.rst
@@ -13,6 +13,7 @@ debops.machine
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 .. note:: Name of this role was based on the :file:`/etc/machine-info`

--- a/docs/ansible/roles/mailman/man_index.rst
+++ b/docs/ansible/roles/mailman/man_index.rst
@@ -14,6 +14,13 @@ debops.mailman
    man_description
    getting-started
    mailman2-migration
+   defaults/main/core_configuration
+   defaults/main/dependent
+   defaults/main/environment
+   defaults/main/hyperkitty_configuration
+   defaults/main/ldap
+   defaults/main/templates
+   defaults/main/web_configuration
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/mariadb/man_index.rst
+++ b/docs/ansible/roles/mariadb/man_index.rst
@@ -13,6 +13,7 @@ debops.mariadb
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/mariadb_server/man_index.rst
+++ b/docs/ansible/roles/mariadb_server/man_index.rst
@@ -13,6 +13,7 @@ debops.mariadb_server
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/metricbeat/man_index.rst
+++ b/docs/ansible/roles/metricbeat/man_index.rst
@@ -13,6 +13,7 @@ debops.metricbeat
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/minidlna/man_index.rst
+++ b/docs/ansible/roles/minidlna/man_index.rst
@@ -13,6 +13,7 @@ debops.minidlna
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/miniflux/man_index.rst
+++ b/docs/ansible/roles/miniflux/man_index.rst
@@ -13,6 +13,7 @@ debops.miniflux
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/minio/man_index.rst
+++ b/docs/ansible/roles/minio/man_index.rst
@@ -14,6 +14,7 @@ debops.minio
    man_description
    getting-started
    deployment-guide
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/monit/man_index.rst
+++ b/docs/ansible/roles/monit/man_index.rst
@@ -14,6 +14,7 @@ debops.monit
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/mosquitto/man_index.rst
+++ b/docs/ansible/roles/mosquitto/man_index.rst
@@ -13,6 +13,7 @@ debops.mosquitto
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/mount/man_index.rst
+++ b/docs/ansible/roles/mount/man_index.rst
@@ -13,6 +13,7 @@ debops.mount
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/netbase/man_index.rst
+++ b/docs/ansible/roles/netbase/man_index.rst
@@ -13,6 +13,7 @@ debops.netbase
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/netbox/man_index.rst
+++ b/docs/ansible/roles/netbox/man_index.rst
@@ -13,6 +13,7 @@ debops.netbox
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/networkd/man_index.rst
+++ b/docs/ansible/roles/networkd/man_index.rst
@@ -13,6 +13,7 @@ debops.networkd
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
    man_seealso
 

--- a/docs/ansible/roles/nfs/man_index.rst
+++ b/docs/ansible/roles/nfs/man_index.rst
@@ -13,6 +13,7 @@ debops.nfs
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/nfs_server/man_index.rst
+++ b/docs/ansible/roles/nfs_server/man_index.rst
@@ -13,6 +13,7 @@ debops.nfs_server
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/nginx/man_index.rst
+++ b/docs/ansible/roles/nginx/man_index.rst
@@ -15,6 +15,7 @@ debops.nginx
    man_description
    getting-started
    acme-support
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/nixos/man_index.rst
+++ b/docs/ansible/roles/nixos/man_index.rst
@@ -13,6 +13,7 @@ debops.nixos
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/nscd/man_index.rst
+++ b/docs/ansible/roles/nscd/man_index.rst
@@ -13,6 +13,7 @@ debops.nscd
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/nslcd/man_index.rst
+++ b/docs/ansible/roles/nslcd/man_index.rst
@@ -13,6 +13,7 @@ debops.nslcd
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/nsswitch/man_index.rst
+++ b/docs/ansible/roles/nsswitch/man_index.rst
@@ -13,6 +13,7 @@ debops.nsswitch
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/nullmailer/man_index.rst
+++ b/docs/ansible/roles/nullmailer/man_index.rst
@@ -13,6 +13,7 @@ debops.nullmailer
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/opendkim/man_index.rst
+++ b/docs/ansible/roles/opendkim/man_index.rst
@@ -13,6 +13,7 @@ debops.opendkim
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
    defaults-config
 

--- a/docs/ansible/roles/opensearch/man_index.rst
+++ b/docs/ansible/roles/opensearch/man_index.rst
@@ -13,6 +13,7 @@ debops.opensearch
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/owncloud/man_index.rst
+++ b/docs/ansible/roles/owncloud/man_index.rst
@@ -17,6 +17,7 @@ debops.owncloud
    getting-started
    external-users
    external-storage
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/pam_access/man_index.rst
+++ b/docs/ansible/roles/pam_access/man_index.rst
@@ -13,6 +13,7 @@ debops.pam_access
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/pdns/man_index.rst
+++ b/docs/ansible/roles/pdns/man_index.rst
@@ -13,6 +13,7 @@ debops.pdns
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/persistent_paths/man_index.rst
+++ b/docs/ansible/roles/persistent_paths/man_index.rst
@@ -14,6 +14,7 @@ debops.persistent_paths
    man_description
    getting-started
    guides
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/pgbadger/man_index.rst
+++ b/docs/ansible/roles/pgbadger/man_index.rst
@@ -13,6 +13,7 @@ debops.pgbadger
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/php/man_index.rst
+++ b/docs/ansible/roles/php/man_index.rst
@@ -14,6 +14,7 @@ ebops.php
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/pki/man_index.rst
+++ b/docs/ansible/roles/pki/man_index.rst
@@ -24,6 +24,7 @@ debops.pki
    custom-files
    custom-hooks
    ansible-integration
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/postfix/man_index.rst
+++ b/docs/ansible/roles/postfix/man_index.rst
@@ -15,6 +15,7 @@ debops.postfix
    getting-started
    guides
    dependency
+   defaults/main
    defaults-detailed
    defaults-maincf
    defaults-mastercf

--- a/docs/ansible/roles/postgresql/man_index.rst
+++ b/docs/ansible/roles/postgresql/man_index.rst
@@ -13,6 +13,7 @@ debops.postgresql
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/postgresql_server/man_index.rst
+++ b/docs/ansible/roles/postgresql_server/man_index.rst
@@ -13,6 +13,7 @@ debops.postgresql_server
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/postscreen/man_index.rst
+++ b/docs/ansible/roles/postscreen/man_index.rst
@@ -13,6 +13,7 @@ debops.postscreen
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/preseed/man_index.rst
+++ b/docs/ansible/roles/preseed/man_index.rst
@@ -14,6 +14,7 @@ debops.preseed
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/rabbitmq_server/man_index.rst
+++ b/docs/ansible/roles/rabbitmq_server/man_index.rst
@@ -14,6 +14,7 @@ debops.rabbitmq_server
    man_description
    getting-started
    dependency
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/radvd/man_index.rst
+++ b/docs/ansible/roles/radvd/man_index.rst
@@ -13,6 +13,7 @@ debops.radvd
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/redis_sentinel/man_index.rst
+++ b/docs/ansible/roles/redis_sentinel/man_index.rst
@@ -14,6 +14,7 @@ debops.redis_sentinel
    man_description
    getting-started
    config-pipeline
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/redis_server/man_index.rst
+++ b/docs/ansible/roles/redis_server/man_index.rst
@@ -14,6 +14,7 @@ debops.redis_server
    man_description
    getting-started
    config-pipeline
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/reprepro/man_index.rst
+++ b/docs/ansible/roles/reprepro/man_index.rst
@@ -13,6 +13,7 @@ debops.reprepro
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/resolvconf/man_index.rst
+++ b/docs/ansible/roles/resolvconf/man_index.rst
@@ -13,6 +13,7 @@ debops.resolvconf
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/resolved/man_index.rst
+++ b/docs/ansible/roles/resolved/man_index.rst
@@ -14,6 +14,7 @@ debops.resolved
    man_description
    getting-started
    dnssd-support
+   defaults/main
    defaults-detailed
    man_seealso
 

--- a/docs/ansible/roles/resources/man_index.rst
+++ b/docs/ansible/roles/resources/man_index.rst
@@ -13,6 +13,7 @@ debops.resources
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/roundcube/man_index.rst
+++ b/docs/ansible/roles/roundcube/man_index.rst
@@ -13,6 +13,7 @@ debops.roundcube
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/rsnapshot/man_index.rst
+++ b/docs/ansible/roles/rsnapshot/man_index.rst
@@ -14,6 +14,7 @@ debops.rsnapshot
    man_description
    getting-started
    guides
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/rspamd/man_index.rst
+++ b/docs/ansible/roles/rspamd/man_index.rst
@@ -13,6 +13,7 @@ debops.rspamd
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/rstudio_server/man_index.rst
+++ b/docs/ansible/roles/rstudio_server/man_index.rst
@@ -13,6 +13,7 @@ debops.rstudio_server
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/rsyslog/man_index.rst
+++ b/docs/ansible/roles/rsyslog/man_index.rst
@@ -14,6 +14,7 @@ debops.rsyslog
    man_description
    getting-started
    unprivileged-tls
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/ruby/man_index.rst
+++ b/docs/ansible/roles/ruby/man_index.rst
@@ -13,6 +13,7 @@ debops.ruby
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/saslauthd/man_index.rst
+++ b/docs/ansible/roles/saslauthd/man_index.rst
@@ -13,6 +13,7 @@ debops.saslauthd
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/slapd/man_index.rst
+++ b/docs/ansible/roles/slapd/man_index.rst
@@ -18,6 +18,7 @@ debops.slapd
    ldap-acl
    backup-restore
    guide-multi-master-replication
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/sshd/man_index.rst
+++ b/docs/ansible/roles/sshd/man_index.rst
@@ -14,6 +14,7 @@ debops.sshd
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/sssd/man_index.rst
+++ b/docs/ansible/roles/sssd/man_index.rst
@@ -14,6 +14,7 @@ debops.sssd
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/stunnel/man_index.rst
+++ b/docs/ansible/roles/stunnel/man_index.rst
@@ -15,6 +15,7 @@ debops.stunnel
    getting-started
    guides
    troubleshooting
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/sudo/man_index.rst
+++ b/docs/ansible/roles/sudo/man_index.rst
@@ -13,6 +13,7 @@ debops.sudo
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/swapfile/man_index.rst
+++ b/docs/ansible/roles/swapfile/man_index.rst
@@ -14,6 +14,7 @@ debops.swapfile
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/sysctl/man_index.rst
+++ b/docs/ansible/roles/sysctl/man_index.rst
@@ -14,6 +14,7 @@ debops.sysctl
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/sysfs/man_index.rst
+++ b/docs/ansible/roles/sysfs/man_index.rst
@@ -13,6 +13,7 @@ debops.sysfs
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/sysnews/man_index.rst
+++ b/docs/ansible/roles/sysnews/man_index.rst
@@ -13,6 +13,7 @@ debops.sysnews
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/system_groups/man_index.rst
+++ b/docs/ansible/roles/system_groups/man_index.rst
@@ -13,6 +13,7 @@ debops.system_groups
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/system_users/man_index.rst
+++ b/docs/ansible/roles/system_users/man_index.rst
@@ -14,6 +14,7 @@ debops.system_users
    man_description
    getting-started
    control-user
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/systemd/man_index.rst
+++ b/docs/ansible/roles/systemd/man_index.rst
@@ -13,6 +13,7 @@ debops.systemd
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
    man_seealso
 

--- a/docs/ansible/roles/tcpwrappers/man_index.rst
+++ b/docs/ansible/roles/tcpwrappers/man_index.rst
@@ -13,6 +13,7 @@ debops.tcpwrappers
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/telegraf/man_index.rst
+++ b/docs/ansible/roles/telegraf/man_index.rst
@@ -13,6 +13,7 @@ debops.telegraf
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/tgt/man_index.rst
+++ b/docs/ansible/roles/tgt/man_index.rst
@@ -13,6 +13,7 @@ debops.tgt
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/timesyncd/man_index.rst
+++ b/docs/ansible/roles/timesyncd/man_index.rst
@@ -13,6 +13,7 @@ debops.timesyncd
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
    man_seealso
 

--- a/docs/ansible/roles/tinc/man_index.rst
+++ b/docs/ansible/roles/tinc/man_index.rst
@@ -15,6 +15,7 @@ debops.tinc
    man_description
    getting-started
    examples
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/tinyproxy/man_index.rst
+++ b/docs/ansible/roles/tinyproxy/man_index.rst
@@ -14,6 +14,7 @@ debops.tinyproxy
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/unattended_upgrades/man_index.rst
+++ b/docs/ansible/roles/unattended_upgrades/man_index.rst
@@ -14,6 +14,7 @@ debops.unattended_upgrades
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/unbound/man_index.rst
+++ b/docs/ansible/roles/unbound/man_index.rst
@@ -13,6 +13,7 @@ debops.unbound
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
    defaults-server
 

--- a/docs/ansible/roles/users/man_index.rst
+++ b/docs/ansible/roles/users/man_index.rst
@@ -13,6 +13,7 @@ debops.users
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/yadm/man_index.rst
+++ b/docs/ansible/roles/yadm/man_index.rst
@@ -13,6 +13,7 @@ debops.yadm
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/ansible/roles/zabbix_agent/man_index.rst
+++ b/docs/ansible/roles/zabbix_agent/man_index.rst
@@ -13,6 +13,7 @@ debops.zabbix_agent
    man_synopsis
    man_description
    getting-started
+   defaults/main
    defaults-detailed
 
 ..

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,7 @@ sys.path.insert(0, os.path.abspath('_lib'))
 
 import yaml2rst  # noqa
 import edit_url  # noqa
+import manpages  # noqa
 
 rst_ansible_roles = 'ansible/roles/'
 yml_ansible_roles = '../ansible/roles/'
@@ -101,6 +102,7 @@ html_context = {
 def setup(app):
     # app.add_javascript("custom.js")
     app.add_css_file("theme_overrides.css")
+    manpages.setup(app)
 
 
 # -- General configuration ------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,9 @@ yml_ansible_roles = '../ansible/roles/'
 
 # Convert Ansible role defaults files written in YAML to documentation written
 # in reStructuredText
+converter_mtime = os.stat(
+    os.path.join(os.path.dirname(yaml2rst.__file__), 'func.py')
+).st_mtime_ns
 for element in os.listdir(rst_ansible_roles):
     if os.path.isdir(yml_ansible_roles + element + '/defaults'):
         for path, subdirs, files in os.walk(yml_ansible_roles +
@@ -55,7 +58,8 @@ for element in os.listdir(rst_ansible_roles):
                     if os.path.exists(dst_file):
                         src_stat = os.stat(defaults_file)
                         dst_stat = os.stat(dst_file)
-                        if dst_stat.st_mtime_ns >= src_stat.st_mtime_ns:
+                        if (dst_stat.st_mtime_ns >= src_stat.st_mtime_ns
+                                and dst_stat.st_mtime_ns >= converter_mtime):
                             continue
 
                     yaml2rst.convert_file(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,7 @@ for element in os.listdir(rst_ansible_roles):
                         (os.path.splitext(defaults_file)[0]
                             + '.rst').lstrip('../'),
                         strip_regex=r'\s*(:?\[{3}|\]{3})\d?$',
-                        yaml_strip_regex=r'^\s{66,67}#\s\]{3}\d?$',
+                        yaml_strip_regex=r'\s*#\s*(\[{3}|\]{3})\d?\s*$',
                     )
 
 


### PR DESCRIPTION
The manual pages generated for each DebOps role now include the role
default variables, rendered from the `defaults/main.yml` files and
listed before the existing `defaults-detailed` section. Descriptions
and their default values are indented inside each variable definition,
and long lines in the man page output are hard-wrapped to fit a
standard terminal, making the reference readable and removing the
stray vim fold markers that previously appeared in the generated
pages. The mailman role, which keeps its defaults in a `defaults/main`
subdirectory, references each of its defaults files separately.
