### PR TITLE
Fix non-boolean conditionals for Ansible 2.19 (~all roles)

### DIFF
--- a/ansible/roles/apache/tasks/main.yml
+++ b/ansible/roles/apache/tasks/main.yml
@@ -70,7 +70,7 @@
     group: 'root'
     mode: '0644'
   when: (item.value.state | d("present") != "absent" and
-         (item.value.type | d("default") not in ["divert", "dont-create"] or item.value.raw | d()))
+         (item.value.type | d("default") not in ["divert", "dont-create"] or (item.value.raw is defined and item.value.raw is truthy)))
   with_dict: '{{ apache__combined_snippets }}'
   notify: [ 'Test apache and reload' ]
 

--- a/ansible/roles/apt/tasks/main.yml
+++ b/ansible/roles/apt/tasks/main.yml
@@ -39,7 +39,7 @@
                            + apt__host_keys) }}'
   register: apt__register_apt_key
   until: apt__register_apt_key is succeeded
-  when: apt__enabled | bool and (item.url | d() or item.data | d() or item.id | d() or item.file | d()) and
+  when: apt__enabled | bool and ((item.url is defined and item.url is truthy) or (item.data is defined and item.data is truthy) or (item.id is defined and item.id is truthy) or (item.file is defined and item.file is truthy)) and
         (item.apt_key | d(False)) | bool
   tags: [ 'role::apt:keys' ]
 
@@ -75,7 +75,7 @@
                            + apt__host_keys) }}'
   register: apt__register_apt_key_get
   until: apt__register_apt_key_get is succeeded
-  when: apt__enabled | bool and (item.url | d()) and (item.state | d("present")) not in [ "absent" ] and
+  when: apt__enabled | bool and (item.url is defined and item.url is truthy) and (item.state | d("present")) not in [ "absent" ] and
         not (item.apt_key | d(False)) | bool
   tags: [ 'role::apt:keys' ]
 
@@ -86,7 +86,7 @@
   loop: '{{ q("flattened", apt__keys
                            + apt__group_keys
                            + apt__host_keys) }}'
-  when: apt__enabled | bool and ((item.url | d()) or (item.keyring | d())) and
+  when: apt__enabled | bool and ((item.url is defined and item.url is truthy) or (item.keyring is defined and item.keyring is truthy)) and
         (item.state | d("present")) in [ "absent" ] and not (item.apt_key | d(False)) | bool
 
 - name: Add/remove diversion of repository sources
@@ -115,7 +115,7 @@
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
   register: apt__register_apt_repositories
-  when: (apt__enabled | bool and item.repo | d() and item.uris is undefined and
+  when: (apt__enabled | bool and item.repo is defined and item.repo is truthy and item.uris is undefined and
          (item.state | d("present")) not in [ "divert", "ignore", "init" ])
 
 - name: Configure custom APT Deb822 repositories
@@ -163,7 +163,7 @@
     dest: '{{ "/etc/apt/auth.conf.d/" + (item.filename | d(item.name | regex_replace(".conf$", "") + ".conf")) }}'
     mode: '0640'
   loop: '{{ q("flattened", (apt__auth_files + apt__group_auth_files + apt__host_auth_files)) }}'
-  when: apt__enabled | bool and item.machine | d() and item.login | d() and item.password | d() and
+  when: apt__enabled | bool and item.machine is defined and item.machine is truthy and item.login is defined and item.login is truthy and item.password is defined and item.password is truthy and
         item.state | d('present') not in ['absent', 'ignore']
   no_log: '{{ debops__no_log | d(True) }}'
 
@@ -214,7 +214,7 @@
   loop: '{{ apt__combined_configuration | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
-  when: apt__enabled | bool and item.raw | d() and item.state | d('present') == 'absent'
+  when: apt__enabled | bool and item.raw is defined and item.raw is truthy and item.state | d('present') == 'absent'
 
 - name: Generate APT configuration files
   ansible.builtin.template:
@@ -224,7 +224,7 @@
   loop: '{{ apt__combined_configuration | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
-  when: apt__enabled | bool and item.raw | d() and
+  when: apt__enabled | bool and item.raw is defined and item.raw is truthy and
         item.state | d('present') not in [ 'divert', 'absent', 'ignore', 'init' ]
 
 - name: Make sure that Ansible local facts directory exists

--- a/ansible/roles/atd/tasks/main.yml
+++ b/ansible/roles/atd/tasks/main.yml
@@ -85,8 +85,8 @@
   loop: '{{ q("flattened", atd_default_deny
                            + atd_deny) }}'
   when: (atd_enabled | bool and
-         (atd_default_deny | d() or atd_deny | d()) and
-          item | d())
+         ((atd_default_deny is defined and atd_default_deny is truthy) or (atd_deny is defined and atd_deny is truthy)) and
+         (item is defined and item is truthy))
   tags: [ 'role::atd:users' ]
 
 - name: Make sure that Ansible local facts directory exists

--- a/ansible/roles/authorized_keys/tasks/main.yml
+++ b/ansible/roles/authorized_keys/tasks/main.yml
@@ -33,7 +33,7 @@
   loop: '{{ lookup("template", "lookup/authorized_keys__identities.j2") | from_yaml }}'
   loop_control:
     label: '{{ {"identity": item.identity, "group": item.group} }}'
-  when: authorized_keys__enabled | bool and item.group | d() and
+  when: authorized_keys__enabled | bool and item.group is defined and item.group is truthy and
         item.state | d('present') not in ['absent', 'ignore', 'init'] and
         item.file_state | d('present') not in ['absent', 'ignore', 'init']
 
@@ -96,7 +96,7 @@
                                 if (item.owner | d("root") in getent_passwd | d({}))
                                 else "root")),
                 "path": item.path} }}'
-  when: authorized_keys__enabled | bool and item.path | d() and not item.manage_dir | bool and
+  when: authorized_keys__enabled | bool and item.path is defined and item.path is truthy and not item.manage_dir | bool and
         item.state | d('present') not in ['absent', 'ignore', 'init'] and not ansible_check_mode
 
 - name: Make sure that Ansible local facts directory exists

--- a/ansible/roles/avahi/tasks/avahi_alias.yml
+++ b/ansible/roles/avahi/tasks/avahi_alias.yml
@@ -43,7 +43,7 @@
     mode: '0644'
   with_dict: '{{ avahi__combined_services }}'
   register: avahi__register_aliases
-  when: item.value.cname | d()
+  when: item.value.cname is defined and item.value.cname is truthy
 
 - name: Manage avahi-alias.service
   ansible.builtin.systemd:

--- a/ansible/roles/avahi/tasks/main.yml
+++ b/ansible/roles/avahi/tasks/main.yml
@@ -109,7 +109,7 @@
     state: 'present'
     mode: '0644'
   with_dict: '{{ avahi__hosts | combine(avahi__group_hosts) | combine(avahi__host_hosts) }}'
-  when: item.key | d() and item.value | d()
+  when: item.key is defined and item.key is truthy and item.value is defined and item.value is truthy
 
 - name: Configure Avahi CNAME aliases
   ansible.builtin.include_tasks: avahi_alias.yml
@@ -133,7 +133,8 @@
     mode: '0644'
   with_dict: '{{ avahi__combined_services }}'
   when: (item.value.filename | d(item.key) and item.value.state | d('present') != 'absent' and
-         (item.value.services | d() or item.value.type | d()))
+         ((item.value.services is defined and item.value.services is truthy) or
+          (item.value.type is defined and item.value.type is truthy)))
   tags: [ 'role::avahi:alias', 'role::avahi:services' ]
 
 - name: Ensure that the avahi-daemon service in in the desired state

--- a/ansible/roles/controller/tasks/main.yml
+++ b/ansible/roles/controller/tasks/main.yml
@@ -43,12 +43,12 @@
     dest: '{{ controller__project_name if controller__project_name else controller__project_git_repo | basename }}'
     version: 'master'
     update: True
-  when: controller__project_git_repo | d()
+  when: controller__project_git_repo is defined and controller__project_git_repo is truthy
 
 - name: Initialize new project
   become: '{{ controller__install_systemwide | bool }}'
   ansible.builtin.command: debops-init '{{ controller__project_name }}'
   args:
     creates: '{{ controller__project_name }}/.debops.cfg'
-  when: controller__project_name | d() and
+  when: controller__project_name is defined and controller__project_name is truthy and
         not controller__project_git_repo | d()

--- a/ansible/roles/cran/tasks/main.yml
+++ b/ansible/roles/cran/tasks/main.yml
@@ -23,7 +23,7 @@
   register: cran__register_java_reconf
   changed_when: cran__register_java_reconf.changed | bool
   when: (cran__java_integration | bool and
-         (ansible_local | d() and ansible_local.cran is undefined))
+         (ansible_local is defined and ansible_local.cran is undefined))
 
 - name: Manage R packages
   cran:  # noqa fqcn

--- a/ansible/roles/cron/tasks/main.yml
+++ b/ansible/roles/cron/tasks/main.yml
@@ -64,7 +64,7 @@
     - '{{ cron__combined_jobs | selectattr("custom_files", "defined") | list }}'
     - 'custom_files'
   when: (cron__enabled | bool and (item.0.state | d('present') == 'absent' or item.1.state | d('present') == 'absent') and
-         (item.1.src | d() or item.1.content | d()) and item.1.dest | d())
+         ((item.1.src is defined and item.1.src is truthy) or (item.1.content is defined and item.1.content is truthy)) and item.1.dest is defined and item.1.dest is truthy))
 
 - name: Manage custom cron files
   ansible.builtin.copy:
@@ -80,7 +80,7 @@
     - 'custom_files'
   when: (cron__enabled | bool and item.0.state | d('present') not in ['absent', 'ignore'] and
          item.1.state | d('present') != 'absent' and
-         (item.1.src | d() or item.1.content | d()) and item.1.dest | d())
+         ((item.1.src is defined and item.1.src is truthy) or (item.1.content is defined and item.1.content is truthy)) and item.1.dest is defined and item.1.dest is truthy))
 
 - name: Remove cron job files
   ansible.builtin.file:

--- a/ansible/roles/cryptsetup/tasks/manage_devices.yml
+++ b/ansible/roles/cryptsetup/tasks/manage_devices.yml
@@ -274,7 +274,7 @@
     force:  '{{ item.0.format_force | d(omit) }}'
     fstype: '{{ item.0.fstype | d(cryptsetup__fstype) }}'
     opts:   '{{ item.0.format_options | d(omit) }}'
-  when: (item.1 | d() and item.1.stat | d() and item.1.stat.exists | d() and
+  when: (item.1 is defined and item.1.stat is defined and item.1.stat.exists is defined and item.1.stat.exists is truthy and
          (item.0.create_filesystem | d(item.0.manage_filesystem | d(True)) | bool) and
          not (item.0.swap | d(False) | bool))
   with_together:

--- a/ansible/roles/debconf/tasks/main.yml
+++ b/ansible/roles/debconf/tasks/main.yml
@@ -70,7 +70,7 @@
                            + debconf__alternatives
                            + debconf__group_alternatives
                            + debconf__host_alternatives) }}'
-  when: item.name | d() and item.path | d()
+  when: item.name is defined and item.name is truthy and item.path is defined and item.path is truthy
 
 - name: Configure automatic alternatives
   ansible.builtin.command: update-alternatives --auto {{ item.name }}
@@ -78,8 +78,8 @@
   loop: '{{ q("flattened", debconf__alternatives
                            + debconf__group_alternatives
                            + debconf__host_alternatives) }}'
-  when: item.name | d() and not item.path | d()
-  changed_when: debconf__register_alternatives.stdout | d()
+  when: item.name is defined and item.name is truthy and not item.path | d()
+  changed_when: debconf__register_alternatives.stdout is defined and debconf__register_alternatives.stdout is truthy
 
 # Execute custom shell commands [[[1
 # This is not an alternative to a fully-fledged Ansible role.
@@ -88,6 +88,6 @@
   loop: '{{ q("flattened", debconf__combined_commands) | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"name": item.name} }}'
-  when: item.name | d() and item.state | d('present') not in [ 'absent', 'ignore' ]
+  when: item.name is defined and item.name is truthy and item.state | d('present') not in [ 'absent', 'ignore' ]
   no_log: '{{ debops__no_log | d(item.no_log) | d(False) }}'
   tags: [ 'role::debconf:commands' ]

--- a/ansible/roles/debconf/tasks/shell_commands.yml
+++ b/ansible/roles/debconf/tasks/shell_commands.yml
@@ -10,6 +10,6 @@
     creates:    '{{ item.creates | d(omit) }}'
     removes:    '{{ item.removes | d(omit) }}'
     executable: '{{ item.executable | d("bash") }}'
-  when: item.name | d() and item.state not in ['absent', 'ignore']
+  when: item.name is defined and item.name is truthy and item.state not in ['absent', 'ignore']
   no_log: '{{ debops__no_log | d(item.no_log) | d(False) }}'
   tags: [ 'role::late_tasks:commands' ]

--- a/ansible/roles/dhcp_probe/tasks/main.yml
+++ b/ansible/roles/dhcp_probe/tasks/main.yml
@@ -48,7 +48,7 @@
   loop: '{{ dhcp_probe__combined_interfaces | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"name": item.name, "state": item.state} }}'
-  when: ansible_service_mgr == 'systemd' and item.name | d() and
+  when: ansible_service_mgr == 'systemd' and item.name is defined and item.name is truthy and
         item.state | d('present') == 'absent'
 
 - name: Enable DHCP Probe instances if requested
@@ -58,7 +58,7 @@
   loop: '{{ dhcp_probe__combined_interfaces | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"name": item.name, "state": item.state} }}'
-  when: ansible_service_mgr == 'systemd' and item.name | d() and
+  when: ansible_service_mgr == 'systemd' and item.name is defined and item.name is truthy and
         item.state | d('present') != 'absent'
   notify: [ 'Restart dhcp-probe' ]
 

--- a/ansible/roles/dnsmasq/tasks/main.yml
+++ b/ansible/roles/dnsmasq/tasks/main.yml
@@ -58,7 +58,7 @@
     state: 'absent'
   with_items: '{{ dnsmasq__combined_configuration | debops.debops.parse_kv_items }}'
   notify: [ 'Test and restart dnsmasq' ]
-  when: (item.name | d() and item.state | d('present') == 'absent')
+  when: (item.name is defined and item.name is truthy and item.state | d('present') == 'absent')
 
 - name: Generate dnsmasq configuration
   ansible.builtin.template:
@@ -69,14 +69,14 @@
     mode: '0644'
   with_items: '{{ dnsmasq__combined_configuration | debops.debops.parse_kv_items }}'
   notify: [ 'Test and restart dnsmasq' ]
-  when: (item.name | d() and item.state | d('present') not in ['absent', 'ignore', 'init'])
+  when: (item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore', 'init'])
 
 - name: Remove DHCP host configuration and DNS records if requested
   ansible.builtin.file:
     path: '/etc/dnsmasq.d/{{ dnsmasq__dhcp_dns_filename }}'
     state: 'absent'
   notify: [ 'Test and restart dnsmasq' ]
-  when: not dnsmasq__dhcp_hosts | d() and not dnsmasq__dns_records | d()
+  when: not dnsmasq__dhcp_hosts is truthy and not dnsmasq__dns_records is truthy
 
 - name: Generate DHCP host configuration and DNS records
   ansible.builtin.template:
@@ -86,7 +86,7 @@
     group: 'root'
     mode: '0644'
   notify: [ 'Test and restart dnsmasq' ]
-  when: dnsmasq__dhcp_hosts | d() or dnsmasq__dns_records | d()
+  when: dnsmasq__dhcp_hosts is truthy or dnsmasq__dns_records is truthy
 
 - name: Divert original dnsmasq environment file
   debops.debops.dpkg_divert:
@@ -112,4 +112,4 @@
     mode: '0644'
     unsafe_writes: '{{ True if (core__unsafe_writes | d(ansible_local.core.unsafe_writes | d()) | bool) else omit }}'
   notify: [ 'Test and restart dnsmasq' ]
-  when: dnsmasq__nameservers | d()
+  when: dnsmasq__nameservers is truthy

--- a/ansible/roles/dnsmasq/templates/lookup/dnsmasq__interface_configuration.j2
+++ b/ansible/roles/dnsmasq/templates/lookup/dnsmasq__interface_configuration.j2
@@ -81,7 +81,7 @@
 }) %}
 {%       endfor %}
 {%       for host_address in dnsmasq__tpl_ipv6 %}
-{%         if (interface.dhcp_ipv6_mode is string and interface.dhcp_ipv6_mode == '') %}
+{%         if (interface.dhcp_ipv6_mode is defined and interface.dhcp_ipv6_mode is string and interface.dhcp_ipv6_mode == '') %}
 {%           set ra_separator = '' %}
 {%         else %}
 {%           set ra_separator = ',' %}

--- a/ansible/roles/docker_gen/tasks/main.yml
+++ b/ansible/roles/docker_gen/tasks/main.yml
@@ -96,5 +96,5 @@
     name: 'docker-gen'
     state: 'started'
     enabled: True
-  when: docker_gen__register_install | d() and
+  when: docker_gen__register_install is defined and
         docker_gen__register_install is changed

--- a/ansible/roles/docker_service/tasks/main.yml
+++ b/ansible/roles/docker_service/tasks/main.yml
@@ -91,7 +91,7 @@
     label: '{{ docker_service__config_dir_service.name }}'
   when:
     - docker_service__config_dir_service.state | d('present') not in ['absent', 'ignore']
-    - docker_service__config_dir_service.config_dir.src | d()
+    - docker_service__config_dir_service.config_dir.src is defined and docker_service__config_dir_service.config_dir.src is truthy
   tags: ['role::docker_service:config']
 
 - name: Create Docker networks referenced by services

--- a/ansible/roles/dokuwiki/tasks/main.yml
+++ b/ansible/roles/dokuwiki/tasks/main.yml
@@ -111,7 +111,8 @@
   loop: '{{ q("flattened", dokuwiki__default_plugins
                            + dokuwiki__plugins) }}'
   when: (dokuwiki__plugins_enabled | bool and
-         (item.dest | d() and item.dest) and (item.state | d() and item.state == 'absent'))
+         (item.dest is defined and item.dest is truthy) and
+        (item.state | d('present') == 'absent'))
 
 - name: Install specified plugins from git repositories
   ansible.builtin.git:
@@ -126,8 +127,8 @@
   register: dokuwiki__register_git_plugins
   until: dokuwiki__register_git_plugins is succeeded
   when: (dokuwiki__plugins_enabled | bool and
-         (item.repo | d() and item.repo) and (item.dest | d() and item.dest) and
-         (item.state is undefined or (item.state | d() and item.state != 'absent')))
+         (item.repo is defined and item.repo is truthy) and (item.dest is defined and item.dest is truthy) and
+         (item.state | d('present') != 'absent'))
 
 - name: Remove specified templates if requested
   ansible.builtin.file:
@@ -136,7 +137,8 @@
   loop: '{{ q("flattened", dokuwiki__default_templates
                            + dokuwiki__templates) }}'
   when: (dokuwiki__plugins_enabled | bool and
-         (item.dest | d() and item.dest) and (item.state | d() and item.state == 'absent'))
+         (item.dest is defined and item.dest is truthy) and
+        (item.state | d('present') == 'absent'))
 
 - name: Install specified templates from git repositories
   ansible.builtin.git:
@@ -151,8 +153,8 @@
   register: dokuwiki__register_git_templates
   until: dokuwiki__register_git_templates is succeeded
   when: (dokuwiki__plugins_enabled | bool and
-         (item.repo | d() and item.repo) and (item.dest | d() and item.dest) and
-         (item.state is undefined or (item.state | d() and item.state != 'absent')))
+         (item.repo is defined and item.repo is truthy) and (item.dest is defined and item.dest is truthy) and
+         (item.state | d('present') != 'absent'))
 
 - name: Generate protected local configuration file
   ansible.builtin.template:
@@ -241,7 +243,7 @@
   loop: '{{ q("flattened", dokuwiki__extra_files
                            + dokuwiki__group_extra_files
                            + dokuwiki__host_extra_files) }}'
-  when: (item.dest | d() or item.path | d() or item.name | d()) and
+  when: ((item.dest is defined and item.dest is truthy) or (item.path is defined and item.path is truthy) or (item.name is defined and item.name is truthy)) and
         (item.state | d('present') == 'absent')
   tags: [ 'role::dokuwiki' ]
 
@@ -266,8 +268,8 @@
   loop: '{{ q("flattened", dokuwiki__extra_files
                            + dokuwiki__group_extra_files
                            + dokuwiki__host_extra_files) }}'
-  when: (item.src | d() or item.content is defined) and
-        (item.dest | d() or item.path | d() or item.name | d()) and
+  when: ((item.src is defined and item.src is truthy) or (item.content is defined)) and
+        ((item.dest is defined and item.dest is truthy) or (item.path is defined and item.path is truthy) or (item.name is defined and item.name is truthy)) and
         (item.state | d('present') != 'absent')
   tags: [ 'role::dokuwiki' ]
 

--- a/ansible/roles/elasticsearch/tasks/authentication.yml
+++ b/ansible/roles/elasticsearch/tasks/authentication.yml
@@ -37,7 +37,7 @@
   loop: '{{ elasticsearch__register_builtin_users.stdout_lines }}'
   become: False
   delegate_to: 'localhost'
-  when: elasticsearch__register_builtin_users.stdout_lines | d()
+  when: elasticsearch__register_builtin_users.stdout_lines is defined and elasticsearch__register_builtin_users.stdout_lines is truthy
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Save generated user passwords on Ansible Controller
@@ -48,5 +48,5 @@
   loop: '{{ elasticsearch__register_builtin_users.stdout_lines }}'
   become: False
   delegate_to: 'localhost'
-  when: elasticsearch__register_builtin_users.stdout_lines | d()
+  when: elasticsearch__register_builtin_users.stdout_lines is defined and elasticsearch__register_builtin_users.stdout_lines is truthy
   no_log: '{{ debops__no_log | d(True) }}'

--- a/ansible/roles/elasticsearch/tasks/main.yml
+++ b/ansible/roles/elasticsearch/tasks/main.yml
@@ -31,7 +31,7 @@
     name: '{{ elasticsearch__user }}'
     groups: '{{ elasticsearch__additional_groups }}'
     append: True
-  when: elasticsearch__additional_groups | d()
+  when: elasticsearch__additional_groups is truthy
 
 - name: Make sure that Ansible local facts directory exists
   ansible.builtin.file:
@@ -78,7 +78,7 @@
   register: elasticsearch__register_dependent_config_file
   become: False
   delegate_to: 'localhost'
-  when: (ansible_local.elasticsearch.installed | d())
+  when: (ansible_local.elasticsearch.installed is defined and ansible_local.elasticsearch.installed is truthy)
   tags: [ 'role::elasticsearch:config' ]
 
 - name: Load the dependent configuration from Ansible Controller
@@ -87,7 +87,7 @@
   register: elasticsearch__register_dependent_config
   become: False
   delegate_to: 'localhost'
