### PR TITLE
Add hook scripts support for extending DebOps CLI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,6 +46,9 @@ General
   role-specific custom playbooks that are not part of the main :file:`site.yml`
   playbook.
 
+- Added :ref:`hook scripts <debops_hooks>` support for extending DebOps CLI
+  behavior at various execution points.
+
 :ref:`debops.java` role
 '''''''''''''''''''''''
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -87,6 +87,7 @@ infrastructure environments.
    user-guide/debops-for-ansible
    user-guide/project-directories
    user-guide/scripts/index
+   user-guide/hooks
    user-guide/global-variables
    user-guide/custom-environment
    user-guide/playbooks

--- a/docs/user-guide/hooks.rst
+++ b/docs/user-guide/hooks.rst
@@ -1,0 +1,180 @@
+.. Copyright (C) 2026 Maciej Delmanowski <drybjed@gmail.com>
+.. Copyright (C) 2026 DebOps <https://debops.org/>
+.. SPDX-License-Identifier: GPL-3.0-or-later
+
+.. _debops_hooks:
+
+Hook scripts
+============
+
+DebOps CLI supports hook scripts that let you extend or customize its behavior
+at various points during execution. You can use hooks to run custom commands
+before or after Ansible playbook execution, project initialization, secrets
+locking, and other operations.
+
+Hook locations
+--------------
+
+DebOps searches for hook scripts in two directories, in priority order:
+
+1. :file:`<project>/.debops/hooks/<hook_name>/` — project-local hooks
+2. :file:`$XDG_CONFIG_HOME/debops/hooks/<hook_name>/` — user-global hooks
+
+Scripts from the project-local directory run first, followed by user-global
+scripts. Within each directory, scripts run in sorted order. Use numeric
+prefixes like ``00-``, ``99-`` for deterministic ordering.
+
+The project-local hooks directory (``.debops/hooks/``) is intentionally **not**
+created automatically during :command:`debops project init`. This avoids
+polluting git repositories with empty directories and ``.gitkeep`` files. Create
+the directory manually when you need it:
+
+.. code-block:: shell
+
+   mkdir -p .debops/hooks/pre-run
+
+Available hook points
+---------------------
+
+The following hook names are available. Each hook point has a ``pre-`` variant
+that runs before the operation, and a ``post-`` variant that runs after.
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Hook name
+     - Triggered by
+   * - ``pre-run`` / ``post-run``
+     - :command:`debops run` (playbook execution)
+   * - ``pre-check`` / ``post-check``
+     - :command:`debops check`, or :command:`debops run` with ``--check``
+   * - ``pre-exec`` / ``post-exec``
+     - :command:`debops exec` (ad-hoc Ansible command)
+   * - ``pre-env`` / ``post-env``
+     - :command:`debops env` (environment inspection)
+   * - ``pre-init`` / ``post-init``
+     - :command:`debops project init`
+   * - ``pre-commit`` / ``post-commit``
+     - :command:`debops project commit`
+   * - ``pre-refresh`` / ``post-refresh``
+     - :command:`debops project refresh`
+   * - ``pre-lock`` / ``post-lock``
+     - :command:`debops project lock`
+   * - ``pre-unlock`` / ``post-unlock``
+     - :command:`debops project unlock`
+
+The ``run`` and ``check`` hook points are distinguished by the actual execution
+mode, not the CLI subcommand. If you run :command:`debops run` with ``--check``
+in the ansible arguments, or if the ``read_only_friday`` project option is
+enabled, the ``pre-check``/``post-check`` hooks will fire instead of
+``pre-run``/``post-run``.
+
+Execution environment
+---------------------
+
+Each hook script runs as a subprocess with the following environment:
+
+``DEBOPS_HOOK_NAME``
+  Name of the hook being executed (e.g. ``pre-run``, ``post-lock``).
+
+``DEBOPS_PROJECT_PATH``
+  Absolute path to the DebOps project directory.
+
+``DEBOPS_RETURN_CODE``
+  Exit code of the preceding operation. Available only in ``post-`` hooks
+  for :command:`debops run`, :command:`debops check`, :command:`debops exec`,
+  and :command:`debops env`. Not available in ``pre-`` hooks or project
+  lifecycle hooks.
+
+The script also inherits the full process environment, which includes all
+DebOps-configured variables (``DEBOPS_ANSIBLE_COLLECTIONS_PATH``,
+``ANSIBLE_CONFIG``, etc.).
+
+The working directory for the script is set to the project directory.
+
+Script requirements
+-------------------
+
+Hook scripts must be:
+
+- **Executable** — non-executable files in the hooks directory are silently
+  skipped.
+- **Well-behaved** — each script should complete within 5 minutes (300 seconds).
+  Scripts that exceed the timeout are killed and treated as failures.
+- **Exit-code aware** — a non-zero exit code from any script aborts the
+  operation. Subsequent scripts in the same hook point are not executed.
+
+Secrets visibility
+------------------
+
+The availability of decrypted secrets depends on the hook point:
+
+- **Pre-hooks in runners** (``pre-run``, ``pre-check``, ``pre-exec``,
+  ``pre-env``) run **before** the secrets are unlocked. Encrypted files are not
+  accessible at this point.
+- **Post-hooks in runners** (``post-run``, ``post-check``, ``post-exec``,
+  ``post-env``) run **after** the secrets have been re-locked. Encrypted files
+  are not accessible.
+- **Pre-hooks for lock/unlock** run before the respective operation, so secrets
+  may be in either state depending on the current lock status.
+- **Post-hooks for lock/unlock** run after the respective operation completes.
+
+Examples
+--------
+
+Log playbook execution
+~~~~~~~~~~~~~~~~~~~~~~
+
+Create a hook that logs every playbook run to a file:
+
+.. code-block:: shell
+
+   #!/bin/bash
+   # .debops/hooks/pre-run/00-log-run
+
+   LOGFILE="${DEBOPS_PROJECT_PATH}/.debops/hooks.log"
+   echo "$(date -Iseconds) pre-run: starting playbook execution" >> "${LOGFILE}"
+
+Notify on failure
+~~~~~~~~~~~~~~~~~
+
+Create a hook that sends a notification when a playbook fails. This example
+uses the ``DEBOPS_RETURN_CODE`` variable available in ``post-`` hooks:
+
+.. code-block:: shell
+
+   #!/bin/bash
+   # .debops/hooks/post-run/99-notify-failure
+
+   if [ "${DEBOPS_RETURN_CODE:-0}" -ne 0 ]; then
+       echo "Playbook execution failed in ${DEBOPS_PROJECT_PATH}" \
+           | mail -s "DebOps failure" admin@example.com
+   fi
+
+Prevent commits on Fridays
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Create a hook that blocks project commits on Fridays:
+
+.. code-block:: shell
+
+   #!/bin/bash
+   # .debops/hooks/pre-commit/00-no-friday-commits
+
+   if [ "$(date +%u)" -eq 5 ]; then
+       echo "Friday commits are not allowed. Try again Monday."
+       exit 1
+   fi
+
+See also
+--------
+
+- :ref:`debops-cli` for an overview of the DebOps command-line interface
+- :ref:`project_directory` for project directory structure
+
+..
+ Local Variables:
+ mode: rst
+ ispell-local-dictionary: "american"
+ End:

--- a/docs/user-guide/hooks.rst
+++ b/docs/user-guide/hooks.rst
@@ -81,6 +81,9 @@ Each hook script runs as a subprocess with the following environment:
 ``DEBOPS_PROJECT_PATH``
   Absolute path to the DebOps project directory.
 
+``DEBOPS_PROJECT_VIEW``
+  Name of the current infrastructure view (e.g. ``system``, ``deployment``).
+
 ``DEBOPS_RETURN_CODE``
   Exit code of the preceding operation. Available only in ``post-`` hooks
   for :command:`debops run`, :command:`debops check`, :command:`debops exec`,

--- a/docs/user-guide/scripts/debops-env/debops-env.rst
+++ b/docs/user-guide/scripts/debops-env/debops-env.rst
@@ -16,6 +16,9 @@ If a project directory contains encrypted secrets, they will be automatically
 unlocked before executing the external command and locked afterwards if
 necessary.
 
+This command executes :ref:`hook scripts <debops_hooks>` (``pre-env`` and
+``post-env``) before and after command execution.
+
 
 Options
 ~~~~~~~

--- a/docs/user-guide/scripts/debops-exec/debops-exec.rst
+++ b/docs/user-guide/scripts/debops-exec/debops-exec.rst
@@ -15,6 +15,9 @@ The :command:`debops exec` command will automatically unlock and lock the
 encrypted :file:`ansible/secret/` directory as needed, to give the Ansible
 module access to secrets.
 
+This command executes :ref:`hook scripts <debops_hooks>` (``pre-exec`` and
+``post-exec``) before and after the Ansible module execution.
+
 Options
 ~~~~~~~
 

--- a/docs/user-guide/scripts/debops-project/debops-project.rst
+++ b/docs/user-guide/scripts/debops-project/debops-project.rst
@@ -10,6 +10,9 @@ the main argument. The script will check if a :file:`.debops.cfg` file exists
 in a given directory; if not, it will be created along with a basic directory
 structure.
 
+This command executes :ref:`hook scripts <debops_hooks>` (``pre-init`` and
+``post-init``) before and after project initialization.
+
 Options
 ~~~~~~~
 
@@ -171,6 +174,9 @@ well as any untracked files will be committed automatically. The commit message
 is taken from the DebOps configuration; users can use :command:`git commit
 --amend` command to edit the commit message afterwards.
 
+This command executes :ref:`hook scripts <debops_hooks>` (``pre-commit`` and
+``post-commit``) before and after the git commit.
+
 Options
 ~~~~~~~
 
@@ -194,6 +200,9 @@ file. This allows the user to test new configuration if needed. When the
 :file:`ansible.cfg` configuration file based on the contents of its own
 internal configuration. The script will also ensure that the basic directory
 structure of a project exists.
+
+This command executes :ref:`hook scripts <debops_hooks>` (``pre-refresh`` and
+``post-refresh``) before and after the refresh.
 
 Options
 ~~~~~~~
@@ -226,6 +235,9 @@ When ``git-crypt`` is used to encrypt secrets, unlocking them will fail if the
 behavior. Easiest way to mitigate this is to unlock the project before making
 any changes.
 
+This command executes :ref:`hook scripts <debops_hooks>` (``pre-unlock`` and
+``post-unlock``) before and after unlocking the secrets.
+
 Options
 ~~~~~~~
 
@@ -257,6 +269,9 @@ When ``git-crypt`` is used to encrypt secrets, locking them will fail if the
 ``git`` working directory contains uncommitted changes. This is expected
 behavior. Easiest way to mitigate this is to commit any changes before locking
 the project directory.
+
+This command executes :ref:`hook scripts <debops_hooks>` (``pre-lock`` and
+``post-lock``) before and after locking the secrets.
 
 Options
 ~~~~~~~

--- a/docs/user-guide/scripts/debops-run/debops-run.rst
+++ b/docs/user-guide/scripts/debops-run/debops-run.rst
@@ -18,6 +18,10 @@ this process might fail if the project directory contains uncommitted changes.
 Easiest way to mitigate this is to unlock the project directory using the
 ``debops project unlock`` command before making any changes.
 
+This command executes :ref:`hook scripts <debops_hooks>` before and after
+playbook execution: ``pre-run``/``post-run`` for normal runs, or
+``pre-check``/``post-check`` when ``--check`` is active.
+
 Options
 ~~~~~~~
 

--- a/docs/user-guide/scripts/debops.rst
+++ b/docs/user-guide/scripts/debops.rst
@@ -108,3 +108,15 @@ execution:
 ``DEBOPS_CMD_FUSERMOUNT``
   Path to the :command:`fusermount` binary used by DebOps. Can be overridden by
   configuration files.
+
+``DEBOPS_PROJECT_PATH``
+  Absolute path to the DebOps project directory.
+
+``DEBOPS_PROJECT_VIEW``
+  Name of the current infrastructure view (e.g. ``system``, ``deployment``).
+
+``DEBOPS_ANSIBLE_COLLECTIONS_PATH``
+  Path to the Ansible Collections directory in the project.
+
+``DEBOPS_ANSIBLE_INVENTORY``
+  Path to the default Ansible inventory directory.

--- a/src/debops/ansibleplaybookrunner.py
+++ b/src/debops/ansibleplaybookrunner.py
@@ -395,6 +395,7 @@ class AnsiblePlaybookRunner(object):
                 self.inventory.lock()
 
         post_hook_name = 'post-' + run_check_mode
-        run_hooks(self.project.path, post_hook_name)
+        run_hooks(self.project.path, post_hook_name,
+                  extra_env={'DEBOPS_RETURN_CODE': rc})
 
         return rc

--- a/src/debops/ansibleplaybookrunner.py
+++ b/src/debops/ansibleplaybookrunner.py
@@ -5,6 +5,7 @@
 from .utils import unexpanduser
 from .ansibleconfig import AnsibleConfig
 from .ansible.inventory import AnsibleInventory
+from .hooks import run_hooks
 import subprocess
 import datetime
 import configparser
@@ -22,6 +23,7 @@ class AnsiblePlaybookRunner(object):
         self.args = args
         self.kwargs = kwargs
 
+        self.project = project
         self.inventory = AnsibleInventory(project, name=project.view)
 
         try:
@@ -163,6 +165,12 @@ class AnsiblePlaybookRunner(object):
         # Notify user at end of execution
         if self.kwargs.get('bell', False):
             print('\a', end='')
+
+    def _get_check_mode(self):
+        if ('--check' in self._ansible_command or
+                '-C' in self._ansible_command):
+            return 'check'
+        return 'run'
 
     def _expand_playbook_paths(self, project):
         playbook_dirs = []
@@ -333,11 +341,19 @@ class AnsiblePlaybookRunner(object):
 
         for key, value in self._ansible_env.items():
             os.environ[key] = value
+
+        run_check_mode = self._get_check_mode()
+
+        hook_name = 'pre-' + run_check_mode
+        if not run_hooks(self.project.path, hook_name):
+            raise RuntimeError('Hook {} aborted, not running playbooks'
+                               .format(hook_name))
+
+        rc = 0
         try:
             unlocked = self.inventory.unlock()
 
-            if ('--check' in self._ansible_command or
-                    '-C' in self._ansible_command):
+            if run_check_mode == 'check':
                 logger.info('Checking Ansible playbooks: {}'.format(
                         ','.join(self._found_playbooks)),
                         extra={'block': 'stderr'})
@@ -359,7 +375,7 @@ class AnsiblePlaybookRunner(object):
                 logger.error('Ansible finished with '
                              'return code {}'.format(executor.returncode))
             self._ring_bell()
-            return executor.returncode
+            rc = executor.returncode
 
         except ChildProcessError:
             raise ChildProcessError('Cannot unlock project secrets, '
@@ -377,3 +393,8 @@ class AnsiblePlaybookRunner(object):
         finally:
             if unlocked:
                 self.inventory.lock()
+
+        post_hook_name = 'post-' + run_check_mode
+        run_hooks(self.project.path, post_hook_name)
+
+        return rc

--- a/src/debops/ansiblerunner.py
+++ b/src/debops/ansiblerunner.py
@@ -150,6 +150,7 @@ class AnsibleRunner(object):
             if unlocked:
                 self.inventory.lock()
 
-        run_hooks(self.project.path, 'post-exec')
+        run_hooks(self.project.path, 'post-exec',
+                  extra_env={'DEBOPS_RETURN_CODE': rc})
 
         return rc

--- a/src/debops/ansiblerunner.py
+++ b/src/debops/ansiblerunner.py
@@ -5,6 +5,7 @@
 from .utils import unexpanduser
 from .ansibleconfig import AnsibleConfig
 from .ansible.inventory import AnsibleInventory
+from .hooks import run_hooks
 import subprocess
 import configparser
 import textwrap
@@ -18,6 +19,7 @@ class AnsibleRunner(object):
         self.args = args
         self.kwargs = kwargs
 
+        self.project = project
         self.inventory = AnsibleInventory(project, name=project.view)
 
         try:
@@ -121,6 +123,12 @@ class AnsibleRunner(object):
 
         for key, value in self._ansible_env.items():
             os.environ[key] = value
+
+        if not run_hooks(self.project.path, 'pre-exec'):
+            raise RuntimeError('Hook pre-exec aborted, '
+                               'not executing Ansible command')
+
+        rc = 0
         try:
             unlocked = self.inventory.unlock()
 
@@ -128,7 +136,7 @@ class AnsibleRunner(object):
                                         shell=True)
             std_out, std_err = executor.communicate()
             self._ring_bell()
-            return executor.returncode
+            rc = executor.returncode
 
         except KeyboardInterrupt:
             if unlocked:
@@ -141,3 +149,7 @@ class AnsibleRunner(object):
         finally:
             if unlocked:
                 self.inventory.lock()
+
+        run_hooks(self.project.path, 'post-exec')
+
+        return rc

--- a/src/debops/envrunner.py
+++ b/src/debops/envrunner.py
@@ -5,6 +5,7 @@
 from .utils import unexpanduser
 from .ansibleconfig import AnsibleConfig
 from .ansible.inventory import AnsibleInventory
+from .hooks import run_hooks
 import subprocess
 import configparser
 import textwrap
@@ -57,13 +58,19 @@ class EnvRunner(object):
 
         for key, value in self.project.config._env_vars.items():
             os.environ[key] = value
+
+        if not run_hooks(self.project.path, 'pre-env'):
+            raise RuntimeError('Hook pre-env aborted, '
+                               'not running command in environment')
+
+        rc = 0
         try:
             unlocked = self.inventory.unlock()
 
             executor = subprocess.Popen(' '.join(self._command),
                                         shell=True)
             std_out, std_err = executor.communicate()
-            return executor.returncode
+            rc = executor.returncode
 
         except KeyboardInterrupt:
             if unlocked:
@@ -73,3 +80,7 @@ class EnvRunner(object):
         finally:
             if unlocked:
                 self.inventory.lock()
+
+        run_hooks(self.project.path, 'post-env')
+
+        return rc

--- a/src/debops/envrunner.py
+++ b/src/debops/envrunner.py
@@ -81,6 +81,7 @@ class EnvRunner(object):
             if unlocked:
                 self.inventory.lock()
 
-        run_hooks(self.project.path, 'post-env')
+        run_hooks(self.project.path, 'post-env',
+                  extra_env={'DEBOPS_RETURN_CODE': rc})
 
         return rc

--- a/src/debops/hooks.py
+++ b/src/debops/hooks.py
@@ -1,0 +1,108 @@
+# Copyright (C) 2026 Maciej Delmanowski <drybjed@gmail.com>
+# Copyright (C) 2026 DebOps <https://debops.org/>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import subprocess
+import os
+import logging
+
+from xdg.BaseDirectory import xdg_config_home
+
+logger = logging.getLogger(__name__)
+
+# Default timeout for hook scripts in seconds (5 minutes)
+DEFAULT_HOOK_TIMEOUT = 300
+
+
+def _discover_hooks(hook_dir):
+    """Discover executable scripts in a hooks directory.
+
+    Returns a sorted list of absolute paths to executable files.
+    Non-executable files and directories are silently skipped.
+    """
+    scripts = []
+    if not os.path.isdir(hook_dir):
+        return scripts
+
+    for entry in sorted(os.listdir(hook_dir)):
+        entry_path = os.path.join(hook_dir, entry)
+        if not os.path.isfile(entry_path):
+            continue
+        if not os.access(entry_path, os.X_OK):
+            continue
+        scripts.append(os.path.abspath(entry_path))
+
+    return scripts
+
+
+def run_hooks(project_path, hook_name, timeout=DEFAULT_HOOK_TIMEOUT):
+    """Run all executable scripts for a given hook name.
+
+    Searches for scripts in two locations, in priority order:
+
+      1. <project_path>/.debops/hooks/<hook_name>/  (project-local)
+      2. ~/.config/debops/hooks/<hook_name>/        (user-global)
+
+    Scripts from the project-local directory run first, followed by
+    user-global scripts. Within each directory, scripts run in sorted
+    order (use numeric prefixes like 00-, 99- for deterministic ordering).
+
+    Each hook script receives the following environment variables:
+
+      DEBOPS_HOOK_NAME    - name of the hook being executed
+      DEBOPS_PROJECT_PATH - path to the project directory
+
+    The script inherits the full process environment, which includes
+    all DebOps-configured variables (DEBOPS_ANSIBLE_COLLECTIONS_PATH,
+    ANSIBLE_CONFIG, etc.).
+
+    Args:
+        project_path: Absolute path to the DebOps project directory.
+        hook_name: Name of the hook point (e.g. 'pre-run', 'post-lock').
+        timeout: Maximum seconds to wait for each script. Default: 300.
+
+    Returns:
+        True if all hooks executed successfully (exit code 0).
+        False if any hook failed (non-zero exit code).
+        True if no hooks were found (no-op).
+    """
+    project_hooks_dir = os.path.join(project_path, '.debops', 'hooks',
+                                     hook_name)
+    user_hooks_dir = os.path.join(xdg_config_home, 'debops', 'hooks',
+                                  hook_name)
+
+    project_scripts = _discover_hooks(project_hooks_dir)
+    user_scripts = _discover_hooks(user_hooks_dir)
+
+    all_scripts = project_scripts + user_scripts
+
+    if not all_scripts:
+        return True
+
+    logger.debug('Found {} hook script(s) for "{}"'.format(
+        len(all_scripts), hook_name))
+
+    hook_env = os.environ.copy()
+    hook_env['DEBOPS_HOOK_NAME'] = hook_name
+    hook_env['DEBOPS_PROJECT_PATH'] = os.path.abspath(project_path)
+
+    for script in all_scripts:
+        logger.notice('Running hook script: {}'.format(script),
+                      extra={'block': 'stderr'})
+        try:
+            result = subprocess.run(
+                [script],
+                cwd=os.path.abspath(project_path),
+                env=hook_env,
+                timeout=timeout)
+        except subprocess.TimeoutExpired:
+            logger.error('Hook script {} timed out after {} seconds'.format(
+                script, timeout), extra={'block': 'stderr'})
+            return False
+
+        if result.returncode != 0:
+            logger.error('Hook script {} failed with exit code {}'.format(
+                script, result.returncode), extra={'block': 'stderr'})
+            return False
+
+    return True

--- a/src/debops/hooks.py
+++ b/src/debops/hooks.py
@@ -35,7 +35,8 @@ def _discover_hooks(hook_dir):
     return scripts
 
 
-def run_hooks(project_path, hook_name, timeout=DEFAULT_HOOK_TIMEOUT):
+def run_hooks(project_path, hook_name, timeout=DEFAULT_HOOK_TIMEOUT,
+              extra_env=None):
     """Run all executable scripts for a given hook name.
 
     Searches for scripts in two locations, in priority order:
@@ -60,6 +61,8 @@ def run_hooks(project_path, hook_name, timeout=DEFAULT_HOOK_TIMEOUT):
         project_path: Absolute path to the DebOps project directory.
         hook_name: Name of the hook point (e.g. 'pre-run', 'post-lock').
         timeout: Maximum seconds to wait for each script. Default: 300.
+        extra_env: Optional dict of additional environment variables
+            to pass to the hook scripts. Values are converted to strings.
 
     Returns:
         True if all hooks executed successfully (exit code 0).
@@ -85,6 +88,9 @@ def run_hooks(project_path, hook_name, timeout=DEFAULT_HOOK_TIMEOUT):
     hook_env = os.environ.copy()
     hook_env['DEBOPS_HOOK_NAME'] = hook_name
     hook_env['DEBOPS_PROJECT_PATH'] = os.path.abspath(project_path)
+    if extra_env:
+        for key, value in extra_env.items():
+            hook_env[key] = str(value)
 
     for script in all_scripts:
         logger.notice('Running hook script: {}'.format(script),

--- a/src/debops/projectdir.py
+++ b/src/debops/projectdir.py
@@ -6,6 +6,7 @@ from .constants import DEBOPS_USER_HOME_DIR
 from .utils import unexpanduser
 from .ansibleconfig import AnsibleConfig
 from .ansible.inventory import AnsibleInventory
+from .hooks import run_hooks
 import os
 import pkgutil
 import jinja2
@@ -535,6 +536,9 @@ class ProjectDir(object):
             raise IsADirectoryError('You are inside another '
                                     'DebOps project directory')
 
+        if not run_hooks(self.path, 'pre-init'):
+            raise RuntimeError('Hook pre-init aborted, not creating project')
+
         # Let's make a new project
         if self.project_type == 'modern':
             self._create_modern_project(self.path)
@@ -601,6 +605,8 @@ class ProjectDir(object):
                                   'not installing Ansible Collections')
                 logger.debug('Ansible Collections installed in project '
                              'directory')
+
+        run_hooks(self.path, 'post-init')
 
     def mkview(self, view):
 
@@ -731,34 +737,45 @@ class ProjectDir(object):
     def commit(self, interactive=False):
         """Commit the current contents of the project directory to the git
         repository automatically."""
-        if self._is_git_repo(self.path):
-            logger.debug('Detected git repository in project directory')
-            repo = git.Repo(self.path)
-            repo.git.add(all=True)
+        if not self._is_git_repo(self.path):
+            return
 
-            # Check if there are any differences between the current HEAD and
-            # the index. If there are, we need to commit them.
-            diff_list = repo.head.commit.diff()
-            if diff_list:
-                try:
-                    logger.debug('New changes detected, committing')
-                    repo.index.commit(
-                        self.config.raw['project']['git']['auto_commit_message'])
-                    logger.debug('New changes committed in git repository')
-                except KeyError:
-                    # There was an issue in the configuration, unstage any
-                    # changes in git index
-                    logger.warning('Issue in DebOps configuration, unstaging '
-                                   'changes in git index')
-                    repo.git.reset()
-                    if interactive:
-                        print('The "project.git.auto_commit_message" option is '
-                              'not defined. Not committing any changes.')
-            else:
-                logger.debug('No new changes detected, nothing to commit')
+        run_hooks(self.path, 'pre-commit')
+
+        logger.debug('Detected git repository in project directory')
+        repo = git.Repo(self.path)
+        repo.git.add(all=True)
+
+        # Check if there are any differences between the current HEAD and
+        # the index. If there are, we need to commit them.
+        diff_list = repo.head.commit.diff()
+        if diff_list:
+            try:
+                logger.debug('New changes detected, committing')
+                repo.index.commit(
+                    self.config.raw['project']['git']['auto_commit_message'])
+                logger.debug('New changes committed in git repository')
+            except KeyError:
+                # There was an issue in the configuration, unstage any
+                # changes in git index
+                logger.warning('Issue in DebOps configuration, unstaging '
+                               'changes in git index')
+                repo.git.reset()
+                if interactive:
+                    print('The "project.git.auto_commit_message" option is '
+                          'not defined. Not committing any changes.')
+        else:
+            logger.debug('No new changes detected, nothing to commit')
+
+        run_hooks(self.path, 'post-commit')
 
     def refresh(self):
         logger.debug("Refresing project directory")
+
+        if not run_hooks(self.path, 'pre-refresh'):
+            print('Hook pre-refresh aborted, not refreshing project')
+            return
+
         if self.project_type == 'modern':
             self.createdirs(self.path)
 
@@ -786,10 +803,16 @@ class ProjectDir(object):
                 self.ansible_cfg.write_config()
         print('Refreshed DebOps project in', self.path)
 
+        run_hooks(self.path, 'post-refresh')
+
     def unlock(self):
+        run_hooks(self.path, 'pre-unlock')
         inventory = AnsibleInventory(self, self.view)
         inventory.unlock()
+        run_hooks(self.path, 'post-unlock')
 
     def lock(self):
+        run_hooks(self.path, 'pre-lock')
         inventory = AnsibleInventory(self, self.view)
         inventory.lock()
+        run_hooks(self.path, 'post-lock')

--- a/src/debops/projectdir.py
+++ b/src/debops/projectdir.py
@@ -158,6 +158,9 @@ class ProjectDir(object):
             }
         self.config.merge(view_data)
 
+        # Expose current view in runtime environment
+        self.config.set_env('DEBOPS_PROJECT_VIEW', self.view)
+
         if self.project_type == 'legacy':
             self.ansible_cfg = AnsibleConfig(
                     os.path.join(self.path, 'ansible.cfg'),


### PR DESCRIPTION
Add a hook scripts mechanism that lets users extend DebOps CLI behavior at various execution points. Hook scripts are discovered from project-local and user-global directories, and executed before and after Ansible playbook runs, project initialization, secrets locking and unlocking, and other operations.

This allows integration of custom workflows such as logging, notifications, precondition checks, and post-operation cleanup without modifying DebOps itself.