### PR TITLE
[authorized_keys] Fix ansible breaking due to undefined loop label

### DIFF
--- a/ansible/roles/authorized_keys/tasks/main.yml
+++ b/ansible/roles/authorized_keys/tasks/main.yml
@@ -32,7 +32,7 @@
     state: 'present'
   loop: '{{ lookup("template", "lookup/authorized_keys__identities.j2") | from_yaml }}'
   loop_control:
-    label: '{{ {"identity": item.identity, "group": item.group} }}'
+    label: '{{ {"identity": item.identity, "group": item.group | d()} }}'
   when: authorized_keys__enabled | bool and item.group | d() and
         item.state | d('present') not in ['absent', 'ignore', 'init'] and
         item.file_state | d('present') not in ['absent', 'ignore', 'init']
@@ -95,7 +95,7 @@
                           else (getent_passwd[item.owner | d("root")][2] | d({})
                                 if (item.owner | d("root") in getent_passwd | d({}))
                                 else "root")),
-                "path": item.path} }}'
+                "path": item.path | d()} }}'
   when: authorized_keys__enabled | bool and item.path | d() and not item.manage_dir | bool and
         item.state | d('present') not in ['absent', 'ignore', 'init'] and not ansible_check_mode
 


### PR DESCRIPTION
When running debops with ansible-core > =14, the playbook fails on step `Ensure the required groups exist`, if an account is defined with `home: True`. For example:

```
  - name: "loniasgr"
    sshkeys:
      ["{{ lookup('file', '{{ playbook_dir }}/files/ssh_keys/loniasgr')}}"]
    state: present
    accounts:
      - name: "loniasgr"
        home: True
```
would fail, because group is not defined in the loop label, even though it should skip. This PR fixes this issue in the two following steps:
- Ensure the required groups exist
- Enforce state of authorized_keys user files

by adding a default value on the inciminating values.

Edit: I had a previous PR, but for some reason it got closed automatically when I tried to rebase on the current master. 