-  when: (ansible_local.elasticsearch.installed | d() and
+  when: (ansible_local.elasticsearch.installed is defined and ansible_local.elasticsearch.installed is truthy and
          elasticsearch__register_dependent_config_file.stat.exists | bool)
   tags: [ 'role::elasticsearch:config' ]
 
@@ -168,7 +168,7 @@
   loop: '{{ q("flattened", elasticsearch__combined_plugins) }}'
   register: elasticsearch__register_plugin_install
   changed_when: elasticsearch__register_plugin_install.changed | bool
-  when: (item.name | d() and item.state | d('present') != 'absent' and
+  when: (item.name is defined and item.name is truthy and item.state | d('present') != 'absent' and
          (item.name if ':' not in item.name else item.name.split(':')[1])
          not in elasticsearch__register_plugins.stdout_lines)
 
@@ -180,7 +180,7 @@
   loop: '{{ q("flattened", elasticsearch__combined_plugins) }}'
   register: elasticsearch__register_plugin_remove
   changed_when: elasticsearch__register_plugin_remove.changed | bool
-  when: (item.name | d() and item.state | d('present') == 'absent' and
+  when: (item.name is defined and item.name is truthy and item.state | d('present') == 'absent' and
          (item.name if ':' not in item.name else item.name.split(':')[1])
          in elasticsearch__register_plugins.stdout_lines)
 

--- a/ansible/roles/elasticsearch/tasks/reset_password.yml
+++ b/ansible/roles/elasticsearch/tasks/reset_password.yml
@@ -21,7 +21,7 @@
     mode: '0755'
   become: False
   delegate_to: 'localhost'
-  when: elasticsearch__register_builtin_password.stdout_lines | d()
+  when: elasticsearch__register_builtin_password.stdout_lines is defined and elasticsearch__register_builtin_password.stdout_lines is truthy
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Save generated password of account '{{ item }}'
@@ -31,5 +31,5 @@
     mode: '0644'
   become: False
   delegate_to: 'localhost'
-  when: elasticsearch__register_builtin_password.stdout | d()
+  when: elasticsearch__register_builtin_password.stdout is defined and elasticsearch__register_builtin_password.stdout is truthy
   no_log: '{{ debops__no_log | d(True) }}'

--- a/ansible/roles/etc_aliases/tasks/main.yml
+++ b/ansible/roles/etc_aliases/tasks/main.yml
@@ -21,7 +21,7 @@
   register: etc_aliases__register_dependent_recipients_file
   become: False
   delegate_to: 'localhost'
-  when: (ansible_local | d() and ansible_local.etc_aliases | d() and
+  when: (ansible_local is defined and ansible_local.etc_aliases is defined and
          ansible_local.etc_aliases.configured is defined and
          ansible_local.etc_aliases.configured | bool)
 
@@ -31,7 +31,7 @@
   register: etc_aliases__register_dependent_recipients
   become: False
   delegate_to: 'localhost'
-  when: (ansible_local | d() and ansible_local.etc_aliases | d() and
+  when: (ansible_local is defined and ansible_local.etc_aliases is defined and
          ansible_local.etc_aliases.configured is defined and
          ansible_local.etc_aliases.configured | bool and
          etc_aliases__register_dependent_recipients_file.stat.exists | bool)

--- a/ansible/roles/etc_services/tasks/main.yml
+++ b/ansible/roles/etc_services/tasks/main.yml
@@ -55,7 +55,7 @@
     path: '/etc/services.d/{{ item.filename | default("20_local_service_" + item.name) }}'
     state: 'absent'
   loop: '{{ q("flattened", etc_services__combined_list) }}'
-  when: ((not etc_services__enabled | bool or item.delete | d() or
+  when: ((not etc_services__enabled | bool or (item.delete | d() | bool) or
           item.state | d('present') == 'absent') and
          ((item.name is defined and item.name is truthy and item.port is defined and item.port is truthy) or (item.custom is defined and item.custom is truthy)))
 

--- a/ansible/roles/etckeeper/tasks/main.yml
+++ b/ansible/roles/etckeeper/tasks/main.yml
@@ -146,7 +146,7 @@
 - name: Configure other VCS software
   ansible.builtin.include_tasks: 'other_vcs.yml'
   when: etckeeper__enabled | bool and etckeeper__vcs != 'git' and
-        etckeeper__vcs_user | d() and etckeeper__vcs_email | d()
+        etckeeper__vcs_user is defined and etckeeper__vcs_user is truthy and etckeeper__vcs_email is defined and etckeeper__vcs_email is truthy
 
 - name: Unstage and remove ignored files from Git index
   ansible.builtin.shell: set -o nounset -o pipefail -o errexit &&

--- a/ansible/roles/etckeeper/tasks/other_vcs.yml
+++ b/ansible/roles/etckeeper/tasks/other_vcs.yml
@@ -8,16 +8,16 @@
   ansible.builtin.command: etckeeper vcs whoami '{{ etckeeper__vcs_user }} <{{ etckeeper__vcs_email }}>'
   register: etckeeper__register_bzr_owner
   changed_when: etckeeper__register_bzr_owner.changed | bool
-  when: (etckeeper__vcs == 'bzr' and etckeeper__vcs_user | d() and etckeeper__vcs_email | d())
+  when: (etckeeper__vcs == 'bzr' and etckeeper__vcs_user is defined and etckeeper__vcs_user is truthy and etckeeper__vcs_email is defined and etckeeper__vcs_email is truthy)
 
 - name: Set user, email for the darcs repository
   ansible.builtin.command: etckeeper vcs setpref author '{{ etckeeper__vcs_user }} <{{ etckeeper__vcs_email }}>'
   register: etckeeper__register_darcs_owner
   changed_when: etckeeper__register_darcs_owner.changed | bool
-  when: (etckeeper__vcs == 'darcs' and etckeeper__vcs_user | d() and etckeeper__vcs_email | d())
+  when: (etckeeper__vcs == 'darcs' and etckeeper__vcs_user is defined and etckeeper__vcs_user is truthy and etckeeper__vcs_email is defined and etckeeper__vcs_email is truthy)
 
 - name: Set user, email for the hg repository  # noqa no-shorthand
   ansible.builtin.command: "etckeeper vcs --config 'ui.username={{ etckeeper__vcs_user }} <{{ etckeeper__vcs_email }}>'"
   register: etckeeper__register_hg_owner
   changed_when: etckeeper__register_hg_owner.changed | bool
-  when: (etckeeper__vcs == 'hg' and etckeeper__vcs_user | d() and etckeeper__vcs_email | d())
+  when: (etckeeper__vcs == 'hg' and etckeeper__vcs_user is defined and etckeeper__vcs_user is truthy and etckeeper__vcs_email is defined and etckeeper__vcs_email is truthy)

--- a/ansible/roles/etesync/handlers/main.yml
+++ b/ansible/roles/etesync/handlers/main.yml
@@ -7,5 +7,5 @@
   ansible.builtin.service:
     name: 'gunicorn@etesync'
     state: 'restarted'
-  when: (ansible_local | d() and ansible_local.gunicorn | d() and
+  when: (ansible_local is defined and ansible_local.gunicorn is defined and
          ansible_local.gunicorn.installed | bool)

--- a/ansible/roles/etesync/tasks/main.yml
+++ b/ansible/roles/etesync/tasks/main.yml
@@ -191,7 +191,7 @@
     to: '{{ etesync__mail_to | d([]) | list | join(",") }}'
     charset: 'utf8'
     body: '{{ etesync__mail_body }}'
-  when: (etesync__http_psk_subpath | d() and etesync__mail_to | d() and "etesync" not in ansible_local)
+  when: (etesync__http_psk_subpath is defined and etesync__http_psk_subpath is truthy and etesync__mail_to is defined and etesync__mail_to is truthy and "etesync" not in ansible_local)
 
 # Save EteSync local facts [[[1
 - name: Make sure that Ansible local facts directory exists

--- a/ansible/roles/etherpad/tasks/main.yml
+++ b/ansible/roles/etherpad/tasks/main.yml
@@ -232,7 +232,7 @@
 - name: Display API call responses for debugging
   ansible.builtin.debug:
     var: etherpad_api_calls_exec
-  when: etherpad_api_calls_exec | d() and etherpad_api_calls_debug
+  when: etherpad_api_calls_exec is defined and etherpad_api_calls_debug
   tags: [ 'role::etherpad:api', 'role::etherpad:api:call' ]
 
 - name: Make sure that Ansible local facts directory exists

--- a/ansible/roles/ferm/tasks/main.yml
+++ b/ansible/roles/ferm/tasks/main.yml
@@ -156,7 +156,7 @@
                            + ferm_input_group_list
                            + ferm_input_host_list
                            + ferm_input_dependent_list) }}'
-  when: (ferm__enabled | bool and item.type | d() and (item.delete | d() | bool))
+  when: (ferm__enabled | bool and item.type is defined and item.type is truthy and (item.delete | d() | bool))
   register: ferm__register_input_rules_del
   tags: [ 'role::ferm:rules' ]
 
@@ -173,7 +173,7 @@
                            + ferm_input_group_list
                            + ferm_input_host_list
                            + ferm_input_dependent_list) }}'
-  when: (ferm__enabled | bool and item.type | d() and not (item.delete | d() | bool))
+  when: (ferm__enabled | bool and item.type is defined and item.type is truthy and not (item.delete | d() | bool))
   register: ferm__register_input_rules_add
   tags: [ 'role::ferm:rules' ]
 

--- a/ansible/roles/filebeat/tasks/main.yml
+++ b/ansible/roles/filebeat/tasks/main.yml
@@ -64,7 +64,7 @@
   loop: '{{ filebeat__combined_snippets | debops.debops.parse_kv_config }}'
   loop_control:
     label:  '{{ {"name": item.name, "state": item.state} }}'
-  when: item.state | d('present') not in ['absent', 'ignore', 'init'] and item.config | d()
+  when: item.state | d('present') not in ['absent', 'ignore', 'init'] and item.config is defined and item.config is truthy
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Remove snippet configuration if requested
@@ -75,7 +75,7 @@
   loop_control:
     label:  '{{ {"name": item.name, "state": item.state, "config": item.config} }}'
   notify: [ 'Test filebeat configuration and restart' ]
-  when: item.state | d('present') == 'absent' and item.config | d()
+  when: item.state | d('present') == 'absent' and item.config is defined and item.config is truthy
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Generate snippet configuration
@@ -87,7 +87,7 @@
   loop_control:
     label:  '{{ {"name": item.name, "state": item.state, "config": item.config} }}'
   notify: [ 'Test filebeat configuration and restart' ]
-  when: item.state | d('present') not in ['absent', 'ignore', 'init'] and item.config | d()
+  when: item.state | d('present') not in ['absent', 'ignore', 'init'] and item.config is defined and item.config is truthy
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Check if the Filebeat keystore exists

--- a/ansible/roles/freeradius/tasks/main.yml
+++ b/ansible/roles/freeradius/tasks/main.yml
@@ -76,7 +76,7 @@
                 "divert": freeradius__var_divert_divert,
                 "state": item.state | d("present")} }}'
   notify: [ 'Check freeradius configuration and restart' ]
-  when: (item.name | d() and item.divert | d(False) | bool and
+  when: (item.name is defined and item.name is truthy and item.divert | d(False) | bool and
          item.state | d('present') in ['present', 'absent'])
   no_log: '{{ debops__no_log | d(item.no_log) | d(False) }}'
 
@@ -90,8 +90,8 @@
   with_items: '{{ freeradius__combined_configuration | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"path": ((freeradius__conf_base_path + "/" + (item.filename | d(item.name))) | dirname)} }}'
-  when: (item.name | d() and item.state | d('present') not in ['absent', 'ignore', 'init'] and
-         (item.link_src | d() or item.options | d() or item.raw | d()))
+  when: (item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore', 'init'] and
+         ((item.link_src is defined and item.link_src is truthy) or (item.options is defined and item.options is truthy) or (item.raw is defined and item.raw is truthy)))
   no_log: '{{ debops__no_log | d(item.no_log) | d(False) }}'
 
 - name: Generate FreeRADIUS configuration files
@@ -103,8 +103,8 @@
     mode:  '{{ item.mode | d("0640") }}'
   with_items: '{{ freeradius__combined_configuration | debops.debops.parse_kv_items }}'
   notify: [ 'Check freeradius configuration and restart' ]
-  when: (item.name | d() and item.state | d('present') not in ['absent', 'ignore', 'init'] and
-         not item.link_src | d() and (item.options | d() or item.raw | d()))
+  when: (item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore', 'init'] and
+         not item.link_src | d() and ((item.options is defined and item.options is truthy) or (item.raw is defined and item.raw is truthy)))
   no_log: '{{ debops__no_log | d(item.no_log) | d(False) }}'
 
 - name: Create configuration file symlinks
@@ -117,8 +117,8 @@
     mode:  '{{ item.mode | d("0640") }}'
   with_items: '{{ freeradius__combined_configuration | debops.debops.parse_kv_items }}'
   notify: [ 'Check freeradius configuration and restart' ]
-  when: (item.name | d() and item.state | d('present') not in ['absent', 'ignore', 'init'] and
-         item.link_src | d())
+  when: (item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore', 'init'] and
+         item.link_src is defined and item.link_src is truthy)
   no_log: '{{ debops__no_log | d(item.no_log) | d(False) }}'
 
 - name: Remove FreeRADIUS configuration files
@@ -127,6 +127,6 @@
     state: 'absent'
   with_items: '{{ freeradius__combined_configuration | debops.debops.parse_kv_items }}'
   notify: [ 'Check freeradius configuration and restart' ]
-  when: (item.name | d() and not item.divert | d(False) | bool and
+  when: (item.name is defined and item.name is truthy and not item.divert | d(False) | bool and
          item.state | d('present') == 'absent')
   no_log: '{{ debops__no_log | d(item.no_log) | d(False) }}'

--- a/ansible/roles/gitlab_runner/tasks/main.yml
+++ b/ansible/roles/gitlab_runner/tasks/main.yml
@@ -40,7 +40,7 @@
     name: '{{ gitlab_runner__user }}'
     groups: 'docker'
     append: True
-  when: (ansible_local | d() and ansible_local.docker_server | d() and
+  when: (ansible_local is defined and ansible_local.docker_server is defined and
          (ansible_local.docker_server.installed | d()) | bool)
 
 - name: Copy custom files to GitLab Runner host
@@ -57,7 +57,9 @@
   loop: '{{ q("flattened", gitlab_runner__custom_files
                            + gitlab_runner__group_custom_files
                            + gitlab_runner__host_custom_files) }}'
-  when: ((item.src | d() or item.content | d()) and item.dest | d())
+  when: (((item.src is defined and item.src is truthy) or
+          (item.content is defined and item.content is truthy)) and
+         item.dest is defined and item.dest is truthy)
 
 - name: Make sure APT can access HTTPS repositories
   ansible.builtin.apt:
@@ -107,11 +109,14 @@
                            + gitlab_runner__instances
                            + gitlab_runner__group_instances
                            + gitlab_runner__host_instances) }}'
-  when: ((item.api_token | d() or gitlab_runner__api_token) and item.name and
+  when: (((item.api_token is defined and item.api_token is truthy) or
+          (gitlab_runner__api_token is defined and gitlab_runner__api_token is truthy)) and
+         item.name is defined and item.name is truthy and
          (item.state is undefined or item.state != 'absent') and
          (ansible_local is undefined or
-          (ansible_local | d() and (ansible_local.gitlab_runner is undefined or
-           (ansible_local.gitlab_runner | d() and ansible_local.gitlab_runner.instances is defined and
+          (ansible_local is defined and (ansible_local.gitlab_runner is undefined or
+           (ansible_local.gitlab_runner is defined and
+            ansible_local.gitlab_runner.instances is defined and
             item.name not in ansible_local.gitlab_runner.instances)))))
 
 - name: Generate GitLab Runner configuration files
@@ -133,9 +138,12 @@
     - '{{ gitlab_runner__default_instances + gitlab_runner__instances
           + gitlab_runner__group_instances + gitlab_runner__host_instances }}'
     - '{{ ansible_local.gitlab_runner.instance_tokens | d([]) }}'
-  when: ((item.0.api_token | d() or gitlab_runner__api_token)
-         and item.0.name | d() and item.1.name | d() and item.0.name == item.1.name and
-         (item.0.state | d() and item.0.state == 'absent'))
+  when: (((item.0.api_token is defined and item.0.api_token is truthy) or
+          (gitlab_runner__api_token is defined and gitlab_runner__api_token is truthy)) and
+         item.0.name is defined and item.0.name is truthy and
+         item.1.name is defined and item.1.name is truthy and
+         item.0.name == item.1.name and
+         (item.0.state is defined and item.0.state == 'absent'))
   failed_when: False
   no_log: '{{ debops__no_log | d(True) }}'
 
@@ -154,7 +162,9 @@
   delegate_to: '{{ item.host }}'
   become: '{{ item.become | d(True) }}'
   with_items: '{{ gitlab_runner__ssh_install_to }}'
-  when: gitlab_runner__ssh_generate | bool and item.user | d() and item.host | d()
+  when: gitlab_runner__ssh_generate | bool and
+        item.user is defined and item.user is truthy and
+        item.host is defined and item.host is truthy
 
 - name: Make sure that the ~/.ssh directory exists
   ansible.builtin.file:
@@ -163,7 +173,7 @@
     owner: '{{ gitlab_runner__user }}'
     group: '{{ gitlab_runner__group }}'
     mode: '0700'
-  when: gitlab_runner__ssh_known_hosts | d()
+  when: gitlab_runner__ssh_known_hosts is truthy
 
 - name: Make sure the ~/.ssh/known_hosts file exists
   ansible.builtin.copy:
@@ -173,7 +183,7 @@
     group: '{{ gitlab_runner__group }}'
     mode: '0644'
     force: False
-  when: gitlab_runner__ssh_known_hosts | d()
+  when: gitlab_runner__ssh_known_hosts is truthy
 
 - name: Get list of already scanned host fingerprints
   ansible.builtin.shell: set -o nounset -o pipefail -o errexit &&
@@ -181,7 +191,7 @@
   args:
     executable: 'bash'
   with_items: '{{ gitlab_runner__ssh_known_hosts }}'
-  when: gitlab_runner__ssh_known_hosts | d()
+  when: gitlab_runner__ssh_known_hosts is truthy
   register: gitlab_runner__register_known_hosts
   changed_when: False
   failed_when: False
@@ -215,7 +225,7 @@
     owner: 'root'
     group: 'root'
     mode: '0440'
-  when: (ansible_local | d() and ansible_local.sudo | d() and
+  when: (ansible_local is defined and ansible_local.sudo is defined and
          (ansible_local.sudo.installed | d()) | bool and
          gitlab_runner__vagrant_libvirt | bool)
 
@@ -244,7 +254,7 @@
     owner: 'root'
     group: 'root'
     mode: '0440'
-  when: (ansible_local | d() and ansible_local.sudo | d() and
+  when: (ansible_local is defined and ansible_local.sudo is defined and
          (ansible_local.sudo.installed | d()) | bool and
          gitlab_runner__vagrant_lxc | bool)
 

--- a/ansible/roles/golang/tasks/golang_build_install.yml
+++ b/ansible/roles/golang/tasks/golang_build_install.yml
@@ -12,7 +12,7 @@
   args:
     executable: '/bin/bash'
   register: golang__register_build_apt_packages
-  when: build.apt_packages | d()
+  when: build.apt_packages is defined and build.apt_packages is truthy
   changed_when: False
   check_mode: False
 
@@ -24,11 +24,11 @@
   until: golang__register_install_apt_packages is succeeded
   when: (not (build.upstream | d()) | bool and
          (build.apt_packages is defined and
-          (([build.apt_packages] if (build.apt_packages is string) else build.apt_packages)
-           | intersect(golang__register_build_apt_packages.stdout_lines))))
+          ((([build.apt_packages] if (build.apt_packages is string) else build.apt_packages)
+            | intersect(golang__register_build_apt_packages.stdout_lines)) is truthy)))
 
 - name: Prepare Go UNIX environment
-  when: ((build.git | d() or build.url | d()) and ((build.upstream | d()) | bool or
+  when: ((build.git is defined and build.git is truthy) or (build.url is defined and build.url is truthy) and ((build.upstream | d()) | bool or
          (build.apt_packages is undefined or
           (not (([build.apt_packages] if (build.apt_packages is string) else build.apt_packages)
                 | intersect(golang__register_build_apt_packages.stdout_lines))))))
@@ -56,13 +56,13 @@
     state: 'present'
   register: golang__register_install_apt_required_packages
   until: golang__register_install_apt_required_packages is succeeded
-  when: (build.url | d() and build.upstream_type | d('git') == 'url' and (((build.upstream | d()) | bool or
+  when: (build.url is defined and build.url is truthy and build.upstream_type | d('git') == 'url' and (((build.upstream | d()) | bool or
          (build.apt_packages is undefined or
           (not (([build.apt_packages] if (build.apt_packages is string) else build.apt_packages)
                 | intersect(golang__register_build_apt_packages.stdout_lines)))))))
 
 - name: Download Go binaries directly
-  when: (build.url | d() and build.upstream_type | d('git') == 'url' and ((build.upstream | d()) | bool or
+  when: (build.url is defined and build.url is truthy and build.upstream_type | d('git') == 'url' and ((build.upstream | d()) | bool or
          (build.apt_packages is undefined or
           (not (([build.apt_packages] if (build.apt_packages is string) else build.apt_packages)
                 | intersect(golang__register_build_apt_packages.stdout_lines))))))
@@ -132,7 +132,7 @@
   loop: '{{ build.url_binaries | d([]) }}'
   loop_control:
     loop_var: 'binary_item'
-  when: (build.url_binaries | d() and build.upstream_type | d('git') == 'url' and ((build.upstream | d()) | bool or
+  when: (build.url_binaries is defined and build.url_binaries is truthy and build.upstream_type | d('git') == 'url' and ((build.upstream | d()) | bool or
          (build.apt_packages is undefined or
           (not (([build.apt_packages] if (build.apt_packages is string) else build.apt_packages)
                 | intersect(golang__register_build_apt_packages.stdout_lines))))))
@@ -143,13 +143,13 @@
     state: 'present'
   register: golang__register_install_apt_dev_packages
   until: golang__register_install_apt_dev_packages is succeeded
-  when: (build.git | d() and build.upstream_type | d('git') == 'git' and (((build.upstream | d()) | bool or
+  when: (build.git is defined and build.git is truthy and build.upstream_type | d('git') == 'git' and (((build.upstream | d()) | bool or
          (build.apt_packages is undefined or
           (not (([build.apt_packages] if (build.apt_packages is string) else build.apt_packages)
                 | intersect(golang__register_build_apt_packages.stdout_lines)))))))
 
 - name: Build Go applications from source
-  when: (build.git | d() and build.upstream_type | d('git') == 'git' and (((build.upstream | d()) | bool or
+  when: (build.git is defined and build.git is truthy and build.upstream_type | d('git') == 'git' and (((build.upstream | d()) | bool or
          (build.apt_packages is undefined or
           (not (([build.apt_packages] if (build.apt_packages is string) else build.apt_packages)
                 | intersect(golang__register_build_apt_packages.stdout_lines)))))))
@@ -182,7 +182,7 @@
       loop: '{{ build.git }}'
       loop_control:
         loop_var: 'git_item'
-      when: git_item.build_script | d() and
+      when: git_item.build_script is defined and git_item.build_script is truthy and
             golang__register_build_source is changed
       register: golang__register_build
       changed_when: golang__register_build.changed | bool
@@ -204,7 +204,7 @@
   loop: '{{ build.git_binaries | d([]) }}'
   loop_control:
     loop_var: 'binary_item'
-  when: (build.git_binaries | d() and build.upstream_type | d('git') == 'git' and ((build.upstream | d()) | bool or
+  when: (build.git_binaries is defined and build.git_binaries is truthy and build.upstream_type | d('git') == 'git' and ((build.upstream | d()) | bool or
          (build.apt_packages is undefined or
           (not (([build.apt_packages] if (build.apt_packages is string) else build.apt_packages)
                 | intersect(golang__register_build_apt_packages.stdout_lines))))))
@@ -218,7 +218,7 @@
     dest: '{{ golang__bin_database }}'
     mode: '0644'
     force: False
-  when: build.url_binaries | d() or build.git_binaries | d()
+  when: (build.url_binaries is defined and build.url_binaries is truthy) or (build.git_binaries is defined and build.git_binaries is truthy)
 
 - name: Register binaries for {{ build.name }}
   ansible.builtin.lineinfile:
@@ -233,13 +233,13 @@
   loop_control:
     loop_var: 'binary_item'
   register: golang__register_build_database
-  when: build.url_binaries | d() or build.git_binaries | d()
+  when: (build.url_binaries is defined and build.url_binaries is truthy) or (build.git_binaries is defined and build.git_binaries is truthy)
 
   # An exception to the rule. Role needs to refresh facts without executing any
   # other pending handlers.
 - name: Update Ansible local facts if they were modified
   ansible.builtin.setup:  # noqa no-handler
-  when: (ansible_local | d() and ansible_local.golang | d() and
+  when: (ansible_local is defined and ansible_local.golang is defined and
          (ansible_local.golang.configured | d()) | bool and
          (golang__register_build_database is changed or
           golang__register_download_install is changed or

--- a/ansible/roles/golang/tasks/main.yml
+++ b/ansible/roles/golang/tasks/main.yml
@@ -13,7 +13,7 @@
   loop_control:
     loop_var: 'build'
   loop: '{{ q("flattened", golang__combined_packages) | debops.debops.parse_kv_items }}'
-  when: build.name | d() and build.state | d('present') not in [ 'absent', 'ignore' ]
+  when: build.name is defined and build.name is truthy and build.state | d('present') not in [ 'absent', 'ignore' ]
 
 - name: Make sure that Ansible local facts directory exists
   ansible.builtin.file:

--- a/ansible/roles/grub/tasks/main.yml
+++ b/ansible/roles/grub/tasks/main.yml
@@ -46,7 +46,7 @@
   with_items: '{{ grub__combined_users }}'
   become: False
   delegate_to: 'localhost'
-  when: item.name | d()
+  when: item.name is defined and item.name is truthy
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Save plaintext password in secrets
@@ -58,7 +58,7 @@
   register: grub__register_pw_plain
   become: False
   delegate_to: 'localhost'
-  when: item.name | d()
+  when: item.name is defined and item.name is truthy
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Save temporary grub-mkpasswd formatted password in secrets
@@ -71,7 +71,7 @@
     - '{{ grub__register_pw_plain.results | d({}) }}'
   become: False
   delegate_to: 'localhost'
-  when: (item.0.name | d() and item.1 is changed)
+  when: (item.0.name is defined and item.0.name is truthy and item.1 is changed)
   no_log: '{{ debops__no_log | d(True) }}'
 
 ## There seems to be no way to specify the salt (except using a custom script).
@@ -97,7 +97,7 @@
   become: False
   delegate_to: 'localhost'
   changed_when: False
-  when: (item.0.name | d() and item.1 is changed)
+  when: (item.0.name is defined and item.0.name is truthy and item.1 is changed)
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Remove temporary grub-mkpassword formatted password
@@ -109,7 +109,7 @@
     - '{{ grub__register_pw_plain.results | d({}) }}'
   become: False
   delegate_to: 'localhost'
-  when: (item.0.name | d() and item.1 is changed)
+  when: (item.0.name is defined and item.0.name is truthy and item.1 is changed)
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Save hashed password in secrets

--- a/ansible/roles/gunicorn/tasks/newer_releases.yml
+++ b/ansible/roles/gunicorn/tasks/newer_releases.yml
@@ -18,8 +18,8 @@
     state: 'present'
   loop: '{{ q("flattened", gunicorn__applications
                            + gunicorn__dependent_applications) }}'
-  when: item.name | d() and item.state | d('present') != 'absent' and
-        item.group | d()
+  when: item.name is defined and item.name is truthy and item.state | d('present') != 'absent' and
+        item.group is defined and item.group is truthy
 
 - name: Ensure that required users exist
   ansible.builtin.user:
@@ -30,8 +30,8 @@
     state: 'present'
   loop: '{{ q("flattened", gunicorn__applications
                            + gunicorn__dependent_applications) }}'
-  when: item.name | d() and item.state | d('present') != 'absent' and
-        item.user | d() and item.home | d()
+  when: item.name is defined and item.name is truthy and item.state | d('present') != 'absent' and
+        item.user is defined and item.user is truthy and item.home is defined and item.home is truthy
 
 - name: Create log directories
   ansible.builtin.file:
@@ -42,7 +42,7 @@
     mode: '0775'
   loop: '{{ q("flattened", gunicorn__applications
                            + gunicorn__dependent_applications) }}'
-  when: item.name | d() and item.state | d('present') != 'absent'
+  when: item.name is defined and item.name is truthy and item.state | d('present') != 'absent'
 
 - name: Create logrotate configs
   ansible.builtin.template:
@@ -53,7 +53,7 @@
     mode: '0644'
   loop: '{{ q("flattened", gunicorn__applications
                            + gunicorn__dependent_applications) }}'
-  when: item.name | d() and item.state | d('present') != 'absent'
+  when: item.name is defined and item.name is truthy and item.state | d('present') != 'absent'
 
 - name: Check if systemd instances for Green Unicorn are configured
   ansible.builtin.stat:
@@ -69,9 +69,9 @@
                            + gunicorn__dependent_applications) }}'
   notify: [ 'Reload systemd daemon (gunicorn)' ]
   when: ansible_service_mgr == 'systemd' and
-        gunicorn__register_systemd_templated.stat | d() and
+        gunicorn__register_systemd_templated.stat is defined and
         gunicorn__register_systemd_templated.stat.exists | bool and
-        item.name | d() and item.state | d('present') == 'absent'
+        item.name is defined and item.name is truthy and item.state | d('present') == 'absent'
 
 - name: Generate systemd configuration files
   ansible.builtin.template:
@@ -92,7 +92,7 @@
                            + gunicorn__dependent_applications) }}'
   notify: [ 'Reload systemd daemon (gunicorn)' ]
   when: ansible_service_mgr == 'systemd' and
-        item.name | d() and item.state | d('present') == 'absent'
+        item.name is defined and item.name is truthy and item.state | d('present') == 'absent'
 
 - name: Create per-instance systemd directory
   ansible.builtin.file:
@@ -104,7 +104,7 @@
   loop: '{{ q("flattened", gunicorn__applications
                            + gunicorn__dependent_applications) }}'
   when: ansible_service_mgr == 'systemd' and
-        item.name | d() and item.state | d('present') != 'absent'
+        item.name is defined and item.name is truthy and item.state | d('present') != 'absent'
 
 - name: Generate per-instance systemd configuration
   ansible.builtin.template:
@@ -117,7 +117,7 @@
                            + gunicorn__dependent_applications) }}'
   notify: [ 'Reload systemd daemon (gunicorn)', 'Start Green Unicorn instances' ]
   when: ansible_service_mgr == 'systemd' and
-        item.name | d() and item.state | d('present') != 'absent'
+        item.name is defined and item.name is truthy and item.state | d('present') != 'absent'
 
 - name: Remove Unicorn instance configuration
   ansible.builtin.file:
@@ -125,7 +125,7 @@
     state: 'absent'
   loop: '{{ q("flattened", gunicorn__applications
                            + gunicorn__dependent_applications) }}'
-  when: item.name | d() and item.state | d('present') == 'absent'
+  when: item.name is defined and item.name is truthy and item.state | d('present') == 'absent'
 
 - name: Generate Unicorn instance configuration
   ansible.builtin.template:
@@ -137,7 +137,7 @@
   notify: [ 'Start Green Unicorn instances' ]
   loop: '{{ q("flattened", gunicorn__applications
                            + gunicorn__dependent_applications) }}'
-  when: item.name | d() and item.state | d('present') != 'absent'
+  when: item.name is defined and item.name is truthy and item.state | d('present') != 'absent'
 
 - name: Reload systemd configuration
   ansible.builtin.meta: 'flush_handlers'
@@ -150,4 +150,4 @@
   loop: '{{ q("flattened", gunicorn__applications
                            + gunicorn__dependent_applications) }}'
   when: ansible_service_mgr == 'systemd' and
