### PR TITLE
Fixed various bugs in apparmor.fact.j2 fact script

### DIFF
--- a/ansible/roles/apparmor/templates/etc/ansible/facts.d/apparmor.fact.j2
+++ b/ansible/roles/apparmor/templates/etc/ansible/facts.d/apparmor.fact.j2
@@ -9,14 +9,11 @@
 
 from __future__ import print_function
 from json import dumps, loads
-import os
+from shutil import which
 
 
 def cmd_exists(cmd):
-    return any(
-        os.access(os.path.join(path, cmd), os.X_OK)
-        for path in os.environ["PATH"].split(os.pathsep)
-    )
+    return which(cmd) is not None
 
 
 def read_kernel_bool(path):
@@ -34,12 +31,16 @@ def read_kernel_bool(path):
 
 output = loads('''{{ {
                        "enabled": apparmor__enabled | d(False) | bool,
-                       "grub_enabled" apparmor__manage_grub | d(False) | bool
+                       "grub_enabled": apparmor__manage_grub | d(False) | bool
                      } | to_nice_json }}''')
 
-output.append({'installed': (cmd_exists('aa-status') and
-                             cmd_exists('aa-teardown'))})
-output.append({'kernel_enabled':
-               read_kernel_bool('/sys/module/apparmor/parameters/enabled')})
+output['installed'] = (
+    cmd_exists('aa-status') and
+    cmd_exists('aa-teardown')
+)
+
+output['kernel_enabled'] = read_kernel_bool(
+    '/sys/module/apparmor/parameters/enabled'
+)
 
 print(dumps(output, sort_keys=True, indent=4))


### PR DESCRIPTION
Apparmor fact script did contains some bugs resulting in errors after running apparmor role and later fact gathering. Namely there's a missing colon, the output dict uses append, cmd_exists leaves room for errors with empty PATH variable.