### PR TITLE
Fixed apparmor.fact.j2 template bug

### DIFF
--- a/ansible/roles/apparmor/templates/etc/ansible/facts.d/apparmor.fact.j2
+++ b/ansible/roles/apparmor/templates/etc/ansible/facts.d/apparmor.fact.j2
@@ -34,7 +34,7 @@ def read_kernel_bool(path):
 
 output = loads('''{{ {
                        "enabled": apparmor__enabled | d(False) | bool,
-                       "grub_enabled" apparmor__manage_grub | d(False) | bool
+                       "grub_enabled": apparmor__manage_grub | d(False) | bool
                      } | to_nice_json }}''')
 
 output.append({'installed': (cmd_exists('aa-status') and


### PR DESCRIPTION
Jinja template of apparmor ansible facts is missing a colon, which results in a broken JSON being returned on fact gathering. Error being reported is:
`AnsibleError: template error while templating string: expected token ':', got 'apparmor__manage_grub'. String: #!{{ ansible_python['executable'] }}\n# -*- coding: utf-8 -*-\n\n# Copyright (C) 2022 David Härdeman <david@hardeman.nu>\n# Copyright (C) 2022 DebOps <https://debops.org/>\n# SPDX-License-Identifier: GPL-3.0-only\n\n# {{ ansible_managed }}\n\nfrom __future__ import print_function\nfrom json import dumps, loads\nimport os\n\n\ndef cmd_exists(cmd):\n    return any(\n        os.access(os.path.join(path, cmd), os.X_OK)\n        for path in os.environ[\"PATH\"].split(os.pathsep)\n    )\n\n\ndef read_kernel_bool(path):\n    value = 'N'\n\n    try:\n        with open(path, 'r') as file:\n            value = file.read().strip()\n\n    except Exception:\n        pass\n\n    return value.upper() == 'Y'\n\n\noutput = loads('''{{ {\n                       \"enabled\": apparmor__enabled | d(False) | bool,\n                       \"grub_enabled\" apparmor__manage_grub | d(False) | bool\n                     } | to_nice_json }}''')\n\noutput.append({'installed': (cmd_exists('aa-status') and\n                             cmd_exists('aa-teardown'))})\noutput.append({'kernel_enabled':\n               read_kernel_bool('/sys/module/apparmor/parameters/enabled')})\n\nprint(dumps(output, sort_keys=True, indent=4))\n. expected token ':', got 'apparmor__manage_grub'`