-        item.name | d() and item.state | d('present') != 'absent'
+        item.name is defined and item.name is truthy and item.state | d('present') != 'absent'

--- a/ansible/roles/gunicorn/tasks/older_releases.yml
+++ b/ansible/roles/gunicorn/tasks/older_releases.yml
@@ -18,7 +18,7 @@
   loop: '{{ q("flattened", gunicorn__applications
                            + gunicorn__dependent_applications) }}'
   notify: [ 'Restart gunicorn' ]
-  when: item.name | d() and item.state | d('present') == 'absent'
+  when: item.name is defined and item.name is truthy and item.state | d('present') == 'absent'
 
 - name: Generate gunicorn configuration
   ansible.builtin.template:
@@ -30,4 +30,4 @@
   loop: '{{ q("flattened", gunicorn__applications
                            + gunicorn__dependent_applications) }}'
   notify: [ 'Restart gunicorn' ]
-  when: item.name | d() and item.state | d('present') != 'absent'
+  when: item.name is defined and item.name is truthy and item.state | d('present') != 'absent'

--- a/ansible/roles/hashicorp/tasks/main.yml
+++ b/ansible/roles/hashicorp/tasks/main.yml
@@ -115,7 +115,7 @@
         - '{{ (hashicorp__applications + hashicorp__dependent_applications) | unique }}'
         - [ '{{ hashicorp__tar_suffix }}', '{{ hashicorp__hash_suffix }}', '{{ hashicorp__sig_suffix }}' ]
       when: (ansible_local.hashicorp is not defined or
-             (ansible_local.hashicorp | d() and ansible_local.hashicorp.applications | d() and
+             (ansible_local.hashicorp is defined and ansible_local.hashicorp.applications is defined and
               (ansible_local.hashicorp.applications[item.0] is not defined or
                (ansible_local.hashicorp.applications[item.0] != hashicorp__combined_version_map[item.0]))))
       tags: [ 'role::hashicorp:download', 'role::hashicorp:verify' ]
@@ -133,7 +133,7 @@
       when: (hashicorp__consul_webui | bool and
              ('consul' in (hashicorp__applications + hashicorp__dependent_applications) | unique) and
               (ansible_local.hashicorp is not defined or
-               (ansible_local.hashicorp | d() and ansible_local.hashicorp.applications | d() and
+               (ansible_local.hashicorp is defined and ansible_local.hashicorp.applications is defined and
                 (ansible_local.hashicorp.applications['consul'] is not defined or
                  (ansible_local.hashicorp.applications['consul'] != hashicorp__combined_version_map['consul'])) or
                 not ansible_local.hashicorp.consul_webui | bool)))
@@ -220,9 +220,9 @@
     - '{{ hashicorp__register_unpack.results }}'
   register: hashicorp__register_app_install
   changed_when: hashicorp__register_app_install.changed | bool
-  when: (item.1 is changed or (ansible_local | d() and
+  when: (item.1 is changed or (ansible_local is defined and
          (ansible_local.hashicorp is not defined or
-          (ansible_local.hashicorp | d() and ansible_local.hashicorp.applications | d() and
+          (ansible_local.hashicorp is defined and ansible_local.hashicorp.applications is defined and
            (ansible_local.hashicorp.applications[item.0] is not defined or
             (ansible_local.hashicorp.applications[item.0] != hashicorp__combined_version_map[item.0]))))))
   tags: [ 'role::hashicorp:install' ]

--- a/ansible/roles/icinga/tasks/main.yml
+++ b/ansible/roles/icinga/tasks/main.yml
@@ -36,7 +36,7 @@
     dir: '{{ secret + "/icinga/dependent_config/" + inventory_hostname }}'
     depth: 1
     name: 'icinga__vars_dependent_configuration'
-  when: (ansible_local | d() and ansible_local.icinga | d() and
+  when: (ansible_local is defined and ansible_local.icinga is defined and
          (ansible_local.icinga.configured | d()) | bool)
 
 - name: Make sure that Ansible local facts directory exists
@@ -69,7 +69,7 @@
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
   notify: [ 'Check icinga2 configuration and restart' ]
-  when: (item.name | d() and
+  when: (item.name is defined and item.name is truthy and
          item.state | d('present') in ['absent', 'present'] and
          item.divert | d(False) | bool)
 
@@ -81,8 +81,8 @@
     group: 'root'
     mode: '0755'
   with_items: '{{ icinga__combined_configuration | debops.debops.parse_kv_items }}'
-  when: (item.name | d() and item.state | d('present') not in ['absent', 'ignore', 'init', 'feature'] and
-         ((item.filename | d(item.name | regex_replace(".conf$", "") + ".conf")) | dirname | d()))
+  when: (item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore', 'init', 'feature'] and
+         (((item.filename | d(item.name | regex_replace(".conf$", "") + ".conf")) | dirname | d()) is truthy))
 
 - name: Remove Icinga configuration files
   ansible.builtin.file:
@@ -90,7 +90,7 @@
     state: 'absent'
   with_items: '{{ icinga__combined_configuration | debops.debops.parse_kv_items }}'
   notify: [ 'Check icinga2 configuration and restart' ]
-  when: (item.name | d() and item.state | d('present') == 'absent' and
+  when: (item.name is defined and item.name is truthy and item.state | d('present') == 'absent' and
          not item.divert | d(False) | bool)
 
 - name: Generate Icinga configuration files
@@ -102,7 +102,7 @@
     mode:  '{{ item.mode | d("0644") }}'
   with_items: '{{ icinga__combined_configuration | debops.debops.parse_kv_items }}'
   notify: [ 'Check icinga2 configuration and restart' ]
-  when: (item.name | d() and item.state | d('present') not in ['absent', 'ignore', 'init', 'divert', 'feature'])
+  when: (item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore', 'init', 'divert', 'feature'])
   no_log: '{{ debops__no_log | d(item.no_log) | d(False) }}'
 
 - name: Ensure that configuration directories exist on the master node
@@ -115,8 +115,8 @@
     mode: '0755'
   with_items: '{{ icinga__master_combined_configuration | debops.debops.parse_kv_items }}'
   delegate_to: '{{ icinga__master_delegate_to }}'
-  when: (item.name | d() and item.state | d('present') not in ['absent', 'ignore', 'init', 'feature'] and
-         ((item.filename | d(item.name | regex_replace(".conf$", "") + ".conf")) | dirname | d()))
+  when: (item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore', 'init', 'feature'] and
+         (((item.filename | d(item.name | regex_replace(".conf$", "") + ".conf")) | dirname | d()) is truthy))
 
 - name: Remove Icinga configuration on the master node if requested
   ansible.builtin.file:
@@ -125,7 +125,7 @@
   with_items: '{{ icinga__master_combined_configuration | debops.debops.parse_kv_items }}'
   delegate_to: '{{ icinga__master_delegate_to }}'
   notify: [ 'Check icinga2 configuration and restart it on the master node' ]
-  when: (item.name | d() and item.state | d('present') == 'absent')
+  when: (item.name is defined and item.name is truthy and item.state | d('present') == 'absent')
 
 - name: Generate Icinga configuration files on the master node
   ansible.builtin.template:
@@ -137,7 +137,7 @@
   with_items: '{{ icinga__master_combined_configuration | debops.debops.parse_kv_items }}'
   delegate_to: '{{ icinga__master_delegate_to }}'
   notify: [ 'Check icinga2 configuration and restart it on the master node' ]
-  when: (item.name | d() and item.state | d('present') not in ['absent', 'ignore', 'init', 'divert', 'feature'])
+  when: (item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore', 'init', 'divert', 'feature'])
   no_log: '{{ debops__no_log | d(item.no_log) | d(False) }}'
 
 - name: Configure state of Icinga features
@@ -150,8 +150,8 @@
     force: '{{ True if ansible_check_mode | bool else omit }}'
   with_items: '{{ icinga__combined_configuration | debops.debops.parse_kv_items }}'
   notify: [ 'Check icinga2 configuration and restart' ]
-  when: (item.name | d() and item.state | d('present') not in ['absent', 'ignore', 'init', 'divert'] and
-         item.feature_name | d() and item.feature_state | d())
+  when: (item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore', 'init', 'divert'] and
+         item.feature_name is defined and item.feature_name is truthy and item.feature_state is defined and item.feature_state is truthy)
 
 - name: Copy custom files for Icinga
   ansible.builtin.copy:
@@ -165,8 +165,8 @@
   loop: '{{ q("flattened", icinga__custom_files
                            + icinga__group_custom_files
                            + icinga__host_custom_files) }}'
-  when: ((item.src | d() or item.content | d()) and
-         item.dest | d() and item.state | d("present") != "absent")
+  when: (((item.src is defined and item.src is truthy) or (item.content is defined and item.content is truthy)) and
+         item.dest is defined and item.dest is truthy and item.state | d("present") != "absent")
 
 - name: Save dependent configuration on Ansible Controller
   ansible.builtin.template:

--- a/ansible/roles/icinga_web/tasks/main.yml
+++ b/ansible/roles/icinga_web/tasks/main.yml
@@ -63,8 +63,8 @@
     dest: '{{ icinga_web__src + "/" + item.git_repo.split("://")[1] }}'
     version: '{{ item.git_version }}'
   with_items: '{{ (icinga_web__default_modules + icinga_web__modules) | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.git_repo | d() and
-        item.git_version | d() and item.state | d('present') != 'absent'
+  when: item.name is defined and item.name is truthy and item.git_repo is defined and item.git_repo is truthy and
+        item.git_version is defined and item.git_version is truthy and item.state | d('present') != 'absent'
 
 - name: Symlink Icinga upstream modules to Icinga Web application
   ansible.builtin.file:
@@ -74,8 +74,8 @@
     force: '{{ True if ansible_check_mode | bool else omit }}'
     mode: '0755'
   with_items: '{{ (icinga_web__default_modules + icinga_web__modules) | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.git_repo | d() and
-        item.git_version | d() and item.state | d('present') != 'absent'
+  when: item.name is defined and item.name is truthy and item.git_repo is defined and item.git_repo is truthy and
+        item.git_version is defined and item.git_version is truthy and item.state | d('present') != 'absent'
 
 - name: Manage Icinga Web modules
   ansible.builtin.file:
@@ -86,7 +86,7 @@
     force: '{{ True if ansible_check_mode | bool else omit }}'
     mode: '0755'
   with_items: '{{ (icinga_web__default_modules + icinga_web__modules) | debops.debops.parse_kv_items }}'
-  when: item.name | d()
+  when: item.name is defined and item.name is truthy
 
 - name: Generate Icinga Web configuration
   ansible.builtin.template:

--- a/ansible/roles/ifupdown/tasks/main.yml
+++ b/ansible/roles/ifupdown/tasks/main.yml
@@ -48,7 +48,7 @@
   ansible.builtin.file:
     path: '/etc/network/interfaces.config.d'
     state: 'absent'
-  when: (ansible_local | d() and ansible_local.debops_fact | d() and
+  when: (ansible_local is defined and ansible_local.debops_fact is defined and
          ansible_local.debops_fact.enabled | bool and
          (ansible_local.debops_fact.version is undefined or
           (ansible_local.debops_fact.version.ifupdown | d("0.0.0") is version_compare("0.3.0", "<"))))
@@ -104,7 +104,7 @@
     - '{{ ifupdown__register_interfaces_created.results }}'
   register: ifupdown__register_iface_cleanup
   changed_when: ifupdown__register_iface_cleanup.changed | bool
-  when: (item.item.key | d() and item is changed)
+  when: item.item.key is defined and item.item.key is truthy and item is changed
 
 - name: Mark modified interfaces for processing
   ansible.builtin.copy:  # noqa no-handler
@@ -112,12 +112,12 @@
       {{ ("created"
           if ((item.item.key | replace(':', '_') | replace('.', '_')) not in ansible_interfaces and
               (item.diff is undefined or
-               (item.diff | d() and item.diff.after | d() and
-                item.diff.after_header | d() and
+               (item.diff is defined and item.diff.after is defined and
+                item.diff.after_header is defined and
                 item.diff.after_header == "dynamically generated")))
           else ("removed"
-                if (item.diff | d() and item.diff.after | d() and
-                    item.diff.after.state | d() and
+                if (item.diff is defined and item.diff.after is defined and
+                    item.diff.after.state is defined and
                     item.diff.after.state == "absent")
                 else "changed")) }}
     dest: '{{ "/run/network/debops-ifupdown-reconfigure," +
@@ -133,7 +133,7 @@
     - '{{ ifupdown__register_interfaces_removed.results }}'
     - '{{ ifupdown__register_interfaces_created.results }}'
   notify: [ 'Apply ifupdown configuration' ]
-  when: (item.item.key | d() and item is changed)
+  when: item.item.key is defined and item.item.key is truthy and item is changed
 
 - name: Remove custom configuration files
   ansible.builtin.file:
@@ -143,7 +143,8 @@
                            + ifupdown__custom_group_files
                            + ifupdown__custom_host_files
                            + ifupdown__custom_dependent_files) }}'
-  when: ((item.dest | d() or item.path | d()) and
+  when: (((item.dest is defined and item.dest is truthy) or
+          (item.path is defined and item.path is truthy)) and
          item.state | d('present') == 'absent')
 
 - name: Generate custom configuration files
@@ -159,8 +160,10 @@
                            + ifupdown__custom_group_files
                            + ifupdown__custom_host_files
                            + ifupdown__custom_dependent_files) }}'
-  when: ((item.dest | d() or item.path | d()) and
-         (item.src | d() or item.content | d()) and
+  when: (((item.dest is defined and item.dest is truthy) or
+          (item.path is defined and item.path is truthy)) and
+         ((item.src is defined and item.src is truthy) or
+          (item.content is defined and item.content is truthy)) and
          item.state | d('present') != 'absent')
 
 - name: Remove custom ifupdown hooks
@@ -168,7 +171,7 @@
     path: '{{ item.dest | d("/" + item.hook) }}'
     state: 'absent'
   loop: '{{ q("flattened", ifupdown__custom_hooks) }}'
-  when: item.name | d() and item.state | d('present') == 'absent'
+  when: item.name is defined and item.name is truthy and item.state | d('present') == 'absent'
 
 - name: Install custom ifupdown hooks
   ansible.builtin.template:
@@ -178,7 +181,7 @@
     group: 'root'
     mode: '{{ item.mode | d("0755") }}'
   loop: '{{ q("flattened", ifupdown__custom_hooks) }}'
-  when: item.name | d() and item.state | d('present') != 'absent'
+  when: item.name is defined and item.name is truthy and item.state | d('present') != 'absent'
 
 - name: Install reconfiguration script if needed
   ansible.builtin.copy:
@@ -196,5 +199,5 @@
     option: 'ifupdown'
     value: '{{ ifupdown__role_metadata.version }}'
     mode: '0644'
-  when: ansible_local | d() and ansible_local.debops_fact | d() and
+  when: ansible_local is defined and ansible_local.debops_fact is defined and
         ansible_local.debops_fact.enabled | bool

--- a/ansible/roles/ipxe/tasks/debian_netboot.yml
+++ b/ansible/roles/ipxe/tasks/debian_netboot.yml
@@ -10,7 +10,7 @@
     state: 'directory'
     mode: '0755'
   loop: '{{ ipxe__debian_netboot_combined_release_map | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'ignore'] and
+  when: item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore'] and
         item.release in ipxe__debian_netboot_releases and item.architecture in ipxe__debian_netboot_architectures
 
 - name: Create Debian installer directories
@@ -20,7 +20,7 @@
     state: 'directory'
     mode: '0775'  # tarball enforces this mode
   loop: '{{ ipxe__debian_netboot_combined_release_map | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'ignore'] and
+  when: item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore'] and
         item.release in ipxe__debian_netboot_releases and item.architecture in ipxe__debian_netboot_architectures
 
 - name: Download Debian netboot tarballs
@@ -34,7 +34,7 @@
     checksum: '{{ item.netboot_checksum | d(omit) }}'
     mode: '0644'
   loop: '{{ ipxe__debian_netboot_combined_release_map | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'ignore'] and
+  when: item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore'] and
         item.release in ipxe__debian_netboot_releases and item.architecture in ipxe__debian_netboot_architectures
   register: ipxe__register_get_netboot
   until: ipxe__register_get_netboot is succeeded
@@ -51,7 +51,7 @@
                  + item.netboot_version + (item.netboot_subdir | d("")) + "/pxelinux.0" }}'
   loop: '{{ ipxe__debian_netboot_combined_release_map | debops.debops.parse_kv_items }}'
   register: ipxe__register_debian_installer
-  when: item.name | d() and item.state | d('present') not in ['absent', 'ignore'] and
+  when: item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore'] and
         item.release in ipxe__debian_netboot_releases and item.architecture in ipxe__debian_netboot_architectures
 
 - name: Point current Debian netboot symlink to correct version
@@ -61,7 +61,7 @@
     state: 'link'
     mode: '0775'
   loop: '{{ ipxe__debian_netboot_combined_release_map | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'ignore'] and
+  when: item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore'] and
         item.release in ipxe__debian_netboot_releases and item.architecture in ipxe__debian_netboot_architectures and
         (item.netboot_current | d(True)) | bool
 
@@ -71,8 +71,8 @@
     state: 'directory'
     mode: '0755'
   loop: '{{ ipxe__debian_netboot_combined_release_map | debops.debops.parse_kv_items }}'
-  when: ipxe__debian_netboot_firmware | bool and item.name | d() and item.state | d('present') not in ['absent', 'ignore'] and
-        item.release in ipxe__debian_netboot_releases and item.firmware_version | d()
+  when: ipxe__debian_netboot_firmware | bool and item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore'] and
+        item.release in ipxe__debian_netboot_releases and item.firmware_version is defined and item.firmware_version is truthy
 
 - name: Download Debian firmware tarballs
   ansible.builtin.get_url:
@@ -83,8 +83,8 @@
     checksum: '{{ item.firmware_checksum | d(omit) }}'
     mode: '0644'
   loop: '{{ ipxe__debian_netboot_combined_release_map | debops.debops.parse_kv_items }}'
-  when: ipxe__debian_netboot_firmware | bool and item.name | d() and item.state | d('present') not in ['absent', 'ignore'] and
-        item.release in ipxe__debian_netboot_releases and item.firmware_version | d()
+  when: ipxe__debian_netboot_firmware | bool and item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore'] and
+        item.release in ipxe__debian_netboot_releases and item.firmware_version is defined and item.firmware_version is truthy
   register: ipxe__register_get_firmware
   until: ipxe__register_get_firmware is succeeded
 
@@ -97,4 +97,4 @@
   loop: '{{ ipxe__register_debian_installer.results }}'  # noqa no-handler
   register: ipxe__register_netboot_merge
   changed_when: ipxe__register_netboot_merge.changed | bool
-  when: ipxe__debian_netboot_firmware | bool and item.item.firmware_version | d() and item is changed
+  when: ipxe__debian_netboot_firmware | bool and item.item.firmware_version is defined and item.item.firmware_version is truthy and item is changed

--- a/ansible/roles/ipxe/tasks/main.yml
+++ b/ansible/roles/ipxe/tasks/main.yml
@@ -24,7 +24,7 @@
     label: '{{ {"name": item.name,
                 "path": (ipxe__tftp_root + "/" + ((item.name | regex_replace("\.ipxe$", "") + ".ipxe") | dirname)),
                 "state": item.state | d("present")} }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'ignore', 'init']
+  when: item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore', 'init']
 
 - name: Generate iPXE scripts
   ansible.builtin.template:
@@ -35,7 +35,7 @@
   loop_control:
     label: '{{ {"name": item.name,
                 "state": item.state | d("present")} }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'ignore', 'init']
+  when: item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore', 'init']
 
 - name: Remove iPXE scripts if requested
   ansible.builtin.file:
@@ -45,7 +45,7 @@
   loop_control:
     label: '{{ {"name": item.name,
                 "state": item.state | d("present")} }}'
-  when: item.name | d() and item.state | d('present') == 'absent'
+  when: item.name is defined and item.name is truthy and item.state | d('present') == 'absent'
 
 - name: Install bootloader files in the TFTP root directory
   ansible.builtin.copy:

--- a/ansible/roles/iscsi/tasks/main.yml
+++ b/ansible/roles/iscsi/tasks/main.yml
@@ -49,7 +49,7 @@
   ansible.builtin.service:  # noqa no-handler
     name:  'open-iscsi'
     state: 'restarted'
-  when: iscsi__enabled | d() and iscsi__register_initiatorname | d() and iscsi__register_initiatorname is changed
+  when: iscsi__enabled | d() and iscsi__register_initiatorname is defined and iscsi__register_initiatorname is changed
 
 - name: Generate iSCSI interface configuration
   ansible.builtin.shell: iscsiadm -m iface -I {{ item }} -o new ;
@@ -78,7 +78,7 @@
     auto_node_startup: '{{ False if (not item.auto | d(True)) else True }}'
   with_items: '{{ iscsi__targets }}'
   register: iscsi__register_targets
-  when: iscsi__targets | d()
+  when: iscsi__targets is truthy
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Make sure that local facts directory exists

--- a/ansible/roles/iscsi/tasks/manage_lvm.yml
+++ b/ansible/roles/iscsi/tasks/manage_lvm.yml
@@ -11,7 +11,9 @@
     state:  'absent'
   with_items: '{{ iscsi__logical_volumes }}'
   when: iscsi__logical_volumes | d(False) and
-        item.vg | d() and item.lv | d() and item.size | d() and
+        item.vg is defined and item.vg is truthy and
+        item.lv is defined and item.lv is truthy and
+        item.size is defined and item.size is truthy and
         item.mount | d(False) and
         (item.state is defined and item.state == 'absent')
 
@@ -24,8 +26,10 @@
     state: 'absent'
   with_items: '{{ iscsi__logical_volumes }}'
   when: iscsi__logical_volumes | d(False) and
-        item.vg | d() and item.lv | d() and item.size | d() and
-        item.state | d() and item.state == 'absent'
+        item.vg is defined and item.vg is truthy and
+        item.lv is defined and item.lv is truthy and
+        item.size is defined and item.size is truthy and
+        item.state is defined and item.state == 'absent'
 
 - name: Manage LVM Volume Groups
   community.general.lvg:
@@ -36,8 +40,8 @@
     force:      '{{ item.item.lvm_force | d(omit) }}'
     vg_options: '{{ item.item.lvm_options | d(omit) }}'
   with_items: '{{ iscsi__register_targets.results }}'
-  when: iscsi__register_targets | d(False) and iscsi__register_targets.results | d() and
-        item.devicenodes | d() and item.item.lvm_vg | d()
+  when: iscsi__register_targets is defined and iscsi__register_targets.results is defined and iscsi__register_targets.results is truthy and
+        item.devicenodes is defined and item.devicenodes is truthy and item.item.lvm_vg is defined and item.item.lvm_vg is truthy
 
 - name: Manage LVM Logical Volumes
   community.general.lvol:
@@ -48,7 +52,9 @@
     state: 'present'
   with_items: '{{ iscsi__logical_volumes }}'
   when: iscsi__logical_volumes | d(False) and
-        item.vg | d() and item.lv | d() and item.size | d() and
+        item.vg is defined and item.vg is truthy and
+        item.lv is defined and item.lv is truthy and
+        item.size is defined and item.size is truthy and
         (item.state is undefined or item.state != 'absent')
 
 - name: Manage filesystems
@@ -59,10 +65,13 @@
     opts:   '{{ item.fs_opts | d(omit) }}'
   with_items: '{{ iscsi__logical_volumes }}'
   when: iscsi__logical_volumes | d(False) and
-        item.vg | d() and item.lv | d() and item.size | d() and
+        item.vg is defined and item.vg is truthy and
+        item.lv is defined and item.lv is truthy and
+        item.size is defined and item.size is truthy and
         (item.state is undefined or item.state != 'absent') and
-        ((item.mount | d() and (item.fs is undefined or item.fs | d()) or
-         item.fs | d()))
+        ((item.mount is defined and item.mount is truthy and
+          (item.fs is undefined or (item.fs is defined and item.fs is truthy))) or
+         (item.fs is defined and item.fs is truthy))
 
 - name: Manage mount points
   ansible.posix.mount:
@@ -76,6 +85,8 @@
     fstab:  '{{ item.mount_fstab | d(omit) }}'
   with_items: '{{ iscsi__logical_volumes }}'
   when: iscsi__logical_volumes | d(False) and
-        item.vg | d() and item.lv | d() and item.size | d() and
+        item.vg is defined and item.vg is truthy and
+        item.lv is defined and item.lv is truthy and
+        item.size is defined and item.size is truthy and
         item.mount | d(False) and
         (item.state is undefined or item.state != 'absent')

--- a/ansible/roles/java/tasks/main.yml
+++ b/ansible/roles/java/tasks/main.yml
@@ -24,7 +24,7 @@
   ansible.builtin.command: 'update-java-alternatives -s {{ java__alternatives }}'
   register: java__register_update_alternatives
   changed_when: java__register_update_alternatives.changed | bool
-  when: java__alternatives | d()
+  when: java__alternatives is truthy
 
 - name: Make sure that Ansible local facts directory exists
   ansible.builtin.file:

--- a/ansible/roles/keyring/tasks/main.yml
+++ b/ansible/roles/keyring/tasks/main.yml
@@ -140,7 +140,7 @@
     mode: '0640'
   loop: '{{ q("flattened", (keyring__dependent_apt_auth_files)) }}'
   when: keyring__enabled | bool and ansible_pkg_mgr == 'apt' and
-        item.machine | d() and item.login | d() and item.password | d() and
+        item.machine is defined and item.machine is truthy and item.login is defined and item.login is truthy and item.password is defined and item.password is truthy and
         item.state | d('present') not in ['absent', 'ignore']
   no_log: '{{ debops__no_log | d(True) }}'
 

--- a/ansible/roles/keyring/tasks/main.yml
+++ b/ansible/roles/keyring/tasks/main.yml
@@ -104,7 +104,7 @@
   loop: '{{ q("flattened", (keyring__dependent_apt_keys)) }}'
   register: keyring__register_get_url
   until: keyring__register_get_url is succeeded
-  when: keyring__enabled | bool and (item.url | d(item.id | d())) and (item.state | d("present")) not in [ "absent" ] and
+  when: keyring__enabled | bool and ((item.url is defined and item.url is truthy) or (item.id is defined and item.id is truthy)) and (item.state | d("present")) not in [ "absent" ] and
         not (item.apt_key | d(False)) | bool and item.keyring is defined and
         (item.extrepo is undefined or
          item.extrepo not in (ansible_local.extrepo.sources | d([]))) and
@@ -119,7 +119,7 @@
     update_cache: False
   loop: '{{ q("flattened", (keyring__dependent_apt_keys)) }}'
   register: keyring__register_apt_repository
-  when: keyring__enabled | bool and ansible_pkg_mgr == 'apt' and item.repo | d() and
+  when: keyring__enabled | bool and ansible_pkg_mgr == 'apt' and item.repo is defined and item.repo is truthy and
         (item.extrepo is undefined or
          item.extrepo not in (ansible_local.extrepo.sources | d([])))
   tags: [ 'role::keyring:apt_repository' ]

--- a/ansible/roles/kibana/tasks/main.yml
+++ b/ansible/roles/kibana/tasks/main.yml
@@ -29,7 +29,7 @@
     name: '{{ kibana__user }}'
     groups: '{{ kibana__additional_groups }}'
     append: True
-  when: kibana__additional_groups | d()
+  when: kibana__additional_groups is truthy
 
 - name: Make sure that Ansible local facts directory exists
   ansible.builtin.file:
@@ -58,7 +58,7 @@
   register: kibana__register_dependent_config_file
   become: False
   delegate_to: 'localhost'
