### PR TITLE
Update AI contributions policy to v0.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Set up an Ansible Controller with DebOps support as a Docker container
 #
-# Copyright (C) 2017-2019 Maciej Delmanowski <drybjed@gmail.com>
-# Copyright (C) 2017-2019 DebOps <https://debops.org/>
+# Copyright (C) 2017-2026 Maciej Delmanowski <drybjed@gmail.com>
+# Copyright (C) 2017-2026 DebOps <https://debops.org/>
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
@@ -17,7 +17,7 @@
 #     debops run common --diff
 
 
-FROM debian:bullseye-slim AS builder
+FROM debian:trixie-slim AS builder
 
 LABEL maintainer="Maciej Delmanowski <drybjed@gmail.com>" \
       project="DebOps" homepage="https://debops.org/"
@@ -41,7 +41,7 @@ WORKDIR /root/src/debops
 RUN make man wheel-quiet \
     && cp lib/docker/docker-entrypoint /usr/local/bin/
 
-FROM debian:bullseye-slim
+FROM debian:trixie-slim
 
 LABEL maintainer="Maciej Delmanowski <drybjed@gmail.com>" \
       project="DebOps" homepage="https://debops.org/"
@@ -57,7 +57,6 @@ RUN apt-get -q update \
        python3-cryptography \
        python3-distro \
        python3-dnspython \
-       python3-future \
        python3-ldap \
        python3-netaddr \
        python3-pip \
@@ -71,14 +70,14 @@ RUN apt-get -q update \
        make \
        git \
        man-db \
