### PR TITLE
pki: silence successful certbot output in weekly pki-realm jobs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -261,6 +261,12 @@ General
 :ref:`debops.pki` role
 ''''''''''''''''''''''
 
+- The :command:`pki-realm` script now runs :command:`certbot` with the
+  ``--quiet`` option for DNS-01 and manual ACME flows, and creates realm
+  symlinks without :command:`ln` ``-v``. Periodic ``batch``/``at`` jobs no
+  longer mail root on successful renewals or when a certificate is not yet
+  due; errors still produce mail.
+
 - Don't include the content of the Subject field in the list of domains in
   a certificate request. This fixes potential issues with the
   :command:`certbot` command setting wrong certificate name and signature.

--- a/ansible/roles/pki/files/usr/local/lib/pki/pki-realm
+++ b/ansible/roles/pki/files/usr/local/lib/pki/pki-realm
@@ -1229,16 +1229,16 @@ request_acme_dns_certificate() {
     esac
 
     # shellcheck disable=SC2086
-    certbot certonly $acme_extra -n --authenticator ${config['acme_type']} --expand --agree-tos "${email}" --${config['acme_type']}-credentials ${credentials} --server "${config['acme_ca_api']}" ${all_dns_str}
+    certbot certonly $acme_extra -n --quiet --authenticator ${config['acme_type']} --expand --agree-tos "${email}" --${config['acme_type']}-credentials ${credentials} --server "${config['acme_ca_api']}" ${all_dns_str}
 
     local folder
     local letsencrypt
     folder=$(printf '%s\n' "${all_dns[@]}" | xargs | cut -d' ' -f1)
     letsencrypt="/etc/letsencrypt/live/${folder}"
     if [ -f "${letsencrypt}/privkey.pem" ]; then
-        ln -vsfT "${letsencrypt}/privkey.pem"   "${pkirealm}/private/key.pem"
-        ln -vsfT "${letsencrypt}/cert.pem"      "${pkirealm}/acme/cert.pem"
-        ln -vsfT "${letsencrypt}/chain.pem"     "${pkirealm}/acme/intermediate.pem"
+        ln -sfT "${letsencrypt}/privkey.pem"   "${pkirealm}/private/key.pem"
+        ln -sfT "${letsencrypt}/cert.pem"      "${pkirealm}/acme/cert.pem"
+        ln -sfT "${letsencrypt}/chain.pem"     "${pkirealm}/acme/intermediate.pem"
     else
       echo "error: could not symlink let's encrypt certificates into pki realm" >&2
     fi
@@ -1298,10 +1298,10 @@ request_acme_manual_certificate() {
 
     if test "${config['acme_ca']}" == 'le-live-v2'; then
       # shellcheck disable=SC2086
-      certbot certonly -n --authenticator ${config['acme_type']} --preferred-challenges=dns --expand --agree-tos "${email}" ${all_dns_str}
+      certbot certonly -n --quiet --authenticator ${config['acme_type']} --preferred-challenges=dns --expand --agree-tos "${email}" ${all_dns_str}
     elif test "${config['acme_ca']}" == 'le-staging-v2'; then
       # shellcheck disable=SC2086
-      certbot certonly --test-cert -n --authenticator ${config['acme_type']} --preferred-challenges=dns --expand --agree-tos "${email}" ${all_dns_str}
+      certbot certonly --test-cert -n --quiet --authenticator ${config['acme_type']} --preferred-challenges=dns --expand --agree-tos "${email}" ${all_dns_str}
     fi
 
     local folder
@@ -1309,9 +1309,9 @@ request_acme_manual_certificate() {
     folder=$(printf '%s\n' "${all_dns[@]}" | xargs | cut -d' ' -f1)
     letsencrypt="/etc/letsencrypt/live/${folder}"
     if [ -f "${letsencrypt}/privkey.pem" ]; then
-        ln -vsfT "${letsencrypt}/privkey.pem"   "${pkirealm}/private/key.pem"
-        ln -vsfT "${letsencrypt}/cert.pem"      "${pkirealm}/acme/cert.pem"
-        ln -vsfT "${letsencrypt}/chain.pem"     "${pkirealm}/acme/intermediate.pem"
+        ln -sfT "${letsencrypt}/privkey.pem"   "${pkirealm}/private/key.pem"
+        ln -sfT "${letsencrypt}/cert.pem"      "${pkirealm}/acme/cert.pem"
+        ln -sfT "${letsencrypt}/chain.pem"     "${pkirealm}/acme/intermediate.pem"
     else
       echo "error: could not symlink let's encrypt certificates into pki realm" >&2
     fi


### PR DESCRIPTION
## Summary

The weekly `pki-realm schedule` path queues `batch`/`at` jobs that always run `certbot certonly` for DNS-01 and manual ACME flows. Even when a certificate is not yet due for renewal, certbot and verbose `ln -v` write to stdout, so `at` mails root on every host with messages like “Certificate not yet due for renewal” and symlink listings.

This change runs certbot with `--quiet` and creates the realm symlinks with `ln -sfT` (without `-v`) in those two ACME paths. Successful runs and “not yet due” cases stay silent; failures still emit stderr and therefore still produce mail. The `--expand` behaviour is unchanged, so Ansible-driven SAN updates continue to work.

## Test plan

- Deploy the updated `pki-realm` script via the `debops.pki` role.
- Manually run `pki-realm run -n <realm>` on a host whose certificate is not due and confirm no stdout from certbot/`ln`.
- Confirm a deliberate certbot failure still produces stderr (and thus mail from `at` if that is how the job is scheduled).