-  when: (ansible_local.kibana.installed | d())
+  when: (ansible_local.kibana.installed is defined and ansible_local.kibana.installed is truthy)
   tags: [ 'role::kibana:config' ]
 
 - name: Load the dependent configuration from Ansible Controller
@@ -67,7 +67,7 @@
   register: kibana__register_dependent_config
   become: False
   delegate_to: 'localhost'
-  when: (ansible_local.kibana.installed | d() and
+  when: (ansible_local.kibana.installed is defined and ansible_local.kibana.installed is truthy and
          kibana__register_dependent_config_file.stat.exists | bool)
   tags: [ 'role::kibana:config' ]
 
@@ -109,7 +109,7 @@
   loop: '{{ q("flattened", kibana__combined_plugins) }}'
   register: kibana__register_plugin_install
   changed_when: kibana__register_plugin_install.changed | bool
-  when: (item.name | d() and item.state | d('present') != 'absent' and
+  when: (item.name is defined and item.name is truthy and item.state | d('present') != 'absent' and
          (item.name if ':' not in item.name else item.name.split(':')[1]) not in kibana__register_plugins.stdout_lines)
 
 - name: Remove Kibana plugins
@@ -122,7 +122,7 @@
   loop: '{{ q("flattened", kibana__combined_plugins) }}'
   register: kibana__register_plugin_remove
   changed_when: kibana__register_plugin_remove.changed | bool
-  when: (item.name | d() and item.state | d('present') == 'absent' and
+  when: (item.name is defined and item.name is truthy and item.state | d('present') == 'absent' and
          (item.name if ':' not in item.name else item.name.split(':')[1]) in kibana__register_plugins.stdout_lines)
 
 # The keystore handling is very similar to ../../metricbeat/tasks/main.yml

--- a/ansible/roles/kmod/tasks/main.yml
+++ b/ansible/roles/kmod/tasks/main.yml
@@ -59,7 +59,7 @@
     state: 'absent'
   with_items: '{{ kmod__combined_load | debops.debops.parse_kv_items }}'
   when: kmod__enabled | bool and ansible_service_mgr == 'systemd' and
-        item.name | d() and item.state | d('present') == 'absent'
+        item.name is defined and item.name is truthy and item.state | d('present') == 'absent'
 
 - name: Configure module loading at boot
   ansible.builtin.template:
@@ -70,7 +70,7 @@
     mode: '0644'
   with_items: '{{ kmod__combined_load | debops.debops.parse_kv_items }}'
   when: kmod__enabled | bool and ansible_service_mgr == 'systemd' and
-        item.name | d() and item.state | d('present') not in ['absent', 'ignore']
+        item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore']
 
 - name: Manage module loading in /etc/modules
   ansible.builtin.lineinfile:
@@ -83,7 +83,7 @@
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
   when: kmod__enabled | bool and ansible_service_mgr != 'systemd' and
-        item.name | d() and item.state | d('present') in ['present', 'absent']
+        item.name is defined and item.name is truthy and item.state | d('present') in ['present', 'absent']
 
 - name: Load missing kernel modules enabled at boot
   community.general.modprobe:
@@ -91,8 +91,12 @@
     state: 'present'
   with_items: '{{ kmod__combined_load | debops.debops.parse_kv_items }}'
   notify: [ 'Refresh host facts' ]
-  when: kmod__enabled | bool and item.name | d() and item.state | d('present') not in ['config', 'absent', 'ignore'] and
-        item.modules is undefined and ansible_local.kmod.modules | d() and item.name not in ansible_local.kmod.modules
+  when: kmod__enabled | bool and
+        item.name is defined and item.name is truthy and
+        item.state | d('present') not in ['config', 'absent', 'ignore'] and
+        item.modules is undefined and
+        ansible_local.kmod.modules is defined and ansible_local.kmod.modules is truthy and
+        item.name not in ansible_local.kmod.modules
 
 - name: Update Ansible facts if modules were loaded
   ansible.builtin.meta: 'flush_handlers'

--- a/ansible/roles/kmod/tasks/modprobe.yml
+++ b/ansible/roles/kmod/tasks/modprobe.yml
@@ -10,7 +10,7 @@
     state: 'absent'
   notify: [ 'Refresh host facts' ]
   register: kmod__register_module_config_delete
-  when: module.name | d() and module.state | d('present') == 'absent'
+  when: module.name is defined and module.name is truthy and module.state | d('present') == 'absent'
 
 - name: Generate module configuration
   ansible.builtin.template:
@@ -21,7 +21,7 @@
     mode: '0644'
   notify: [ 'Refresh host facts' ]
   register: kmod__register_module_config_create
-  when: module.name | d() and module.state | d('present') != 'absent'
+  when: module.name is defined and module.name is truthy and module.state | d('present') != 'absent'
 
 - name: Unload kernel module if configuration changed
   community.general.modprobe:  # noqa no-handler
@@ -30,7 +30,7 @@
   when: ((kmod__register_module_config_delete is changed or
           kmod__register_module_config_create is changed) and
          module.blacklist is not defined and
-         ansible_local.kmod.modules | d() and
+         ansible_local.kmod.modules is defined and ansible_local.kmod.modules is truthy and
          module.name in ansible_local.kmod.modules and
          module.state | d('present') not in ['config'])
 

--- a/ansible/roles/ldap/tasks/ldap_tasks.yml
+++ b/ansible/roles/ldap/tasks/ldap_tasks.yml
@@ -17,7 +17,7 @@
   become_user: '{{ ldap__admin_become_user if ldap__admin_become_user | d() else omit }}'
   delegate_to: '{{ ldap__admin_delegate_to if ldap__admin_delegate_to | d() else omit }}'
   run_once:    '{{ item.run_once | d(False) }}'
-  when: (item.objectClass | d() or item.entry_state | d()) and item.state not in ['init', 'ignore']
+  when: ((item.objectClass is defined and item.objectClass is truthy) or (item.entry_state is defined and item.entry_state is truthy)) and item.state not in ['init', 'ignore']
   tags: [ 'role::ldap:tasks', 'skip::ldap:tasks' ]
   no_log: '{{ debops__no_log | d(item.no_log | d(True
                                  if ("userPassword" in (item.attributes | d({})).keys() or

--- a/ansible/roles/ldap/tasks/main.yml
+++ b/ansible/roles/ldap/tasks/main.yml
@@ -84,7 +84,7 @@
                 "dn": item.dn,
                 "attributes": item.attributes | d({})} }}'
   when: ldap__enabled | bool and ldap__admin_enabled | bool and
-        item.name | d() and item.dn | d() and
+        item.name is defined and item.name is truthy and item.dn is defined and item.dn is truthy and
         item.state | d('present') not in [ 'init', 'ignore' ]
   tags: [ 'role::ldap:tasks', 'skip::ldap:tasks' ]
   no_log: '{{ debops__no_log | d(item.no_log | d(True

--- a/ansible/roles/librenms/tasks/main.yml
+++ b/ansible/roles/librenms/tasks/main.yml
@@ -131,7 +131,7 @@
     working_dir: '{{ librenms__install_path }}'
   register: librenms__register_composer
   until: librenms__register_composer is succeeded
-  when: (librenms__register_database_status | d() and librenms__register_database_status is changed)
+  when: (librenms__register_database_status is defined and librenms__register_database_status is changed)
   become: True
   become_user: '{{ librenms__user }}'
 
@@ -143,7 +143,7 @@
   become_user: '{{ librenms__user }}'
   register: librenms__register_database_init
   changed_when: librenms__register_database_init.changed | bool
-  when: (librenms__register_database_status | d() and librenms__register_database_status is changed)
+  when: (librenms__register_database_status is defined and librenms__register_database_status is changed)
   tags: [ 'role::librenms:database' ]
 
 - name: Get list of existing users from LibreNMS database
@@ -187,7 +187,7 @@
   register: librenms__register_passwd
   changed_when: False
   check_mode: False
-  when: librenms__home_snmp_conf | d() and librenms__home_snmp_conf
+  when: librenms__home_snmp_conf is defined and librenms__home_snmp_conf is truthy
   tags: [ 'role::librenms:config', 'role::librenms:snmp_conf' ]
 
 - name: Create ~/.snmp directories
@@ -199,8 +199,8 @@
     mode: '0700'
   with_items: '{{ librenms__home_snmp_conf }}'
   check_mode: False
-  when: ((librenms__home_snmp_conf | d() and librenms__home_snmp_conf) and
-         (librenms__register_passwd | d() and item in librenms__register_passwd.stdout_lines))
+  when: ((librenms__home_snmp_conf is defined and librenms__home_snmp_conf is truthy) and
+         (librenms__register_passwd is defined and item in librenms__register_passwd.stdout_lines))
   tags: [ 'role::librenms:config', 'role::librenms:snmp_conf' ]
 
 - name: Generate ~/.snmp/snmp.conf configuration
@@ -211,8 +211,8 @@
     group: '{{ item }}'
     mode: '0600'
   with_items: '{{ librenms__home_snmp_conf }}'
-  when: ((librenms__home_snmp_conf | d() and librenms__home_snmp_conf) and
-         (librenms__register_passwd | d() and item in librenms__register_passwd.stdout_lines))
+  when: ((librenms__home_snmp_conf is defined and librenms__home_snmp_conf is truthy) and
+         (librenms__register_passwd is defined and item in librenms__register_passwd.stdout_lines))
   tags: [ 'role::librenms:config', 'role::librenms:snmp_conf' ]
 
 - name: Get list of known devices from LibreNMS database

--- a/ansible/roles/libvirt/tasks/manage_networks.yml
+++ b/ansible/roles/libvirt/tasks/manage_networks.yml
@@ -11,7 +11,7 @@
     state: 'inactive'
   loop: '{{ q("flattened", libvirt__networks) }}'
   become: False
-  when: (item.name | d() and (item.state | d() in ['inactive', 'undefined', 'absent']))
+  when: (item.name is defined and item.name is truthy and (item.state | d() in ['inactive', 'undefined', 'absent']))
 
 - name: Undefine networks if requested
   community.libvirt.virt_net:
@@ -20,7 +20,7 @@
     state: 'absent'
   loop: '{{ q("flattened", libvirt__networks) }}'
   become: False
-  when: (item.name | d() and (item.state | d() in ['undefined', 'absent']))
+  when: (item.name is defined and item.name is truthy and (item.state | d() in ['undefined', 'absent']))
 
 - name: Define networks
   community.libvirt.virt_net:
@@ -30,7 +30,7 @@
     state: 'present'
   loop: '{{ q("flattened", libvirt__networks) }}'
   become: False
-  when: ((item.name | d()) and
+  when: ((item.name is defined and item.name is truthy) and
          (item.state | d("active") not in ['undefined', 'absent']) and
          (item.interface_present is undefined or
           (item.interface_present in ansible_interfaces and not item.uri | d())))
@@ -42,7 +42,7 @@
     uri: '{{ libvirt__connections[item.uri | d(libvirt__uri)] }}'
   loop: '{{ q("flattened", libvirt__networks) }}'
   become: False
-  when: ((item.name | d()) and
+  when: ((item.name is defined and item.name is truthy) and
          (item.state is undefined or item.state in ['active']) and
          (item.interface_present is undefined or
           (item.interface_present in ansible_interfaces and not item.uri | d())))
@@ -54,7 +54,7 @@
     uri: '{{ libvirt__connections[item.uri | d(libvirt__uri)] }}'
   loop: '{{ q("flattened", libvirt__networks) }}'
   become: False
-  when: ((item.name | d()) and
+  when: ((item.name is defined and item.name is truthy) and
          (item.state is undefined or item.state not in ['undefined', 'absent']) and
          (item.interface_present is undefined or
           (item.interface_present in ansible_interfaces and not item.uri | d())))

--- a/ansible/roles/libvirt/tasks/manage_pools.yml
+++ b/ansible/roles/libvirt/tasks/manage_pools.yml
@@ -12,7 +12,7 @@
   loop: '{{ q("flattened", libvirt__pools) }}'
   become: False
   register: libvirt__register_stop
-  when: ((item.name | d()) and (item.state | d() in ['inactive', 'undefined', 'absent']))
+  when: ((item.name is defined and item.name is truthy) and (item.state | d() in ['inactive', 'undefined', 'absent']))
 
 - name: Delete storage pools if requested
   community.libvirt.virt_pool:  # noqa no-handler
@@ -22,7 +22,7 @@
     mode: '{{ item.item.mode | d(omit) }}'
   loop: '{{ q("flattened", libvirt__register_stop.results) }}'
   become: False
-  when: (item is changed and item.item.name | d() and item.item.delete | d(False) and
+  when: (item is changed and item.item.name is defined and item.item.name is truthy and item.item.delete | d(False) and
          item.item.state | d() in ['undefined'] and
          item.item.type in ['dir', 'nfs', 'logical'])
 
@@ -33,7 +33,7 @@
     state: 'absent'
   loop: '{{ q("flattened", libvirt__pools) }}'
   become: False
-  when: ((item.name | d()) and (item.state | d() in ['undefined', 'absent']))
+  when: ((item.name is defined and item.name is truthy) and (item.state | d() in ['undefined', 'absent']))
 
 - name: Define storage pools
   community.libvirt.virt_pool:
@@ -44,7 +44,7 @@
   loop: '{{ q("flattened", libvirt__pools) }}'
   become: False
   register: libvirt__register_define
-  when: ((item.name | d()) and (item.state | d('active') not in ['undefined', 'absent']))
+  when: ((item.name is defined and item.name is truthy) and (item.state | d('active') not in ['undefined', 'absent']))
 
 - name: Build new storage pools
   community.libvirt.virt_pool:  # noqa no-handler
@@ -54,11 +54,11 @@
     mode: '{{ item.item.mode | d(omit) }}'
   loop: '{{ q("flattened", libvirt__register_define.results) }}'
   become: False
-  when: (item is changed and item.item.name | d() and
+  when: (item is changed and item.item.name is defined and item.item.name is truthy and
          (item.item.state | d('active') not in ['undefined', 'absent']) and
          (item.item.build | d(True)) and
          (item.item.type in ['dir', 'nfs'] or
-         (item.item.type == 'logical' and item.item.devices | d())))
+         (item.item.type == 'logical' and item.item.devices is defined and item.item.devices is truthy)))
 
 - name: Start storage pools if not started
   community.libvirt.virt_pool:
@@ -67,7 +67,7 @@
     uri: '{{ libvirt__connections[item.uri | d(libvirt__uri)] }}'
   loop: '{{ q("flattened", libvirt__pools) }}'
   become: False
-  when: (item.name | d() and item.state | d('active') in ['active'])
+  when: (item.name is defined and item.name is truthy and item.state | d('active') in ['active'])
 
 - name: Set autostart attribute on storage pools
   community.libvirt.virt_pool:
@@ -76,4 +76,4 @@
     uri: '{{ libvirt__connections[item.uri | d(libvirt__uri)] }}'
   loop: '{{ q("flattened", libvirt__pools) }}'
   become: False
-  when: (item.name | d() and item.state | d('active') not in ['undefined', 'absent'])
+  when: (item.name is defined and item.name is truthy and item.state | d('active') not in ['undefined', 'absent'])

--- a/ansible/roles/libvirtd/tasks/main.yml
+++ b/ansible/roles/libvirtd/tasks/main.yml
@@ -91,7 +91,7 @@
     groups: "{{ libvirtd__unix_sock_group }}"
     append: True
   with_items: '{{ libvirtd__admins }}'
-  when: libvirtd__admins | d()
+  when: libvirtd__admins is truthy
 
 - name: Install ferm post hook
   ansible.builtin.template:

--- a/ansible/roles/libvirtd_qemu/tasks/main.yml
+++ b/ansible/roles/libvirtd_qemu/tasks/main.yml
@@ -30,8 +30,8 @@
   register: libvirtd_qemu__register_packages
   until: libvirtd_qemu__register_packages is succeeded
   when: (ansible_local is undefined or
-         (ansible_local | d() and ansible_local.libvirtd is undefined or
-          (ansible_local | d() and ansible_local.libvirtd | d() and
+         (ansible_local is defined and ansible_local.libvirtd is undefined or
+          (ansible_local is defined and ansible_local.libvirtd is defined and
            (ansible_local.libvirtd.installed is undefined or
             not ansible_local.libvirtd.installed | bool))))
 

--- a/ansible/roles/lvm/tasks/manage_lvm.yml
+++ b/ansible/roles/lvm/tasks/manage_lvm.yml
@@ -7,8 +7,8 @@
   ansible.builtin.command: 'vgscan'  # noqa no-handler
   register: lvm__register_vgscan
   changed_when: lvm__register_vgscan.changed | bool
-  when: ((lvm__register_devices_filter | d() and lvm__register_devices_filter is changed) or
-         (lvm__register_devices_global_filter | d() and lvm__register_devices_global_filter is changed))
+  when: ((lvm__register_devices_filter is defined and lvm__register_devices_filter is changed) or
+         (lvm__register_devices_global_filter is defined and lvm__register_devices_global_filter is changed))
 
 - name: Unmount filesystems if requested
   ansible.posix.mount:
@@ -18,7 +18,9 @@
     state:  'absent'
   with_items: '{{ lvm__logical_volumes }}'
   when: lvm__logical_volumes | d(False) and
-        item.vg | d() and item.lv | d() and item.size | d() and
+        item.vg is defined and item.vg is truthy and
+        item.lv is defined and item.lv is truthy and
+        item.size is defined and item.size is truthy and
         item.mount | d(False) and
         item.state | d('present') == 'absent'
 
@@ -31,7 +33,9 @@
     state: 'absent'
   with_items: '{{ lvm__logical_volumes }}'
   when: lvm__logical_volumes | d(False) and
-        item.vg | d() and item.lv | d() and item.size | d() and
+        item.vg is defined and item.vg is truthy and
+        item.lv is defined and item.lv is truthy and
+        item.size is defined and item.size is truthy and
         item.state | d('present') == 'absent'
 
 - name: Manage LVM Volume Groups
@@ -53,7 +57,9 @@
     opts:     '{{ item.opts | d(omit) }}'
   with_items: '{{ lvm__thin_pools }}'
   when: lvm__thin_pools | d(False) and
-        item.vg | d() and item.thinpool | d() and item.size | d() and
+        item.vg is defined and item.vg is truthy and
+        item.thinpool is defined and item.thinpool is truthy and
+        item.size is defined and item.size is truthy and
         item.state | d('present') != 'absent'
 
 - name: Manage LVM Logical Volumes
@@ -68,7 +74,9 @@
     state:      'present'
   with_items: '{{ lvm__logical_volumes }}'
   when: lvm__logical_volumes | d(False) and
-        item.vg | d() and item.lv | d() and item.size | d() and
+        item.vg is defined and item.vg is truthy and
+        item.lv is defined and item.lv is truthy and
+        item.size is defined and item.size is truthy and
         item.state | d('present') != 'absent'
   register: lvm__register_logical_volumes
 
@@ -81,9 +89,13 @@
     resizefs: '{{ item.fs_resizefs | d(omit) }}'
   with_items: '{{ lvm__logical_volumes }}'
   when: lvm__logical_volumes | d(False) and
-        item.vg | d() and item.lv | d() and item.size | d() and
+        item.vg is defined and item.vg is truthy and
+        item.lv is defined and item.lv is truthy and
+        item.size is defined and item.size is truthy and
         item.state | d('present') != 'absent' and
-        ((item.mount | d() and item.fs | d(True)) or item.fs | d()) and
+        ((item.mount is defined and item.mount is truthy and
+          (item.fs is undefined or (item.fs is defined and item.fs is truthy))) or
+         (item.fs is defined and item.fs is truthy)) and
         (not ansible_check_mode or
          (ansible_check_mode and lvm__register_logical_volumes is not changed))
 
@@ -99,6 +111,9 @@
     fstab:  '{{ item.mount_fstab | d(omit) }}'
   with_items: '{{ lvm__logical_volumes }}'
   when: lvm__logical_volumes | d(False) and
-        item.vg | d() and item.lv | d() and item.size | d() and
-        item.fs | d(True) and item.mount | d() and
+        item.vg is defined and item.vg is truthy and
+        item.lv is defined and item.lv is truthy and
+        item.size is defined and item.size is truthy and
+        (item.fs is undefined or (item.fs is defined and item.fs is truthy)) and
+        (item.mount is defined and item.mount is truthy) and
         item.state | d('present') != 'absent'

--- a/ansible/roles/lxc/tasks/main.yml
+++ b/ansible/roles/lxc/tasks/main.yml
@@ -150,7 +150,7 @@
     group: 'root'
     mode: '0755'
   when: (lxc__net_deploy_state == 'present' and
-         ansible_local | d() and ansible_local.ferm | d() and
+         ansible_local is defined and ansible_local.ferm is defined and
          (ansible_local.ferm.enabled | d()) | bool)
   tags: [ 'role::lxc:net' ]
 
@@ -214,14 +214,14 @@
     user: 'root'
     state: 'present'
     exclusive: True
-  when: lxc__default_container_ssh_root_sshkeys | d()
+  when: lxc__default_container_ssh_root_sshkeys is truthy
 
 - name: Remove LXC configuration if requested
   ansible.builtin.file:
     path: '/etc/lxc/{{ item.filename | d(item.name + ".conf") }}'
     state: 'absent'
   with_items: '{{ lxc__combined_configuration | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') == 'absent'
+  when: item.name is defined and item.name is truthy and item.state | d('present') == 'absent'
 
 - name: Generate LXC configuration
   ansible.builtin.template:
@@ -231,14 +231,14 @@
     group: 'root'
     mode: '0644'
   with_items: '{{ lxc__combined_configuration | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'ignore', 'init']
+  when: item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore', 'init']
 
 - name: Remove common LXC container configuration if requested
   ansible.builtin.file:
     path: '/usr/share/lxc/config/common.conf.d/{{ item.filename | d(item.name + ".conf") }}'
     state: 'absent'
   with_items: '{{ lxc__common_combined_conf | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') == 'absent'
+  when: item.name is defined and item.name is truthy and item.state | d('present') == 'absent'
 
 - name: Generate common LXC container configuration
   ansible.builtin.template:
@@ -248,7 +248,7 @@
     group: 'root'
     mode: '0644'
   with_items: '{{ lxc__common_combined_conf | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'ignore', 'init']
+  when: item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore', 'init']
 
 - name: Stop LXC containers if requested
   ansible.builtin.systemd:
@@ -256,7 +256,7 @@
     state: 'stopped'
     enabled: '{{ True if item.state | d("started") == "stopped" else False }}'
   loop: '{{ lxc__containers }}'
-  when: ansible_local | d() and ansible_local.lxc | d() and
+  when: ansible_local is defined and ansible_local.lxc is defined and
         (item.name | d(item)) in ansible_local.lxc.containers | d() and
         item.state | d("started") in ["stopped", "absent"]
   tags: [ 'role::lxc:containers' ]
@@ -267,7 +267,7 @@
     state: 'absent'
   loop: '{{ lxc__containers }}'
   tags: [ 'role::lxc:containers' ]
-  when: ansible_local | d() and ansible_local.lxc | d() and
+  when: ansible_local is defined and ansible_local.lxc is defined and
         (item.name | d(item)) in ansible_local.lxc.containers | d() and
         item.state | d("started") == "absent"
 
@@ -277,9 +277,9 @@
     state: 'absent'
   loop: '{{ lxc__containers }}'
   register: lxc__register_systemd_remove_override
-  when: ansible_local | d() and ansible_local.lxc | d() and
+  when: ansible_local is defined and ansible_local.lxc is defined and
         (item.name | d(item)) in ansible_local.lxc.containers | d() and
-        item.state | d("started") == "absent" and item.systemd_override | d()
+        item.state | d("started") == "absent" and item.systemd_override is defined and item.systemd_override is truthy
   tags: [ 'role::lxc:containers' ]
 
 - name: Create systemd override directories for LXC instances
@@ -290,7 +290,7 @@
     group: 'root'
     mode: '0755'
   loop: '{{ lxc__containers }}'
-  when: item.state | d("started") != "absent" and item.systemd_override | d()
+  when: item.state | d("started") != "absent" and item.systemd_override is defined and item.systemd_override is truthy
   tags: [ 'role::lxc:containers' ]
 
 - name: Generate systemd LXC instance override files
@@ -302,7 +302,7 @@
     mode: '0644'
   loop: '{{ lxc__containers }}'
   register: lxc__register_systemd_create_override
-  when: item.state | d("started") != "absent" and item.systemd_override | d()
+  when: item.state | d("started") != "absent" and item.systemd_override is defined and item.systemd_override is truthy
   tags: [ 'role::lxc:containers' ]
 
 - name: Reload systemd configuration when needed
@@ -354,7 +354,7 @@
       - '--arch {{ (item.architecture | d(lxc__default_container_architecture)) | lower }}'
   loop: '{{ lxc__containers }}'
   tags: [ 'role::lxc:containers' ]
-  when: ansible_local | d() and ansible_local.lxc | d() and
+  when: ansible_local is defined and ansible_local.lxc is defined and
         (item.name | d(item)) not in ansible_local.lxc.containers | d() and
         item.state | d("started") != "absent"
 
@@ -363,7 +363,7 @@
   loop: '{{ lxc__containers }}'
   register: lxc__register_hwaddr_static
   changed_when: lxc__register_hwaddr_static.changed | bool
-  when: ansible_local | d() and ansible_local.lxc | d() and
+  when: ansible_local is defined and ansible_local.lxc is defined and
         (item.name | d(item)) not in ansible_local.lxc.containers | d() and
         item.state | d("started") == "started"
   tags: [ 'role::lxc:containers' ]
@@ -377,9 +377,9 @@
     state: 'present'
     mode: '0644'
   loop: '{{ lxc__containers }}'
-  when: ansible_local | d() and ansible_local.lxc | d() and
+  when: ansible_local is defined and ansible_local.lxc is defined and
         (item.name | d(item)) not in ansible_local.lxc.containers | d() and
-        item.state | d("started") == "started" and item.fstab | d() and
+        item.state | d("started") == "started" and item.fstab is defined and item.fstab is truthy and
         lxc__version is version("4.0", operator="lt", strict=True)
   tags: [ 'role::lxc:containers' ]
 
@@ -392,9 +392,9 @@
     state: 'present'
     mode: '0644'
   loop: '{{ lxc__containers }}'
-  when: ansible_local | d() and ansible_local.lxc | d() and
+  when: ansible_local is defined and ansible_local.lxc is defined and
         (item.name | d(item)) not in ansible_local.lxc.containers | d() and
-        item.state | d("started") == "started" and item.fstab | d() and
+        item.state | d("started") == "started" and item.fstab is defined and item.fstab is truthy and
         lxc__version is version("4.0", operator=">=", strict=True)
   tags: [ 'role::lxc:containers' ]
 
@@ -408,9 +408,9 @@
     group: 'root'
     mode: '0644'
   loop: '{{ lxc__containers }}'
-  when: ansible_local | d() and ansible_local.lxc | d() and
+  when: ansible_local is defined and ansible_local.lxc is defined and
         (item.name | d(item)) not in ansible_local.lxc.containers | d() and
-        item.state | d("started") == "started" and item.fstab | d()
+        item.state | d("started") == "started" and item.fstab is defined and item.fstab is truthy
   tags: [ 'role::lxc:containers' ]
 
 - name: Start LXC containers after creation
@@ -419,7 +419,7 @@
     state: '{{ "restarted" if (item.state is defined) else "started" }}'
     enabled: '{{ True if item.state | d("started") == "started" else False }}'
   loop: '{{ lxc__containers }}'
-  when: ansible_local | d() and ansible_local.lxc | d() and
+  when: ansible_local is defined and ansible_local.lxc is defined and
         (item.name | d(item)) not in ansible_local.lxc.containers | d() and
         item.state | d("started") == "started"
   tags: [ 'role::lxc:containers' ]
@@ -429,7 +429,7 @@
     name: 'lxc@{{ item.0.name | d(item.0) }}.service'
     state: 'restarted'
   loop: '{{ lxc__containers | zip(lxc__register_systemd_create_override.results | d([])) | list }}'
-  when: ansible_local | d() and ansible_local.lxc | d() and
+  when: ansible_local is defined and ansible_local.lxc is defined and
         (item.0.name | d(item.0)) in ansible_local.lxc.containers | d() and
         item.0.state | d('started') == 'started' and item.1 is changed
   tags: [ 'role::lxc:containers' ]
@@ -446,7 +446,7 @@
   loop: '{{ lxc__containers }}'
   register: lxc__register_prepare_ssh
   changed_when: lxc__register_prepare_ssh.changed | bool
-  when: ansible_local | d() and ansible_local.lxc | d() and
+  when: ansible_local is defined and ansible_local.lxc is defined and
         (item.name | d(item)) not in ansible_local.lxc.containers | d() and
         (item.ssh | d(lxc__default_container_ssh)) | bool and item.state | d("started") == "started"
   tags: [ 'role::lxc:containers' ]

--- a/ansible/roles/machine/tasks/main.yml
+++ b/ansible/roles/machine/tasks/main.yml
@@ -60,7 +60,7 @@
     group: 'root'
     mode: '0644'
   when: machine__enabled | bool and machine__etc_motd_state | d('present') != 'absent' and
-        machine__motd | d()
+        machine__motd is defined and machine__motd is truthy
 
 - name: Ensure that required directories exist
   ansible.builtin.file:
@@ -131,7 +131,7 @@
     label: '{{ item.item.name }}'
   register: machine__register_remove_unknown
   changed_when: machine__register_remove_unknown.changed | bool
-  when: (item.item.name | d() and not item.item.divert | d(False) | bool and
+  when: (item.item.name is defined and item.item.name is truthy and not item.item.divert | d(False) | bool and
          item.item.filename is undefined and item is changed)
 
 - name: Make sure that Ansible local facts directory exists

--- a/ansible/roles/mariadb/tasks/main.yml
+++ b/ansible/roles/mariadb/tasks/main.yml
@@ -39,14 +39,14 @@
   ansible.builtin.set_fact:
     mariadb__delegate_to: '{{ mariadb__server | d("undefined") }}'
   when: (not mariadb__register_version.stdout | d(False) and
-         (mariadb__register_tunnel | d() and mariadb__register_tunnel.rc == 0))
+         (mariadb__register_tunnel is defined and mariadb__register_tunnel.rc == 0))
 
 - name: Override configuration if local server is detected
   ansible.builtin.set_fact:
     mariadb__server: 'localhost'
     mariadb__client: 'localhost'
   when: (mariadb__register_version.stdout | d(False) or
-         (mariadb__register_tunnel | d() and mariadb__register_tunnel.rc == 0))
+         (mariadb__register_tunnel is defined and mariadb__register_tunnel.rc == 0))
 
 - name: Install database client packages
   ansible.builtin.package:

--- a/ansible/roles/mariadb_server/tasks/configure_server.yml
+++ b/ansible/roles/mariadb_server/tasks/configure_server.yml
@@ -18,7 +18,7 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  when: mariadb_server__backup | d()
+  when: mariadb_server__backup is truthy
 
 - name: Enable events table backup in mysqldump
   community.general.ini_file:

--- a/ansible/roles/mariadb_server/tasks/main.yml
+++ b/ansible/roles/mariadb_server/tasks/main.yml
@@ -45,8 +45,8 @@
   ansible.builtin.service:  # noqa no-handler
     name: 'mysql'
     state: 'stopped'
-  when: ((mariadb_server__register_version | d() and not mariadb_server__register_version.stdout) and
-         (mariadb_server__register_install_status | d() and mariadb_server__register_install_status is changed))
+  when: ((mariadb_server__register_version is defined and not mariadb_server__register_version.stdout) and
+         (mariadb_server__register_install_status is defined and mariadb_server__register_install_status is changed))
 
 - name: Add database server user to specified groups
   ansible.builtin.user:
@@ -74,8 +74,8 @@
     'mv {{ mariadb_server__default_datadir }}/* {{ mariadb_server__datadir }}'
   register: mariadb_server__register_move
   changed_when: mariadb_server__register_move.changed | bool
-  when: ((mariadb_server__register_version | d() and not mariadb_server__register_version.stdout) and
-         (mariadb_server__register_install_status | d() and mariadb_server__register_install_status is changed) and
+  when: ((mariadb_server__register_version is defined and not mariadb_server__register_version.stdout) and
+         (mariadb_server__register_install_status is defined and mariadb_server__register_install_status is changed) and
          (mariadb_server__datadir != mariadb_server__default_datadir))
 
 - name: Configure database client on first install
@@ -85,7 +85,7 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  when: (mariadb_server__register_version | d() and not mariadb_server__register_version.stdout)
+  when: (mariadb_server__register_version is defined and not mariadb_server__register_version.stdout)
 
 - name: Configure database server
   ansible.builtin.include_tasks: 'configure_server.yml'
@@ -95,8 +95,8 @@
   ansible.builtin.service:  # noqa no-handler
     name: 'mysql'
     state: 'started'
-  when: ((mariadb_server__register_version | d() and not mariadb_server__register_version.stdout) and
-         (mariadb_server__register_install_status | d() and mariadb_server__register_install_status is changed))
+  when: ((mariadb_server__register_version is defined and not mariadb_server__register_version.stdout) and
+         (mariadb_server__register_install_status is defined and mariadb_server__register_install_status is changed))
 
 - name: Secure database server
   ansible.builtin.include_tasks: 'secure_installation.yml'

--- a/ansible/roles/mariadb_server/tasks/secure_installation.yml
+++ b/ansible/roles/mariadb_server/tasks/secure_installation.yml
@@ -16,5 +16,5 @@
     db: 'test'
     state: 'absent'
     login_unix_socket: '/run/mysqld/mysqld.sock'
-  when: ((mariadb_server__register_version | d() and not mariadb_server__register_version.stdout) and
-         (mariadb_server__register_install_status | d() and mariadb_server__register_install_status is changed))
+  when: ((mariadb_server__register_version is defined and not mariadb_server__register_version.stdout) and
+         (mariadb_server__register_install_status is defined and mariadb_server__register_install_status is changed))

--- a/ansible/roles/metricbeat/tasks/main.yml
+++ b/ansible/roles/metricbeat/tasks/main.yml
@@ -64,7 +64,7 @@
   loop: '{{ metricbeat__combined_snippets | debops.debops.parse_kv_config }}'
   loop_control:
     label:  '{{ {"name": item.name, "state": item.state} }}'
-  when: item.state | d('present') not in ['absent', 'ignore', 'init'] and item.config | d()
+  when: item.state | d('present') not in ['absent', 'ignore', 'init'] and item.config is defined and item.config is truthy
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Manage snippet diversion and reversion
@@ -76,7 +76,7 @@
   loop_control:
     label:  '{{ {"name": item.name, "state": item.state} }}'
   notify: [ 'Test metricbeat configuration and restart' ]
-  when: ansible_pkg_mgr == 'apt' and item.config | d() and (item.divert | d())
+  when: ansible_pkg_mgr == 'apt' and item.config is defined and item.config is truthy and (item.divert is defined and item.divert is truthy)
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Remove snippet configuration if requested
@@ -87,7 +87,7 @@
   loop_control:
     label:  '{{ {"name": item.name, "state": item.state, "config": item.config} }}'
   notify: [ 'Test metricbeat configuration and restart' ]
-  when: item.state | d('present') == 'absent' and item.config | d()
+  when: item.state | d('present') == 'absent' and item.config is defined and item.config is truthy
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Generate snippet configuration
@@ -99,7 +99,7 @@
   loop_control:
     label:  '{{ {"name": item.name, "state": item.state, "config": item.config} }}'
   notify: [ 'Test metricbeat configuration and restart' ]
-  when: item.state | d('present') not in ['absent', 'ignore', 'init'] and item.config | d()
+  when: item.state | d('present') not in ['absent', 'ignore', 'init'] and item.config is defined and item.config is truthy
   no_log: '{{ debops__no_log | d(True) }}'
 
 # The keystore handling is very similar to ../../kibana/tasks/main.yml
@@ -160,4 +160,4 @@
   ansible.builtin.service:  # noqa no-handler
     name: 'metricbeat'
     enabled: True
-  when: ansible_local.metricbeat.installed | d() and metricbeat__register_config_divert is changed
+  when: ansible_local.metricbeat.installed is defined and ansible_local.metricbeat.installed is truthy and metricbeat__register_config_divert is changed

--- a/ansible/roles/minio/tasks/main.yml
+++ b/ansible/roles/minio/tasks/main.yml
@@ -100,7 +100,7 @@
     enabled: False
   loop: '{{ minio__combined_instances | debops.debops.parse_kv_items }}'
   when: ansible_service_mgr == 'systemd' and
-        item.name | d() and item.state | d('present') in ['absent']
+        item.name is defined and item.name is truthy and item.state | d('present') in ['absent']
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Remove MinIO instance configuration files if requested
@@ -108,7 +108,7 @@
     path: '{{ minio__config_dir + "/" + item.name }}'
     state: 'absent'
   loop: '{{ minio__combined_instances | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') in ['absent']
+  when: item.name is defined and item.name is truthy and item.state | d('present') in ['absent']
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Generate MinIO instance configuration files
@@ -120,7 +120,7 @@
     mode: '0640'
   loop: '{{ minio__combined_instances | debops.debops.parse_kv_items }}'
   register: minio__register_instance_config
-  when: item.name | d() and item.port | d() and
+  when: item.name is defined and item.name is truthy and item.port is defined and item.port is truthy and
         item.state | d('present') not in ['absent', 'ignore', 'init']
   no_log: '{{ debops__no_log | d(True) }}'
 
@@ -131,7 +131,7 @@
     enabled: True
   loop: '{{ minio__combined_instances | debops.debops.parse_kv_items }}'
   when: ansible_service_mgr == 'systemd' and
-        item.name | d() and item.port | d() and
+        item.name is defined and item.name is truthy and item.port is defined and item.port is truthy and
         item.state | d('present') not in ['absent', 'ignore', 'init']
   no_log: '{{ debops__no_log | d(True) }}'
 

--- a/ansible/roles/monit/tasks/main.yml
+++ b/ansible/roles/monit/tasks/main.yml
@@ -29,7 +29,7 @@
     path: '/etc/monit/conf.d/{{ ((item.weight | string + "_") if (item.weight != 0) else "") + item.name }}'
     state: 'absent'
   with_items: '{{ monit__combined_config | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') == 'absent'
+  when: item.name is defined and item.name is truthy and item.state | d('present') == 'absent'
   notify: [ 'Test monit and reload' ]
   no_log: '{{ debops__no_log | d(True if (item.mode | d("0644") == "0600") else False) }}'
 
@@ -41,7 +41,7 @@
     group: 'root'
     mode: '{{ item.mode | d("0600") }}'
   with_items: '{{ monit__combined_config | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['init', 'absent']
+  when: item.name is defined and item.name is truthy and item.state | d('present') not in ['init', 'absent']
   notify: [ 'Test monit and reload' ]
   no_log: '{{ debops__no_log | d(True if (item.mode | d("0644") == "0600") else False) }}'
 

--- a/ansible/roles/mosquitto/tasks/main.yml
+++ b/ansible/roles/mosquitto/tasks/main.yml
@@ -33,7 +33,7 @@
   with_items: '{{ mosquitto__pip_packages }}'
   register: mosquitto__register_pip_install
   until: mosquitto__register_pip_install is succeeded
-  when: mosquitto__pip_packages | d()
+  when: mosquitto__pip_packages is truthy
 
 - name: Check the installed Mosquitto version
   ansible.builtin.shell: set -o nounset -o pipefail -o errexit &&

--- a/ansible/roles/netbox/tasks/main.yml
+++ b/ansible/roles/netbox/tasks/main.yml
@@ -120,7 +120,8 @@
   until: netbox__register_checkout is succeeded
   notify: [ 'Restart gunicorn for netbox', 'Restart netbox internal appserver', 'Restart netbox Request Queue Worker' ]
   when: (netbox__register_source.before is undefined or
-         (netbox__register_source.before | d() and netbox__register_target_branch.stdout | d() and
+         (netbox__register_source.before is defined and netbox__register_source.before is truthy and
+          netbox__register_target_branch.stdout is defined and netbox__register_target_branch.stdout is truthy and
           netbox__register_source.before != netbox__register_target_branch.stdout) or
           not netbox__register_installed.stat.exists | bool or
           netbox__register_virtalenv_deleted.changed | bool)

--- a/ansible/roles/networkd/tasks/main.yml
+++ b/ansible/roles/networkd/tasks/main.yml
@@ -82,7 +82,7 @@
   loop: '{{ networkd__combined_units | flatten | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
-  when: networkd__enabled | bool and item.raw | d() and
+  when: networkd__enabled | bool and item.raw is defined and item.raw is truthy and
         item.state | d("present") not in ['absent', 'ignore', 'init'] and
         (item.name | dirname).endswith('.d')
 
@@ -95,7 +95,7 @@
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
   notify: [ 'Restart systemd-networkd service' ]
-  when: networkd__enabled | bool and item.raw | d() and
+  when: networkd__enabled | bool and item.raw is defined and item.raw is truthy and
         item.state | d("present") not in ['absent', 'ignore', 'init']
 
 - name: Flush handlers when needed

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -143,7 +143,7 @@
   ansible.builtin.service:
     name: 'nginx'
     state: 'restarted'
-  when: (nginx_register_installed | d() and not nginx_register_installed.stat.exists and
+  when: (nginx_register_installed is defined and not nginx_register_installed.stat.exists and
          nginx__deploy_state in ['present', 'config'])
 
 - name: Get list of nameservers configured in /etc/resolv.conf
@@ -188,7 +188,7 @@
     owner: 'root'
     group: 'root'
     mode: '0440'
-  when: (ansible_local | d() and ansible_local.sudo | d() and
+  when: (ansible_local is defined and ansible_local.sudo is defined and
          (ansible_local.sudo.installed | d()) | bool and
          nginx__deploy_state in ['present', 'config'])
 

--- a/ansible/roles/nginx/tasks/nginx_configs.yml
+++ b/ansible/roles/nginx/tasks/nginx_configs.yml
@@ -24,9 +24,9 @@
                            + nginx_default_maps | d([])
                            + nginx_dependent_maps | d([])) }}'
   notify: [ 'Test nginx and reload' ]
-  when: (item.name | d() and
-         ((item.state | d() and item.state == 'absent') or
-          (item.delete | d() and item.delete | bool)))
+  when: (item.name is defined and item.name is truthy and
+         ((item.state is defined and item.state == 'absent') or
+          (item.delete is defined and item.delete | bool)))
   tags: [ 'role::nginx:servers' ]
 
 - name: Configure nginx maps
@@ -43,7 +43,7 @@
                            + nginx_default_maps | d([])
                            + nginx_dependent_maps | d([])) }}'
   notify: [ 'Test nginx and reload' ]