-    && pip3 install ansible \
+    && pip3 install --break-system-packages ansible \
     && echo "Cleaning up cache directories..." \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*.deb /root/.cache/*
 
 COPY --from=builder /root/src/debops/dist /root/src/debops/dist
 COPY --from=builder /usr/local/bin/docker-entrypoint /usr/local/bin/docker-entrypoint
 
-RUN pip3 install /root/src/debops/dist/debops-*.whl \
+RUN pip3 install --break-system-packages /root/src/debops/dist/debops-*.whl \
     && chmod +x /usr/local/bin/docker-entrypoint \
     && rm -rf /root/src /root/.cache/*
 
@@ -94,7 +93,7 @@ WORKDIR /home/ansible
 
 # Docker does not set expected environment variables by default
 # Ref: https://stackoverflow.com/questions/54411218/
-ENV USER ansible
+ENV USER=ansible
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]
 CMD ["/bin/bash"]

--- a/docs/meta/policy/ai-contributions.rst
+++ b/docs/meta/policy/ai-contributions.rst
@@ -11,8 +11,8 @@ DebOps LLM-Generated Contributions Policy
 
 :Date drafted: 2026-07-02
 :Date effective: 2026-09-01
-:Last changed: 2026-08-05
-:Version: 0.2.0
+:Last changed: 2026-08-30
+:Version: 0.3.0
 :Authors: - drybjed_
 
 .. This version may not correspond directly to the debops-policy version.
@@ -229,6 +229,28 @@ Code review feedback that draws on LLM suggestions is subject to the same
 Core Principle: the reviewer MUST understand and stand behind the feedback
 they post.
 
+Large-Scale and Automated Actions
+---------------------------------
+
+The use of generative AI does not change the project's expectations regarding
+large-scale or automated actions. Contributors intending to perform actions
+with broad project impact SHOULD seek prior discussion and consensus through
+the appropriate project channel before proceeding. This includes, for example:
+
+- mass bug filing or patch submission
+- automated processes and tools that act on project infrastructure
+- bulk changes spanning multiple roles, playbooks, or other components
+- automated changes or requests affecting many components or contributors
+
+Automated processes SHOULD be overseen by a human who remains accountable for
+their behavior and output. This complements the prohibitions on unauthorized
+agents and proxy submissions above: those rules govern who or what may act,
+this section governs actions whose scope affects the project as a whole.
+
+A coordinated change that forms a single logical unit — for example a
+variable rename across several roles as part of one feature — remains subject
+to the normal review process and does not require prior consensus.
+
 Scope
 -----
 
@@ -256,7 +278,36 @@ This policy governs contributions to the DebOps Project. It does not govern
 the use of LLM output against live infrastructure — for example playbooks
 generated or modified by an LLM and executed against managed hosts. That
 use is covered by the project's operational safeguards and verification
-tooling, not by this document.
+tooling, not by this document. The "Confidentiality of Information" section
+below is the exception: its requirements apply to operational use as well.
+
+Confidentiality of Information
+------------------------------
+
+Third-party generative AI services collect and retain what they are given;
+treat them as what they are — external parties. Contributors MUST NOT disclose
+confidential or non-public material relating to the DebOps Project, its
+managed infrastructure, or its community to such services unless the
+disclosure has been explicitly authorized. This includes, for example:
+
+- Ansible vault contents and other encrypted secrets
+- inventory files, ``group_vars``, and ``host_vars`` data
+- cryptographic keys, certificates, and credentials
+- internal hostnames, IP addresses, and network topology
+- private communications between contributors
+- security-sensitive information, including embargoed or not-yet-public
+  details of security issues
+- personal data relating to the DebOps Project community
+
+This requirement applies to operational use of generative AI tools in
+addition to contributions. The carve-out in the "Scope" section above
+excludes most operational use from this policy; the confidentiality rules
+are the exception and apply regardless of how the tools are used.
+
+Before sending project or infrastructure material to a generative AI service,
+contributors SHOULD check the service's data-retention and privacy settings,
+and SHOULD replace real values — credentials, hostnames, IP addresses — with
+the reserved example values used elsewhere in the project's documentation.
 
 Transition
 ----------
@@ -339,6 +390,8 @@ Additional References
 - Rust Project, `LLM Usage Policy <https://forge.rust-lang.org/policies/llm-usage.html>`__
 - Jynn Nelson, `rust-lang/rust is adopting an LLM policy <https://blog.rust-lang.org/inside-rust/2026/08/05/rust-langrust-is-adopting-an-llm-policy/>`__
 - rustc-dev-guide, `LLM Guidance <https://rustc-dev-guide.rust-lang.org/llm-guidance.html>`__
+- Debian Project, `General Resolution 2026-002: LLM usage in Debian <https://www.debian.org/vote/2026/vote_002>`__
+- LWN.net, `Debian votes to allow "responsible use of generative AI" <https://lwn.net/Articles/1091231/>`__
 
 .. _REUSE: https://reuse.software/
 .. _SPDX: https://spdx.dev/

--- a/docs/meta/policy/ai-contributions.rst
+++ b/docs/meta/policy/ai-contributions.rst
@@ -11,7 +11,7 @@ DebOps LLM-Generated Contributions Policy
 
 :Date drafted: 2026-07-02
 :Date effective: 2026-09-01
-:Last changed: 2026-08-30
+:Last changed: 2026-09-11
 :Version: 0.3.0
 :Authors: - drybjed_
 
@@ -58,12 +58,21 @@ Submitting unreviewed AI-generated content wastes scarce maintainer time and
 is unacceptable. Contributions that lack thoughtfulness and care may be
 declined outright.
 
-Contributors MUST review their work and not submit content they recognize
-as a verbatim copy of copyrighted sources. Contributors MUST apply the same
-license-compatibility diligence to AI-generated content as to any other
-third-party code. Contributors MUST NOT use AI tools whose terms of service
-place restrictions on generated output that conflict with the project's
-licensing or the ability to OpenPGP-sign the resulting commits.
+Contributors MUST review their work and MUST NOT knowingly submit content
+that infringes third-party copyright or licensing terms. Contributors MUST
+apply the same license-compatibility diligence to AI-generated content as
+to any other third-party code. Reproducing or regenerating copyrighted
+material with an AI tool does not remove its copyright. Contributors MUST
+NOT assume that generated content is original solely because an AI tool
+produced it; where they recognize generated output as third-party material,
+or tooling flags substantial similarity, they MUST establish the applicable
+license and their right to submit it before proceeding. Contributors are
+not required to audit output against unknown sources; they are required to
+act on what they can reasonably know, investigate, and recognize.
+
+Contributors MUST NOT use AI tools whose terms of service place restrictions
+on generated output that conflict with the project's licensing or the
+ability to OpenPGP-sign the resulting commits.
 
 Meaning of "originally created by an LLM"
 -----------------------------------------
@@ -130,7 +139,10 @@ This trailer lives in the Git metadata, not in file content. It is compatible
 with REUSE_ and SPDX_ file-level license and copyright headers — the trailer
 makes no statement about file-level licensing. It provides a machine-parseable
 record of provenance that automated tooling can use to evaluate compliance
-with this policy.
+with this policy. Because LLM output can carry provenance uncertainty that a
+contributor cannot fully resolve, the trailer lets maintainers identify where
+the diligence obligations described in the Core Principle section apply and
+where extra review is warranted.
 
 Maintainers MUST preserve the ``Generated-By: LLM`` trailer during merge. If
 a PR branch is squashed, the committer SHALL add the trailer to the resulting


### PR DESCRIPTION
Updates the LLM-Generated Contributions Policy to v0.3.0 with two new sections. The "Confidentiality of Information" section requires contributors to keep keys, credentials, vault contents, and other non-public project material away from third-party AI services — and, unusually for this policy, it also covers operational use of LLM tooling against managed infrastructure, which the scope carve-out otherwise leaves out. The "Large-Scale and Automated Actions" section asks contributors to seek consensus before mass filing, bulk cross-role changes, or other broad-impact automated actions, while keeping coordinated single-logical-unit changes in the normal review path.

The revision aligns the policy with Debian's GR 2026-002 (Responsible Use of Generative AI), which is now cited in the Additional References.