-  when: (item.name | d() and item.state | d('present') != 'absent' and
+  when: (item.name is defined and item.name is truthy and item.state | d('present') != 'absent' and
          (item.delete is undefined or not item.delete | bool))
   tags: [ 'role::nginx:servers' ]
 
@@ -58,9 +58,9 @@
                            + nginx_default_upstreams | d([])
                            + nginx_dependent_upstreams | d([])) }}'
   notify: [ 'Test nginx and reload' ]
-  when: (item.name | d() and
+  when: (item.name is defined and item.name is truthy and
          ((item.state | d('present') == 'absent') or
-          (item.delete | d() and item.delete | bool)))
+          (item.delete is defined and item.delete | bool)))
   tags: [ 'role::nginx:servers' ]
 
 - name: Configure nginx upstreams
@@ -77,7 +77,7 @@
                            + nginx_default_upstreams | d([])
                            + nginx_dependent_upstreams | d([])) }}'
   notify: [ 'Test nginx and reload' ]
-  when: (item.name | d() and item.state | d('present') != 'absent' and
+  when: (item.name is defined and item.name is truthy and item.state | d('present') != 'absent' and
          (item.delete is undefined or not item.delete | bool))
   tags: [ 'role::nginx:servers' ]
 
@@ -88,9 +88,9 @@
   loop: '{{ q("flattened", nginx__log_format
                            + nginx__dependent_log_format) }}'
   notify: [ 'Test nginx and reload' ]
-  when: (item.name | d() and
+  when: (item.name is defined and item.name is truthy and
          ((item.state | d('present') == 'absent') or
-          (item.delete | d() and item.delete | bool)))
+          (item.delete is defined and item.delete is truthy and item.delete | bool)))
   tags: [ 'role::nginx:servers' ]
 
 - name: Configure nginx log_format
@@ -103,7 +103,7 @@
   loop: '{{ q("flattened", nginx__log_format
                            + nginx__dependent_log_format) }}'
   notify: [ 'Test nginx and reload' ]
-  when: (item.name | d() and item.state | d('present') != 'absent' and
+  when: (item.name is defined and item.name is truthy and item.state | d('present') != 'absent' and
          (item.delete is undefined or not item.delete | bool))
   tags: [ 'role::nginx:servers' ]
 
@@ -114,9 +114,9 @@
   loop: '{{ q("flattened", nginx__custom_config
                            + nginx_custom_config | d([])) }}'
   notify: [ 'Test nginx and reload' ]
-  when: (item.name | d() and
-         ((item.state | d() and item.state == 'absent') or
-          (item.delete | d() and item.delete | bool)))
+  when: (item.name is defined and item.name is truthy and
+         ((item.state is defined and item.state == 'absent') or
+          (item.delete is defined and item.delete | bool)))
   tags: [ 'role::nginx:servers' ]
 
 - name: Add custom nginx configuration
@@ -129,6 +129,6 @@
   loop: '{{ q("flattened", nginx__custom_config
                            + nginx_custom_config | d([])) }}'
   notify: [ 'Test nginx and reload' ]
-  when: (item.name | d() and item.state | d('present') != 'absent' and
+  when: (item.name is defined and item.name is truthy and item.state | d('present') != 'absent' and
          (item.delete is undefined or not item.delete | bool))
   tags: [ 'role::nginx:servers' ]

--- a/ansible/roles/nginx/tasks/nginx_htpasswd.yml
+++ b/ansible/roles/nginx/tasks/nginx_htpasswd.yml
@@ -20,7 +20,7 @@
                            + nginx__default_htpasswd
                            + nginx__dependent_htpasswd
                            + nginx_htpasswd | d([])) }}'
-  when: (item.name | d() and (item.state | d() and item.state == 'absent'))
+  when: (item.name is defined and item.name is truthy and (item.state is defined and item.state == 'absent'))
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Manage users in htpasswd files
@@ -40,5 +40,5 @@
   with_subelements:
     - '{{ nginx__htpasswd + nginx__default_htpasswd + nginx__dependent_htpasswd + nginx_htpasswd | d([]) }}'
     - 'users'
-  when: (item.0.name | d() and item.0.state | d('present') != 'absent' and item.1 | d())
+  when: (item.0.name is defined and item.0.name is truthy and item.0.state | d('present') != 'absent' and item.1 is defined and item.1 is truthy)
   no_log: '{{ debops__no_log | d(True) }}'

--- a/ansible/roles/nginx/tasks/nginx_servers.yml
+++ b/ansible/roles/nginx/tasks/nginx_servers.yml
@@ -129,7 +129,7 @@
                             + nginx_internal_servers | d([]) + nginx_dependent_servers | d([]))[::-1]) }}'
   when: (item.state | d('present') != 'absent' and
          (item.enabled | d(True) | bool) and
-         (item.listen | d(True)) and
+         (item.listen is undefined or (item.listen is defined and item.listen is truthy)) and
          ((item.ssl is undefined or not item.ssl | bool) or not nginx_pki | bool))
   tags: [ 'role::nginx:servers' ]
 
@@ -140,7 +140,7 @@
                             + nginx_servers | d([]) + nginx_default_servers | d([])
                             + nginx_internal_servers | d([]) + nginx_dependent_servers | d([]))[::-1]) }}'
   when: (item.state | d('present') != 'absent' and (item.enabled is undefined or item.enabled | bool) and
-         (item.listen_ssl is undefined or item.listen_ssl | d()) and
+         (item.listen_ssl is undefined or (item.listen_ssl is defined and item.listen_ssl is truthy)) and
          ((item.ssl | d() and item.ssl | bool) or
           (item.ssl is undefined and nginx_pki | bool)))
   tags: [ 'role::nginx:servers' ]

--- a/ansible/roles/nslcd/tasks/main.yml
+++ b/ansible/roles/nslcd/tasks/main.yml
@@ -42,7 +42,7 @@
     group: '{{ nslcd__group }}'
     mode: '0640'
   register: nslcd__register_config
-  when: nslcd__ldap_base_dn | d()
+  when: nslcd__ldap_base_dn is truthy
 
 - name: Restart nslcd if its configuration was modified
   ansible.builtin.service:  # noqa no-handler

--- a/ansible/roles/owncloud/tasks/copy.yml
+++ b/ansible/roles/owncloud/tasks/copy.yml
@@ -16,7 +16,7 @@
     owner:   '{{ item.parent_dirs_owner | d(owncloud__app_user) }}'
     group:   '{{ item.parent_dirs_group | d(owncloud__app_group) }}'
     mode:    '{{ item.parent_dirs_mode | d("0755") }}'
-  when: ((item.parent_dirs_create | d(True) | bool) and item.dest | d() and item.state | d("present") != 'absent')
+  when: ((item.parent_dirs_create | d(True) | bool) and item.dest is defined and item.dest is truthy and item.state | d("present") != 'absent')
   loop: '{{ q("flattened", owncloud__user_files
                            + owncloud__user_files_group
                            + owncloud__user_files_host) }}'
@@ -43,7 +43,7 @@
   loop: '{{ q("flattened", owncloud__user_files
                            + owncloud__user_files_group
                            + owncloud__user_files_host) }}'
-  when: ((item.src | d() or item.content | d()) and item.dest | d() and
+  when: (((item.src is defined and item.src is truthy) or (item.content is defined and item.content is truthy)) and item.dest is defined and item.dest is truthy and
          (item.state | d('present') != 'absent'))
 
 - name: Delete files on remote hosts
@@ -54,7 +54,7 @@
   loop: '{{ q("flattened", owncloud__user_files
                            + owncloud__user_files_group
                            + owncloud__user_files_host) }}'
-  when: (item.dest | d() and (item.state | d('present') == 'absent'))
+  when: (item.dest is defined and item.dest is truthy and (item.state | d('present') == 'absent'))
 
 - name: Run occ commands as specified in the inventory
   ansible.builtin.include_tasks: 'run_occ.yml'  # noqa no-handler

--- a/ansible/roles/owncloud/tasks/main_env.yml
+++ b/ansible/roles/owncloud/tasks/main_env.yml
@@ -14,7 +14,7 @@
     owner: '{{ ansible_local.nginx.user | d("www-data") }}'
     group: 'root'
     mode: '0700'
-  when: (owncloud__webserver in ["nginx"] and owncloud__nginx_client_body_temp_path | d())
+  when: (owncloud__webserver in ["nginx"] and owncloud__nginx_client_body_temp_path is defined and owncloud__nginx_client_body_temp_path is truthy)
 
 - name: Ensure the custom temp directories are setup
   ansible.builtin.file:
@@ -23,7 +23,7 @@
     owner: '{{ owncloud__app_user }}'
     group: '{{ owncloud__app_group }}'
     mode: '{{ item.mode | d("1750") }}'
-  when: item.path | d()
+  when: item.path is defined and item.path is truthy
   with_items:
     - path: '{{ owncloud__temp_path }}'
     - path: '{{ owncloud__php_temp_path }}'

--- a/ansible/roles/owncloud/tasks/run_occ.yml
+++ b/ansible/roles/owncloud/tasks/run_occ.yml
@@ -59,8 +59,8 @@
   become_user: '{{ owncloud__app_user }}'
   ## https://github.com/debops/ansible-owncloud/issues/62
   when: (owncloud__do_autosetup | d() | bool and
-         owncloud__occ_item | d() and
-         owncloud__occ_item.command | d() and
+         owncloud__occ_item is defined and
+         owncloud__occ_item.command is defined and owncloud__occ_item.command is truthy and
          (owncloud__occ_item.when | d(True) | bool) and not
           (ansible_local.owncloud.maintenance | d() | bool and
            (owncloud__occ_item.command.startswith("dav") or
@@ -85,5 +85,5 @@
     ## regex_replace: Relies on the fact that `json_pretty` indents the JSON encoded object.
     owncloud__occ_run_output: '{{ owncloud__occ_run.stdout_lines
                                   | map("regex_replace", "^[^{} ].*$", "") | join("") | from_json }}'
-  when: (owncloud__do_autosetup | d() | bool and owncloud__occ_item | d() and (owncloud__occ_item.get_output | d() | bool) and (not ansible_check_mode))
+  when: (owncloud__do_autosetup | d() | bool and owncloud__occ_item is defined and (owncloud__occ_item.get_output | d() | bool) and (not ansible_check_mode))
   tags: [ 'role::owncloud:occ_config', 'role::owncloud:occ' ]

--- a/ansible/roles/owncloud/tasks/theme.yml
+++ b/ansible/roles/owncloud/tasks/theme.yml
@@ -24,7 +24,7 @@
     path: '{{ owncloud__deploy_path + "/themes/" + owncloud__theme_directory_name }}'
     state: 'directory'
     mode: '0755'
-  when: (owncloud__theme_directory_name | d())
+  when: (owncloud__theme_directory_name is defined and owncloud__theme_directory_name is truthy)
   tags:
     - 'role::owncloud:theme:common_settings'
 
@@ -37,7 +37,7 @@
     group: '{{ owncloud__app_group }}'
     mode: '0640'
     validate: 'php -f %s'
-  when: (owncloud__theme_directory_name | d())
+  when: (owncloud__theme_directory_name is defined and owncloud__theme_directory_name is truthy)
   tags: [ 'role::owncloud:theme:common_settings' ]
 
 - name: Ensure that parent directories exist
@@ -48,7 +48,7 @@
     group: '{{ item.value.base_directory_group | d(omit) }}'
     mode:  '{{ item.value.base_directory_mode | d(omit) }}'
   with_dict: '{{ owncloud__theme_copy_files_combined }}'
-  when: (owncloud__theme_directory_name | d() and item.value.state | d("present") == "present")
+  when: (owncloud__theme_directory_name is defined and owncloud__theme_directory_name is truthy and item.value.state | d("present") == "present")
   tags: [ 'role::owncloud:theme:copy' ]
 
 - name: Copy additional theme files
@@ -70,7 +70,7 @@
     src:            '{{ item.value.src | d(omit) }}'
     validate:       '{{ item.value.validate | d(omit) }}'
   with_dict: '{{ owncloud__theme_copy_files_combined }}'
-  when: (owncloud__theme_directory_name | d() and item.value.state | d("present") == "present")
+  when: (owncloud__theme_directory_name is defined and owncloud__theme_directory_name is truthy and item.value.state | d("present") == "present")
   tags: [ 'role::owncloud:theme:copy' ]
 
 - name: Activate custom theme
@@ -80,7 +80,7 @@
     owner: 'root'
     group: '{{ owncloud__app_group }}'
     mode: '0640'
-  when: (owncloud__theme_active | d())
+  when: (owncloud__theme_active is defined and owncloud__theme_active is truthy)
   tags: [ 'role::owncloud:theme:activate' ]
 
 # .. ]]]
@@ -98,7 +98,7 @@
   ansible.builtin.file:
     path: '{{ owncloud__deploy_path + "/themes/" + owncloud__theme_directory_name + "/" + item.key }}'
     state: 'absent'
-  when: (owncloud__theme_directory_name | d() and item.value.state | d("present") == "absent")
+  when: (owncloud__theme_directory_name is defined and owncloud__theme_directory_name is truthy and item.value.state | d("present") == "absent")
   with_dict: '{{ owncloud__theme_copy_files_combined }}'
   tags: [ 'role::owncloud:theme:copy' ]
 

--- a/ansible/roles/pam_access/tasks/main.yml
+++ b/ansible/roles/pam_access/tasks/main.yml
@@ -22,7 +22,7 @@
   loop: '{{ pam_access__combined_rules | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"access_conf": pam_access__var_access_conf, "state": item.state | d("present")} }}'
-  when: (pam_access__enabled | bool and item.name | d() and
+  when: (pam_access__enabled | bool and item.name is defined and item.name is truthy and
          item.divert | d(False) | bool and
          item.state | d('present') in ['present', 'absent'])
 

--- a/ansible/roles/php/tasks/main.yml
+++ b/ansible/roles/php/tasks/main.yml
@@ -71,7 +71,7 @@
     owner: 'root'
     group: 'root'
     mode: '0440'
-  when: (ansible_local | d() and ansible_local.sudo | d() and
+  when: (ansible_local is defined and ansible_local.sudo is defined and
          (ansible_local.sudo.installed | d()) | bool)
 
                                                                    # ]]]
@@ -102,7 +102,7 @@
                            + php__group_configuration
                            + php__host_configuration
                            + php__dependent_configuration) }}'
-  when: item.state | d() and item.state == 'absent'
+  when: item.state is defined and item.state is truthy and item.state == 'absent'
   notify: [ 'Restart php-fpm' ]
   tags: [ 'role::php:config' ]
 
@@ -112,7 +112,7 @@
   ansible.builtin.script: script/php-synchronize-config.sh {{ php__version }}
   register: php__register_synchronize_config
   changed_when: php__register_synchronize_config.stdout is defined and
-                php__register_synchronize_config.stdout | d()
+                php__register_synchronize_config.stdout is truthy
   notify: [ 'Restart php-fpm' ]
   tags: [ 'role::php:config' ]
 
@@ -165,7 +165,7 @@
                            + php__group_pools
                            + php__host_pools
                            + php__dependent_pools) }}'
-  when: '"fpm" in php__server_api_packages and item.state | d() and item.state == "absent"'
+  when: '"fpm" in php__server_api_packages and item.state is defined and item.state is truthy and item.state == "absent"'
   notify: [ 'Restart php-fpm' ]
   tags: [ 'role::php:pools', 'role::php:config' ]
 
@@ -182,7 +182,7 @@
                            + php__group_pools
                            + php__host_pools
                            + php__dependent_pools) }}'
-  when: '"fpm" in php__server_api_packages and item.state | d("present") != "absent" and item.owner | d() and item.home | d()'
+  when: '"fpm" in php__server_api_packages and item.state | d("present") != "absent" and item.owner is defined and item.owner is truthy and item.home is defined and item.home is truthy'
 
 - name: Make sure required system accounts exist
   ansible.builtin.user:
@@ -197,7 +197,7 @@
                            + php__group_pools
                            + php__host_pools
                            + php__dependent_pools) }}'
-  when: '"fpm" in php__server_api_packages and item.state | d("present") != "absent" and item.owner | d() and item.home | d()'
+  when: '"fpm" in php__server_api_packages and item.state | d("present") != "absent" and item.owner is defined and item.owner is truthy and item.home is defined and item.home is truthy'
 
                                                                    # ]]]
 # Ansible local facts [[[

--- a/ansible/roles/postfix/tasks/main.yml
+++ b/ansible/roles/postfix/tasks/main.yml
@@ -35,7 +35,7 @@
     name: '{{ postfix__purge_packages | flatten }}'
     state: 'absent'
     purge: True
-  when: postfix__purge_packages | d() and ansible_pkg_mgr == 'apt'
+  when: postfix__purge_packages is defined and postfix__purge_packages is truthy and ansible_pkg_mgr == 'apt'
   tags: [ 'meta::provision' ]
 
 - name: Disable Postfix configuration in debconf
@@ -107,7 +107,7 @@
     path: '/etc/postfix/{{ item.name }}'
     state: 'absent'
   loop: '{{ postfix__combined_lookup_tables | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') == 'absent'
+  when: item.name is defined and item.name is truthy and item.state | d('present') == 'absent'
   notify: [ 'Process Postfix Makefile', 'Check postfix and reload' ]
   no_log: '{{ debops__no_log | d(item.no_log)
               | d(True if (item.mode | d("0644") == "0600") else False) }}'
@@ -121,7 +121,7 @@
     mode:  '{{ item.mode | d("0640") }}'
   loop: '{{ postfix__combined_lookup_tables | debops.debops.parse_kv_items }}'
   notify: [ 'Process Postfix Makefile', 'Check postfix and reload' ]
-  when: item.name | d() and item.state | d('present') != 'absent'
+  when: item.name is defined and item.name is truthy and item.state | d('present') != 'absent'
   no_log: '{{ debops__no_log | d(item.no_log)
               | d(True if (item.mode | d("0640") in ["0640", "0600"])
                   else False) }}'

--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -178,7 +178,7 @@
   become_user: '{{ postgresql__user }}'
   delegate_to: '{{ postgresql__delegate_to }}'
   when: (item.state | d('present') == 'present') and
-        item.owner | d()
+        item.owner is defined and item.owner is truthy
 
 - name: Grant PostgreSQL groups
   community.postgresql.postgresql_privs:
@@ -212,7 +212,7 @@
   become_user: '{{ postgresql__user }}'
   delegate_to: '{{ postgresql__delegate_to }}'
   when: (item.state | d('present') == 'present') and
-        (item.db | d() and item.priv | d())
+        (item.db is defined and item.db is truthy and item.priv is defined and item.priv is truthy)
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Grant or revoke extra privileges

--- a/ansible/roles/postgresql_server/tasks/install_postgresql.yml
+++ b/ansible/roles/postgresql_server/tasks/install_postgresql.yml
@@ -37,9 +37,9 @@
   ansible.builtin.command: pg_dropcluster --stop {{ postgresql_server__version }} main
   register: postgresql_server__register_dropcluster
   changed_when: postgresql_server__register_dropcluster.changed | bool
-  when: ((postgresql_server__register_installed | d() and not postgresql_server__register_installed.stdout) and
-         (postgresql_server__register_installed_main | d() and postgresql_server__register_installed_main.stat.exists) and
+  when: ((postgresql_server__register_installed is defined and not postgresql_server__register_installed.stdout) and
+         (postgresql_server__register_installed_main is defined and postgresql_server__register_installed_main.stat.exists) and
           (ansible_local is undefined or
-           (ansible_local | d() and ansible_local.postgresql is undefined or
-            (ansible_local | d() and ansible_local.postgresql | d() and
+           (ansible_local is defined and ansible_local.postgresql is undefined or
+            (ansible_local is defined and ansible_local.postgresql is defined and
              ansible_local.postgresql.server != 'localhost'))))

--- a/ansible/roles/postwhite/tasks/main.yml
+++ b/ansible/roles/postwhite/tasks/main.yml
@@ -75,8 +75,8 @@
   register: postwhite__register_scrape_yahoo
   changed_when: postwhite__register_scrape_yahoo.changed | bool
   when: (ansible_local is undefined or
-         (ansible_local | d() and ansible_local.postwhite is undefined or
-          (ansible_local.postwhite | d() and
+         (ansible_local is defined and ansible_local.postwhite is undefined or
+          (ansible_local.postwhite is defined and
            not (ansible_local.postwhite.installed | d()) | bool)))
 
 - name: Initialize whitelist/blacklist files
@@ -90,8 +90,8 @@
     - '{{ postwhite__spf_whitelist_path }}'
     - '{{ postwhite__spf_blacklist_path }}'
   when: (ansible_local is undefined or
-         (ansible_local | d() and ansible_local.postwhite is undefined or
-          (ansible_local.postwhite | d() and
+         (ansible_local is defined and ansible_local.postwhite is undefined or
+          (ansible_local.postwhite is defined and
            not (ansible_local.postwhite.installed | d()) | bool)))
 
 - name: Update Postwhite access lists daily

--- a/ansible/roles/python/tasks/main.yml
+++ b/ansible/roles/python/tasks/main.yml
@@ -44,8 +44,8 @@
     dest: '/etc/ansible/facts.d/python.fact'
     mode: '0755'
   notify: [ 'Refresh host facts' ]
-  when: (python__enabled | bool and ansible_local | d() and
-         ansible_local.python | d() and
+  when: (python__enabled | bool and ansible_local is defined and
+         ansible_local.python is defined and
          not ansible_local.python.configured | bool)
 
 - name: Re-read local facts if they have been modified

--- a/ansible/roles/rabbitmq_server/tasks/main.yml
+++ b/ansible/roles/rabbitmq_server/tasks/main.yml
@@ -81,7 +81,7 @@
   register: rabbitmq_server__register_dependent_config_file
   become: False
   delegate_to: 'localhost'
-  when: (ansible_local | d() and ansible_local.rabbitmq_server | d() and
+  when: (ansible_local is defined and ansible_local.rabbitmq_server is defined and
          ansible_local.rabbitmq_server.installed is defined and
          ansible_local.rabbitmq_server.installed | bool)
   tags: [ 'role::rabbitmq_server:config' ]
@@ -92,7 +92,7 @@
   register: rabbitmq_server__register_dependent_config
   become: False
   delegate_to: 'localhost'
-  when: (ansible_local | d() and ansible_local.rabbitmq_server | d() and
+  when: (ansible_local is defined and ansible_local.rabbitmq_server is defined and
          ansible_local.rabbitmq_server.installed is defined and
          ansible_local.rabbitmq_server.installed | bool and
          rabbitmq_server__register_dependent_config_file.stat.exists | bool)
@@ -153,7 +153,7 @@
     cmd: >-
       rabbitmqctl update_vhost_metadata {{ item.name | d(item) }}
       --default-queue-type {{ item.default_queue_type }}
-  when: item.default_queue_type | d()
+  when: item.default_queue_type is defined and item.default_queue_type is truthy
   loop: '{{ q("flattened", rabbitmq_server__combined_vhosts) }}'
   register: rabbitmq_server__register_vhost_dqt
   changed_when: rabbitmq_server__register_vhost_dqt.rc == 0
@@ -195,7 +195,7 @@
                                                  | list }}'
   changed_when: true
   when:
-    - item.name | d()
+    - item.name is defined and item.name is truthy
     - item.opt_in | d(False) | bool
     - item.name not in _rabbitmq_server__enabled_feature_flags
 
@@ -211,7 +211,7 @@
     node: '{{ item.node | d(omit) }}'
   loop: '{{ q("flattened", rabbitmq_server__combined_feature_flags) }}'
   when:
-    - item.name | d()
+    - item.name is defined and item.name is truthy
     - not (item.opt_in | d(False) | bool)
     - item.name in (rabbitmq_server__register_feature_flags_list.stdout_lines
                     | default([]) | map('split', '\t') | map('first') | list)
@@ -234,7 +234,7 @@
     value:     '{{ item.value | d(omit) }}'
     vhost:     '{{ item.vhost | d(omit) }}'
   loop: '{{ q("flattened", rabbitmq_server__combined_parameters) }}'
-  when: (item.name | d() and item.component | d())
+  when: (item.name is defined and item.name is truthy and item.component is defined and item.component is truthy)
   tags: [ 'role::rabbitmq_server:parameter' ]
 
 - name: Manage RabbitMQ policies
@@ -248,7 +248,7 @@
     state:    '{{ item.state | d("present") }}'
     vhost:    '{{ item.vhost | d(omit) }}'
   loop: '{{ q("flattened", rabbitmq_server__combined_policies) }}'
-  when: (item.name | d() and item.pattern | d() and item.tags | d())
+  when: (item.name is defined and item.name is truthy and item.pattern is defined and item.pattern is truthy and item.tags is defined and item.tags is truthy)
   tags: [ 'role::rabbitmq_server:policy' ]
 
 - name: Manage RabbitMQ user accounts

--- a/ansible/roles/redis_sentinel/tasks/main.yml
+++ b/ansible/roles/redis_sentinel/tasks/main.yml
@@ -67,7 +67,7 @@
     mode: '0755'
   loop: '{{ redis_sentinel__combined_configuration | debops.debops.parse_kv_items
             | product(["", "/reconfig.d", "/notify.d"]) | list }}'
-  when: item.0.name | d() and item.0.state | d('present') not in ['absent', 'init', 'ignore']
+  when: item.0.name is defined and item.0.name is truthy and item.0.state | d('present') not in ['absent', 'init', 'ignore']
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Generate initial Redis Sentinel configuration
@@ -79,7 +79,7 @@
     mode: '0640'
     force: False
   with_items: '{{ redis_sentinel__combined_configuration | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'init', 'ignore']
+  when: item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'init', 'ignore']
   notify: [ 'Refresh host facts' ]
   no_log: '{{ debops__no_log | d(True) }}'
 
@@ -92,7 +92,7 @@
     mode: '0755'
   loop: '{{ redis_sentinel__combined_configuration | debops.debops.parse_kv_items
             | product(["notify.sh", "reconfig.sh"]) | list }}'
-  when: item.0.name | d() and item.0.state | d('present') not in ['absent', 'init', 'ignore']
+  when: item.0.name is defined and item.0.name is truthy and item.0.state | d('present') not in ['absent', 'init', 'ignore']
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Install custom systemd unit files
@@ -115,8 +115,8 @@
     group: 'root'
     mode: '0755'
   with_items: '{{ redis_sentinel__combined_configuration | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'init', 'ignore'] and
-        item.systemd_override | d()
+  when: item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'init', 'ignore'] and
+        item.systemd_override is defined and item.systemd_override is truthy
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Generate systemd instance override files
@@ -127,8 +127,8 @@
     group: 'root'
     mode: '0644'
   with_items: '{{ redis_sentinel__combined_configuration | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'init', 'ignore'] and
-        item.systemd_override | d()
+  when: item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'init', 'ignore'] and
+        item.systemd_override is defined and item.systemd_override is truthy
   notify: [ 'Reload service manager' ]
   no_log: '{{ debops__no_log | d(True) }}'
 
@@ -138,7 +138,7 @@
     state: 'stopped'
     enabled: False
   with_items: '{{ redis_sentinel__combined_configuration | debops.debops.parse_kv_items }}'
-  when: ansible_service_mgr == 'systemd' and item.name | d() and
+  when: ansible_service_mgr == 'systemd' and item.name is defined and item.name is truthy and
         item.state | d('present') == 'absent'
   no_log: '{{ debops__no_log | d(True) }}'
 
@@ -148,7 +148,7 @@
     state: 'absent'
   with_items: '{{ redis_sentinel__combined_configuration | debops.debops.parse_kv_items }}'
   notify: [ 'Reload service manager' ]
-  when: ansible_service_mgr == 'systemd' and item.name | d() and
+  when: ansible_service_mgr == 'systemd' and item.name is defined and item.name is truthy and
         item.state | d('present') == 'absent'
   no_log: '{{ debops__no_log | d(True) }}'
 
@@ -157,7 +157,7 @@
     path: '/etc/redis/sentinel-{{ item.name }}'
     state: 'absent'
   with_items: '{{ redis_sentinel__combined_configuration | debops.debops.parse_kv_items }}'
-  when: ansible_service_mgr == 'systemd' and item.name | d() and
+  when: ansible_service_mgr == 'systemd' and item.name is defined and item.name is truthy and
         item.state | d('present') == 'absent'
   no_log: '{{ debops__no_log | d(True) }}'
 
@@ -170,6 +170,6 @@
     state: 'started'
     enabled: True
   with_items: '{{ redis_sentinel__combined_configuration | debops.debops.parse_kv_items }}'
-  when: ansible_service_mgr == 'systemd' and item.name | d() and
+  when: ansible_service_mgr == 'systemd' and item.name is defined and item.name is truthy and
         item.state | d('present') not in ['absent', 'init', 'ignore']
   no_log: '{{ debops__no_log | d(True) }}'

--- a/ansible/roles/redis_server/tasks/main.yml
+++ b/ansible/roles/redis_server/tasks/main.yml
@@ -74,7 +74,7 @@
     group: 'root'
     mode: '0755'
   with_items: '{{ redis_server__combined_configuration | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'init', 'ignore']
+  when: item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'init', 'ignore']
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Install the original Redis config file to instance
@@ -83,7 +83,7 @@
   args:
     creates: '/etc/redis/{{ item.name }}/redis.conf'
   with_items: '{{ redis_server__combined_configuration | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'init', 'ignore']
+  when: item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'init', 'ignore']
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Generate dynamic Redis configuration scripts
@@ -94,7 +94,7 @@
     group: '{{ redis_server__group }}'
     mode: '0750'
   with_items: '{{ redis_server__combined_configuration | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'init', 'ignore']
+  when: item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'init', 'ignore']
   register: redis_server__register_config_dynamic
   notify: [ 'Refresh host facts' ]
   no_log: '{{ debops__no_log | d(True) }}'
@@ -107,7 +107,7 @@
     group: '{{ redis_server__group }}'
     mode: '0640'
   with_items: '{{ redis_server__combined_configuration | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'init', 'ignore']
+  when: item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'init', 'ignore']
   register: redis_server__register_config_static
   notify: [ 'Refresh host facts' ]
   no_log: '{{ debops__no_log | d(True) }}'
@@ -153,8 +153,8 @@
     group: 'root'
     mode: '0755'
   with_items: '{{ redis_server__combined_configuration | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'init', 'ignore'] and
-        item.systemd_override | d()
+  when: item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'init', 'ignore'] and
+        item.systemd_override is defined and item.systemd_override is truthy
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Generate systemd instance override files
@@ -165,8 +165,8 @@
     group: 'root'
     mode: '0644'
   with_items: '{{ redis_server__combined_configuration | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') not in ['absent', 'init', 'ignore'] and
-        item.systemd_override | d()
+  when: item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'init', 'ignore'] and
+        item.systemd_override is defined and item.systemd_override is truthy
   notify: [ 'Reload service manager' ]
   no_log: '{{ debops__no_log | d(True) }}'
 
@@ -176,7 +176,7 @@
     state: 'stopped'
     enabled: False
   with_items: '{{ redis_server__combined_configuration | debops.debops.parse_kv_items }}'
-  when: ansible_service_mgr == 'systemd' and item.name | d() and
+  when: ansible_service_mgr == 'systemd' and item.name is defined and item.name is truthy and
         item.state | d('present') == 'absent'
   no_log: '{{ debops__no_log | d(True) }}'
 
@@ -186,7 +186,7 @@
     state: 'absent'
   with_items: '{{ redis_server__combined_configuration | debops.debops.parse_kv_items }}'
   notify: [ 'Reload service manager' ]
-  when: ansible_service_mgr == 'systemd' and item.name | d() and
+  when: ansible_service_mgr == 'systemd' and item.name is defined and item.name is truthy and
         item.state | d('present') == 'absent'
   no_log: '{{ debops__no_log | d(True) }}'
 
@@ -195,7 +195,7 @@
     path: '/etc/redis/{{ item.name }}'
     state: 'absent'
   with_items: '{{ redis_server__combined_configuration | debops.debops.parse_kv_items }}'
-  when: ansible_service_mgr == 'systemd' and item.name | d() and
+  when: ansible_service_mgr == 'systemd' and item.name is defined and item.name is truthy and
         item.state | d('present') == 'absent'
   no_log: '{{ debops__no_log | d(True) }}'
 
@@ -208,7 +208,7 @@
     state: 'started'
     enabled: True
   with_items: '{{ redis_server__combined_configuration | debops.debops.parse_kv_items }}'
-  when: ansible_service_mgr == 'systemd' and item.name | d() and
+  when: ansible_service_mgr == 'systemd' and item.name is defined and item.name is truthy and
         item.state | d('present') not in ['absent', 'init', 'ignore']
   no_log: '{{ debops__no_log | d(True) }}'
 
@@ -244,5 +244,5 @@
               | selectattr('name', 'defined') | list
               | map(attribute='name') | list))))) and
          item.state | d('present') not in ['absent', 'ignore', 'init'] and
-         item.master_host | d() and item.master_port | d())
+         item.master_host is defined and item.master_host is truthy and item.master_port is defined and item.master_port is truthy)
   no_log: '{{ debops__no_log | d(True) }}'

--- a/ansible/roles/reprepro/tasks/configure_reprepro.yml
+++ b/ansible/roles/reprepro/tasks/configure_reprepro.yml
@@ -83,7 +83,7 @@
   become_user: '{{ reprepro__user }}'
   register: reprepro__register_export
   changed_when: reprepro__register_export.changed | bool
-  when: (repo.state | d('present') not in ['absent', 'ignore'] and repo.distributions | d() and
+  when: (repo.state | d('present') not in ['absent', 'ignore'] and repo.distributions is defined and repo.distributions is truthy and
          (reprepro__register_config is changed or reprepro__register_uploaders is changed))
 
 - name: Generate symlinks
@@ -93,7 +93,7 @@
   become: True
   become_user: '{{ reprepro__user }}'
   changed_when: False
-  when: (repo.state | d('present') not in ['absent', 'ignore'] and repo.distributions | d())
+  when: (repo.state | d('present') not in ['absent', 'ignore'] and repo.distributions is defined and repo.distributions is truthy)
 
 - name: Enable incoming queue monitoring
   ansible.builtin.systemd:
@@ -104,7 +104,7 @@
     enabled: '{{ True
                if (repo.state | d("present") not in ["absent", "ignore"])
                else False }}'
-  when: repo.incoming | d()
+  when: repo.incoming is defined and repo.incoming is truthy
 
 - name: Manage reprepro scripts
   ansible.builtin.template:

--- a/ansible/roles/reprepro/tasks/main.yml
+++ b/ansible/roles/reprepro/tasks/main.yml
@@ -44,7 +44,7 @@
     state: 'present'
     user: '{{ reprepro__user }}'
     exclusive: False
-  when: reprepro__admin_sshkeys | d()
+  when: reprepro__admin_sshkeys is defined and reprepro__admin_sshkeys is truthy
 
 - name: Generate queue processing services
   ansible.builtin.template:

--- a/ansible/roles/resolved/tasks/main.yml
+++ b/ansible/roles/resolved/tasks/main.yml
@@ -160,7 +160,7 @@
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
   when: resolved__enabled | bool and resolved__dnssd_enabled | bool and
-        item.raw | d() and item.state | d("present") not in ['absent', 'ignore', 'init'] and
+        item.raw is defined and item.raw is truthy and item.state | d("present") not in ['absent', 'ignore', 'init'] and
         (item.name | dirname).endswith('.d')
 
 - name: Generate dnssd units
@@ -173,7 +173,7 @@
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
   notify: [ 'Restart systemd-resolved service' ]
   when: resolved__enabled | bool and resolved__dnssd_enabled | bool and
-        item.raw | d() and item.state | d("present") not in ['absent', 'ignore', 'init']
+        item.raw is defined and item.raw is truthy and item.state | d("present") not in ['absent', 'ignore', 'init']
 
 - name: Flush handlers when needed
   ansible.builtin.meta: 'flush_handlers'

--- a/ansible/roles/resources/tasks/main.yml
+++ b/ansible/roles/resources/tasks/main.yml
@@ -44,8 +44,8 @@
   loop: '{{ q("flattened", resources__repositories
                            + resources__group_repositories
                            + resources__host_repositories) }}'
-  when: (resources__enabled | bool and (item.repo | d() or item.url | d() or item.src | d()) and
-         (item.dest | d() or item.name | d() or item.path | d()))
+  when: (resources__enabled | bool and ((item.repo is defined and item.repo is truthy) or (item.url is defined and item.url is truthy) or (item.src is defined and item.src is truthy)) and
+         ((item.dest is defined and item.dest is truthy) or (item.name is defined and item.name is truthy) or (item.path is defined and item.path is truthy)))
   tags: [ 'role::resources:repositories' ]
 
 # Manage custom templates [[[1
@@ -106,7 +106,7 @@
                            + resources__group_paths
                            + resources__host_paths) }}'
   when: (resources__enabled | bool and
-         ((item.path | d() or item.dest | d() or item.name | d()) or item))
+         ((item.path is defined and item.path is truthy) or (item.dest is defined and item.dest is truthy) or (item.name is defined and item.name is truthy) or (item is defined and item is truthy)))
   tags: [ 'role::resources:paths' ]
 
 # Create parent directories [[[1
@@ -153,8 +153,8 @@
   loop: '{{ q("flattened", resources__urls
                            + resources__group_urls
                            + resources__host_urls) }}'
-  when: (resources__enabled | bool and (item.url | d() or item.src | d()) and
-         (item.dest | d() or item.name | d() or item.path | d()))
+  when: (resources__enabled | bool and ((item.url is defined and item.url is truthy) or (item.src is defined and item.src is truthy)) and
+         ((item.dest is defined and item.dest is truthy) or (item.name is defined and item.name is truthy) or (item.path is defined and item.path is truthy)))
   no_log: '{{ debops__no_log | d(True if item.url_password | d() else omit) }}'
   tags: [ 'role::resources:urls' ]
 
@@ -182,8 +182,8 @@
   loop: '{{ q("flattened", resources__archives
                            + resources__group_archives
                            + resources__host_archives) }}'
-  when: (resources__enabled | bool and item.src | d() and
-         (item.dest | d() or item.name | d() or item.path | d()))
+  when: (resources__enabled | bool and item.src is defined and item.src is truthy and
+         ((item.dest is defined and item.dest is truthy) or (item.name is defined and item.name is truthy) or (item.path is defined and item.path is truthy)))
   tags: [ 'role::resources:archives' ]
 
 # Manage custom files [[[1
@@ -196,7 +196,7 @@
                            + resources__group_files
                            + resources__host_files) }}'
   when: (resources__enabled | bool and
-         (item.dest | d() or item.path | d() or item.name | d()) and
+         ((item.dest is defined and item.dest is truthy) or (item.path is defined and item.path is truthy) or (item.name is defined and item.name is truthy)) and
          (item.state | d('present') == 'absent'))
   tags: [ 'role::resources:files' ]
 
@@ -222,8 +222,8 @@
                            + resources__group_files
                            + resources__host_files) }}'
   when: (resources__enabled | bool and
-         (item.src | d() or item.content is defined) and
-         (item.dest | d() or item.path | d() or item.name | d()) and
+         ((item.src is defined and item.src is truthy) or (item.content is defined)) and
+         ((item.dest is defined and item.dest is truthy) or (item.path is defined and item.path is truthy) or (item.name is defined and item.name is truthy)) and
          (item.state | d('present') != 'absent'))
   tags: [ 'role::resources:files' ]
 
@@ -275,8 +275,8 @@
   loop: '{{ q("flattened", resources__replacements
                            + resources__group_replacements
                            + resources__host_replacements) }}'
-  when: (resources__enabled | bool and item.regexp | d() and
-         (item.dest | d() or item.path | d() or item.name | d()))
+  when: (resources__enabled | bool and item.regexp is defined and item.regexp is truthy and
+         ((item.dest is defined and item.dest is truthy) or (item.path is defined and item.path is truthy) or (item.name is defined and item.name is truthy)))
   tags: [ 'role::resources:lineinfile' ]
 
 # Manage ACLs [[[1
@@ -341,7 +341,7 @@
                            + resources__group_delayed_paths
                            + resources__host_delayed_paths) }}'
   when: (resources__enabled | bool and
-         ((item.path | d() or item.dest | d() or item.name | d()) or item))
+         ((item.path is defined and item.path is truthy) or (item.dest is defined and item.dest is truthy) or (item.name is defined and item.name is truthy) or (item is defined and item is truthy)))
   tags: [ 'role::resources:paths' ]
 
 - name: Set custom file capabilities
@@ -361,7 +361,7 @@
   loop_control:
     label: '{{ {"name": item.name} }}'
   when: resources__enabled | bool and
-        item.name | d() and item.state | d('present') not in [ 'absent', 'ignore' ]
+        item.name is defined and item.name is truthy and item.state | d('present') not in [ 'absent', 'ignore' ]
   no_log: '{{ debops__no_log | d(item.no_log) | d(False) }}'
   tags: [ 'role::resources:commands' ]
 

--- a/ansible/roles/root_account/tasks/main.yml
+++ b/ansible/roles/root_account/tasks/main.yml
@@ -124,7 +124,7 @@
     fi
   register: root_account__register_dotfiles
   changed_when: ('Already up to date.' not in root_account__register_dotfiles.stdout_lines | regex_replace('-', ' '))
-  when: ((ansible_local | d() and ansible_local.yadm | d() and (ansible_local.yadm.installed | d()) | bool) and
+  when: ((ansible_local is defined and ansible_local.yadm is defined and (ansible_local.yadm.installed | d()) | bool) and
          root_account__dotfiles_enabled | bool)
   check_mode: False
 

--- a/ansible/roles/roundcube/tasks/deploy_roundcube.yml
+++ b/ansible/roles/roundcube/tasks/deploy_roundcube.yml
@@ -62,7 +62,7 @@
   ansible.builtin.slurp:  # noqa no-handler
     src: '{{ roundcube__git_dest + "/composer.json" }}'
   register: roundcube__register_composer_installed
-  when: (ansible_local | d() and ansible_local.roundcube | d() and
+  when: (ansible_local is defined and ansible_local.roundcube is defined and
          (ansible_local.roundcube.installed | d()) | bool and
         roundcube__register_git is changed)
 

--- a/ansible/roles/roundcube/tasks/main.yml
+++ b/ansible/roles/roundcube/tasks/main.yml
@@ -120,8 +120,8 @@
   become: True
   become_user: '{{ roundcube__user }}'
   register: roundcube__register_updatedb
-  changed_when: roundcube__register_updatedb.stdout | d()
-  when: (roundcube__register_version.stdout | d() and
+  changed_when: roundcube__register_updatedb.stdout is defined and roundcube__register_updatedb.stdout is truthy
+  when: (roundcube__register_version.stdout is defined and roundcube__register_version.stdout is truthy and
          (ansible_local.roundcube.version | d("0.0.0")) is version_compare(roundcube__register_version.stdout, '>'))
   tags: [ 'role::roundcube:database' ]
 

--- a/ansible/roles/rsnapshot/tasks/main.yml
+++ b/ansible/roles/rsnapshot/tasks/main.yml
@@ -59,7 +59,7 @@
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
   notify: [ 'Refresh host facts' ]
-  when: item.name | d() and item.state | d('present') not in ['absent', 'ignore']
+  when: item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore']
 
 - name: Make sure /root/.ssh/known_hosts file exists
   ansible.builtin.command: touch /root/.ssh/known_hosts
@@ -96,8 +96,8 @@
   loop: '{{ rsnapshot__combined_hosts | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
-  when: (item.name | d() and item.state | d('present') not in ['absent', 'ignore'] and
-         not item.fqdn | d() and hostvars[item.name] | d() and
+  when: (item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore'] and
+         not item.fqdn | d() and hostvars[item.name] is defined and hostvars[item.name] is truthy and
          hostvars[item.name]['ansible_fqdn'] is not defined and
          (not rsnapshot__limit | d() or (item.name in rsnapshot__limit)))
 
@@ -112,8 +112,8 @@
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present"),
                 "packages": q("flattened", rsnapshot__host_packages)} }}'
-  when: (item.name | d() and item.state | d('present') not in ['absent', 'ignore'] and
-         (item.rsync | d(True)) | bool and hostvars[item.name] | d() and
+  when: (item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore'] and
+         (item.rsync | d(True)) | bool and hostvars[item.name] is defined and hostvars[item.name] is truthy and
          (not rsnapshot__limit | d() or (item.name in rsnapshot__limit)))
 
   # Example: https://github.com/anamba/rrsync-custom
@@ -138,8 +138,8 @@
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present"),
                 "packages": q("flattened", rsnapshot__host_packages)} }}'
-  when: (item.name | d() and item.state | d('present') not in ['absent', 'ignore'] and
-         (item.rsync | d(True)) | bool and hostvars[item.name] | d() and
+  when: (item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore'] and
+         (item.rsync | d(True)) | bool and hostvars[item.name] is defined and hostvars[item.name] is truthy and
          (not rsnapshot__limit | d() or (item.name in rsnapshot__limit)))
 
 - name: Deploy root ssh public key on configured hosts
@@ -156,7 +156,7 @@
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
   register: rsnapshot__register_ssh_keys
-  when: (item.name | d() and item.state | d('present') not in ['ignore'] and
+  when: (item.name is defined and item.name is truthy and item.state | d('present') not in ['ignore'] and
          not (item.local | d()) | bool and (item.ssh_key | d(True)) | bool and
          (not rsnapshot__limit | d() or (item.name in rsnapshot__limit)))
 
@@ -185,7 +185,7 @@
     label: '{{ {"name": item.item.name, "state": item.item.state | d("present")} }}'
   register: rsnapshot__register_keygen_remove
   changed_when: rsnapshot__register_keygen_remove.changed | bool
-  when: (item.item.name | d() and item.item.state | d('present') not in ['absent', 'ignore'] and
+  when: (item.item.name is defined and item.item.name is truthy and item.item.state | d('present') not in ['absent', 'ignore'] and
          not (item.item.local | d()) | bool and (item.item.ssh_scan | d(True)) | bool and item is changed and
          (not rsnapshot__limit | d() or (item.item.name in rsnapshot__limit)))
 
@@ -198,7 +198,7 @@
   loop: '{{ rsnapshot__combined_hosts | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
-  when: (item.name | d() and item.state | d('present') not in ['absent', 'ignore'] and
+  when: (item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore'] and
          not (item.local | d()) | bool and (item.ssh_scan | d(True)) | bool and
          (not rsnapshot__limit | d() or (item.name in rsnapshot__limit)))
   register: rsnapshot__register_known_hosts
@@ -214,7 +214,7 @@
     label: '{{ {"name": item.item.name, "state": item.item.state | d("present")} }}'
   register: rsnapshot__register_ssh_keyscan
   changed_when: rsnapshot__register_ssh_keyscan.changed | bool
-  when: (item.item.name | d() and item.item.state | d('present') not in ['absent', 'ignore'] and
+  when: (item.item.name is defined and item.item.name is truthy and item.item.state | d('present') not in ['absent', 'ignore'] and
          not (item.item.local | d()) | bool and (item.item.ssh_scan | d(True)) | bool and item.rc | d() > 0 and
          (not rsnapshot__limit | d() or (item.item.name in rsnapshot__limit)))
 
@@ -225,7 +225,7 @@
   loop: '{{ rsnapshot__combined_hosts | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
-  when: (item.name | d() and item.state | d('present') == 'absent' and
+  when: (item.name is defined and item.name is truthy and item.state | d('present') == 'absent' and
          (not rsnapshot__limit | d() or (item.name in rsnapshot__limit)))
 
 - name: Create host configuration directories
@@ -236,7 +236,7 @@
   loop: '{{ rsnapshot__combined_hosts | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
-  when: (item.name | d() and item.state | d('present') not in ['absent', 'ignore'] and
+  when: (item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore'] and
          (not rsnapshot__limit | d() or (item.name in rsnapshot__limit)))
 
 - name: Generate host configuration files
@@ -251,5 +251,5 @@
             | product(["include.txt", "exclude.txt", "rsnapshot.conf"]) | list }}'
   loop_control:
     label: '{{ {"name": item.0.name, "state": item.0.state | d("present"), "file": item.1} }}'
-  when: (item.0.name | d() and item.0.state | d('present') not in ['absent', 'ignore'] and
+  when: (item.0.name is defined and item.0.name is truthy and item.0.state | d('present') not in ['absent', 'ignore'] and
          (not rsnapshot__limit | d() or (item.0.name in rsnapshot__limit)))

--- a/ansible/roles/ruby/tasks/main.yml
+++ b/ansible/roles/ruby/tasks/main.yml
@@ -40,7 +40,7 @@
                            + ruby__group_user_gems
                            + ruby__host_user_gems
                            + ruby__dependent_user_gems) }}'
-  when: (item.group | d() or item.owner | d())
+  when: ((item.group is defined and item.group is truthy) or (item.owner is defined and item.owner is truthy))
 
 - name: Make sure that required users exist
   ansible.builtin.user:
@@ -54,7 +54,7 @@
                            + ruby__group_user_gems
                            + ruby__host_user_gems
                            + ruby__dependent_user_gems) }}'
-  when: item.owner | d()
+  when: item.owner is defined and item.owner is truthy
 
 - name: Install Ruby user gems
   community.general.gem:
@@ -73,4 +73,4 @@
                            + ruby__dependent_user_gems) }}'
   become: True
   become_user: '{{ item.user | d(item.owner) }}'
-  when: (item.user | d() or item.owner | d())
+  when: ((item.user is defined and item.user is truthy) or (item.owner is defined and item.owner is truthy))

--- a/ansible/roles/saslauthd/tasks/main.yml
+++ b/ansible/roles/saslauthd/tasks/main.yml
@@ -28,7 +28,7 @@
   with_items: '{{ saslauthd__combined_instances | debops.debops.parse_kv_items }}'
   register: saslauthd__register_stop_instance
   changed_when: saslauthd__register_stop_instance.changed | bool
-  when: item.name | d() and item.socket_path | d() and
+  when: item.name is defined and item.name is truthy and item.socket_path is defined and item.socket_path is truthy and
         item.state | d('present') == 'absent'
 
 - name: Remove saslauthd instance if requested
@@ -36,7 +36,7 @@
     path: '/etc/default/saslauthd-{{ item.name }}'
     state: 'absent'
   with_items: '{{ saslauthd__combined_instances | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.socket_path | d() and
+  when: item.name is defined and item.name is truthy and item.socket_path is defined and item.socket_path is truthy and
         item.state | d('present') == 'absent'
 
 - name: Generate saslauthd instance configuration
@@ -48,7 +48,7 @@
     mode: '0644'
   with_items: '{{ saslauthd__combined_instances | debops.debops.parse_kv_items }}'
   notify: [ 'Restart saslauthd' ]
-  when: item.name | d() and item.socket_path | d() and
+  when: item.name is defined and item.name is truthy and item.socket_path is defined and item.socket_path is truthy and
         item.state | d('present') != 'absent'
 
 - name: Ensure that required UNIX groups exist
@@ -57,7 +57,7 @@
     state: 'present'
     system: '{{ (item.system | d(True)) | bool }}'
   with_items: '{{ saslauthd__combined_instances | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.group | d() and
+  when: item.name is defined and item.name is truthy and item.group is defined and item.group is truthy and
         item.state | d('present') != 'absent'
 
 - name: Create SASL config directory
@@ -68,7 +68,7 @@
     group: '{{ item.config_dir_group | d("root") }}'
     mode: '{{ item.config_dir_mode | d("0755") }}'
   with_items: '{{ saslauthd__combined_instances | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.config_path | d() and
+  when: item.name is defined and item.name is truthy and item.config_path is defined and item.config_path is truthy and
         item.state | d('present') != 'absent'
 
 - name: Remove SASL instance configuration if requested
@@ -77,7 +77,7 @@
     state: 'absent'
   with_items: '{{ saslauthd__combined_instances | debops.debops.parse_kv_items }}'
   notify: '{{ item.notify if item.notify | d() else omit }}'
-  when: item.name | d() and item.config_path | d() and
+  when: item.name is defined and item.name is truthy and item.config_path is defined and item.config_path is truthy and
         item.state | d('present') == 'absent'
 
 - name: Generate SASL instance configuration
@@ -89,7 +89,7 @@
     mode: '{{ item.config_mode | d("0640") }}'
   with_items: '{{ saslauthd__combined_instances | debops.debops.parse_kv_items }}'
   notify: '{{ item.notify if item.notify | d() else omit }}'
-  when: item.name | d() and item.config_path | d() and
+  when: item.name is defined and item.name is truthy and item.config_path is defined and item.config_path is truthy and
         item.state | d('present') != 'absent'
 
 - name: Remove SASL LDAP profiles if requested
@@ -99,7 +99,7 @@
               else "/etc/saslauthd-" + item.name + ".conf" }}'
     state: 'absent'
   with_items: '{{ saslauthd__ldap_combined_profiles | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') == 'absent'
+  when: item.name is defined and item.name is truthy and item.state | d('present') == 'absent'
 
 - name: Generate SASL LDAP profiles
   ansible.builtin.template:
@@ -112,7 +112,7 @@
     mode: '{{ item.mode | d("0640") }}'
   with_items: '{{ saslauthd__ldap_combined_profiles | debops.debops.parse_kv_items }}'
   notify: [ 'Restart saslauthd' ]
-  when: item.name | d() and item.state | d('present') not in ['absent', 'ignore']
+  when: item.name is defined and item.name is truthy and item.state | d('present') not in ['absent', 'ignore']
 
 - name: Get list of dpkg-stateoverride paths
   ansible.builtin.shell: set -o nounset -o pipefail -o errexit && dpkg-statoverride --list | awk '{print $4}'
@@ -128,7 +128,7 @@
   notify: [ 'Restart saslauthd' ]
   register: saslauthd__register_statoverride_remove
   changed_when: saslauthd__register_statoverride_remove.changed | bool
-  when: item.name | d() and item.socket_path | d() and item.state | d('present') == 'absent' and
+  when: item.name is defined and item.name is truthy and item.socket_path is defined and item.socket_path is truthy and item.state | d('present') == 'absent' and
         item.socket_path in saslauthd__register_statoverride.stdout_lines
 
 - name: Create a dpkg-statoverride entry
@@ -141,7 +141,7 @@
   notify: [ 'Restart saslauthd' ]
   register: saslauthd__register_statoverride_add
   changed_when: saslauthd__register_statoverride_add.changed | bool
-  when: item.name | d() and item.socket_path | d() and item.state | d('present') != 'absent' and
+  when: item.name is defined and item.name is truthy and item.socket_path is defined and item.socket_path is truthy and item.state | d('present') != 'absent' and
         item.socket_path not in saslauthd__register_statoverride.stdout_lines
 
 - name: Make sure that Ansible local facts directory exists

--- a/ansible/roles/slapd/tasks/main.yml
+++ b/ansible/roles/slapd/tasks/main.yml
@@ -108,7 +108,7 @@
   ansible.builtin.script: 'script/ldap-load-schema {{ item }}'
   loop: '{{ q("flattened", slapd__combined_schemas) }}'
   register: slapd__register_load_schemas
-  changed_when: (slapd__register_load_schemas.stdout | d() and
+  changed_when: (slapd__register_load_schemas.stdout is defined and slapd__register_load_schemas.stdout is truthy and
                  (item | basename | regex_replace('.schema$', '') + ' already exists in the LDAP, skipping…')
                  not in slapd__register_load_schemas.stdout_lines)
   tags: [ 'role::slapd:schema' ]
@@ -163,7 +163,7 @@
     label: '{{ {"state": item.state,
                 "dn": item.dn,
                 "attributes": item.attributes | d({})} }}'
-  when: item.name | d() and item.dn | d() and
+  when: item.name is defined and item.name is truthy and item.dn is defined and item.dn is truthy and
         item.state | d('present') not in [ 'init', 'ignore' ]
   tags: [ 'role::slapd:tasks' ]
   no_log: '{{ debops__no_log | d(item.no_log)
@@ -187,7 +187,7 @@
                 "dn": item.dn,
                 "attributes": item.attributes | d({})} }}'
   when: slapd__slapacl_deploy_state == 'present' and
-        item.name | d() and item.dn | d() and
+        item.name is defined and item.name is truthy and item.dn is defined and item.dn is truthy and
         item.state | d('present') not in [ 'init', 'ignore' ]
   tags: [ 'role::slapd:slapacl', 'role::slapd:tasks' ]
   no_log: '{{ debops__no_log | d(item.no_log)
@@ -215,5 +215,5 @@
   register: slapd__register_slapacl_test
   when: slapd__slapacl_deploy_state == 'present' and
         slapd__slapacl_run_tests | bool
-  changed_when: slapd__register_slapacl_test.stderr | d()
+  changed_when: slapd__register_slapacl_test.stderr is defined and slapd__register_slapacl_test.stderr is truthy
   tags: [ 'role::slapd:slapacl', 'role::slapd:tasks' ]

--- a/ansible/roles/slapd/tasks/slapd_tasks.yml
+++ b/ansible/roles/slapd/tasks/slapd_tasks.yml
@@ -10,7 +10,7 @@
     attributes:  '{{ item.attributes | d(omit) }}'
     state:       '{{ item.entry_state | d(item.state) }}'
   run_once:      '{{ item.run_once | d(False) }}'
-  when: (item.objectClass | d() or item.entry_state | d()) and item.state not in ['init', 'ignore']
+  when: ((item.objectClass is defined and item.objectClass is truthy) or (item.entry_state is defined and item.entry_state is truthy)) and item.state not in ['init', 'ignore']
   tags: [ 'role::slapd:tasks', 'role::slapd:slapacl' ]
   no_log: '{{ debops__no_log | d(item.no_log)
               | d(True

--- a/ansible/roles/smstools/tasks/main.yml
+++ b/ansible/roles/smstools/tasks/main.yml
@@ -26,19 +26,19 @@
   ansible.builtin.service:
     name: 'smstools'
     state: 'stopped'
-  when: smstools_register_home is defined and smstools_register_home.stdout | d()
+  when: smstools_register_home is defined and smstools_register_home.stdout is defined and smstools_register_home.stdout is truthy
 
 - name: Fix smsd home directory
   ansible.builtin.user:
     name: 'smsd'
     home: '/var/spool/sms'
-  when: smstools_register_home is defined and smstools_register_home.stdout | d()
+  when: smstools_register_home is defined and smstools_register_home.stdout is defined and smstools_register_home.stdout is truthy
 
 - name: Start smsd with new home directory
   ansible.builtin.service:
     name: 'smstools'
     state: 'started'
-  when: smstools_register_home is defined and smstools_register_home.stdout | d()
+  when: smstools_register_home is defined and smstools_register_home.stdout is defined and smstools_register_home.stdout is truthy
 
 - name: Configure smsd
   ansible.builtin.template:
@@ -119,7 +119,7 @@
     owner: 'root'
     group: 'root'
     mode: '0440'
-  when: (ansible_local | d() and ansible_local.sudo | d() and
+  when: (ansible_local is defined and ansible_local.sudo is defined and
          (ansible_local.sudo.installed | d()) | bool)
 
 - name: Configure xinetd SMS service

--- a/ansible/roles/snmpd/tasks/main.yml
+++ b/ansible/roles/snmpd/tasks/main.yml
@@ -72,7 +72,7 @@
     line: '#mibs :'
     mode: '0644'
   notify: [ 'Restart snmpd' ]
-  when: snmpd_download_mibs | d() and snmpd_download_mibs
+  when: snmpd_download_mibs is defined and snmpd_download_mibs is truthy
 
 - name: Divert default configuration file
   debops.debops.dpkg_divert:
@@ -129,7 +129,7 @@
     snmpd_fact_account_agent_username: '{{ snmpd_account_agent_username }}'
     snmpd_fact_account_agent_password: '{{ snmpd_account_agent_password }}'
   no_log: '{{ debops__no_log | d(True) }}'
-  when: snmpd_account | d() and snmpd_account
+  when: snmpd_account is defined and snmpd_account is truthy
 
 - name: Configure snmpd service
   ansible.builtin.template:
@@ -142,8 +142,8 @@
 
 - name: Configure SNMPv3 credentials
   ansible.builtin.include_tasks: configure_snmpv3_credentials.yml
-  when: ((snmpd_register_version | d() and not snmpd_register_version.stdout) and
-         (snmpd_account | d() and snmpd_account))
+  when: ((snmpd_register_version is defined and not snmpd_register_version.stdout) and
+         (snmpd_account is defined and snmpd_account is truthy))
 
 - name: Save local SNMPv3 password for retrieval via Ansible facts
   ansible.builtin.template:

--- a/ansible/roles/sssd/tasks/main.yml
+++ b/ansible/roles/sssd/tasks/main.yml
@@ -38,7 +38,7 @@
     dest: '/etc/sssd/sssd.conf'
     mode: '0600'
   register: sssd__register_config
-  when: sssd__ldap_base_dn | d()
+  when: sssd__ldap_base_dn is truthy
 
 - name: Restart sssd if its configuration was modified
   ansible.builtin.service:  # noqa no-handler

--- a/ansible/roles/sudo/tasks/main.yml
+++ b/ansible/roles/sudo/tasks/main.yml
@@ -74,7 +74,7 @@
   with_items: '{{ sudo__combined_sudoers | flatten | debops.debops.parse_kv_items }}'
   notify: [ 'Refresh host facts' ]
   when: sudo__enabled | bool and
-        item.name | d() and item.state | d('present') == 'absent'
+        item.name is defined and item.name is truthy and item.state | d('present') == 'absent'
 
 - name: Configure sudoers
   ansible.builtin.template:
@@ -87,7 +87,7 @@
   with_items: '{{ sudo__combined_sudoers | flatten | debops.debops.parse_kv_items }}'
   notify: [ 'Refresh host facts' ]
   when: sudo__enabled | bool and
-        item.name | d() and item.state | d('present') not in ['init', 'absent', 'ignore']
+        item.name is defined and item.name is truthy and item.state | d('present') not in ['init', 'absent', 'ignore']
 
 - name: Configure workaround for logind sessions via sudo
   ansible.builtin.template:

--- a/ansible/roles/sysctl/tasks/main.yml
+++ b/ansible/roles/sysctl/tasks/main.yml
@@ -51,7 +51,7 @@
   loop: '{{ sysctl__combined_parameters | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
-  when: (sysctl__enabled | bool and item.name | d() and
+  when: (sysctl__enabled | bool and item.name is defined and item.name is truthy and
          item.state | d('present') in ['present', 'absent'] and
          item.divert | d(False) | bool)
 
@@ -61,7 +61,7 @@
     state: 'absent'
   with_items: '{{ sysctl__combined_parameters | debops.debops.parse_kv_items }}'
   register: sysctl__register_config_removed
-  when: sysctl__enabled | bool and item.name | d() and item.state | d('present') == 'absent'
+  when: sysctl__enabled | bool and item.name is defined and item.name is truthy and item.state | d('present') == 'absent'
 
 - name: Generate custom sysctl configuration files
   ansible.builtin.template:
@@ -74,7 +74,7 @@
   loop_control:
     label: '{{ item.name }}'
   register: sysctl__register_config_created
-  when: sysctl__enabled | bool and item.name | d() and item.options | d() and item.state | d('present') not in ['absent', 'ignore', 'init']
+  when: sysctl__enabled | bool and item.name is defined and item.name is truthy and item.options is defined and item.options is truthy and item.state | d('present') not in ['absent', 'ignore', 'init']
 
 - name: Check sysctl command capabilities
   ansible.builtin.shell: set -o nounset -o pipefail -o errexit &&

--- a/ansible/roles/sysfs/tasks/main.yml
+++ b/ansible/roles/sysfs/tasks/main.yml
@@ -30,7 +30,7 @@
   register: sysfs__register_dependent_attributes_file
   become: False
   delegate_to: 'localhost'
-  when: (sysfs__enabled | bool and ansible_local | d() and ansible_local.sysfs | d() and
+  when: (sysfs__enabled | bool and ansible_local is defined and ansible_local.sysfs is defined and
          (ansible_local.sysfs.configured | d()) | bool)
 
 - name: Load the dependent configuration from Ansible Controller
@@ -39,7 +39,7 @@
   register: sysfs__register_dependent_attributes
   become: False
   delegate_to: 'localhost'
-  when: (sysfs__enabled | bool and ansible_local | d() and ansible_local.sysfs | d() and
+  when: (sysfs__enabled | bool and ansible_local is defined and ansible_local.sysfs is defined and
          (ansible_local.sysfs.configured | d()) | bool and
          sysfs__register_dependent_attributes_file.stat.exists | bool)
 
@@ -49,7 +49,7 @@
     state: 'absent'
   with_items: '{{ sysfs__combined_attributes | debops.debops.parse_kv_items }}'
   notify: [ 'Restart sysfsutils' ]
-  when: (sysfs__enabled | bool and item.name | d() and
+  when: (sysfs__enabled | bool and item.name is defined and item.name is truthy and
          item.state | d('present') == 'absent')
 
 - name: Generate sysfs configuration files
@@ -61,7 +61,7 @@
     mode: '0644'
   with_items: '{{ sysfs__combined_attributes | debops.debops.parse_kv_items }}'
   notify: [ 'Restart sysfsutils' ]
-  when: (sysfs__enabled | bool and item.name | d() and
+  when: (sysfs__enabled | bool and item.name is defined and item.name is truthy and
          item.state | d('present') not in ['defined', 'absent'])
 
 - name: Make sure that Ansible local facts directory exists

--- a/ansible/roles/sysnews/tasks/main.yml
+++ b/ansible/roles/sysnews/tasks/main.yml
@@ -39,7 +39,7 @@
     path: '/var/lib/sysnews/{{ item.name }}'
     state: 'absent'
   with_items: '{{ sysnews__combined_entries | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') == 'absent'
+  when: item.name is defined and item.name is truthy and item.state | d('present') == 'absent'
 
 - name: Generate persistent news files
   ansible.builtin.copy:
@@ -50,7 +50,7 @@
     group: 'root'
     mode: '0644'
   with_items: '{{ sysnews__combined_entries | debops.debops.parse_kv_items }}'
-  when: item.name | d() and item.state | d('present') != 'absent'
+  when: item.name is defined and item.name is truthy and item.state | d('present') != 'absent'
 
 - name: Update list of persistent news files
   ansible.builtin.blockinfile:

--- a/ansible/roles/system_groups/tasks/main.yml
+++ b/ansible/roles/system_groups/tasks/main.yml
@@ -24,7 +24,7 @@
     system: '{{ item.system | d(True) }}'
   with_items: '{{ system_groups__combined_list | debops.debops.parse_kv_items }}'
   when: system_groups__enabled | bool and
-        item.name | d() and item.state | d('present') not in ['init', 'absent', 'ignore']
+        item.name is defined and item.name is truthy and item.state | d('present') not in ['init', 'absent', 'ignore']
 
 - name: Get list of existing UNIX accounts
   ansible.builtin.getent:

--- a/ansible/roles/system_users/tasks/main.yml
+++ b/ansible/roles/system_users/tasks/main.yml
@@ -52,7 +52,7 @@
   loop_control:
     label: '{{ {"name": (item.prefix | d(system_users__prefix)) + (item.group | d(item.name)),
                 "state": item.state | d("present")} }}'
-  when: (system_users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (system_users__enabled | bool and item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and
          (item.private_group | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
@@ -98,7 +98,7 @@
   loop_control:
     label: '{{ {"name": (item.prefix | d(system_users__prefix)) + item.name,
                 "state": item.state | d("present"), "gecos": item.comment | d()} }}'
-  when: (system_users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (system_users__enabled | bool and item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') not in ['ignore'] and (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
 
@@ -130,7 +130,7 @@
     label: '{{ {"name": (item.prefix | d(system_users__prefix)) + item.name,
                 "state": item.state | d("present"), "gecos": item.comment | d(),
                 "groups": item.groups | d()} }}'
-  when: (system_users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (system_users__enabled | bool and item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') not in ['ignore'] and
          (item.groups | d() or (item.admin | d()) | bool) and
          (item.user | d(True)) | bool)
@@ -157,7 +157,7 @@
                                         else (system_users__home_root + "/" + ((item.prefix | d(system_users__prefix)) + item.name)))
                                        if ((item.create_home | d(True)) | bool)
                                        else ""))} }}'
-  when: (system_users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (system_users__enabled | bool and item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and (item.create_home | d(True)) | bool and
          (item.home_owner | d() or item.home_group | d() or item.home_mode | d() or (item.local | d(True)) | bool) and
          (item.user | d(True)) | bool)
@@ -186,9 +186,9 @@
     label: '{{ {"name": (item.0.prefix | d(system_users__prefix)) + item.0.name,
                 "state": item.0.state | d("present"), "home_acl": item.1} }}'
   when: (system_users__enabled | bool and system_users__acl_enabled | bool and
-         item.0.name | d() and item.0.name != 'root' and
+         item.0.name is defined and item.0.name is truthy and item.0.name != 'root' and
          item.0.state | d('present') not in ['absent', 'ignore'] and (item.0.create_home | d(True)) | bool and
-         item.0.home_acl | d() and (item.user | d(True)) | bool)
+         item.0.home_acl is defined and item.0.home_acl is truthy and (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.0.no_log) | d(True if item.0.password | d() else False) }}'
   tags: [ 'role::system_users:home_acl', 'skip::system_users:home_acl', 'skip::check' ]
 
@@ -201,7 +201,7 @@
     label: '{{ {"name": (item.prefix | d(system_users__prefix)) + item.name,
                 "state": item.state | d("present"), "linger": item.linger | d(False)} }}'
   when: (system_users__enabled | bool and ansible_service_mgr == 'systemd' and
-         item.name | d() and item.name != 'root' and
+         item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and
          item.linger is defined and item.linger | bool and (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
@@ -215,7 +215,7 @@
     label: '{{ {"name": (item.prefix | d(system_users__prefix)) + item.name,
                 "state": item.state | d("present"), "linger": item.linger | d(False)} }}'
   when: (system_users__enabled | bool and ansible_service_mgr == 'systemd' and
-         item.name | d() and item.name != 'root' and
+         item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and
          item.linger is defined and not item.linger | bool and (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
@@ -231,9 +231,9 @@
   loop_control:
     label: '{{ {"name": (item.prefix | d(system_users__prefix)) + item.name,
                 "state": item.state | d("present"), "sshkeys": item.sshkeys | d()} }}'
-  when: (system_users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (system_users__enabled | bool and item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and (item.create_home | d(True)) | bool and
-         item.sshkeys | d() and item.sshkeys_state | d('present') != 'absent' and (item.user | d(True)) | bool and
+         item.sshkeys is defined and item.sshkeys is truthy and item.sshkeys_state | d('present') != 'absent' and (item.user | d(True)) | bool and
          not ansible_check_mode)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
   tags: [ 'role::system_users:authorized_keys', 'skip::system_users:authorized_keys', 'skip::check' ]
@@ -247,9 +247,9 @@
     label: '{{ {"name": (item.prefix | d(system_users__prefix)) + item.name,
                 "state": item.state | d("present"),
                 "sshkeys_state": item.sshkeys_state | d("present")} }}'
-  when: (system_users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (system_users__enabled | bool and item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and (item.create_home | d(True)) | bool and
-         item.sshkeys | d() and item.sshkeys_state | d('present') == 'absent' and (item.user | d(True)) | bool)
+         item.sshkeys is defined and item.sshkeys is truthy and item.sshkeys_state | d('present') == 'absent' and (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
 
 - name: Configure system user mail forwarding
@@ -328,9 +328,9 @@
     label: '{{ {"name": ((item.0.prefix | d(system_users__prefix)) + item.0.name),
                 "state": item.0.state | d("present"), "resources": item.1} }}'
   when: (system_users__enabled | bool and
-         item.0.name | d() and item.0.name != 'root' and
+         item.0.name is defined and item.0.name is truthy and item.0.name != 'root' and
          item.0.state | d('present') not in ['absent', 'ignore'] and
-         item.0.create_home | d(True) and item.0.resources | d() and (item.0.user | d(True)) | bool and
+         item.0.create_home | d(True) and item.0.resources is defined and item.0.resources is truthy and (item.0.user | d(True)) | bool and
          item.1.state | d('directory') in ['directory', 'link', 'touch'] and
          item.1.content is undefined)
   no_log: '{{ debops__no_log | d(item.0.no_log) | d(True if item.0.password | d() else False) }}'
@@ -351,9 +351,9 @@
     label: '{{ {"name": ((item.0.prefix | d(system_users__prefix)) + item.0.name),
                 "state": item.0.state | d("present"), "resources": item.1} }}'
   when: (system_users__enabled | bool and
-         item.0.name | d() and item.0.name != 'root' and
+         item.0.name is defined and item.0.name is truthy and item.0.name != 'root' and
          item.0.state | d('present') not in ['absent', 'ignore'] and
-         item.0.create_home | d(True) and item.0.resources | d() and (item.0.user | d(True)) | bool and
+         item.0.create_home | d(True) and item.0.resources is defined and item.0.resources is truthy and (item.0.user | d(True)) | bool and
          item.1.state | d('directory') in ['present', 'file'])
   no_log: '{{ debops__no_log | d(item.0.no_log) | d(True if item.0.password | d() else False) }}'
 
@@ -373,11 +373,11 @@
     label: '{{ {"name": ((item.0.prefix | d(system_users__prefix)) + item.0.name),
                 "state": item.0.state | d("present"), "resources": item.1} }}'
   when: (system_users__enabled | bool and
-         item.0.name | d() and item.0.name != 'root' and
+         item.0.name is defined and item.0.name is truthy and item.0.name != 'root' and
          item.0.state | d('present') not in ['absent', 'ignore'] and
-         item.0.create_home | d(True) and item.0.resources | d() and (item.0.user | d(True)) | bool and
+         item.0.create_home | d(True) and item.0.resources is defined and item.0.resources is truthy and (item.0.user | d(True)) | bool and
          item.1.state | d('directory') in ['present', 'file'] and
-         (item.1.dest | d() or item.1.path | d()) and (item.1.src | d() or item.1.content | d()))
+         ((item.1.dest is defined and item.1.dest is truthy) or (item.1.path is defined and item.1.path is truthy)) and ((item.1.src is defined and item.1.src is truthy) or (item.1.content is defined and item.1.content is truthy)))
   no_log: '{{ debops__no_log | d(item.0.no_log) | d(True if item.0.password | d() else False) }}'
 
 - name: Remove system user resources if requested
@@ -391,9 +391,9 @@
     label: '{{ {"name": ((item.0.prefix | d(system_users__prefix)) + item.0.name),
                 "state": item.0.state | d("present"), "resources": item.1} }}'
   when: (system_users__enabled | bool and
-         item.0.name | d() and item.0.name != 'root' and
+         item.0.name is defined and item.0.name is truthy and item.0.name != 'root' and
          item.0.state | d('present') not in ['absent', 'ignore'] and
-         item.0.create_home | d(True) and item.0.resources | d() and (item.0.user | d(True)) | bool and
+         item.0.create_home | d(True) and item.0.resources is defined and item.0.resources is truthy and (item.0.user | d(True)) | bool and
          item.1.state | d('directory') == 'absent')
   no_log: '{{ debops__no_log | d(item.0.no_log) | d(True if item.0.password | d() else False) }}'
 
@@ -406,7 +406,7 @@
   loop_control:
     label: '{{ {"name": (item.prefix | d(system_users__prefix)) + item.name,
                 "state": item.state | d("present")} }}'
-  when: (system_users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (system_users__enabled | bool and item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') == 'absent' and
          (item.private_group | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'

--- a/ansible/roles/systemd/tasks/main.yml
+++ b/ansible/roles/systemd/tasks/main.yml
@@ -80,7 +80,7 @@
   loop: '{{ systemd__combined_units | flatten | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
-  when: systemd__enabled | bool and item.raw | d() and
+  when: systemd__enabled | bool and item.raw is defined and item.raw is truthy and
         item.state | d("present") not in ['absent', 'ignore', 'init'] and
         (item.name | dirname).endswith('.d')
 
@@ -94,7 +94,7 @@
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
   register: systemd__register_units_created
   notify: [ 'Reload systemd daemon' ]
-  when: systemd__enabled | bool and item.raw | d() and
+  when: systemd__enabled | bool and item.raw is defined and item.raw is truthy and
         item.state | d("present") not in ['absent', 'ignore', 'init']
 
 - name: Remove user units if requested
@@ -127,7 +127,7 @@
   loop: '{{ systemd__user_combined_units | flatten | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
-  when: systemd__enabled | bool and item.raw | d() and
+  when: systemd__enabled | bool and item.raw is defined and item.raw is truthy and
         item.state | d("present") not in ['absent', 'ignore', 'init'] and
         (item.name | dirname).endswith('.d')
 
@@ -140,7 +140,7 @@
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
   notify: [ 'Reload systemd daemon' ]
-  when: systemd__enabled | bool and item.raw | d() and
+  when: systemd__enabled | bool and item.raw is defined and item.raw is truthy and
         item.state | d("present") not in ['absent', 'ignore', 'init']
 
 - name: Flush handlers when needed
@@ -167,7 +167,7 @@
   loop: '{{ systemd__combined_units | flatten | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"restart": item.restart | d()} }}'
-  when: systemd__enabled | bool and item.restart | d() and
+  when: systemd__enabled | bool and item.restart is defined and item.restart is truthy and
         item.state | d("present") not in ['ignore', 'init'] and
         ((item.name in (systemd__register_units_removed.results | selectattr("changed", "true") | map(attribute="item.name") | list)) or
          (item.name in (systemd__register_units_created.results | selectattr("changed", "true") | map(attribute="item.name") | list)))

--- a/ansible/roles/telegraf/tasks/main.yml
+++ b/ansible/roles/telegraf/tasks/main.yml
@@ -39,7 +39,7 @@
   loop: '{{ telegraf__combined_plugins | debops.debops.parse_kv_items }}'
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
-  when: item.state | d('present') == 'absent' and item.config | d()
+  when: item.state | d('present') == 'absent' and item.config is defined and item.config is truthy
   notify: [ 'Check telegraf and restart' ]
 
 - name: Find plugins which are in filesystem
@@ -69,7 +69,7 @@
   loop_control:
     label: '{{ {"name": item.name, "state": item.state | d("present")} }}'
   when: (item.state | d('present') not in ['absent', 'ignore'] and
-         (item.config | d() or item.raw | d()))
+         ((item.config is defined and item.config is truthy) or (item.raw is defined and item.raw is truthy)))
   no_log: '{{ debops__no_log | d(True) }}'
   notify: [ 'Check telegraf and restart' ]
 

--- a/ansible/roles/tinc/tasks/main.yml
+++ b/ansible/roles/tinc/tasks/main.yml
@@ -112,7 +112,7 @@
     mode: '0644'
     unsafe_writes: '{{ True if (core__unsafe_writes | d(ansible_local.core.unsafe_writes | d()) | bool) else omit }}'
   with_dict: '{{ tinc__combined_networks }}'
-  when: item.value.state | d('present') != 'absent' and item.value.tinc_options | d()
+  when: item.value.state | d('present') != 'absent' and item.value.tinc_options is defined and item.value.tinc_options is truthy
   notify: [ 'Reload tinc' ]
 
 - name: Remove deprecated dhclient hook script
@@ -254,7 +254,7 @@
   with_nested:
     - '{{ lookup("template", "lookup/tinc__network_list.j2", convert_data=False) | from_yaml }}'
     - '{{ lookup("template", "lookup/tinc__inventory_groups.j2", convert_data=False) | from_yaml }}'
-  when: (item.0.name | d() and item.0.state | d('present') != 'absent' and
+  when: (item.0.name is defined and item.0.name is truthy and item.0.state | d('present') != 'absent' and
          item.1 in item.0.inventory_groups | d([]) and item.1 in group_names)
   notify: [ 'Reload tinc' ]
 
@@ -330,7 +330,7 @@
     state: '{{ (item.value.state | d("present") in ["absent"]) | ternary("stopped", "started") }}'
   with_dict: '{{ tinc__combined_networks }}'
   when: tinc__systemd | bool and item.value.state | d('present') != 'absent' and
-        item.value.port | d()
+        item.value.port is defined and item.value.port is truthy
 
 # Ansible facts [[[1
 

--- a/ansible/roles/unattended_upgrades/tasks/main.yml
+++ b/ansible/roles/unattended_upgrades/tasks/main.yml
@@ -30,7 +30,7 @@
     group: 'root'
     mode: '0644'
   when: ((unattended_upgrades__periodic | bool) or
-         (ansible_local | d() and ansible_local.unattended_upgrades | d() and
+         (ansible_local is defined and ansible_local.unattended_upgrades is defined and
           ansible_local.unattended_upgrades.periodic | bool))
 
 - name: Configure periodic APT upgrades
@@ -41,7 +41,7 @@
     group: 'root'
     mode: '0644'
   when: ((unattended_upgrades__enabled | bool) or
-         (ansible_local | d() and ansible_local.unattended_upgrades | d() and
+         (ansible_local is defined and ansible_local.unattended_upgrades is defined and
           ansible_local.unattended_upgrades.enabled | bool))
 
 - name: Add/remove diversion of unattended-upgrades configuration

--- a/ansible/roles/unbound/tasks/main.yml
+++ b/ansible/roles/unbound/tasks/main.yml
@@ -28,14 +28,14 @@
     path: '/etc/unbound/unbound.conf.d/ansible-server.conf'
     state: 'absent'
   notify: [ 'Check unbound configuration and reload' ]
-  when: not unbound__combined_server | d()
+  when: unbound__combined_server is falsy
 
 - name: Remove Unbound remote control configuration
   ansible.builtin.file:
     path: '/etc/unbound/unbound.conf.d/ansible-remote-control.conf'
     state: 'absent'
   notify: [ 'Check unbound configuration and reload' ]
-  when: not unbound__combined_remote_control | d()
+  when: unbound__combined_remote_control is falsy
 
 - name: Generate Unbound server configuration
   ansible.builtin.template:
@@ -45,7 +45,7 @@
     group: 'root'
     mode: '0644'
   notify: [ 'Check unbound configuration and reload' ]
-  when: unbound__combined_server | d()
+  when: unbound__combined_server is truthy
 
 - name: Generate Unbound remote control configuration
   ansible.builtin.template:
@@ -55,7 +55,7 @@
     group: 'root'
     mode: '0644'
   notify: [ 'Check unbound configuration and reload' ]
-  when: unbound__combined_remote_control | d()
+  when: unbound__combined_remote_control is truthy
 
 - name: Remove DNS zones if requested
   ansible.builtin.file:
@@ -63,7 +63,7 @@
     state: 'absent'
   loop: '{{ q("flattened", unbound__parsed_zones) }}'
   notify: [ 'Check unbound configuration and reload' ]
-  when: item.name | d() and item.state | d('present') == 'absent'
+  when: item.name is defined and item.name is truthy and item.state | d('present') == 'absent'
 
 - name: Configure DNS zones
   ansible.builtin.template:
@@ -74,7 +74,7 @@
     mode: '0644'
   loop: '{{ q("flattened", unbound__parsed_zones) }}'
   notify: [ 'Check unbound configuration and reload' ]
-  when: item.name | d() and item.state | d('present') != 'absent'
+  when: item.name is defined and item.name is truthy and item.state | d('present') != 'absent'
 
 - name: Install unbound APT packages
   ansible.builtin.package:

--- a/ansible/roles/users/tasks/main.yml
+++ b/ansible/roles/users/tasks/main.yml
@@ -39,7 +39,7 @@
   loop_control:
     label: '{{ {"name": (item.group | d(item.name)),
                 "state": item.state | d("present")} }}'
-  when: (users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (users__enabled | bool and item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') != 'absent' and (item.private_group | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
 
@@ -84,7 +84,7 @@
   loop_control:
     label: '{{ {"name": item.name,
                 "state": item.state | d("present"), "gecos": item.comment | d()} }}'
-  when: (users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (users__enabled | bool and item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') not in ['ignore'] and (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
 
@@ -116,7 +116,7 @@
     label: '{{ {"name": item.name,
                 "state": item.state | d("present"), "gecos": item.comment | d(),
                 "groups": item.groups | d()} }}'
-  when: (users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (users__enabled | bool and item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') not in ['ignore'] and
          (item.groups | d() or (item.chroot | d()) | bool) and
          (item.user | d(True)) | bool)
@@ -143,7 +143,7 @@
                                         else ("~" + item.name))
                                        if ((item.create_home | d(True)) | bool)
                                        else ""))} }}'
-  when: (users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (users__enabled | bool and item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and item.create_home | d(True) and
          (item.home_owner | d() or item.home_group | d() or item.home_mode | d() or (item.local | d(True)) | bool) and
          (item.user | d(True)) | bool)
@@ -172,9 +172,9 @@
     label: '{{ {"name": item.0.name,
                 "state": item.0.state | d("present"), "home_acl": item.1} }}'
   when: (users__enabled | bool and users__acl_enabled | bool and
-         item.0.name | d() and item.0.name != 'root' and
+         item.0.name is defined and item.0.name is truthy and item.0.name != 'root' and
          item.0.state | d('present') not in ['absent', 'ignore'] and
-         item.0.create_home | d(True) and item.0.home_acl | d() and (item.0.user | d(True)) | bool)
+         item.0.create_home | d(True) and item.0.home_acl is defined and item.0.home_acl is truthy and (item.0.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
   tags: [ 'role::users:home_acl', 'skip::users:home_acl', 'skip::check' ]
 
@@ -187,7 +187,7 @@
     label: '{{ {"name": item.name,
                 "state": item.state | d("present"), "linger": item.linger | d(False)} }}'
   when: (users__enabled | bool and ansible_service_mgr == 'systemd' and
-         item.name | d() and item.name != 'root' and
+         item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and
          item.linger is defined and item.linger | bool and (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
@@ -201,7 +201,7 @@
     label: '{{ {"name": item.name,
                 "state": item.state | d("present"), "linger": item.linger | d(False)} }}'
   when: (users__enabled | bool and ansible_service_mgr == 'systemd' and
-         item.name | d() and item.name != 'root' and
+         item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and
          item.linger is defined and not item.linger | bool and (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
@@ -217,9 +217,9 @@
   loop_control:
     label: '{{ {"name": item.name,
                 "state": item.state | d("present"), "sshkeys": item.sshkeys | d()} }}'
-  when: (users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (users__enabled | bool and item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and item.create_home | d(True) and
-         item.sshkeys | d() and item.sshkeys_state | d('present') != 'absent' and (item.user | d(True)) | bool)
+         item.sshkeys is defined and item.sshkeys is truthy and item.sshkeys_state | d('present') != 'absent' and (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
   tags: [ 'role::users:authorized_keys', 'skip::users:authorized_keys', 'skip::check' ]
 
@@ -232,7 +232,7 @@
     label: '{{ {"name": item.name,
                 "state": item.state | d("present"),
                 "sshkeys_state": item.sshkeys_state | d("present")} }}'
-  when: (users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (users__enabled | bool and item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and item.create_home | d(True) and
          item.sshkeys_state | d('present') == 'absent' and (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
@@ -254,9 +254,9 @@
     label: '{{ {"name": item.name,
                 "state": item.state | d("present"),
                 "forward": item.forward | d()} }}'
-  when: (users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (users__enabled | bool and item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and
-         item.create_home | d(True) and item.forward | d() and (item.user | d(True)) | bool)
+         item.create_home | d(True) and item.forward is defined and item.forward is truthy and (item.user | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
   tags: [ 'role::users:forward', 'skip::users:forward', 'skip::check' ]
 
@@ -282,11 +282,11 @@
   check_mode: False
   register: users__register_dotfiles
   changed_when: ('Already up to date.' not in users__register_dotfiles.stdout_lines | regex_replace('-', ' '))
-  when: (users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (users__enabled | bool and item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') not in ['absent', 'ignore'] and item.create_home | d(True) and
-         (ansible_local | d() and ansible_local.yadm | d() and (ansible_local.yadm.installed | d()) | bool) and
+         (ansible_local is defined and ansible_local.yadm is defined and (ansible_local.yadm.installed | d()) | bool) and
          (item.dotfiles | d(item.dotfiles_enabled | d(users__dotfiles_enabled))) | bool and
-         (item.dotfiles_repo | d(users__dotfiles_repo)) and (item.user | d(True)) | bool and not (item.chroot | d()) | bool)
+         ((item.dotfiles_repo | d(users__dotfiles_repo)) is truthy) and (item.user | d(True)) | bool and not (item.chroot | d()) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'
   tags: [ 'role::users:dotfiles', 'skip::users:dotfiles', 'skip::check' ]
 
@@ -307,9 +307,9 @@
     label: '{{ {"name": item.0.name,
                 "state": item.0.state | d("present"), "resources": item.1} }}'
   when: (users__enabled | bool and
-         item.0.name | d() and item.0.name != 'root' and
+         item.0.name is defined and item.0.name is truthy and item.0.name != 'root' and
          item.0.state | d('present') not in ['absent', 'ignore'] and
-         item.0.create_home | d(True) and item.0.resources | d() and (item.0.user | d(True)) | bool and
+         item.0.create_home | d(True) and item.0.resources is defined and item.0.resources is truthy and (item.0.user | d(True)) | bool and
          item.1.state | d('directory') in ['directory', 'link', 'touch'] and
          item.1.content is undefined)
   no_log: '{{ debops__no_log | d(item.0.no_log) | d(True if item.0.password | d() else False) }}'
@@ -330,9 +330,9 @@
     label: '{{ {"name": item.0.name,
                 "state": item.0.state | d("present"), "resources": item.1} }}'
   when: (users__enabled | bool and
-         item.0.name | d() and item.0.name != 'root' and
+         item.0.name is defined and item.0.name is truthy and item.0.name != 'root' and
          item.0.state | d('present') not in ['absent', 'ignore'] and
-         item.0.create_home | d(True) and item.0.resources | d() and (item.0.user | d(True)) | bool and
+         item.0.create_home | d(True) and item.0.resources is defined and item.0.resources is truthy and (item.0.user | d(True)) | bool and
          item.1.state | d('directory') in ['present', 'file'])
   no_log: '{{ debops__no_log | d(item.0.no_log) | d(True if item.0.password | d() else False) }}'
 
@@ -352,11 +352,11 @@
     label: '{{ {"name": item.0.name,
                 "state": item.0.state | d("present"), "resources": item.1} }}'
   when: (users__enabled | bool and
-         item.0.name | d() and item.0.name != 'root' and
+         item.0.name is defined and item.0.name is truthy and item.0.name != 'root' and
          item.0.state | d('present') not in ['absent', 'ignore'] and
-         item.0.create_home | d(True) and item.0.resources | d() and (item.0.user | d(True)) | bool and
+         item.0.create_home | d(True) and item.0.resources is defined and item.0.resources is truthy and (item.0.user | d(True)) | bool and
          item.1.state | d('directory') in ['present', 'file'] and
-         (item.1.dest | d() or item.1.path | d()) and (item.1.src | d() or item.1.content | d()))
+         ((item.1.dest is defined and item.1.dest is truthy) or (item.1.path is defined and item.1.path is truthy)) and ((item.1.src is defined and item.1.src is truthy) or (item.1.content is defined and item.1.content is truthy)))
   no_log: '{{ debops__no_log | d(item.0.no_log) | d(True if item.0.password | d() else False) }}'
 
 - name: Remove user resources if requested
@@ -370,9 +370,9 @@
     label: '{{ {"name": item.0.name,
                 "state": item.0.state | d("present"), "resources": item.1} }}'
   when: (users__enabled | bool and
-         item.0.name | d() and item.0.name != 'root' and
+         item.0.name is defined and item.0.name is truthy and item.0.name != 'root' and
          item.0.state | d('present') not in ['absent', 'ignore'] and
-         item.0.create_home | d(True) and item.0.resources | d() and (item.0.user | d(True)) | bool and
+         item.0.create_home | d(True) and item.0.resources is defined and item.0.resources is truthy and (item.0.user | d(True)) | bool and
          item.1.state | d('directory') == 'absent')
   no_log: '{{ debops__no_log | d(item.0.no_log) | d(True if item.0.password | d() else False) }}'
 
@@ -385,7 +385,7 @@
   loop_control:
     label: '{{ {"name": (item.group | d(item.name)),
                 "state": item.state | d("present")} }}'
-  when: (users__enabled | bool and item.name | d() and item.name != 'root' and
+  when: (users__enabled | bool and item.name is defined and item.name is truthy and item.name != 'root' and
          item.state | d('present') == 'absent' and
          (item.private_group | d(True)) | bool)
   no_log: '{{ debops__no_log | d(item.no_log) | d(True if item.password | d() else False) }}'

--- a/ansible/roles/yadm/tasks/manage_dotfiles.yml
+++ b/ansible/roles/yadm/tasks/manage_dotfiles.yml
@@ -15,7 +15,7 @@
   loop: '{{ q("flattened", dotfile.git) }}'
   loop_control:
     loop_var: 'item_git'
-  when: dotfile.git | d() and dotfile.state | d('present') not in ['absent', 'ignore'] and
+  when: dotfile.git is defined and dotfile.git is truthy and dotfile.state | d('present') not in ['absent', 'ignore'] and
         not ansible_check_mode
 
 - name: Remove dotfiles repo {{ dotfile.name }}
@@ -27,7 +27,7 @@
   loop: '{{ q("flattened", dotfile.git) }}'
   loop_control:
     loop_var: 'item_git'
-  when: dotfile.git | d() and dotfile.state | d('present') == 'absent'
+  when: dotfile.git is defined and dotfile.git is truthy and dotfile.state | d('present') == 'absent'
 
 - name: Manage the cloned dotfiles repo in system-wide /etc/gitconfig
   community.general.git_config:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,5 +6,5 @@ skip = "./.git,./docs/_build,./docs/ansible/roles/*/defaults/*,.venv,*/includes/
 # 'alse' is to ignore literal regex '[Ff]alse'
 # hass is home assistant contraction
 # aNULL is used as a cipher name in SSL
-ignore-words-list = "referer, referers, alse, keyserver, keyservers, hass, anull"
+ignore-words-list = "referer, referers, alse, keyserver, keyservers, hass, anull, falsy"
 exclude-file = ".codespell.exclude"


### PR DESCRIPTION
This PR makes `when:` and `changed_when:` conditions in the roles of every playbook layer compatible with Ansible 2.19, which enables Jinja2 native types by default so a condition that evaluates to a bare string or list no longer passes the boolean check and fails at runtime. The bare `| d()` calls used in boolean contexts are replaced with `is defined` and `truthy`/`falsy` tests, following the same approach @drybjed started in commit 7ec2fcb. 

I am aware of the alternative approach proposed by @scibi in the debops PRs #2656–#2660, which uses the `| d() | length > 0` idiom. I deliberately stayed with the `is defined`/`is truthy` form: unlike the length filter, it also handles scalar booleans and numbers without raising. Furthermore, it keeps the fix consistent with the style already established in the project. I also chose to submit this as a single PR covering all layers rather than splitting it per role group.